### PR TITLE
Auth audit: fix INVALID_ORIGIN on dev-j + role guards UI + Coolify docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ uploads/
 
 # Source documents (content captured in design-system.md)
 docs/CharteGraphique_Devfest2024.pdf
+tests/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,6 @@ services:
       dockerfile: src/backend/Dockerfile
       args:
         - SEED_SCRIPT=prisma/seed-dev.ts
-    container_name: devfest-${ENV_NAME:-local}-backend
     volumes:
       - uploads:/app/uploads
     environment:
@@ -51,10 +50,17 @@ services:
     # exposed via Traefik — the frontend proxies /api/* to it through the
     # Next.js rewrites. Joining `coolify` would put it side-by-side with the
     # backend of every other Coolify project that uses the same service name,
-    # and Docker DNS would round-robin between them. See:
-    # https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/issues/...
+    # and Docker DNS would round-robin between them.
+    #
+    # Network alias gives the backend a unique, env-scoped hostname inside
+    # the project's `default` network. The frontend points BACKEND_URL at
+    # this alias instead of the bare `backend` to avoid resolving against
+    # other projects' backends through the shared `coolify` network (Coolify
+    # ignores `container_name` so we can't rely on that).
     networks:
-      - default
+      default:
+        aliases:
+          - devfest-${ENV_NAME:-local}-backend
 
   db:
     image: postgres:16-alpine

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,10 @@ services:
       dockerfile: src/frontend/Dockerfile
     environment:
       - BASE_URL=${BASE_URL}
-      - BACKEND_URL=http://backend:4000
+      # Pinned to the env-scoped backend container name. Resolving the bare
+      # `backend` hostname picks up other Coolify projects' backends via the
+      # shared `coolify` network (IPv6 priority), causing cross-env requests.
+      - BACKEND_URL=http://devfest-${ENV_NAME:-local}-backend:4000
     expose:
       - "3000"
     depends_on:
@@ -20,6 +23,7 @@ services:
       dockerfile: src/backend/Dockerfile
       args:
         - SEED_SCRIPT=prisma/seed-dev.ts
+    container_name: devfest-${ENV_NAME:-local}-backend
     volumes:
       - uploads:/app/uploads
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -68,6 +68,7 @@ services:
 
   mailhog:
     image: mailhog/mailhog:latest
+    container_name: devfest-${ENV_NAME:-local}-mailhog
     expose:
       - "8025"
     networks:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,9 +43,14 @@ services:
         condition: service_healthy
       mailhog:
         condition: service_started
+    # Intentionally NOT on the shared `coolify` network. The backend isn't
+    # exposed via Traefik — the frontend proxies /api/* to it through the
+    # Next.js rewrites. Joining `coolify` would put it side-by-side with the
+    # backend of every other Coolify project that uses the same service name,
+    # and Docker DNS would round-robin between them. See:
+    # https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/issues/...
     networks:
       - default
-      - coolify
 
   db:
     image: postgres:16-alpine

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,10 @@ services:
       dockerfile: src/frontend/Dockerfile
     environment:
       - BASE_URL=${BASE_URL}
-      - BACKEND_URL=http://backend:4000
+      # Pinned to the env-scoped backend container name. Resolving the bare
+      # `backend` hostname picks up other Coolify projects' backends via the
+      # shared `coolify` network (IPv6 priority), causing cross-env requests.
+      - BACKEND_URL=http://devfest-${ENV_NAME:-local}-backend:4000
     expose:
       - "3000"
     depends_on:
@@ -20,6 +23,7 @@ services:
       dockerfile: src/backend/Dockerfile
       args:
         - SEED_SCRIPT=prisma/seed.ts
+    container_name: devfest-${ENV_NAME:-local}-backend
     volumes:
       - uploads:/app/uploads
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,6 @@ services:
       dockerfile: src/backend/Dockerfile
       args:
         - SEED_SCRIPT=prisma/seed.ts
-    container_name: devfest-${ENV_NAME:-local}-backend
     volumes:
       - uploads:/app/uploads
     environment:
@@ -53,8 +52,16 @@ services:
     # Next.js rewrites. Joining `coolify` would put it side-by-side with the
     # backend of every other Coolify project that uses the same service name,
     # and Docker DNS would round-robin between them.
+    #
+    # Network alias gives the backend a unique, env-scoped hostname inside
+    # the project's `default` network. The frontend points BACKEND_URL at
+    # this alias instead of the bare `backend` to avoid resolving against
+    # other projects' backends through the shared `coolify` network (Coolify
+    # ignores `container_name` so we can't rely on that).
     networks:
-      - default
+      default:
+        aliases:
+          - devfest-${ENV_NAME:-local}-backend
 
   db:
     image: postgres:16-alpine

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,9 +44,13 @@ services:
         condition: service_healthy
       postfix:
         condition: service_started
+    # Intentionally NOT on the shared `coolify` network. The backend isn't
+    # exposed via Traefik — the frontend proxies /api/* to it through the
+    # Next.js rewrites. Joining `coolify` would put it side-by-side with the
+    # backend of every other Coolify project that uses the same service name,
+    # and Docker DNS would round-robin between them.
     networks:
       - default
-      - coolify
 
   db:
     image: postgres:16-alpine

--- a/docs/coolify-pieges-multi-environnements.md
+++ b/docs/coolify-pieges-multi-environnements.md
@@ -1,0 +1,130 @@
+# Coolify — pièges en environnement multi-projets / multi-environnements
+
+> **Document générique réutilisable.** Cette note décrit un piège récurrent de Coolify quand plusieurs projets (ou plusieurs environnements d'un même projet) cohabitent sur la même instance. Elle peut être copiée/adaptée pour d'autres projets déployés via Coolify.
+
+---
+
+## Le problème en deux phrases
+
+Sur une instance Coolify qui héberge plusieurs projets, **les services d'un projet peuvent involontairement parler aux services d'un autre projet** à cause du réseau Docker partagé `coolify` et de la résolution DNS Docker.
+
+Combiné au fait que **les variables d'environnement Coolify ne sont disponibles au build qu'avec un toggle explicite**, des bugs très difficiles à diagnostiquer apparaissent : la config a l'air correcte au runtime mais le build a figé d'anciennes valeurs, ou les requêtes partent vers le bon nom de service mais arrivent au mauvais container.
+
+## Les 4 points clés à vérifier sur tout projet Coolify
+
+### 1. `container_name` dans le compose est ignoré
+
+Coolify renomme systématiquement les containers avec son propre hash de projet (ex. `backend-jotu5qn6uevc1z8euqfmk4ox-205852288651`). Le `container_name` du compose est ignoré.
+
+→ **Pour avoir un hostname stable**, utiliser `networks.<network>.aliases` au lieu de `container_name`.
+
+### 2. Le réseau `coolify` est partagé entre tous les projets
+
+Tout service connecté à ce réseau (typiquement le `frontend` pour être atteignable par Traefik) peut résoudre les noms de services d'autres projets. Si deux projets exposent un service `backend`, Docker DNS peut renvoyer celui de l'autre projet (priorité IPv6 ou ordre alphabétique selon les versions).
+
+→ **Garder hors du réseau `coolify`** tout service qui n'a pas besoin d'être atteint par Traefik (typiquement les backends internes proxiés par le frontend).
+→ **Donner à ces services un nom unique par environnement** via `networks.default.aliases`, par exemple `monprojet-${ENV_NAME}-backend`.
+
+### 3. Les variables d'environnement Coolify sont runtime par défaut
+
+Sur Coolify, chaque variable d'environnement a un toggle « **Available at Buildtime** » qui n'est **pas coché par défaut**. Sans ce toggle, la variable est uniquement injectée au runtime — pas pendant `docker build`.
+
+→ **Cocher « Available at Buildtime »** pour toutes les variables utilisées par un build :
+  - Variables figées dans le bundle Next.js / Vite / Webpack (URLs API, feature flags, `NEXT_PUBLIC_*`, `VITE_*`).
+  - Variables interpolées dans des `ARG` Dockerfile.
+  - Toute variable lue au moment de la compilation (ex. génération de manifest, schema GraphQL).
+
+### 4. « Domains for X » n'est pas une variable d'environnement
+
+Le champ « Domains for backend » (et équivalents) configure Traefik pour exposer publiquement le service. Ce **n'est pas** la variable d'environnement utilisée par les autres services pour s'adresser à ce backend en interne.
+
+→ **Toujours configurer séparément** la variable d'environnement (`BACKEND_URL`, `API_URL`, …) qui contient le hostname interne Docker.
+
+## Symptômes observables
+
+- Erreurs `INVALID_ORIGIN`, CORS bloqués, ou auth qui échoue après un déploiement multi-env.
+- Logs : le container backend de l'env A ne reçoit jamais de requêtes alors que le frontend A "marche" (les requêtes vont au backend d'un autre env).
+- Réponses HTTP avec des headers qui ne correspondent pas à ce que ton backend met (ex. CSP, `referrer-policy`, `x-frame-options` différents → c'est un autre backend qui répond).
+- `docker exec <frontend> getent hosts <service-backend>` retourne plusieurs IPs ou une IP IPv6 inattendue.
+- Variable d'env correcte au runtime (`docker exec <container> env`), mais ancienne valeur figée dans `routes-manifest.json` ou équivalent.
+
+## Diagnostic rapide
+
+```bash
+# Quel(s) container(s) répondent au nom du service ?
+docker exec <frontend-container> getent hosts <nom-service-backend>
+# Une seule IP du sous-réseau projet (10.0.x.x) attendue.
+
+# Quels containers existent sur l'instance ?
+docker ps --format '{{.Names}}\t{{.Networks}}' | grep <nom-service>
+
+# Quelle URL le bundle frontend pointe-t-il (Next.js) ?
+docker exec <frontend-container> grep -o 'http://[^"]*:4000' /app/.next/routes-manifest.json | sort -u
+
+# Quel container reçoit réellement la requête ? (lancer puis déclencher la requête)
+docker logs -f <backend-container-de-cet-env>
+```
+
+## Correctifs (pattern docker-compose)
+
+```yaml
+services:
+  frontend:
+    environment:
+      # Pointer sur l'alias unique, pas le nom de service brut
+      - BACKEND_URL=http://monprojet-${ENV_NAME:-local}-backend:4000
+    networks:
+      - default
+      - coolify  # nécessaire pour Traefik
+
+  backend:
+    # Pas de container_name — Coolify l'ignore.
+    # Pas de connexion au réseau `coolify` — évite le leak DNS.
+    networks:
+      default:
+        aliases:
+          - monprojet-${ENV_NAME:-local}-backend
+
+networks:
+  coolify:
+    external: true
+```
+
+Et sur Coolify (pour chaque environnement) :
+- `ENV_NAME=<nom-env>` (ex. `dev`, `beta`, `prod`)
+- `BACKEND_URL=http://monprojet-<nom-env>-backend:4000`
+- Cocher « Available at Buildtime » sur `BACKEND_URL` (et toutes les vars utilisées par le build).
+
+---
+
+## Prompt à utiliser sur un autre projet déployé sur Coolify
+
+Copier-coller le prompt ci-dessous dans une session Claude Code (ou autre assistant) sur un projet Coolify pour vérifier qu'il n'est pas vulnérable au même bug :
+
+```
+Audit Coolify — vulnérabilité au leak inter-projets via le réseau partagé `coolify`.
+
+Contexte : sur Coolify, plusieurs projets coexistent sur la même instance et partagent un réseau Docker externe nommé `coolify`. Trois pièges combinés peuvent provoquer un leak silencieux entre environnements (un service d'un projet/env A reçoit les requêtes destinées à un service d'un projet/env B portant le même nom) :
+
+1. `container_name` dans docker-compose est ignoré par Coolify (renommage avec hash projet).
+2. Le réseau `coolify` est partagé : tout service joint à ce réseau peut résoudre les noms de services d'autres projets via Docker DNS (priorité IPv6 ou ordre alphabétique). Si deux projets/envs exposent un service `backend`, `frontend` peut hit le mauvais.
+3. Les variables d'environnement Coolify ne sont disponibles au build que si le toggle « Available at Buildtime » est coché. Une variable comme `BACKEND_URL` peut être correcte au runtime mais figée à une ancienne valeur dans le bundle (ex. `routes-manifest.json` de Next.js) si le build n'y a pas eu accès.
+
+Audit demandé sur ce projet :
+1. Lire les fichiers `docker-compose*.yml` (et tout fichier de déploiement Coolify pertinent).
+2. Identifier les services qui :
+   a. dépendent d'un autre service interne via son nom court (ex. `BACKEND_URL=http://backend:4000`),
+   b. sont connectés au réseau externe `coolify`.
+3. Pour chaque service exposé via Traefik (typiquement le frontend) :
+   - Lister tous les noms de services internes qu'il appelle.
+   - Vérifier si ces noms sont uniques globalement (improbable s'ils s'appellent `backend`, `api`, `db`, `redis`…) ou s'ils peuvent collisionner avec ceux d'autres projets sur la même instance Coolify.
+4. Identifier les frameworks qui figent des URLs au build : Next.js (`rewrites`, `NEXT_PUBLIC_*`), Vite (`VITE_*`), Webpack (`DefinePlugin`), tout `ARG`/`ENV` Dockerfile lu par une étape `RUN build`.
+5. Pour chaque variable d'env critique au build, indiquer si Coolify doit la marquer « Available at Buildtime » (la décision se fait dans l'UI Coolify, donc juste signaler les variables concernées).
+
+Livrable : un rapport Markdown listant :
+- Les risques identifiés (services à renommer, variables à passer en buildtime, services à sortir du réseau `coolify`).
+- Les correctifs proposés sous forme de diff docker-compose et liste de variables Coolify à reconfigurer.
+- Les vérifications post-déploiement à exécuter (commandes `docker exec ... getent hosts`, `docker logs`, etc.).
+
+Si le projet n'est pas concerné (services aux noms uniques, pas de réseau partagé, pas de framework qui fige des URLs au build), le dire explicitement.
+```

--- a/docs/deployer-nouvel-environnement.md
+++ b/docs/deployer-nouvel-environnement.md
@@ -1,0 +1,173 @@
+# Déployer un nouvel environnement (Coolify)
+
+Ce document explique comment ajouter un nouvel environnement (`dev-x`, `beta`, `prod`, ou un environnement éphémère) au projet **Site DevFest Toulouse 2026** sur Coolify, en évitant les pièges identifiés lors du déploiement initial de `dev-j`.
+
+> Pour le contexte général sur la structure des branches/environnements, voir [`.claude/rules/git-workflow.md`](../.claude/rules/git-workflow.md).
+> Pour la liste des variables d'environnement disponibles, voir [`variables-environnement.md`](variables-environnement.md).
+
+---
+
+## TL;DR — checklist de déploiement
+
+1. Créer la ressource Docker Compose dans Coolify, pointer sur la branche cible et le compose file (`docker-compose.dev.yml` ou `docker-compose.prod.yml`).
+2. Renseigner les **Domains for frontend** (URL publique du site).
+3. Configurer les **Environment Variables** :
+   - Variables minimales : `BASE_URL`, `BACKEND_URL`, `ENV_NAME`, `SESSION_SECRET`, `DATABASE_URL` (variables Postgres), `ADMIN_EMAILS`, `SMTP_FROM`, OAuth, etc.
+   - **Cocher `Available at Buildtime`** sur les variables utilisées par `next build` :
+     - `BACKEND_URL`
+     - `BASE_URL`
+     - `NEXT_PUBLIC_PLAUSIBLE_SRC` (si analytics actifs)
+     - `ENV_NAME` (utilisée pour interpoler l'alias réseau du backend)
+4. Faire un **premier déploiement**.
+5. Vérifier après déploiement (cf. section *Vérifications obligatoires* ci-dessous).
+
+---
+
+## 1. Créer la ressource Coolify
+
+- Type : **Docker Compose** (Build Pack).
+- Source : repo Git du projet, branche cible (`main`, `dev`, `dev-j`, …).
+- Compose file :
+  - **dev / dev-{initiale}** → `docker-compose.dev.yml` (mode dev, MailHog, seed-dev avec comptes test)
+  - **beta / production** → `docker-compose.prod.yml` (mode prod, Postfix, seed minimal)
+
+## 2. Domains
+
+- **Domains for frontend** : URL publique du site (ex. `https://dev-j.site.devfesttoulouse.fr`). Coolify configure Traefik pour router cette URL vers le service `frontend`.
+- **Domains for backend** : laisser tel que recommandé par défaut, ou y mettre la même valeur que `BACKEND_URL`. Ce champ ne sert qu'à exposer publiquement le backend si nécessaire **et ne définit pas la variable d'environnement `BACKEND_URL`**.
+
+## 3. Environment Variables — règles cruciales
+
+### Définir `ENV_NAME`
+
+`ENV_NAME` doit valoir le nom court et unique de l'environnement (ex. `dev-j`, `beta`, `prod`, `dev-m`).
+
+Cette variable est interpolée dans `docker-compose.*.yml` pour générer un **alias réseau unique** pour le backend (`devfest-${ENV_NAME}-backend`). Sans elle, deux environnements partagés sur le même VPS Coolify peuvent leak entre eux via DNS (voir section *Pourquoi*).
+
+### Définir `BACKEND_URL`
+
+Toujours utiliser l'alias réseau, jamais le service brut :
+
+```
+BACKEND_URL=http://devfest-{ENV_NAME}-backend:4000
+```
+
+Exemple pour `dev-j` :
+
+```
+BACKEND_URL=http://devfest-dev-j-backend:4000
+```
+
+> ⚠️ Ne jamais utiliser `http://backend:4000` — ce nom existe dans plusieurs projets Coolify et la résolution DNS peut tomber sur le backend d'un autre projet via le réseau partagé `coolify`.
+
+### Cocher « Available at Buildtime »
+
+Sur Coolify, **chaque variable d'environnement a un toggle « Available at Buildtime »**. Sans ce toggle, la variable est uniquement exposée au runtime — pas pendant `next build`.
+
+Or `next build` fige certaines valeurs dans le bundle :
+- les `rewrites` (donc l'URL backend pointée par les rewrites Next.js → fichier `routes-manifest.json`)
+- les variables `NEXT_PUBLIC_*`
+- les valeurs lues à la compilation (CSP avec `plausibleOrigin`, etc.)
+
+**Activer « Available at Buildtime » au minimum pour** :
+- `BACKEND_URL`
+- `BASE_URL`
+- `NEXT_PUBLIC_PLAUSIBLE_SRC` (si défini)
+
+### Variables sensibles (secrets)
+
+- `SESSION_SECRET` : générer via `openssl rand -hex 32` (32+ caractères aléatoires).
+- `MAGIC_LINK_SECRET` (Lot 2) : idem, distinct du précédent.
+- `POSTGRES_PASSWORD` : générer aléatoirement.
+- `OAUTH_*_CLIENT_SECRET` : récupérer depuis Google Cloud Console / GitHub OAuth Apps.
+
+Ces secrets ne doivent **pas** être cochés « Available at Buildtime » (uniquement runtime).
+
+### Liste complète
+
+Voir [`variables-environnement.md`](variables-environnement.md).
+
+## 4. Persistent Storage
+
+Le compose déclare un volume `uploads` pour les fichiers uploadés (images, logos…). Coolify le crée automatiquement, mais **vérifier dans `Persistent Storage`** qu'il est bien attaché et qu'il survit aux redéploiements.
+
+## 5. Premier déploiement
+
+Lancer un **Deploy** depuis Coolify. Surveiller les logs de build :
+- Le frontend doit builder Next sans erreur (`pnpm build`).
+- Le backend doit lancer Prisma generate + seed sans erreur.
+
+Si erreur : corriger d'abord, retenter ensuite.
+
+---
+
+## Vérifications obligatoires après déploiement
+
+À faire systématiquement après le premier déploiement (et après tout changement d'`ENV_NAME` / `BACKEND_URL`).
+
+### 1. La variable `BACKEND_URL` est correcte au runtime
+
+```bash
+docker exec <frontend-container-id> env | grep BACKEND_URL
+# Attendu : BACKEND_URL=http://devfest-<env-name>-backend:4000
+```
+
+### 2. La variable `BACKEND_URL` est intégrée au build Next
+
+```bash
+docker exec <frontend-container-id> cat /app/.next/routes-manifest.json | grep -o 'http://[^"]*:4000' | sort -u
+# Attendu : http://devfest-<env-name>-backend:4000
+# Si on voit http://backend:4000 → la variable n'a pas été cochée "Available at Buildtime" → corriger sur Coolify et redeploy without cache
+```
+
+### 3. L'alias DNS résout vers le bon backend
+
+```bash
+docker exec <frontend-container-id> getent hosts devfest-<env-name>-backend
+# Attendu : une seule IP, dans le sous-réseau du projet (ex. 10.0.x.x), pas une IPv6
+```
+
+### 4. Le bon backend reçoit les requêtes
+
+```bash
+docker logs -f <backend-container-id-de-cet-env>
+# Dans un autre terminal/onglet : se connecter à l'app et déclencher une requête
+# Le hostname dans les logs (ex. "hostname":"320dc6066338") doit correspondre au container ID du backend de cet env, pas d'un autre projet.
+```
+
+### 5. Le sign-in fonctionne
+
+Naviguer sur l'URL admin (`https://<env>.site.devfesttoulouse.fr/login`) et tenter une connexion avec un compte admin existant. Si retour `INVALID_ORIGIN` (HTTP 403), c'est qu'on parle au mauvais backend (étape 3 ou 4 KO).
+
+---
+
+## Pourquoi ces précautions ?
+
+Coolify a plusieurs comportements qui ne sont pas évidents :
+
+1. **`container_name` dans le compose est ignoré.** Coolify renomme tous les containers avec son propre hash de projet. C'est pour ça qu'on utilise un **alias réseau** (`networks.default.aliases`) au lieu d'un `container_name`.
+
+2. **Le réseau `coolify` est partagé entre tous les projets** d'une même instance Coolify. Tout service joint à ce réseau (typiquement le `frontend` pour être joignable par Traefik) peut résoudre les noms de services d'autres projets. Si deux projets ont un service `backend`, Docker DNS peut renvoyer le backend de l'autre projet (priorité IPv6 dans certains cas).
+
+3. **Les variables d'environnement Coolify sont runtime par défaut.** Pour qu'elles soient disponibles pendant `docker build` (donc utilisables comme `ARG` dans le Dockerfile, et lues par `next build`), il faut explicitement cocher « Available at Buildtime ».
+
+4. **« Domains for backend »** est une URL externe (Traefik), pas la variable `BACKEND_URL`. Ne pas confondre.
+
+L'incident d'avril 2026 a combiné les 3 premiers points : le backend `dev-j` était bien créé mais le frontend `dev-j` résolvait `backend` vers le container du projet `beta` à cause du réseau partagé, et la variable `BACKEND_URL` corrigée n'était utilisée qu'au runtime — pas dans le `routes-manifest.json` figé au build. Tous les sign-in retournaient `INVALID_ORIGIN` parce que le backend `beta` ne reconnaissait pas l'origine `dev-j.site.devfesttoulouse.fr`.
+
+---
+
+## Mise à jour d'un environnement existant
+
+Si on change la valeur de `ENV_NAME` ou `BACKEND_URL` sur un environnement existant :
+
+1. Sauvegarder la base de données si nécessaire.
+2. Modifier la variable dans Coolify, vérifier que « Available at Buildtime » est cochée pour `BACKEND_URL`.
+3. **Redeploy without cache** (sinon `routes-manifest.json` n'est pas régénéré).
+4. Refaire la checklist de vérifications.
+
+## Suppression d'un environnement
+
+1. Supprimer la ressource Coolify (les containers et volumes sont supprimés).
+2. Vérifier qu'aucun container orphelin du projet ne reste : `docker ps -a | grep <hash-projet>`.
+3. Supprimer la branche `dev-{initiale}` correspondante si plus utilisée.

--- a/docs/rapport-audit-auth-2026-04-15.md
+++ b/docs/rapport-audit-auth-2026-04-15.md
@@ -1,0 +1,173 @@
+# Rapport d'audit auth — 2026-04-15
+
+**Branche** : `feature/auth-audit` (dérivée de `dev-j` au commit `97a5178`)
+**Périmètre** : test complet du parcours d'authentification (API + UI) en local
+(Docker Compose), avec correctifs mineurs appliqués au fil de l'audit.
+
+## Méthode
+
+- API : `curl` direct sur les endpoints `/api/auth/*` et `/api/admin/*`
+- UI : Chrome DevTools MCP avec interactions réelles (form fill, clicks, navigation)
+- Comptes seedés : `admin@devfesttoulouse.fr` (ADMIN) et
+  `editor@devfesttoulouse.fr` (EDITOR) avec mots de passe `admin1234!dev` et
+  `editor1234!dev`
+
+## Résultats — ce qui marche
+
+### API auth
+| Test | Résultat |
+|---|---|
+| `POST /api/auth/sign-in/email` admin valide | 200, cookie `better-auth.session_token` HttpOnly posé |
+| `POST /api/auth/sign-in/email` editor valide | 200, idem |
+| `POST /api/auth/sign-in/email` mauvais mot de passe | 401 `INVALID_EMAIL_OR_PASSWORD` |
+| `POST /api/auth/sign-in/email` email inconnu | 401 (même message — pas de user enumeration) |
+| `POST /api/auth/sign-up/email` email hors `ADMIN_EMAILS` | 403 "Inscription sur invitation uniquement" |
+| `POST /api/auth/sign-up/email` email admin existant | 422 `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL` |
+| `POST /api/auth/request-password-reset` (existant) | 200 (token créé en DB, email envoyé via MailHog) |
+| `POST /api/auth/request-password-reset` (inconnu) | 200 (pas de user enumeration) |
+| `POST /api/auth/reset-password` token valide | 200 |
+| `POST /api/auth/reset-password` même token rejoué | 400 `INVALID_TOKEN` |
+| `POST /api/auth/sign-out` avec `Origin` | 200 (session invalidée) |
+| `GET /api/auth/providers` | `{google: false, github: false}` (pas de creds en local) |
+
+### Garde de rôle backend (`/api/admin/*`)
+| Rôle | Routes accessibles | Routes refusées (403) |
+|---|---|---|
+| **ADMIN** | tout (session, articles, pages, images, contact/messages, editions, users, tickets, settings/*, sponsor-plans, cache/purge) | aucune |
+| **EDITOR** | session, articles, pages, images, contact/messages | editions, users, tickets, settings/*, sponsor-plans, cache/purge |
+| **anonymous** | aucune | tout (403 `Forbidden`) |
+
+Vérifié pour les méthodes GET/POST/PUT/DELETE : EDITOR ne peut pas écrire sur
+les routes ADMIN-only (ex. `POST /api/admin/editions`, `PUT /api/admin/settings/general`,
+`POST /api/admin/cache/purge` → tous 403).
+
+EDITOR peut bien écrire sur les routes qui lui sont ouvertes (ex. `POST /api/admin/articles` → 201).
+
+### UI navigateur
+
+- **Login admin** : form rempli + submit → dashboard chargé avec sidebar complète et badge "Administrateur"
+- **Login editor** : form rempli + submit → dashboard chargé avec sidebar **filtrée**
+  (Dashboard, Articles, Pages, Fichiers, Messages — pas d'Éditions, Utilisateurs, Paramètres)
+  et badge "Éditeur"
+- **Reset password full round-trip** :
+  1. Click "Mot de passe oublié ?" → form email
+  2. Submit email → message "Si un compte existe avec cet email, un lien a été envoyé"
+  3. Email arrive dans MailHog avec `http://localhost:3000/admin/reset-password?token=...`
+  4. Visite du lien → form de nouveau mot de passe (sans demande de session)
+  5. Submit → message succès + redirect vers `/admin` après 1.5s
+  6. Re-login avec le nouveau mot de passe → dashboard ouvert ✓
+- **Logout** (bouton sidebar) → redirect vers form de login
+
+## Bugs détectés et corrigés (cette branche)
+
+### Bug 1 : `forgotPassword` appelle un endpoint better-auth obsolète
+
+**Sévérité** : critique — la fonction "Mot de passe oublié" du UI était
+totalement cassée.
+
+**Cause** : [admin-api.ts:89](src/frontend/src/lib/admin-api.ts#L89) appelait
+`/api/auth/forget-password` (ancien endpoint better-auth ≤ v1.4) qui retourne
+404 sur la version actuelle (better-auth 1.6.2). L'API actuelle est
+`/api/auth/request-password-reset`. Le fix avait été appliqué dans le chantier
+auth précédent (commit `6eba860`) mais perdu lors du reset de `dev-j` à `ec050f8`.
+
+**Correctif** : URL changée vers `/api/auth/request-password-reset`.
+
+### Bug 2 : page `/admin/reset-password` absente
+
+**Sévérité** : critique — le lien envoyé dans l'email de reset menait à un 404.
+
+**Cause** : la page `src/frontend/src/app/admin/reset-password/page.tsx` n'existait
+pas dans `dev-j` (elle avait été créée dans le chantier auth précédent puis
+perdue lors du reset).
+
+**Correctif** : page recréée, version French-only (cohérent avec le reste de
+l'admin qui n'utilise pas i18n). Hérite du même style que `AdminLogin`.
+
+### Bug 3 : `AdminShell` exige une session sur `/admin/reset-password`
+
+**Sévérité** : critique — un utilisateur qui a oublié son mot de passe n'a
+précisément **pas** de session, donc le AdminShell affichait le formulaire de
+login au-dessus de la page de reset, rendant le reset inutilisable.
+
+**Cause** : `AdminShell` rendait toujours `<AdminLogin />` quand `user` était
+`null`, sans whitelist pour les pages publiques admin.
+
+**Correctif** : ajout de `PUBLIC_ADMIN_PATHS = ["/admin/reset-password"]`.
+Quand `pathname` matche, AdminShell rend directement `children` sans tenter
+de récupérer une session.
+
+## Anomalies identifiées (non corrigées dans cette branche)
+
+### Anomalie 1 : pas de garde de rôle frontend sur les pages admin-only
+
+**Sévérité** : moyenne — UX trompeuse, pas de risque de sécurité (l'API protège).
+
+**Constat** : un EDITOR peut visiter en URL directe `/admin/users`, `/admin/editions`,
+`/admin/settings`. La page se charge, le titre s'affiche, le bouton "Inviter"
+fonctionne et affiche le formulaire d'invitation. Si l'éditeur soumet, l'API
+retourne 403 (donc safe), mais le UX est trompeur : on lui montre une page
+qu'il ne peut pas utiliser.
+
+**Recommandation** : ajouter dans `AdminShell` un mapping `path → roles
+requis`. Si le rôle ne match pas, afficher une page "Accès refusé" plutôt que
+le contenu de la route. Alternative plus légère : guard côté chaque page
+ADMIN-only qui vérifie `user.role === "ADMIN"` et redirige sinon.
+
+Exemple :
+```ts
+const ADMIN_ONLY_PATHS = ["/admin/editions", "/admin/users", "/admin/settings", "/admin/tickets"];
+const requiresAdmin = ADMIN_ONLY_PATHS.some((p) => pathname.startsWith(p));
+if (requiresAdmin && user.role !== "ADMIN") {
+  return <AccessDenied />;
+}
+```
+
+### Anomalie 2 : `POST /api/auth/sign-out` exige `Origin` (better-auth v1.6)
+
+**Sévérité** : faible (comportement attendu de better-auth, juste à connaître).
+
+**Constat** : un appel curl sans header `Origin` reçoit 403 `MISSING_OR_NULL_ORIGIN`.
+Les navigateurs envoient toujours `Origin` sur les fetch, donc l'UI marche.
+Anomalie cosmétique pour les tests CLI.
+
+### Anomalie 3 : `sign-in/email` n'exige pas `Origin`, contrairement à `sign-out`
+
+**Sévérité** : faible — incohérence interne better-auth, hors de notre contrôle.
+
+### Anomalie 4 : flux OAuth probablement cassé (à valider quand creds fournies)
+
+**Sévérité** : moyenne — non vérifiable en local sans creds Google/GitHub.
+
+**Constat** : le frontend pose un `<a href={getAuthUrl(...)}>` qui fait un GET
+vers `/api/auth/sign-in/social?provider=...`. Or la documentation better-auth
+suggère que cet endpoint attend un POST. Test direct :
+- `GET /api/auth/sign-in/social?provider=google&callbackURL=/admin` → 404 `null`
+- `POST /api/auth/sign-in/social` `{provider:"google",callbackURL:"/admin"}` → 500 (creds manquantes, mais accepte le POST)
+
+À valider en condition réelle dès que les creds sont en place sur dev-j.
+Si confirmé, remplacer le lien par un formulaire/handler qui POST.
+
+## Statut sécurité global
+
+| Aspect | État |
+|---|---|
+| Mot de passe haché (better-auth pbkdf2) | ✓ |
+| Session cookie HttpOnly + SameSite=Lax | ✓ |
+| Inscription verrouillée par ALLOWLIST `ADMIN_EMAILS` | ✓ |
+| Pas de user enumeration (login + reset) | ✓ |
+| Token de reset à usage unique | ✓ |
+| Token de reset avec expiration (1h) | ✓ |
+| Garde de rôle ADMIN vs EDITOR sur l'API | ✓ |
+| Garde de rôle ADMIN vs EDITOR sur le UI | ✗ (Anomalie 1) |
+| CSRF cross-origin sur write ops | ✓ (rejet `MISSING_OR_NULL_ORIGIN`) |
+| Rate limit `/api/auth/*` | ✓ (10 req/min/IP, configuré dans backend index.ts) |
+
+## Conclusion
+
+Auth fonctionne après fix des 3 bugs critiques liés au reset password (endpoint
+backend, page frontend, bypass AdminShell). Le contrôle de rôle backend est
+solide. Le seul manque réel est le contrôle de rôle côté UI (anomalie 1) —
+peu grave en sécurité mais à fixer pour l'UX.
+
+OAuth à retester en condition réelle.

--- a/docs/rapport-audit-auth-2026-04-15.md
+++ b/docs/rapport-audit-auth-2026-04-15.md
@@ -1,173 +1,203 @@
 # Rapport d'audit auth — 2026-04-15
 
 **Branche** : `feature/auth-audit` (dérivée de `dev-j` au commit `97a5178`)
-**Périmètre** : test complet du parcours d'authentification (API + UI) en local
-(Docker Compose), avec correctifs mineurs appliqués au fil de l'audit.
+**Scope** : audit complet du parcours d'authentification (API + UI) en local,
+puis validation sur l'environnement dev-j déployé via Coolify.
 
 ## Méthode
 
-- API : `curl` direct sur les endpoints `/api/auth/*` et `/api/admin/*`
-- UI : Chrome DevTools MCP avec interactions réelles (form fill, clicks, navigation)
-- Comptes seedés : `admin@devfesttoulouse.fr` (ADMIN) et
-  `editor@devfesttoulouse.fr` (EDITOR) avec mots de passe `admin1234!dev` et
-  `editor1234!dev`
+- API : `curl` direct sur `/api/auth/*` et `/api/admin/*`
+- UI : Chrome DevTools MCP (interactions réelles)
+- MailHog : récupération des emails de reset via `https://mailhog.dev-j.site.devfesttoulouse.fr`
+- Comptes seedés :
+  - `admin@devfesttoulouse.fr` (ADMIN, mdp `admin1234!dev` en local uniquement)
+  - `editor@devfesttoulouse.fr` (EDITOR, idem)
+  - `julien.delrio@gmail.com` (ADMIN, user réel sur dev-j)
 
-## Résultats — ce qui marche
+## Bugs critiques détectés et corrigés dans cette branche
+
+### Bug 1 — `forgotPassword` utilise un endpoint better-auth obsolète
+- **Commit fix** : inclus dans `9896291`
+- **Cause** : `admin-api.ts` appelait `/api/auth/forget-password` (endpoint v1.4)
+  qui renvoie 404 sur better-auth 1.6.2. Correct : `/api/auth/request-password-reset`.
+- **Effet** : le bouton "Mot de passe oublié ?" était 100 % cassé.
+
+### Bug 2 — page `/admin/reset-password` absente
+- **Commit fix** : `9896291`
+- **Cause** : la page `src/frontend/src/app/admin/reset-password/page.tsx` n'existait
+  pas. Le lien envoyé dans l'email tombait sur un 404.
+
+### Bug 3 — `AdminShell` exige une session sur `/admin/reset-password`
+- **Commit fix** : `9896291`
+- **Cause** : un utilisateur qui a oublié son mot de passe n'a par définition
+  pas de session ; `AdminShell` affichait `<AdminLogin />` par-dessus la page
+  de reset, la rendant inaccessible.
+- **Fix** : whitelist `PUBLIC_ADMIN_PATHS = ["/admin/reset-password"]`.
+
+### Bug 4 — `trustedOrigins` ignorait l'URL publique
+- **Commit fix** : `18c07e2`
+- **Cause** : better-auth ne déclarait que `FRONTEND_URL` (interne Docker
+  `http://frontend:3000`) comme origine valide. Le browser envoie pourtant
+  son origin public (`https://dev-j.site.devfesttoulouse.fr`) → 403
+  `INVALID_ORIGIN` sur chaque tentative de login.
+- **Fix** : dériver `trustedOrigins` depuis `BASE_URL` (public) + `FRONTEND_URL`
+  (interne) + un wildcard sur le root domain pour couvrir dev-j/beta/prod sans
+  config par environnement.
+- **Bonus** : `sendResetPassword` construit maintenant l'URL du lien email
+  depuis `BASE_URL` pointant vers la page frontend `/admin/reset-password?token=…`,
+  au lieu de l'URL auto-générée par better-auth qui pointait sur l'API route
+  (non navigable).
+
+### Bug 5 — `isAdminEmail()` verrouillait l'accès sur ADMIN_EMAILS à vie
+- **Commit fix** : `6c9c6ef`
+- **Cause** : le guard `requireAdmin` et les routes `/api/admin/session` et
+  `/api/admin/profile` croisaient l'email de session avec la variable d'env
+  `ADMIN_EMAILS`. Or cette variable ne doit servir **qu'au bootstrap** (pour
+  créer le(s) premier(s) admin(s) via `prisma/seed.ts`). L'ajout d'admins
+  ultérieurs via le back-office ne remontait pas dans cette variable, donc
+  ces admins étaient rejetés en 403 malgré un rôle ADMIN en DB.
+- **Fix** : la source de vérité pour l'accès back-office devient
+  `user.role ∈ {ADMIN, EDITOR}` en base, avec vérif `banned=false`. Le hook
+  `databaseHooks.user.create.before` continue de bloquer les sign-ups
+  publics hors `ADMIN_EMAILS`, mais les invitations (via
+  `routes/admin/users.ts` qui utilise `prisma.user.create` direct) ne
+  déclenchent pas ce hook et ne sont donc pas affectées.
+
+## Résultats de l'audit — ce qui marche
 
 ### API auth
 | Test | Résultat |
 |---|---|
-| `POST /api/auth/sign-in/email` admin valide | 200, cookie `better-auth.session_token` HttpOnly posé |
-| `POST /api/auth/sign-in/email` editor valide | 200, idem |
-| `POST /api/auth/sign-in/email` mauvais mot de passe | 401 `INVALID_EMAIL_OR_PASSWORD` |
-| `POST /api/auth/sign-in/email` email inconnu | 401 (même message — pas de user enumeration) |
-| `POST /api/auth/sign-up/email` email hors `ADMIN_EMAILS` | 403 "Inscription sur invitation uniquement" |
-| `POST /api/auth/sign-up/email` email admin existant | 422 `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL` |
-| `POST /api/auth/request-password-reset` (existant) | 200 (token créé en DB, email envoyé via MailHog) |
-| `POST /api/auth/request-password-reset` (inconnu) | 200 (pas de user enumeration) |
+| `POST /api/auth/sign-in/email` valides | 200, cookie `better-auth.session_token` HttpOnly |
+| `POST /api/auth/sign-in/email` mauvais mdp | 401 `INVALID_EMAIL_OR_PASSWORD` |
+| Email inconnu | 401 (même message, pas de user enumeration) |
+| `POST /api/auth/sign-up/email` hors ADMIN_EMAILS | 403 "Inscription sur invitation uniquement" |
+| `POST /api/auth/request-password-reset` existant | 200, token en DB, email envoyé |
+| Reset unknown email | 200 (pas d'enumeration) |
 | `POST /api/auth/reset-password` token valide | 200 |
-| `POST /api/auth/reset-password` même token rejoué | 400 `INVALID_TOKEN` |
-| `POST /api/auth/sign-out` avec `Origin` | 200 (session invalidée) |
-| `GET /api/auth/providers` | `{google: false, github: false}` (pas de creds en local) |
+| Replay du même token | 400 `INVALID_TOKEN` |
+| `POST /api/auth/sign-out` avec `Origin` | 200 |
 
 ### Garde de rôle backend (`/api/admin/*`)
 | Rôle | Routes accessibles | Routes refusées (403) |
 |---|---|---|
-| **ADMIN** | tout (session, articles, pages, images, contact/messages, editions, users, tickets, settings/*, sponsor-plans, cache/purge) | aucune |
-| **EDITOR** | session, articles, pages, images, contact/messages | editions, users, tickets, settings/*, sponsor-plans, cache/purge |
-| **anonymous** | aucune | tout (403 `Forbidden`) |
+| ADMIN | toutes | aucune |
+| EDITOR | session, articles, pages, images, contact/messages | editions, users, tickets, settings, sponsor-plans, cache |
+| anonyme | aucune | toutes |
 
-Vérifié pour les méthodes GET/POST/PUT/DELETE : EDITOR ne peut pas écrire sur
-les routes ADMIN-only (ex. `POST /api/admin/editions`, `PUT /api/admin/settings/general`,
-`POST /api/admin/cache/purge` → tous 403).
-
-EDITOR peut bien écrire sur les routes qui lui sont ouvertes (ex. `POST /api/admin/articles` → 201).
+Les write ops (POST/PUT/DELETE) sur routes ADMIN-only sont bien rejetées 403
+pour EDITOR. Les routes partagées acceptent bien les write ops EDITOR (ex.
+POST article → 201).
 
 ### UI navigateur
+- Login admin + editor : sidebar chargée, badge correct
+- Reset password full round-trip : request → email dans MailHog → lien →
+  form → nouveau mdp → redirect `/admin` → re-login OK
+- Sidebar filtrée par rôle : EDITOR ne voit pas Éditions / Utilisateurs /
+  Paramètres
+- Logout fonctionnel
 
-- **Login admin** : form rempli + submit → dashboard chargé avec sidebar complète et badge "Administrateur"
-- **Login editor** : form rempli + submit → dashboard chargé avec sidebar **filtrée**
-  (Dashboard, Articles, Pages, Fichiers, Messages — pas d'Éditions, Utilisateurs, Paramètres)
-  et badge "Éditeur"
-- **Reset password full round-trip** :
-  1. Click "Mot de passe oublié ?" → form email
-  2. Submit email → message "Si un compte existe avec cet email, un lien a été envoyé"
-  3. Email arrive dans MailHog avec `http://localhost:3000/admin/reset-password?token=...`
-  4. Visite du lien → form de nouveau mot de passe (sans demande de session)
-  5. Submit → message succès + redirect vers `/admin` après 1.5s
-  6. Re-login avec le nouveau mot de passe → dashboard ouvert ✓
-- **Logout** (bouton sidebar) → redirect vers form de login
-
-## Bugs détectés et corrigés (cette branche)
-
-### Bug 1 : `forgotPassword` appelle un endpoint better-auth obsolète
-
-**Sévérité** : critique — la fonction "Mot de passe oublié" du UI était
-totalement cassée.
-
-**Cause** : [admin-api.ts:89](src/frontend/src/lib/admin-api.ts#L89) appelait
-`/api/auth/forget-password` (ancien endpoint better-auth ≤ v1.4) qui retourne
-404 sur la version actuelle (better-auth 1.6.2). L'API actuelle est
-`/api/auth/request-password-reset`. Le fix avait été appliqué dans le chantier
-auth précédent (commit `6eba860`) mais perdu lors du reset de `dev-j` à `ec050f8`.
-
-**Correctif** : URL changée vers `/api/auth/request-password-reset`.
-
-### Bug 2 : page `/admin/reset-password` absente
-
-**Sévérité** : critique — le lien envoyé dans l'email de reset menait à un 404.
-
-**Cause** : la page `src/frontend/src/app/admin/reset-password/page.tsx` n'existait
-pas dans `dev-j` (elle avait été créée dans le chantier auth précédent puis
-perdue lors du reset).
-
-**Correctif** : page recréée, version French-only (cohérent avec le reste de
-l'admin qui n'utilise pas i18n). Hérite du même style que `AdminLogin`.
-
-### Bug 3 : `AdminShell` exige une session sur `/admin/reset-password`
-
-**Sévérité** : critique — un utilisateur qui a oublié son mot de passe n'a
-précisément **pas** de session, donc le AdminShell affichait le formulaire de
-login au-dessus de la page de reset, rendant le reset inutilisable.
-
-**Cause** : `AdminShell` rendait toujours `<AdminLogin />` quand `user` était
-`null`, sans whitelist pour les pages publiques admin.
-
-**Correctif** : ajout de `PUBLIC_ADMIN_PATHS = ["/admin/reset-password"]`.
-Quand `pathname` matche, AdminShell rend directement `children` sans tenter
-de récupérer une session.
+### Validation sur dev-j
+- `/admin`, toutes les sous-routes `/admin/*` répondent 200
+- `/fr/admin`, `/en/admin` répondent 404 (admin hors `[locale]`)
+- Login `julien.delrio@gmail.com` avec rôle ADMIN en DB mais **hors**
+  `ADMIN_EMAILS` → accès back-office complet (validation du Bug 5)
 
 ## Anomalies identifiées (non corrigées dans cette branche)
 
-### Anomalie 1 : pas de garde de rôle frontend sur les pages admin-only
+### Anomalie 1 — pas de garde de rôle frontend sur pages ADMIN-only
+**Sévérité** : moyenne (UX trompeuse, sans risque de sécurité).
 
-**Sévérité** : moyenne — UX trompeuse, pas de risque de sécurité (l'API protège).
+Un EDITOR peut saisir `/admin/users` en URL directe : la page se charge,
+le bouton "Inviter" fonctionne, le formulaire s'affiche. Si l'éditeur
+soumet, l'API retourne 403 — safe, mais UX trompeur.
 
-**Constat** : un EDITOR peut visiter en URL directe `/admin/users`, `/admin/editions`,
-`/admin/settings`. La page se charge, le titre s'affiche, le bouton "Inviter"
-fonctionne et affiche le formulaire d'invitation. Si l'éditeur soumet, l'API
-retourne 403 (donc safe), mais le UX est trompeur : on lui montre une page
-qu'il ne peut pas utiliser.
+**Recommandation** : ajouter dans `AdminShell` un mapping `path → rôles
+requis`. Si le rôle ne match pas, afficher une page "Accès refusé" plutôt
+que le contenu de la route.
 
-**Recommandation** : ajouter dans `AdminShell` un mapping `path → roles
-requis`. Si le rôle ne match pas, afficher une page "Accès refusé" plutôt que
-le contenu de la route. Alternative plus légère : guard côté chaque page
-ADMIN-only qui vérifie `user.role === "ADMIN"` et redirige sinon.
+### Anomalie 2 — OAuth Google/GitHub potentiellement cassé
+**Sévérité** : non vérifiable en local (pas de creds). Frontend pose un
+`<a href>` qui fait un GET vers `/api/auth/sign-in/social` → ce handler
+renvoie 404 sur GET. À valider en condition réelle quand les creds sont
+fournies.
 
-Exemple :
-```ts
-const ADMIN_ONLY_PATHS = ["/admin/editions", "/admin/users", "/admin/settings", "/admin/tickets"];
-const requiresAdmin = ADMIN_ONLY_PATHS.some((p) => pathname.startsWith(p));
-if (requiresAdmin && user.role !== "ADMIN") {
-  return <AccessDenied />;
-}
+### Anomalie 3 — SMTP parfois silencieux sur dev-j
+**Sévérité** : moyenne (workaround existant via reset manuel SQL).
+
+Le `POST /api/auth/request-password-reset` retourne 200 sans toujours
+envoyer le mail dans MailHog. Reproductible mais racine non identifiée :
+le send SMTP direct via `nc mailhog 1025` fonctionne toujours, donc le
+pipe réseau est OK. Suspects : race condition au démarrage de nodemailer,
+ou `sendResetPassword` swallowed par un try/catch quelque part dans
+better-auth.
+
+**Workaround opérationnel** : générer manuellement un token de reset en
+base (voir section "Cheat sheet DB" plus bas).
+
+### Anomalie 4 — `/login` redirigé vers `/fr/login` inexistant
+**Sévérité** : faible (chemin n'est pas utilisé par l'UI).
+
+Le middleware next-intl redirige toute URL inconnue vers son équivalent
+préfixé locale. Si un utilisateur tape `/login` par habitude, il tombe
+sur un 404. Le vrai chemin de login est `/admin`.
+
+**Recommandation** : ajouter un redirect `/login → /admin` dans
+`next.config.ts`.
+
+## Cheat sheet DB : reset manuel d'un password
+
+Quand l'email de reset ne part pas, on peut insérer manuellement un token
+en DB. Depuis le container `db` Postgres :
+
+```sql
+-- 1. Récupérer l'ID utilisateur
+SELECT id FROM "user" WHERE email = 'julien.delrio@gmail.com';
+
+-- 2. Insérer un token de reset (remplacer <USER_ID> et <TOKEN_SECRET>)
+INSERT INTO verification (id, identifier, value, "expiresAt", "createdAt", "updatedAt")
+VALUES (
+  'manual_' || substr(md5(random()::text), 1, 20),
+  'reset-password:<TOKEN_SECRET>',
+  '<USER_ID>',
+  NOW() + INTERVAL '1 hour',
+  NOW(),
+  NOW()
+);
 ```
 
-### Anomalie 2 : `POST /api/auth/sign-out` exige `Origin` (better-auth v1.6)
+Puis visiter `https://<domain>/admin/reset-password?token=<TOKEN_SECRET>`.
 
-**Sévérité** : faible (comportement attendu de better-auth, juste à connaître).
-
-**Constat** : un appel curl sans header `Origin` reçoit 403 `MISSING_OR_NULL_ORIGIN`.
-Les navigateurs envoient toujours `Origin` sur les fetch, donc l'UI marche.
-Anomalie cosmétique pour les tests CLI.
-
-### Anomalie 3 : `sign-in/email` n'exige pas `Origin`, contrairement à `sign-out`
-
-**Sévérité** : faible — incohérence interne better-auth, hors de notre contrôle.
-
-### Anomalie 4 : flux OAuth probablement cassé (à valider quand creds fournies)
-
-**Sévérité** : moyenne — non vérifiable en local sans creds Google/GitHub.
-
-**Constat** : le frontend pose un `<a href={getAuthUrl(...)}>` qui fait un GET
-vers `/api/auth/sign-in/social?provider=...`. Or la documentation better-auth
-suggère que cet endpoint attend un POST. Test direct :
-- `GET /api/auth/sign-in/social?provider=google&callbackURL=/admin` → 404 `null`
-- `POST /api/auth/sign-in/social` `{provider:"google",callbackURL:"/admin"}` → 500 (creds manquantes, mais accepte le POST)
-
-À valider en condition réelle dès que les creds sont en place sur dev-j.
-Si confirmé, remplacer le lien par un formulaire/handler qui POST.
-
-## Statut sécurité global
+## Statut sécurité
 
 | Aspect | État |
 |---|---|
-| Mot de passe haché (better-auth pbkdf2) | ✓ |
+| Hash mdp (pbkdf2) | ✓ |
 | Session cookie HttpOnly + SameSite=Lax | ✓ |
-| Inscription verrouillée par ALLOWLIST `ADMIN_EMAILS` | ✓ |
-| Pas de user enumeration (login + reset) | ✓ |
-| Token de reset à usage unique | ✓ |
-| Token de reset avec expiration (1h) | ✓ |
-| Garde de rôle ADMIN vs EDITOR sur l'API | ✓ |
-| Garde de rôle ADMIN vs EDITOR sur le UI | ✗ (Anomalie 1) |
-| CSRF cross-origin sur write ops | ✓ (rejet `MISSING_OR_NULL_ORIGIN`) |
-| Rate limit `/api/auth/*` | ✓ (10 req/min/IP, configuré dans backend index.ts) |
+| Sign-up verrouillé par ADMIN_EMAILS (hook) | ✓ |
+| Pas de user enumeration | ✓ |
+| Token reset à usage unique + expiration 1h | ✓ |
+| Rôle ADMIN vs EDITOR sur API | ✓ |
+| Rôle ADMIN vs EDITOR sur UI | ✗ (Anomalie 1) |
+| CSRF cross-origin sur write ops | ✓ |
+| Rate limit auth | ✓ (10 req/min/IP) |
+| Sign-out invalide la session | ✓ |
+| Admin ajoutable via back-office sans toucher ADMIN_EMAILS | ✓ (Bug 5 fixé) |
+
+## Commits de la branche
+
+| SHA | Objet |
+|---|---|
+| `9896291` | fix: restore reset password flow (endpoint + page + AdminShell bypass) |
+| `18c07e2` | fix: trust public Origin + build reset URL from BASE_URL |
+| `6c9c6ef` | fix: user.role is the source of truth for back-office access |
 
 ## Conclusion
 
-Auth fonctionne après fix des 3 bugs critiques liés au reset password (endpoint
-backend, page frontend, bypass AdminShell). Le contrôle de rôle backend est
-solide. Le seul manque réel est le contrôle de rôle côté UI (anomalie 1) —
-peu grave en sécurité mais à fixer pour l'UX.
+Cinq bugs critiques identifiés et corrigés, tous lié au fait que la
+précédente branche d'audit auth avait été roulée en entier au reset de
+dev-j, perdant ces fixes légitimes.
 
-OAuth à retester en condition réelle.
+L'auth fonctionne maintenant de bout en bout sur dev-j. Trois anomalies
+non bloquantes restent à adresser dans un futur chantier : garde de rôle
+UI, OAuth à valider, SMTP intermittent.

--- a/docs/variables-environnement.md
+++ b/docs/variables-environnement.md
@@ -23,6 +23,7 @@ Un fichier `.env.example` est fourni à la racine du projet avec des valeurs fic
 | `NODE_ENV` | oui | Environnement d'exécution | `production` |
 | `BASE_URL` | oui | URL publique du site (utilisée pour les liens emails, liens de modification) | `https://devfesttoulouse.fr` |
 | `PORT` | non | Port d'écoute du backend (défaut : `4000`) | `4000` |
+| `LOG_LEVEL` | non | Niveau du logger Pino/Fastify (`fatal\|error\|warn\|info\|debug\|trace`). Défaut `info`. Passer à `debug` pour activer les traces verbeuses (auth guards, proxy, etc.) lors d'un diagnostic. | `debug` |
 
 ## Base de données (backend uniquement)
 

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -16,7 +16,17 @@ import adminRoutes from "./routes/admin/index.js";
 const port = Number(process.env.PORT) || 4000;
 const host = process.env.HOST || "0.0.0.0";
 
-const app = Fastify({ logger: true });
+// LOG_LEVEL: set to "debug" (or "trace") to enable verbose .debug() entries
+// scattered across the codebase (auth guards, proxy, etc.). Defaults to "info"
+// so debug entries are filtered out in normal runs and free to leave in place
+// as a permanent diagnostic tool.
+//
+// trustProxy: required behind Traefik/Coolify so request.ip and request.protocol
+// reflect X-Forwarded-* headers set by the reverse proxy.
+const app = Fastify({
+  logger: { level: process.env.LOG_LEVEL || "info" },
+  trustProxy: true,
+});
 
 const corsOrigins = [
   process.env.FRONTEND_URL || "http://localhost:3000",
@@ -79,6 +89,15 @@ app.route({
   async handler(request, reply) {
     const url = new URL(request.url, `http://${request.headers.host}`);
 
+    request.log.debug({
+      authPhase: "proxy.incoming",
+      url: request.url,
+      method: request.method,
+      hasCookie: !!request.headers.cookie,
+      cookiePrefix: request.headers.cookie ? request.headers.cookie.slice(0, 60) : null,
+      origin: request.headers.origin,
+    });
+
     const headers = new Headers();
     for (const [key, value] of Object.entries(request.headers)) {
       if (value) headers.append(key, Array.isArray(value) ? value.join(", ") : value);
@@ -91,6 +110,8 @@ app.route({
     });
 
     const response = await auth.handler(req);
+
+    request.log.debug({ authPhase: "proxy.response", status: response.status });
 
     // Log failed auth attempts for security monitoring
     if (response.status >= 400 && request.url.includes("sign-in")) {

--- a/src/backend/src/lib/admin-guard.ts
+++ b/src/backend/src/lib/admin-guard.ts
@@ -2,13 +2,31 @@ import type { FastifyRequest, FastifyReply } from "fastify";
 import { auth } from "./auth.js";
 import { prisma } from "./prisma.js";
 
+// Convert Fastify's plain-object request headers into a Web API Headers object,
+// which Better Auth's getSession expects (it calls .get("cookie") on it).
+// Without this conversion, the cast `as unknown as Headers` compiles but
+// silently fails at runtime — getSession returns null and every admin route
+// answers 403 even with a valid cookie.
+function toWebHeaders(request: FastifyRequest): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) headers.append(key, v);
+    } else {
+      headers.append(key, String(value));
+    }
+  }
+  return headers;
+}
+
 // Source of truth for back-office access: the user.role column in DB.
 // ADMIN_EMAILS is only used at bootstrap (prisma/seed.ts) to create the very
 // first admin account. After that, admins grant / revoke access through the
 // back-office (Utilisateurs page) which writes to user.role.
 async function getSessionUser(request: FastifyRequest) {
   const session = await auth.api.getSession({
-    headers: request.headers as unknown as Headers,
+    headers: toWebHeaders(request),
   });
 
   if (!session) return null;

--- a/src/backend/src/lib/admin-guard.ts
+++ b/src/backend/src/lib/admin-guard.ts
@@ -8,8 +8,15 @@ import { prisma } from "./prisma.js";
 // first admin account. After that, admins grant / revoke access through the
 // back-office (Utilisateurs page) which writes to user.role.
 async function getSessionUser(request: FastifyRequest) {
+  request.log.debug({ authPhase: "guard.enter", url: request.url, method: request.method, hasCookie: !!request.headers.cookie });
+
   const session = await auth.api.getSession({
     headers: fromNodeHeaders(request.headers),
+  });
+
+  request.log.debug({
+    authPhase: "guard.session",
+    session: session ? { userId: session.user.id, email: session.user.email } : null,
   });
 
   if (!session) return null;
@@ -19,9 +26,18 @@ async function getSessionUser(request: FastifyRequest) {
     select: { role: true, banned: true },
   });
 
-  if (!user || user.banned) return null;
-  if (user.role !== "ADMIN" && user.role !== "EDITOR") return null;
+  request.log.debug({ authPhase: "guard.dbUser", user });
 
+  if (!user || user.banned) {
+    request.log.debug({ authPhase: "guard.reject", reason: !user ? "no_user" : "banned" });
+    return null;
+  }
+  if (user.role !== "ADMIN" && user.role !== "EDITOR") {
+    request.log.debug({ authPhase: "guard.reject", reason: "bad_role", role: user.role });
+    return null;
+  }
+
+  request.log.debug({ authPhase: "guard.accept", role: user.role });
   return {
     ...session.user,
     role: user.role,
@@ -32,6 +48,7 @@ async function getSessionUser(request: FastifyRequest) {
 export async function requireAdmin(request: FastifyRequest, reply: FastifyReply) {
   const user = await getSessionUser(request);
   if (!user) {
+    request.log.debug({ authPhase: "requireAdmin.deny" });
     reply.status(403).send({ error: "Forbidden" });
     return;
   }
@@ -42,6 +59,7 @@ export async function requireAdmin(request: FastifyRequest, reply: FastifyReply)
 export async function requireAdminRole(request: FastifyRequest, reply: FastifyReply) {
   const user = await getSessionUser(request);
   if (!user || user.role !== "ADMIN") {
+    request.log.debug({ authPhase: "requireAdminRole.deny", role: user?.role ?? null });
     reply.status(403).send({ error: "Forbidden — admin only" });
     return;
   }

--- a/src/backend/src/lib/admin-guard.ts
+++ b/src/backend/src/lib/admin-guard.ts
@@ -1,15 +1,17 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
-import { auth, isAdminEmail } from "./auth.js";
+import { auth } from "./auth.js";
 import { prisma } from "./prisma.js";
 
+// Source of truth for back-office access: the user.role column in DB.
+// ADMIN_EMAILS is only used at bootstrap (prisma/seed.ts) to create the very
+// first admin account. After that, admins grant / revoke access through the
+// back-office (Utilisateurs page) which writes to user.role.
 async function getSessionUser(request: FastifyRequest) {
   const session = await auth.api.getSession({
     headers: request.headers as unknown as Headers,
   });
 
-  if (!session || !isAdminEmail(session.user.email)) {
-    return null;
-  }
+  if (!session) return null;
 
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },
@@ -17,14 +19,15 @@ async function getSessionUser(request: FastifyRequest) {
   });
 
   if (!user || user.banned) return null;
+  if (user.role !== "ADMIN" && user.role !== "EDITOR") return null;
 
   return {
     ...session.user,
-    role: user.role || "ADMIN",
+    role: user.role,
   };
 }
 
-/** Requires any authenticated admin (ADMIN or EDITOR) */
+/** Requires any authenticated back-office user (ADMIN or EDITOR) */
 export async function requireAdmin(request: FastifyRequest, reply: FastifyReply) {
   const user = await getSessionUser(request);
   if (!user) {

--- a/src/backend/src/lib/admin-guard.ts
+++ b/src/backend/src/lib/admin-guard.ts
@@ -1,24 +1,7 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
+import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth.js";
 import { prisma } from "./prisma.js";
-
-// Convert Fastify's plain-object request headers into a Web API Headers object,
-// which Better Auth's getSession expects (it calls .get("cookie") on it).
-// Without this conversion, the cast `as unknown as Headers` compiles but
-// silently fails at runtime — getSession returns null and every admin route
-// answers 403 even with a valid cookie.
-function toWebHeaders(request: FastifyRequest): Headers {
-  const headers = new Headers();
-  for (const [key, value] of Object.entries(request.headers)) {
-    if (value === undefined || value === null) continue;
-    if (Array.isArray(value)) {
-      for (const v of value) headers.append(key, v);
-    } else {
-      headers.append(key, String(value));
-    }
-  }
-  return headers;
-}
 
 // Source of truth for back-office access: the user.role column in DB.
 // ADMIN_EMAILS is only used at bootstrap (prisma/seed.ts) to create the very
@@ -26,7 +9,7 @@ function toWebHeaders(request: FastifyRequest): Headers {
 // back-office (Utilisateurs page) which writes to user.role.
 async function getSessionUser(request: FastifyRequest) {
   const session = await auth.api.getSession({
-    headers: toWebHeaders(request),
+    headers: fromNodeHeaders(request.headers),
   });
 
   if (!session) return null;

--- a/src/backend/src/lib/auth.ts
+++ b/src/backend/src/lib/auth.ts
@@ -9,28 +9,58 @@ const ADMIN_EMAILS = (process.env.ADMIN_EMAILS || "")
   .map((e) => e.trim())
   .filter(Boolean);
 
+function normalizeUrl(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+// Build a wildcard origin from the public base URL so we don't have to list
+// each environment subdomain (dev-j, beta, prod). Returns null for non-FQDN
+// hostnames (e.g. localhost) to avoid accidental wildcards in local dev.
+function buildWildcardOrigin(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.hostname.split(".");
+    if (parts.length >= 2 && !/^\d+\.\d+\.\d+\.\d+$/.test(parsed.hostname)) {
+      return `${parsed.protocol}//*.${parts.slice(-2).join(".")}`;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const baseUrl = normalizeUrl(process.env.BASE_URL || "http://localhost:4000");
+const frontendUrl = normalizeUrl(process.env.FRONTEND_URL || "http://localhost:3000");
+const wildcardOrigin = buildWildcardOrigin(baseUrl);
+const trustedOrigins = [baseUrl, frontendUrl, ...(wildcardOrigin ? [wildcardOrigin] : [])].filter(
+  (v, i, arr) => arr.indexOf(v) === i,
+);
+
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
     provider: "postgresql",
   }),
-  baseURL: process.env.BASE_URL || "http://localhost:4000",
+  baseURL: baseUrl,
   basePath: "/api/auth",
-  trustedOrigins: [
-    process.env.FRONTEND_URL || "http://localhost:3000",
-  ],
+  trustedOrigins,
   emailAndPassword: {
     enabled: true,
     minPasswordLength: 10,
-    sendResetPassword: async ({ user, url }) => {
+    sendResetPassword: async ({ user, token }) => {
+      // Build the reset URL manually pointing to the frontend page (not the
+      // Better Auth callback endpoint, which is an API route and not
+      // navigable). baseUrl is the public BASE_URL injected by Coolify or
+      // overridden locally.
+      const resetUrl = `${baseUrl}/admin/reset-password?token=${token}`;
       await sendEmail({
         to: [user.email],
         subject: "DevFest Toulouse — Réinitialisation de mot de passe",
-        text: `Bonjour ${user.name || ""},\n\nCliquez sur ce lien pour réinitialiser votre mot de passe :\n${url}\n\nCe lien expire dans 1 heure.\n\nSi vous n'avez pas demandé cette réinitialisation, ignorez cet email.`,
+        text: `Bonjour ${user.name || ""},\n\nCliquez sur ce lien pour réinitialiser votre mot de passe :\n${resetUrl}\n\nCe lien expire dans 1 heure.\n\nSi vous n'avez pas demandé cette réinitialisation, ignorez cet email.`,
         html: `
           <h3>Réinitialisation de mot de passe</h3>
           <p>Bonjour ${user.name || ""},</p>
           <p>Cliquez sur le lien ci-dessous pour réinitialiser votre mot de passe :</p>
-          <p><a href="${url}">Réinitialiser mon mot de passe</a></p>
+          <p><a href="${resetUrl}">Réinitialiser mon mot de passe</a></p>
           <p>Ce lien expire dans 1 heure.</p>
           <p><em>Si vous n'avez pas demandé cette réinitialisation, ignorez cet email.</em></p>
         `,

--- a/src/backend/src/routes/admin/auth.ts
+++ b/src/backend/src/routes/admin/auth.ts
@@ -1,48 +1,47 @@
-import type { FastifyInstance } from "fastify";
-import { auth, isAdminEmail } from "../../lib/auth.js";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { auth } from "../../lib/auth.js";
 import { prisma } from "../../lib/prisma.js";
 
+// Helper — same rule as admin-guard: rely on user.role in DB, not on the
+// ADMIN_EMAILS env var (which is only used at bootstrap).
+async function getSessionWithRole(request: FastifyRequest) {
+  const session = await auth.api.getSession({ headers: request.headers as unknown as Headers });
+  if (!session) return null;
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { role: true, banned: true },
+  });
+  if (!user || user.banned) return null;
+  if (user.role !== "ADMIN" && user.role !== "EDITOR") return null;
+  return { session, role: user.role };
+}
+
 export default async function adminAuthRoutes(app: FastifyInstance) {
-  // GET /api/admin/session — returns current admin session info with role
+  // GET /api/admin/session — returns current back-office session info with role
   app.get("/session", async (request, reply) => {
-    const session = await auth.api.getSession({
-      headers: request.headers as unknown as Headers,
-    });
-
-    if (!session || !isAdminEmail(session.user.email)) {
-      return reply.status(403).send({ error: "Forbidden" });
-    }
-
-    const user = await prisma.user.findUnique({
-      where: { email: session.user.email },
-      select: { role: true },
-    });
+    const ctx = await getSessionWithRole(request);
+    if (!ctx) return reply.status(403).send({ error: "Forbidden" });
 
     return {
       user: {
-        id: session.user.id,
-        email: session.user.email,
-        name: session.user.name,
-        image: session.user.image,
-        role: user?.role || "ADMIN",
+        id: ctx.session.user.id,
+        email: ctx.session.user.email,
+        name: ctx.session.user.name,
+        image: ctx.session.user.image,
+        role: ctx.role,
       },
     };
   });
 
   // PUT /api/admin/profile — update current user's name
   app.put<{ Body: { name?: string } }>("/profile", async (request, reply) => {
-    const session = await auth.api.getSession({
-      headers: request.headers as unknown as Headers,
-    });
-
-    if (!session || !isAdminEmail(session.user.email)) {
-      return reply.status(403).send({ error: "Forbidden" });
-    }
+    const ctx = await getSessionWithRole(request);
+    if (!ctx) return reply.status(403).send({ error: "Forbidden" });
 
     const { name } = request.body;
 
     const updated = await prisma.user.update({
-      where: { id: session.user.id },
+      where: { id: ctx.session.user.id },
       data: {
         ...(name !== undefined && { name: name.trim() || null }),
       },

--- a/src/backend/src/routes/admin/auth.ts
+++ b/src/backend/src/routes/admin/auth.ts
@@ -1,24 +1,12 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
+import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "../../lib/auth.js";
 import { prisma } from "../../lib/prisma.js";
-
-function toWebHeaders(request: FastifyRequest): Headers {
-  const headers = new Headers();
-  for (const [key, value] of Object.entries(request.headers)) {
-    if (value === undefined || value === null) continue;
-    if (Array.isArray(value)) {
-      for (const v of value) headers.append(key, v);
-    } else {
-      headers.append(key, String(value));
-    }
-  }
-  return headers;
-}
 
 // Helper — same rule as admin-guard: rely on user.role in DB, not on the
 // ADMIN_EMAILS env var (which is only used at bootstrap).
 async function getSessionWithRole(request: FastifyRequest) {
-  const session = await auth.api.getSession({ headers: toWebHeaders(request) });
+  const session = await auth.api.getSession({ headers: fromNodeHeaders(request.headers) });
   if (!session) return null;
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },

--- a/src/backend/src/routes/admin/auth.ts
+++ b/src/backend/src/routes/admin/auth.ts
@@ -6,14 +6,27 @@ import { prisma } from "../../lib/prisma.js";
 // Helper — same rule as admin-guard: rely on user.role in DB, not on the
 // ADMIN_EMAILS env var (which is only used at bootstrap).
 async function getSessionWithRole(request: FastifyRequest) {
+  request.log.debug({ authPhase: "adminAuth.enter", url: request.url, hasCookie: !!request.headers.cookie });
   const session = await auth.api.getSession({ headers: fromNodeHeaders(request.headers) });
+  request.log.debug({
+    authPhase: "adminAuth.session",
+    session: session ? { userId: session.user.id, email: session.user.email } : null,
+  });
   if (!session) return null;
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },
     select: { role: true, banned: true },
   });
-  if (!user || user.banned) return null;
-  if (user.role !== "ADMIN" && user.role !== "EDITOR") return null;
+  request.log.debug({ authPhase: "adminAuth.dbUser", user });
+  if (!user || user.banned) {
+    request.log.debug({ authPhase: "adminAuth.reject", reason: !user ? "no_user" : "banned" });
+    return null;
+  }
+  if (user.role !== "ADMIN" && user.role !== "EDITOR") {
+    request.log.debug({ authPhase: "adminAuth.reject", reason: "bad_role", role: user.role });
+    return null;
+  }
+  request.log.debug({ authPhase: "adminAuth.accept", role: user.role });
   return { session, role: user.role };
 }
 

--- a/src/backend/src/routes/admin/auth.ts
+++ b/src/backend/src/routes/admin/auth.ts
@@ -2,10 +2,23 @@ import type { FastifyInstance, FastifyRequest } from "fastify";
 import { auth } from "../../lib/auth.js";
 import { prisma } from "../../lib/prisma.js";
 
+function toWebHeaders(request: FastifyRequest): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) headers.append(key, v);
+    } else {
+      headers.append(key, String(value));
+    }
+  }
+  return headers;
+}
+
 // Helper — same rule as admin-guard: rely on user.role in DB, not on the
 // ADMIN_EMAILS env var (which is only used at bootstrap).
 async function getSessionWithRole(request: FastifyRequest) {
-  const session = await auth.api.getSession({ headers: request.headers as unknown as Headers });
+  const session = await auth.api.getSession({ headers: toWebHeaders(request) });
   if (!session) return null;
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },

--- a/src/frontend/src/app/admin/reset-password/page.tsx
+++ b/src/frontend/src/app/admin/reset-password/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+
+function ResetPasswordContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get("token");
+  const error = searchParams.get("error");
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (error === "INVALID_TOKEN") {
+      setErrorMsg("Ce lien n'est plus valide ou a expiré.");
+    }
+  }, [error]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrorMsg(null);
+    setMessage(null);
+
+    if (password.length < 10) {
+      setErrorMsg("Le mot de passe doit contenir au moins 10 caractères.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setErrorMsg("Les mots de passe ne correspondent pas.");
+      return;
+    }
+    if (!token) {
+      setErrorMsg("Token manquant.");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newPassword: password, token }),
+      });
+      if (res.ok) {
+        setMessage("Mot de passe réinitialisé. Redirection...");
+        setTimeout(() => router.push("/admin"), 1500);
+      } else {
+        const body = await res.json().catch(() => null);
+        setErrorMsg(body?.message || "Erreur lors de la réinitialisation.");
+      }
+    } catch {
+      setErrorMsg("Impossible de contacter le serveur.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-blanc-casse">
+      <div className="bg-blanc rounded-3xl shadow-card p-10 max-w-md w-full">
+        <h1 className="text-3xl font-bold text-noir mb-2 text-center">
+          <span className="text-malachite">DevFest</span>{" "}
+          <span className="text-terre-cuite">Admin</span>
+        </h1>
+        <p className="text-gris mb-6 text-center">
+          Choisissez un nouveau mot de passe.
+        </p>
+
+        {errorMsg && (
+          <div className="mb-4 p-3 rounded-[12px] bg-rouge/10 text-bismarck text-sm">{errorMsg}</div>
+        )}
+        {message && (
+          <div className="mb-4 p-3 rounded-[12px] bg-malachite/10 text-[#0A6B4B] text-sm">{message}</div>
+        )}
+
+        {token && !message && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-noir mb-1">
+                Nouveau mot de passe
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={10}
+                className="w-full px-4 py-3 rounded-[12px] border-2 border-gris-clair text-noir focus:outline-none focus:ring-2 focus:ring-bleu focus:border-bleu"
+                placeholder="Au moins 10 caractères"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="confirm" className="block text-sm font-medium text-noir mb-1">
+                Confirmer le mot de passe
+              </label>
+              <input
+                id="confirm"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                minLength={10}
+                className="w-full px-4 py-3 rounded-[12px] border-2 border-gris-clair text-noir focus:outline-none focus:ring-2 focus:ring-bleu focus:border-bleu"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="w-full px-6 py-3 rounded-[12px] bg-bleu text-blanc font-bold hover:bg-bleu/90 transition-colors disabled:opacity-50"
+            >
+              {isLoading ? "Envoi..." : "Réinitialiser le mot de passe"}
+            </button>
+          </form>
+        )}
+
+        {!token && !errorMsg && (
+          <p className="text-gris text-sm text-center">
+            Aucun token fourni. Veuillez utiliser le lien reçu par email.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen flex items-center justify-center"><p>...</p></div>}>
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}

--- a/src/frontend/src/components/admin/AdminShell.tsx
+++ b/src/frontend/src/components/admin/AdminShell.tsx
@@ -2,17 +2,19 @@
 
 import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
+import Link from "next/link";
 
 import { getAdminSession, signOut } from "@/lib/admin-api";
 import AdminLogin from "./AdminLogin";
 import AdminSidebar from "./AdminSidebar";
+import { isAdminPathAllowed, type AdminRole } from "./nav-items";
 
 interface AdminUser {
   id: string;
   email: string;
   name: string | null;
   image: string | null;
-  role: "ADMIN" | "EDITOR";
+  role: AdminRole;
 }
 
 // Public admin paths that render their own content without requiring a session.
@@ -107,9 +109,27 @@ export default function AdminShell({ children }: { children: React.ReactNode }) 
         </div>
 
         <div className="p-4 lg:p-8">
-          {children}
+          {isAdminPathAllowed(pathname, user.role) ? children : <ForbiddenSection />}
         </div>
       </main>
+    </div>
+  );
+}
+
+function ForbiddenSection() {
+  return (
+    <div className="mx-auto max-w-xl rounded-[12px] border border-gris/20 bg-blanc p-8 text-center">
+      <h1 className="text-2xl font-bold text-noir">Accès réservé</h1>
+      <p className="mt-3 text-gris">
+        Cette section est réservée aux administrateurs. Contactez un administrateur si vous pensez
+        avoir besoin d&apos;y accéder.
+      </p>
+      <Link
+        href="/admin"
+        className="mt-6 inline-block rounded-[8px] bg-malachite px-5 py-2 text-sm font-bold text-blanc hover:opacity-90"
+      >
+        Retour au tableau de bord
+      </Link>
     </div>
   );
 }

--- a/src/frontend/src/components/admin/AdminShell.tsx
+++ b/src/frontend/src/components/admin/AdminShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 
 import { getAdminSession, signOut } from "@/lib/admin-api";
 import AdminLogin from "./AdminLogin";
@@ -14,12 +15,20 @@ interface AdminUser {
   role: "ADMIN" | "EDITOR";
 }
 
+// Public admin paths that render their own content without requiring a session.
+// A user resetting their password precisely does NOT have a valid session.
+const PUBLIC_ADMIN_PATHS = ["/admin/reset-password"];
+
 export default function AdminShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isPublicPath = PUBLIC_ADMIN_PATHS.some((p) => pathname.startsWith(p));
+
   const [user, setUser] = useState<AdminUser | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(!isPublicPath);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   useEffect(() => {
+    if (isPublicPath) return;
     getAdminSession()
       .then((session) => {
         setUser(session);
@@ -28,7 +37,11 @@ export default function AdminShell({ children }: { children: React.ReactNode }) 
       .catch(() => {
         setIsLoading(false);
       });
-  }, []);
+  }, [isPublicPath]);
+
+  if (isPublicPath) {
+    return <>{children}</>;
+  }
 
   async function handleLogout() {
     await signOut();

--- a/src/frontend/src/components/admin/AdminSidebar.tsx
+++ b/src/frontend/src/components/admin/AdminSidebar.tsx
@@ -15,10 +15,12 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
+import { adminNavItems, type AdminRole } from "./nav-items";
+
 interface AdminUser {
   email: string;
   name: string | null;
-  role: "ADMIN" | "EDITOR";
+  role: AdminRole;
 }
 
 interface AdminSidebarProps {
@@ -38,20 +40,9 @@ const iconMap: Record<string, IconDefinition> = {
   settings: faGear,
 };
 
-const navItems = [
-  { label: "Dashboard", path: "/admin", icon: "grid", roles: ["ADMIN", "EDITOR"] },
-  { label: "\u00c9ditions", path: "/admin/editions", icon: "calendar", roles: ["ADMIN"] },
-  { label: "Articles", path: "/admin/articles", icon: "file-text", roles: ["ADMIN", "EDITOR"] },
-  { label: "Pages", path: "/admin/pages", icon: "book", roles: ["ADMIN", "EDITOR"] },
-  { label: "Fichiers", path: "/admin/images", icon: "image", roles: ["ADMIN", "EDITOR"] },
-  { label: "Messages", path: "/admin/contact/messages", icon: "mail", roles: ["ADMIN", "EDITOR"] },
-  { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
-  { label: "Param\u00e8tres", path: "/admin/settings", icon: "settings", roles: ["ADMIN"] },
-];
-
 export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSidebarProps) {
   const pathname = usePathname();
-  const visibleItems = navItems
+  const visibleItems = adminNavItems
     .filter((item) => item.roles.includes(user.role))
     .map((item) => ({ ...item, href: item.path }));
 

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -1,0 +1,27 @@
+export type AdminRole = "ADMIN" | "EDITOR";
+
+export interface AdminNavItem {
+  label: string;
+  path: string;
+  icon: string;
+  roles: AdminRole[];
+}
+
+export const adminNavItems: AdminNavItem[] = [
+  { label: "Dashboard", path: "/admin", icon: "grid", roles: ["ADMIN", "EDITOR"] },
+  { label: "Éditions", path: "/admin/editions", icon: "calendar", roles: ["ADMIN"] },
+  { label: "Articles", path: "/admin/articles", icon: "file-text", roles: ["ADMIN", "EDITOR"] },
+  { label: "Pages", path: "/admin/pages", icon: "book", roles: ["ADMIN", "EDITOR"] },
+  { label: "Fichiers", path: "/admin/images", icon: "image", roles: ["ADMIN", "EDITOR"] },
+  { label: "Messages", path: "/admin/contact/messages", icon: "mail", roles: ["ADMIN", "EDITOR"] },
+  { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
+  { label: "Paramètres", path: "/admin/settings", icon: "settings", roles: ["ADMIN"] },
+];
+
+export function isAdminPathAllowed(pathname: string, role: AdminRole): boolean {
+  const match = adminNavItems
+    .filter((item) => item.path !== "/admin" && pathname.startsWith(item.path))
+    .sort((a, b) => b.path.length - a.path.length)[0];
+  if (!match) return true;
+  return match.roles.includes(role);
+}

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -86,7 +86,7 @@ export async function signInWithEmail(email: string, password: string): Promise<
 
 export async function forgotPassword(email: string): Promise<{ success: boolean; error?: string }> {
   try {
-    const res = await fetch(`${BACKEND_URL}/api/auth/forget-password`, {
+    const res = await fetch(`${BACKEND_URL}/api/auth/request-password-reset`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email, redirectTo: `${typeof window !== "undefined" ? window.location.origin : ""}/admin` }),


### PR DESCRIPTION
## Summary

- **Auth fixes**: restore reset-password flow, use Better Auth's `fromNodeHeaders`, trust the public Origin via `BASE_URL`, base back-office access on `user.role` (not `ADMIN_EMAILS`), add a `LOG_LEVEL` env var with `authPhase` instrumentation.
- **Coolify deploy fixes**: keep the backend off the shared `coolify` network, pin a per-env network alias (`devfest-${ENV_NAME}-backend`) so the frontend stops resolving to another project's backend (root cause of the `INVALID_ORIGIN` errors on dev-j).
- **Admin UI guard**: block non-admin users from admin-only routes (`/admin/users`, `/admin/settings`, `/admin/editions`) with an explicit "Accès réservé" panel — backend was already returning 403, but the page chrome was misleading.
- **Docs**: add a project-specific deployment checklist (`deployer-nouvel-environnement.md`) and a generic note + audit prompt for Coolify multi-env pitfalls (`coolify-pieges-multi-environnements.md`).

## Test plan

- [x] Login admin avec mauvais mot de passe → message d'erreur clair
- [x] Reset password admin via Mailhog → email reçu + lien fonctionne
- [x] Login admin avec nouveau mot de passe → Dashboard accessible
- [x] Logout admin → session terminée (`/api/admin/session` → 403)
- [x] Reset password editor via Mailhog → flow OK
- [x] Login editor → nav restreinte (pas d'Éditions, Utilisateurs, Paramètres)
- [x] Editor force `/admin/users` → écran "Accès réservé" (testé en local)
- [x] `POST /api/admin/users` en tant qu'editor → 403 backend
- [x] Signup public bloqué → 403 "Inscription sur invitation uniquement"
- [ ] Re-tester le guard UI sur dev-j après déploiement Coolify

## Notes pour le merge

- Penser à appliquer le même fix d'alias réseau (`ENV_NAME` + `BACKEND_URL` + toggle "Available at Buildtime" dans Coolify) sur **beta** et **prod** avant de propager `feature/auth-audit` plus loin que dev-j (cf. `docs/deployer-nouvel-environnement.md`).
- Une fois validé, baisser `LOG_LEVEL=debug` à `info` sur Coolify pour réduire le bruit des logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)