### PR TITLE
feat(openapi): annotate api-keys + health routes [PR 5/8]

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -8,6 +8,7 @@ import fastifyStatic from "@fastify/static";
 import { auth } from "./lib/auth.js";
 import { registerSwagger } from "./plugins/swagger.js";
 import { registerCommonSchemas } from "./schemas/common.js";
+import { registerApiKeySchemas } from "./schemas/api-key.js";
 import editionRoutes from "./routes/editions.js";
 import articleRoutes from "./routes/articles.js";
 import settingsRoutes from "./routes/settings.js";
@@ -69,14 +70,44 @@ await app.register(fastifyStatic, {
 // Exposes /api/docs (UI) and /api/docs/json (raw spec).
 await registerSwagger(app);
 registerCommonSchemas(app);
+registerApiKeySchemas(app);
 
 // Health check
-app.get("/api/health", async () => {
+app.get("/api/health", {
+  schema: {
+    tags: ["health"],
+    summary: "Sonde de santé du service",
+    response: {
+      200: {
+        type: "object",
+        properties: {
+          status: { type: "string", enum: ["ok"] },
+          timestamp: { type: "string", format: "date-time" },
+        },
+        required: ["status", "timestamp"],
+      },
+    },
+  },
+}, async () => {
   return { status: "ok", timestamp: new Date().toISOString() };
 });
 
 // Auth providers availability
-app.get("/api/auth/providers", async () => {
+app.get("/api/auth/providers", {
+  schema: {
+    tags: ["auth"],
+    summary: "Fournisseurs OAuth activés",
+    response: {
+      200: {
+        type: "object",
+        properties: {
+          google: { type: "boolean" },
+          github: { type: "boolean" },
+        },
+      },
+    },
+  },
+}, async () => {
   return {
     google: !!(process.env.OAUTH_GOOGLE_CLIENT_ID && process.env.OAUTH_GOOGLE_CLIENT_SECRET),
     github: !!(process.env.OAUTH_GITHUB_CLIENT_ID && process.env.OAUTH_GITHUB_CLIENT_SECRET),

--- a/src/backend/src/routes/admin/api-keys.ts
+++ b/src/backend/src/routes/admin/api-keys.ts
@@ -11,7 +11,35 @@ interface ListQuery {
 
 export default async function adminApiKeysRoutes(app: FastifyInstance) {
   // GET /api/admin/api-keys — global list with filters
-  app.get<{ Querystring: ListQuery }>("/api-keys", async (request) => {
+  app.get<{ Querystring: ListQuery }>("/api-keys", {
+    schema: {
+      tags: ["admin-api-keys"],
+      summary: "Vue d'ensemble admin des jetons (tous utilisateurs)",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      querystring: {
+        type: "object",
+        properties: {
+          userId: { type: "string" },
+          status: { type: "string", enum: ["active", "revoked", "all"] },
+          page: { type: "string" },
+          limit: { type: "string" },
+        },
+      },
+      response: {
+        200: {
+          type: "object",
+          required: ["page", "limit", "total", "items"],
+          properties: {
+            page: { type: "integer" },
+            limit: { type: "integer" },
+            total: { type: "integer" },
+            items: { type: "array", items: { $ref: "ApiKeyWithUser#" } },
+          },
+        },
+        403: { $ref: "Error#" },
+      },
+    },
+  }, async (request) => {
     const { userId, status = "all" } = request.query;
     const page = Math.max(1, Number(request.query.page) || 1);
     const limit = Math.min(100, Math.max(1, Number(request.query.limit) || 20));
@@ -52,7 +80,26 @@ export default async function adminApiKeysRoutes(app: FastifyInstance) {
   });
 
   // DELETE /api/admin/api-keys/:id — revoke any key
-  app.delete<{ Params: { id: string } }>("/api-keys/:id", async (request, reply) => {
+  app.delete<{ Params: { id: string } }>("/api-keys/:id", {
+    schema: {
+      tags: ["admin-api-keys"],
+      summary: "Révoquer n'importe quelle clé (ADMIN)",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      params: {
+        type: "object",
+        required: ["id"],
+        properties: { id: { type: "string" } },
+      },
+      response: {
+        200: {
+          type: "object",
+          properties: { ok: { type: "boolean" }, alreadyRevoked: { type: "boolean" } },
+        },
+        403: { $ref: "Error#" },
+        404: { $ref: "Error#" },
+      },
+    },
+  }, async (request, reply) => {
     const key = await prisma.apiKey.findUnique({ where: { id: request.params.id } });
     if (!key) return reply.status(404).send({ error: "not_found" });
     if (key.revokedAt) return reply.send({ ok: true, alreadyRevoked: true });

--- a/src/backend/src/routes/me/api-keys.ts
+++ b/src/backend/src/routes/me/api-keys.ts
@@ -47,7 +47,18 @@ export default async function myApiKeysRoutes(app: FastifyInstance) {
   app.addHook("preHandler", requireAnyAuthenticated);
 
   // GET /api/me/api-keys — list caller's own keys (never exposes raw/hash)
-  app.get("/api-keys", async (request) => {
+  app.get("/api-keys", {
+    schema: {
+      tags: ["api-keys"],
+      summary: "Lister ses propres jetons d'API",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      response: {
+        200: { type: "array", items: { $ref: "ApiKey#" } },
+        401: { $ref: "Error#" },
+        403: { $ref: "Error#" },
+      },
+    },
+  }, async (request) => {
     const user = getCurrentUser(request);
     const keys = await prisma.apiKey.findMany({
       where: { userId: user.id },
@@ -57,7 +68,33 @@ export default async function myApiKeysRoutes(app: FastifyInstance) {
   });
 
   // POST /api/me/api-keys — create a new key. The raw value is returned ONCE.
-  app.post<{ Body: CreateApiKeyBody }>("/api-keys", async (request, reply) => {
+  app.post<{ Body: CreateApiKeyBody }>("/api-keys", {
+    schema: {
+      tags: ["api-keys"],
+      summary: "Créer un nouveau jeton d'API",
+      description: "La valeur complète de la clé (`key`) n'est retournée qu'à la création. Stockez-la immédiatement.",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      body: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", minLength: 1, maxLength: 80, description: "Nom libre identifiant la clé" },
+          expiresAt: {
+            type: "string",
+            format: "date-time",
+            nullable: true,
+            description: "Date d'expiration ISO 8601 (optionnelle)",
+          },
+        },
+      },
+      response: {
+        201: { $ref: "CreatedApiKey#" },
+        400: { $ref: "Error#" },
+        401: { $ref: "Error#" },
+        403: { $ref: "Error#" },
+      },
+    },
+  }, async (request, reply) => {
     const user = getCurrentUser(request);
     const { name, expiresAt } = request.body ?? {};
 
@@ -107,7 +144,27 @@ export default async function myApiKeysRoutes(app: FastifyInstance) {
   });
 
   // DELETE /api/me/api-keys/:id — revoke caller's own key
-  app.delete<{ Params: { id: string } }>("/api-keys/:id", async (request, reply) => {
+  app.delete<{ Params: { id: string } }>("/api-keys/:id", {
+    schema: {
+      tags: ["api-keys"],
+      summary: "Révoquer un de ses propres jetons",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      params: {
+        type: "object",
+        required: ["id"],
+        properties: { id: { type: "string" } },
+      },
+      response: {
+        200: {
+          type: "object",
+          properties: { ok: { type: "boolean" }, alreadyRevoked: { type: "boolean" } },
+        },
+        401: { $ref: "Error#" },
+        403: { $ref: "Error#" },
+        404: { $ref: "Error#" },
+      },
+    },
+  }, async (request, reply) => {
     const user = getCurrentUser(request);
     const key = await prisma.apiKey.findUnique({ where: { id: request.params.id } });
     if (!key || key.userId !== user.id) {

--- a/src/backend/src/schemas/api-key.ts
+++ b/src/backend/src/schemas/api-key.ts
@@ -1,0 +1,62 @@
+import type { FastifyInstance } from "fastify";
+
+export function registerApiKeySchemas(app: FastifyInstance) {
+  app.addSchema({
+    $id: "ApiKey",
+    type: "object",
+    required: ["id", "name", "prefix", "createdAt"],
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      prefix: { type: "string", description: "Préfixe public de la clé (12 caractères après dft_<env>_)" },
+      lastUsedAt: { type: "string", format: "date-time", nullable: true },
+      expiresAt: { type: "string", format: "date-time", nullable: true },
+      revokedAt: { type: "string", format: "date-time", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+    },
+  });
+
+  app.addSchema({
+    $id: "ApiKeyWithUser",
+    type: "object",
+    required: ["id", "name", "prefix", "createdAt", "user"],
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      prefix: { type: "string" },
+      lastUsedAt: { type: "string", format: "date-time", nullable: true },
+      expiresAt: { type: "string", format: "date-time", nullable: true },
+      revokedAt: { type: "string", format: "date-time", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+      user: {
+        type: "object",
+        required: ["id", "email", "role"],
+        properties: {
+          id: { type: "string" },
+          email: { type: "string", format: "email" },
+          name: { type: "string", nullable: true },
+          role: { type: "string", enum: ["ADMIN", "EDITOR"] },
+        },
+      },
+    },
+  });
+
+  app.addSchema({
+    $id: "CreatedApiKey",
+    type: "object",
+    required: ["id", "name", "prefix", "key", "createdAt"],
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      prefix: { type: "string" },
+      key: {
+        type: "string",
+        description: "Valeur complète de la clé au format `dft_<env>_<random>`. N'est retournée qu'à la création.",
+      },
+      lastUsedAt: { type: "string", format: "date-time", nullable: true },
+      expiresAt: { type: "string", format: "date-time", nullable: true },
+      revokedAt: { type: "string", format: "date-time", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Annotations OpenAPI minimales pour le ship :

- Nouveau `src/schemas/api-key.ts` avec `ApiKey` / `ApiKeyWithUser` / `CreatedApiKey` référençables via `\$ref`.
- Routes `/api/me/api-keys` et `/api/admin/api-keys` : tags + security (bearerAuth, cookieAuth) + body/response schemas complets.
- `/api/health` et `/api/auth/providers` : schemas minimaux en exemple.

Les 25+ autres routes (editions, articles, pages, settings, contact, admin-*) restent **sans annotations détaillées** dans cette PR. Elles apparaissent toujours dans la spec mais sans détails body/response — TODO backlog dédié.

**Justification** : garder le diff revisable + débloquer les consommateurs externes qui ont juste besoin de `api-keys` + `health` pour commencer.

## Test plan

- [ ] `curl /api/docs/json | jq '.paths | keys'` → contient `/api/me/api-keys`, `/api/admin/api-keys`, `/api/health`, `/api/auth/providers`
- [ ] Swagger UI : bouton "Authorize" accepte `Bearer dft_...`
- [ ] "Try it out" sur `POST /api/me/api-keys` depuis l'UI → fonctionne

## Backlog

Annoter le reste : editions, articles, pages, settings, contact, admin-editions, admin-articles, admin-pages, admin-users, admin-settings, admin-contact, admin-tickets, admin-sponsor-plans, admin-images, admin-cache.

## Context

PR 5/8 du chantier `feature/public-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)