### PR TITLE
feat(admin-ui): API keys management [PR 4/8]

### DIFF
--- a/src/frontend/next.config.ts
+++ b/src/frontend/next.config.ts
@@ -27,6 +27,18 @@ const nextConfig: NextConfig = {
         destination: `${backendUrl}/api/editions/:path*`,
       },
       {
+        source: "/api/me/:path*",
+        destination: `${backendUrl}/api/me/:path*`,
+      },
+      {
+        source: "/api/docs",
+        destination: `${backendUrl}/api/docs/`,
+      },
+      {
+        source: "/api/docs/:path*",
+        destination: `${backendUrl}/api/docs/:path*`,
+      },
+      {
         source: "/uploads/:path*",
         destination: `${backendUrl}/uploads/:path*`,
       },

--- a/src/frontend/src/app/admin/api-keys/page.tsx
+++ b/src/frontend/src/app/admin/api-keys/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+import {
+  adminListApiKeys,
+  adminRevokeApiKey,
+  type AdminApiKeysList,
+  type ApiKeyWithUser,
+} from "@/lib/admin-api";
+
+function formatDate(iso: string | null, placeholder = "—") {
+  if (!iso) return placeholder;
+  return new Date(iso).toLocaleString("fr-FR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+function statusLabel(key: ApiKeyWithUser): { label: string; className: string } {
+  if (key.revokedAt) return { label: "Révoquée", className: "bg-gris/10 text-gris" };
+  if (key.expiresAt && new Date(key.expiresAt) <= new Date()) {
+    return { label: "Expirée", className: "bg-gris/10 text-gris" };
+  }
+  return { label: "Active", className: "bg-malachite/10 text-malachite" };
+}
+
+export default function AdminApiKeysPage() {
+  const [list, setList] = useState<AdminApiKeysList | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"all" | "active" | "revoked">("active");
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError("");
+    const data = await adminListApiKeys({ status: statusFilter, page, limit: 20 });
+    if (!data) setError("Impossible de charger les clés");
+    setList(data);
+    setIsLoading(false);
+  }, [statusFilter, page]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleRevoke(id: string) {
+    if (!confirm("Révoquer cette clé ? Le propriétaire ne pourra plus l'utiliser.")) return;
+    const ok = await adminRevokeApiKey(id);
+    if (!ok) setError("Révocation impossible");
+    await load();
+  }
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-noir mb-2">Clés API</h1>
+      <p className="text-gris mb-6">
+        Vue d&apos;ensemble de toutes les clés d&apos;API. Vous pouvez révoquer n&apos;importe quelle clé à tout moment.
+      </p>
+
+      <div className="flex items-center gap-3 mb-4">
+        <label className="text-sm text-noir">Statut :</label>
+        <select
+          value={statusFilter}
+          onChange={(e) => {
+            setStatusFilter(e.target.value as "all" | "active" | "revoked");
+            setPage(1);
+          }}
+          className="rounded-lg border border-gris/30 px-3 py-1.5 text-sm bg-blanc"
+        >
+          <option value="active">Actives</option>
+          <option value="revoked">Révoquées</option>
+          <option value="all">Toutes</option>
+        </select>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm text-gris py-12 text-center">Chargement...</p>
+      ) : !list || list.items.length === 0 ? (
+        <div className="bg-blanc rounded-xl shadow-card p-12 text-center text-gris">
+          Aucune clé correspondant aux critères.
+        </div>
+      ) : (
+        <div className="bg-blanc rounded-xl shadow-card overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b border-gris/20">
+                <th className="py-3 px-4 text-noir font-medium">Propriétaire</th>
+                <th className="py-3 px-4 text-noir font-medium">Nom</th>
+                <th className="py-3 px-4 text-noir font-medium">Préfixe</th>
+                <th className="py-3 px-4 text-noir font-medium">Statut</th>
+                <th className="py-3 px-4 text-noir font-medium">Dernière utilisation</th>
+                <th className="py-3 px-4 text-noir font-medium">Expiration</th>
+                <th className="py-3 px-4 text-noir font-medium">Créée le</th>
+                <th className="py-3 px-4 text-right text-noir font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.items.map((k) => {
+                const status = statusLabel(k);
+                return (
+                  <tr key={k.id} className="border-b border-gris/10 last:border-b-0">
+                    <td className="py-3 px-4">
+                      <div className="text-noir">{k.user.name ?? k.user.email}</div>
+                      {k.user.name && <div className="text-xs text-gris">{k.user.email}</div>}
+                      <div className="text-xs text-gris mt-0.5">
+                        {k.user.role === "ADMIN" ? "Administrateur" : "Éditeur"}
+                      </div>
+                    </td>
+                    <td className="py-3 px-4 text-noir">{k.name}</td>
+                    <td className="py-3 px-4">
+                      <code className="text-xs font-mono text-gris">{k.prefix}…</code>
+                    </td>
+                    <td className="py-3 px-4">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${status.className}`}>
+                        {status.label}
+                      </span>
+                    </td>
+                    <td className="py-3 px-4 text-gris">{formatDate(k.lastUsedAt, "Jamais")}</td>
+                    <td className="py-3 px-4 text-gris">{formatDate(k.expiresAt)}</td>
+                    <td className="py-3 px-4 text-gris">{formatDate(k.createdAt)}</td>
+                    <td className="py-3 px-4 text-right">
+                      {!k.revokedAt && (
+                        <button
+                          type="button"
+                          onClick={() => handleRevoke(k.id)}
+                          className="text-terre-cuite hover:underline text-sm"
+                        >
+                          Révoquer
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {list && list.total > list.limit && (
+        <div className="flex items-center justify-between mt-4">
+          <span className="text-sm text-gris">
+            {(list.page - 1) * list.limit + 1}–{Math.min(list.page * list.limit, list.total)} sur {list.total}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={list.page <= 1}
+              className="px-3 py-1.5 text-sm bg-blanc border border-gris/30 rounded-lg disabled:opacity-40"
+            >
+              Précédent
+            </button>
+            <button
+              type="button"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={list.page * list.limit >= list.total}
+              className="px-3 py-1.5 text-sm bg-blanc border border-gris/30 rounded-lg disabled:opacity-40"
+            >
+              Suivant
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/profile/page.tsx
+++ b/src/frontend/src/app/admin/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { adminFetch, getAdminSession } from "@/lib/admin-api";
+import ApiKeysSection from "@/components/admin/ApiKeysSection";
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "";
 
@@ -172,6 +173,11 @@ export default function ProfilePage() {
           </div>
         </div>
       </form>
+
+      {/* API keys */}
+      <div className="mb-6">
+        <ApiKeysSection />
+      </div>
 
       {/* Password change */}
       <form onSubmit={handleChangePassword}>

--- a/src/frontend/src/components/admin/AdminSidebar.tsx
+++ b/src/frontend/src/components/admin/AdminSidebar.tsx
@@ -12,6 +12,7 @@ import {
   faEnvelope,
   faUsers,
   faGear,
+  faKey,
 } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
@@ -38,6 +39,7 @@ const iconMap: Record<string, IconDefinition> = {
   mail: faEnvelope,
   users: faUsers,
   settings: faGear,
+  key: faKey,
 };
 
 export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSidebarProps) {

--- a/src/frontend/src/components/admin/ApiKeysSection.tsx
+++ b/src/frontend/src/components/admin/ApiKeysSection.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+import {
+  listMyApiKeys,
+  createApiKey,
+  revokeMyApiKey,
+  type ApiKey,
+  type CreatedApiKey,
+} from "@/lib/admin-api";
+
+function formatDate(iso: string | null, placeholder = "—") {
+  if (!iso) return placeholder;
+  return new Date(iso).toLocaleString("fr-FR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+function statusLabel(key: ApiKey): { label: string; className: string } {
+  if (key.revokedAt) return { label: "Révoquée", className: "bg-gris/10 text-gris" };
+  if (key.expiresAt && new Date(key.expiresAt) <= new Date()) {
+    return { label: "Expirée", className: "bg-gris/10 text-gris" };
+  }
+  return { label: "Active", className: "bg-malachite/10 text-malachite" };
+}
+
+export default function ApiKeysSection() {
+  const [keys, setKeys] = useState<ApiKey[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // Creation form
+  const [isCreating, setIsCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newExpiresAt, setNewExpiresAt] = useState("");
+  const [created, setCreated] = useState<CreatedApiKey | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [copyFeedback, setCopyFeedback] = useState("");
+
+  async function load() {
+    setIsLoading(true);
+    setError("");
+    try {
+      setKeys(await listMyApiKeys());
+    } catch {
+      setError("Impossible de charger les clés");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (!newName.trim()) {
+      setError("Le nom est obligatoire");
+      return;
+    }
+    setIsSaving(true);
+    const { data, status } = await createApiKey(newName.trim(), newExpiresAt || null);
+    setIsSaving(false);
+    if (!data) {
+      if (status === 400) setError("Requête invalide (nom, date d'expiration ou quota dépassé)");
+      else if (status === 401 || status === 403) setError("Session expirée, reconnectez-vous");
+      else setError("Erreur serveur");
+      return;
+    }
+    setCreated(data);
+    setNewName("");
+    setNewExpiresAt("");
+    setIsCreating(false);
+    await load();
+  }
+
+  async function handleRevoke(id: string) {
+    if (!confirm("Révoquer cette clé ? Les requêtes utilisant cette clé échoueront immédiatement.")) return;
+    const ok = await revokeMyApiKey(id);
+    if (!ok) setError("Révocation impossible");
+    await load();
+  }
+
+  async function handleCopy() {
+    if (!created) return;
+    try {
+      await navigator.clipboard.writeText(created.key);
+      setCopyFeedback("Copiée !");
+      setTimeout(() => setCopyFeedback(""), 2000);
+    } catch {
+      setCopyFeedback("Copie manuelle requise");
+    }
+  }
+
+  return (
+    <div className="bg-blanc rounded-xl shadow-card p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-bold text-noir">Mes jetons d&apos;API</h2>
+        {!isCreating && !created && (
+          <button
+            type="button"
+            onClick={() => setIsCreating(true)}
+            className="px-3 py-1.5 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+          >
+            Nouveau jeton
+          </button>
+        )}
+      </div>
+
+      <p className="text-sm text-gris mb-4">
+        Un jeton d&apos;API vous permet d&apos;accéder à l&apos;API depuis un client externe (script,
+        application mobile, etc.). Les jetons héritent de vos droits courants. La valeur complète
+        n&apos;est affichée qu&apos;une seule fois, à la création.
+      </p>
+
+      {/* Creation form */}
+      {isCreating && (
+        <form onSubmit={handleCreate} className="mb-6 p-4 bg-blanc-casse rounded-lg">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+            <div>
+              <label className="block text-sm font-medium text-noir mb-1">Nom du jeton</label>
+              <input
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Mon app mobile"
+                required
+                maxLength={80}
+                className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-noir mb-1">
+                Date d&apos;expiration <span className="text-gris text-xs">(optionnelle)</span>
+              </label>
+              <input
+                type="datetime-local"
+                value={newExpiresAt}
+                onChange={(e) => setNewExpiresAt(e.target.value)}
+                className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+            >
+              {isSaving ? "Création..." : "Créer le jeton"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setIsCreating(false);
+                setNewName("");
+                setNewExpiresAt("");
+                setError("");
+              }}
+              className="px-4 py-2 text-sm font-medium text-gris hover:text-noir"
+            >
+              Annuler
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Created key one-shot display */}
+      {created && (
+        <div className="mb-6 p-4 border-2 border-malachite rounded-lg bg-malachite/5">
+          <h3 className="text-sm font-bold text-malachite mb-2">Nouveau jeton créé : {created.name}</h3>
+          <p className="text-sm text-noir mb-3">
+            <strong>Copiez cette clé maintenant.</strong> Elle ne sera plus jamais affichée.
+          </p>
+          <div className="flex items-stretch gap-2 mb-3">
+            <code className="flex-1 px-3 py-2 bg-blanc border border-gris/30 rounded text-xs font-mono break-all">
+              {created.key}
+            </code>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="px-3 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 whitespace-nowrap"
+            >
+              Copier
+            </button>
+          </div>
+          {copyFeedback && <p className="text-xs text-malachite mb-3">{copyFeedback}</p>}
+          <button
+            type="button"
+            onClick={() => setCreated(null)}
+            className="text-sm font-medium text-gris hover:text-noir"
+          >
+            J&apos;ai copié la clé, fermer
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
+      )}
+
+      {/* Keys list */}
+      {isLoading ? (
+        <p className="text-sm text-gris py-6">Chargement...</p>
+      ) : !keys || keys.length === 0 ? (
+        <p className="text-sm text-gris py-6">Aucun jeton pour le moment.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b border-gris/20">
+                <th className="py-2 pr-4 text-noir font-medium">Nom</th>
+                <th className="py-2 pr-4 text-noir font-medium">Préfixe</th>
+                <th className="py-2 pr-4 text-noir font-medium">Statut</th>
+                <th className="py-2 pr-4 text-noir font-medium">Dernière utilisation</th>
+                <th className="py-2 pr-4 text-noir font-medium">Expiration</th>
+                <th className="py-2 pr-4 text-noir font-medium">Créée le</th>
+                <th className="py-2 text-right text-noir font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => {
+                const status = statusLabel(k);
+                return (
+                  <tr key={k.id} className="border-b border-gris/10">
+                    <td className="py-3 pr-4 text-noir">{k.name}</td>
+                    <td className="py-3 pr-4">
+                      <code className="text-xs font-mono text-gris">{k.prefix}…</code>
+                    </td>
+                    <td className="py-3 pr-4">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${status.className}`}>
+                        {status.label}
+                      </span>
+                    </td>
+                    <td className="py-3 pr-4 text-gris">{formatDate(k.lastUsedAt, "Jamais")}</td>
+                    <td className="py-3 pr-4 text-gris">{formatDate(k.expiresAt)}</td>
+                    <td className="py-3 pr-4 text-gris">{formatDate(k.createdAt)}</td>
+                    <td className="py-3 text-right">
+                      {!k.revokedAt && (
+                        <button
+                          type="button"
+                          onClick={() => handleRevoke(k.id)}
+                          className="text-terre-cuite hover:underline text-sm"
+                        >
+                          Révoquer
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -15,6 +15,7 @@ export const adminNavItems: AdminNavItem[] = [
   { label: "Fichiers", path: "/admin/images", icon: "image", roles: ["ADMIN", "EDITOR"] },
   { label: "Messages", path: "/admin/contact/messages", icon: "mail", roles: ["ADMIN", "EDITOR"] },
   { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
+  { label: "Clés API", path: "/admin/api-keys", icon: "key", roles: ["ADMIN"] },
   { label: "Paramètres", path: "/admin/settings", icon: "settings", roles: ["ADMIN"] },
 ];
 

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -98,3 +98,86 @@ export async function forgotPassword(email: string): Promise<{ success: boolean;
     return { success: false, error: "Impossible de contacter le serveur" };
   }
 }
+
+// --- API Keys ---
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+export interface ApiKeyWithUser extends ApiKey {
+  user: { id: string; email: string; name: string | null; role: "ADMIN" | "EDITOR" };
+}
+
+export interface CreatedApiKey extends ApiKey {
+  key: string;
+}
+
+async function meFetch<T>(path: string, options: RequestInit = {}): Promise<{ data: T | null; status: number }> {
+  try {
+    const headers: Record<string, string> = {};
+    if (options.body && !(options.body instanceof FormData)) {
+      headers["Content-Type"] = "application/json";
+    }
+    const res = await fetch(`${BACKEND_URL}/api/me${path}`, {
+      credentials: "include",
+      headers: { ...headers, ...options.headers },
+      ...options,
+    });
+    if (!res.ok) return { data: null, status: res.status };
+    const data = await res.json();
+    return { data, status: res.status };
+  } catch {
+    return { data: null, status: 0 };
+  }
+}
+
+export async function listMyApiKeys(): Promise<ApiKey[]> {
+  const { data } = await meFetch<ApiKey[]>("/api-keys");
+  return data ?? [];
+}
+
+export async function createApiKey(name: string, expiresAt?: string | null): Promise<{ data: CreatedApiKey | null; status: number }> {
+  return meFetch<CreatedApiKey>("/api-keys", {
+    method: "POST",
+    body: JSON.stringify({ name, expiresAt: expiresAt ?? null }),
+  });
+}
+
+export async function revokeMyApiKey(id: string): Promise<boolean> {
+  const { status } = await meFetch(`/api-keys/${id}`, { method: "DELETE" });
+  return status === 200;
+}
+
+export interface AdminApiKeysList {
+  page: number;
+  limit: number;
+  total: number;
+  items: ApiKeyWithUser[];
+}
+
+export async function adminListApiKeys(params: {
+  userId?: string;
+  status?: "active" | "revoked" | "all";
+  page?: number;
+  limit?: number;
+} = {}): Promise<AdminApiKeysList | null> {
+  const q = new URLSearchParams();
+  if (params.userId) q.set("userId", params.userId);
+  if (params.status) q.set("status", params.status);
+  if (params.page) q.set("page", String(params.page));
+  if (params.limit) q.set("limit", String(params.limit));
+  const { data } = await adminFetch<AdminApiKeysList>(`/api-keys${q.toString() ? `?${q}` : ""}`);
+  return data;
+}
+
+export async function adminRevokeApiKey(id: string): Promise<boolean> {
+  const { status } = await adminFetch(`/api-keys/${id}`, { method: "DELETE" });
+  return status === 200;
+}


### PR DESCRIPTION
## Summary

- Nouveau composant `ApiKeysSection` : liste + création (affichage one-shot de la clé raw avec bouton Copier + avertissement) + révocation. Réutilisé dans `/admin/profile`.
- Nouvelle page `/admin/api-keys` (ADMIN-only, protégée par `nav-items.ts`) : vue paginée avec filtre de statut et action révoquer.
- Sidebar : entrée "Clés API" avec icône 🔑 (ADMIN-only).
- `admin-api.ts` : `listMyApiKeys`, `createApiKey`, `revokeMyApiKey`, `adminListApiKeys`, `adminRevokeApiKey`.
- `next.config.ts` : rewrites `/api/me/*` et `/api/docs/*` vers le backend.

## Test plan

- [ ] `/admin/profile` avec editor : section "Mes jetons d'API" s'affiche, création retourne la clé une fois, copie fonctionne, révocation update la liste
- [ ] `/admin/api-keys` avec editor : redirige vers "Accès réservé"
- [ ] `/admin/api-keys` avec admin : liste toutes les clés, filtre par statut, révocation d'une clé d'un autre user
- [ ] Test curl avec la clé Bearer sur `/api/admin/editions` → 200 si admin, 403 si editor
- [ ] Rebuild Docker local + vérification visuelle Chrome DevTools MCP

## Context

PR 4/8 du chantier `feature/public-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)