### PR TITLE
feat(api): CRUD endpoints for personal and admin API keys [PR 3/8]

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -13,6 +13,7 @@ import articleRoutes from "./routes/articles.js";
 import settingsRoutes from "./routes/settings.js";
 import pageRoutes from "./routes/pages.js";
 import contactRoutes from "./routes/contact.js";
+import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
 const port = Number(process.env.PORT) || 4000;
@@ -142,6 +143,9 @@ await app.register(articleRoutes, { prefix: "/api" });
 await app.register(settingsRoutes, { prefix: "/api" });
 await app.register(pageRoutes, { prefix: "/api" });
 await app.register(contactRoutes, { prefix: "/api" });
+
+// Per-user routes (any authenticated back-office user — own resources only)
+await app.register(myApiKeysRoutes, { prefix: "/api/me" });
 
 // Admin routes (protected by requireAdmin hook)
 await app.register(adminRoutes, { prefix: "/api/admin" });

--- a/src/backend/src/routes/admin/api-keys.ts
+++ b/src/backend/src/routes/admin/api-keys.ts
@@ -1,0 +1,65 @@
+import type { FastifyInstance } from "fastify";
+
+import { prisma } from "../../lib/prisma.js";
+
+interface ListQuery {
+  userId?: string;
+  status?: "active" | "revoked" | "all";
+  page?: string;
+  limit?: string;
+}
+
+export default async function adminApiKeysRoutes(app: FastifyInstance) {
+  // GET /api/admin/api-keys — global list with filters
+  app.get<{ Querystring: ListQuery }>("/api-keys", async (request) => {
+    const { userId, status = "all" } = request.query;
+    const page = Math.max(1, Number(request.query.page) || 1);
+    const limit = Math.min(100, Math.max(1, Number(request.query.limit) || 20));
+
+    const where: Record<string, unknown> = {};
+    if (userId) where.userId = userId;
+    if (status === "active") where.revokedAt = null;
+    else if (status === "revoked") where.revokedAt = { not: null };
+
+    const [total, items] = await Promise.all([
+      prisma.apiKey.count({ where }),
+      prisma.apiKey.findMany({
+        where,
+        include: {
+          user: { select: { id: true, email: true, name: true, role: true } },
+        },
+        orderBy: [{ createdAt: "desc" }],
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+    ]);
+
+    return {
+      page,
+      limit,
+      total,
+      items: items.map((k) => ({
+        id: k.id,
+        name: k.name,
+        prefix: k.prefix,
+        lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
+        expiresAt: k.expiresAt?.toISOString() ?? null,
+        revokedAt: k.revokedAt?.toISOString() ?? null,
+        createdAt: k.createdAt.toISOString(),
+        user: k.user,
+      })),
+    };
+  });
+
+  // DELETE /api/admin/api-keys/:id — revoke any key
+  app.delete<{ Params: { id: string } }>("/api-keys/:id", async (request, reply) => {
+    const key = await prisma.apiKey.findUnique({ where: { id: request.params.id } });
+    if (!key) return reply.status(404).send({ error: "not_found" });
+    if (key.revokedAt) return reply.send({ ok: true, alreadyRevoked: true });
+    await prisma.apiKey.update({
+      where: { id: key.id },
+      data: { revokedAt: new Date() },
+    });
+    return { ok: true };
+  });
+}

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -11,6 +11,7 @@ import adminContactRoutes from "./contact.js";
 import adminImageRoutes from "./images.js";
 import adminUserRoutes from "./users.js";
 import adminSponsorPlanRoutes from "./sponsor-plans.js";
+import adminApiKeyRoutes from "./api-keys.js";
 
 export default async function adminRoutes(app: FastifyInstance) {
   // Auth check route (does its own auth check internally)
@@ -34,5 +35,6 @@ export default async function adminRoutes(app: FastifyInstance) {
     await adminApp.register(adminSettingsRoutes);
     await adminApp.register(adminUserRoutes);
     await adminApp.register(adminSponsorPlanRoutes);
+    await adminApp.register(adminApiKeyRoutes);
   });
 }

--- a/src/backend/src/routes/me/api-keys.ts
+++ b/src/backend/src/routes/me/api-keys.ts
@@ -1,0 +1,125 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+
+import { prisma } from "../../lib/prisma.js";
+import {
+  requireAnyAuthenticated,
+  type AuthContext,
+} from "../../lib/auth-context.js";
+import { generateApiKey, resolveApiKeyEnv } from "../../lib/api-key.js";
+
+// Soft cap on active keys per user. Meant as a sanity safeguard, not a
+// security boundary — an admin can raise/lower it in code as the usage
+// pattern solidifies. Revoked keys do not count.
+const MAX_ACTIVE_KEYS_PER_USER = 20;
+
+interface CreateApiKeyBody {
+  name?: string;
+  expiresAt?: string | null;
+}
+
+function getCurrentUser(request: FastifyRequest) {
+  const ctx = (request as FastifyRequest & { authContext?: AuthContext }).authContext;
+  if (!ctx) throw new Error("authContext missing — requireAnyAuthenticated must run first");
+  return ctx.user;
+}
+
+function serializeApiKey(k: {
+  id: string;
+  name: string;
+  prefix: string;
+  lastUsedAt: Date | null;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+}) {
+  return {
+    id: k.id,
+    name: k.name,
+    prefix: k.prefix,
+    lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
+    expiresAt: k.expiresAt?.toISOString() ?? null,
+    revokedAt: k.revokedAt?.toISOString() ?? null,
+    createdAt: k.createdAt.toISOString(),
+  };
+}
+
+export default async function myApiKeysRoutes(app: FastifyInstance) {
+  app.addHook("preHandler", requireAnyAuthenticated);
+
+  // GET /api/me/api-keys — list caller's own keys (never exposes raw/hash)
+  app.get("/api-keys", async (request) => {
+    const user = getCurrentUser(request);
+    const keys = await prisma.apiKey.findMany({
+      where: { userId: user.id },
+      orderBy: [{ revokedAt: "asc" }, { createdAt: "desc" }],
+    });
+    return keys.map(serializeApiKey);
+  });
+
+  // POST /api/me/api-keys — create a new key. The raw value is returned ONCE.
+  app.post<{ Body: CreateApiKeyBody }>("/api-keys", async (request, reply) => {
+    const user = getCurrentUser(request);
+    const { name, expiresAt } = request.body ?? {};
+
+    if (!name || !name.trim()) {
+      return reply.status(400).send({ error: "name_required" });
+    }
+    const trimmed = name.trim().slice(0, 80);
+
+    let expiresAtDate: Date | null = null;
+    if (expiresAt) {
+      const parsed = new Date(expiresAt);
+      if (Number.isNaN(parsed.getTime())) {
+        return reply.status(400).send({ error: "invalid_expires_at" });
+      }
+      if (parsed.getTime() <= Date.now()) {
+        return reply.status(400).send({ error: "expires_at_in_past" });
+      }
+      expiresAtDate = parsed;
+    }
+
+    const activeCount = await prisma.apiKey.count({
+      where: { userId: user.id, revokedAt: null },
+    });
+    if (activeCount >= MAX_ACTIVE_KEYS_PER_USER) {
+      return reply.status(400).send({ error: "too_many_active_keys" });
+    }
+
+    const { raw, prefix, hashedKey } = await generateApiKey(resolveApiKeyEnv());
+
+    const created = await prisma.apiKey.create({
+      data: {
+        userId: user.id,
+        name: trimmed,
+        prefix,
+        hashedKey,
+        expiresAt: expiresAtDate,
+      },
+    });
+
+    reply.status(201);
+    return {
+      ...serializeApiKey(created),
+      // The raw secret. Client must store it now; the server will never
+      // expose it again.
+      key: raw,
+    };
+  });
+
+  // DELETE /api/me/api-keys/:id — revoke caller's own key
+  app.delete<{ Params: { id: string } }>("/api-keys/:id", async (request, reply) => {
+    const user = getCurrentUser(request);
+    const key = await prisma.apiKey.findUnique({ where: { id: request.params.id } });
+    if (!key || key.userId !== user.id) {
+      return reply.status(404).send({ error: "not_found" });
+    }
+    if (key.revokedAt) {
+      return reply.status(200).send({ ok: true, alreadyRevoked: true });
+    }
+    await prisma.apiKey.update({
+      where: { id: key.id },
+      data: { revokedAt: new Date() },
+    });
+    return { ok: true };
+  });
+}


### PR DESCRIPTION
## Summary

Routes CRUD pour les jetons d'API. Le frontend de la PR 4 va les consommer.

**Per-user (`/api/me/api-keys`)** — accessible à tout user back-office (ADMIN ou EDITOR) :
- `GET` → liste ses propres clés (jamais le hash, jamais le raw).
- `POST` → crée une clé. **Réponse unique** contenant `key: raw` — jamais ré-affiché.
- `DELETE /:id` → révoque sa propre clé.
- Soft cap : 20 clés actives par user.

**Admin (`/api/admin/api-keys`)** — ADMIN-only :
- `GET ?userId=&status=active|revoked|all&page=&limit=` → vue paginée globale avec user joint.
- `DELETE /:id` → révoque n'importe quelle clé.

## Test plan

- [x] `GET /api/me/api-keys` sans auth → 401 ✅
- [x] `GET /api/admin/api-keys` sans auth → 403 ✅
- [ ] Avec cookie admin → liste vide (à tester via UI en PR 4)
- [ ] `POST /api/me/api-keys` retourne la raw key, le hash en DB est différent
- [ ] Le préfixe stocké correspond au début du raw
- [ ] Réutiliser cette clé en Bearer sur `/api/admin/editions` → 200

## Context

PR 3/8 du chantier `feature/public-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)