### PR TITLE
Public API: OpenAPI docs + user-owned API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Les spécifications du projet sont dans le dossier `docs/` :
 | [modele-donnees-metier.md](docs/modele-donnees-metier.md) | Modèle de données métier (entités, relations, bilingue) |
 | [maquettes-figma.md](docs/maquettes-figma.md) | Inventaire des maquettes Figma et structure des pages |
 | [design-system.md](docs/design-system.md) | Design system complet (charte, couleurs, typos, tokens, UI kit) |
+| [api-publique.md](docs/api-publique.md) | API REST publique : authentification, jetons, exemples curl |
+
+## API publique
+
+Le backend expose une API REST documentée via OpenAPI :
+
+- Documentation interactive : `https://devfesttoulouse.fr/api/docs` (Swagger UI)
+- Authentification par cookie de session ou jeton Bearer (`Authorization: Bearer dft_…`)
+- Création / révocation de jetons depuis [`/admin/profile`](https://devfesttoulouse.fr/admin/profile)
+- Voir [docs/api-publique.md](docs/api-publique.md) pour les détails et exemples.
 
 ## Données historiques
 

--- a/docs/api-publique.md
+++ b/docs/api-publique.md
@@ -1,0 +1,146 @@
+# API publique — DevFest Toulouse 2026
+
+Le backend expose une API REST documentée via OpenAPI/Swagger, consommable par le site, une application mobile, ou tout client externe (partenaires, scripts, intégrations).
+
+**URL de la doc interactive** : [`/api/docs`](https://devfesttoulouse.fr/api/docs) (Swagger UI)
+**Spec JSON brute** : `/api/docs/json` (OpenAPI 3.0.3)
+
+---
+
+## Authentification
+
+Deux mécanismes au choix, traités de manière équivalente par toutes les routes protégées :
+
+| Méthode | Usage typique | Entête |
+|---------|---------------|--------|
+| **Cookie de session** | Back-office (navigateur, Better Auth) | Automatique après `/admin` login |
+| **Jeton Bearer** | Scripts, apps mobiles, intégrations | `Authorization: Bearer dft_…` |
+
+### Obtenir un jeton Bearer
+
+1. Connectez-vous sur [`/admin`](https://devfesttoulouse.fr/admin) avec votre compte.
+2. Allez sur **Mon profil** (icône en bas à gauche de la sidebar).
+3. Section **Mes jetons d'API** → bouton **Nouveau jeton**.
+4. Choisissez un nom descriptif, éventuellement une date d'expiration, puis **Créer**.
+5. **Copiez la valeur affichée immédiatement** — elle ne sera plus jamais visible.
+
+Format : `dft_<env>_<32 caractères base64url>` — par exemple `dft_live_K8xQ2mZpV4nW7rJhBvTdY6LsCfNaGeDu`.
+
+### Révoquer un jeton
+
+- **En tant qu'utilisateur** : `/admin/profile` → bouton **Révoquer** en face de la clé.
+- **En tant qu'admin** : `/admin/api-keys` donne la vue d'ensemble de toutes les clés de tous les utilisateurs.
+
+La révocation prend effet **immédiatement** — les requêtes en cours sont rejetées avec un `401`.
+
+---
+
+## Niveaux d'accès
+
+Le jeton hérite **dynamiquement** du rôle de son propriétaire au moment de chaque requête.
+
+| Rôle | Peut accéder à |
+|------|----------------|
+| `ADMIN` | Toutes les routes, y compris `/api/admin/*` (éditions, paramètres, utilisateurs). |
+| `EDITOR` | Routes de contenu (articles, pages, fichiers, messages). Pas d'admin systèmes. |
+
+Si un administrateur rétrograde un utilisateur à `EDITOR`, **tous ses jetons perdent instantanément les droits d'admin**. Aucune action supplémentaire n'est requise.
+
+---
+
+## Limites
+
+| Limite | Valeur | Portée |
+|--------|--------|--------|
+| Rate-limit global | 200 requêtes / minute | Par IP |
+| Rate-limit auth | 10 requêtes / minute | Par IP, sur `/api/auth/*` |
+| Jetons actifs par utilisateur | 20 | Soft cap (les révoqués ne comptent pas) |
+
+À venir : rate-limit par clé (au lieu par IP), scopes granulaires.
+
+---
+
+## Exemples `curl`
+
+### Lire des ressources publiques (pas d'authentification)
+
+```bash
+curl https://devfesttoulouse.fr/api/editions
+curl https://devfesttoulouse.fr/api/editions/current
+curl https://devfesttoulouse.fr/api/articles/latest?limit=4
+```
+
+### Lire ses propres jetons d'API
+
+```bash
+curl -H "Authorization: Bearer dft_live_XXXXXXXX" \
+     https://devfesttoulouse.fr/api/me/api-keys
+```
+
+### Créer un nouvel article (ADMIN ou EDITOR)
+
+```bash
+curl -X POST https://devfesttoulouse.fr/api/admin/articles \
+  -H "Authorization: Bearer dft_live_XXXXXXXX" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "slug": "exemple",
+    "titleFr": "Titre FR",
+    "titleEn": "Title EN",
+    "contentFr": "…",
+    "contentEn": "…",
+    "status": "DRAFT"
+  }'
+```
+
+### Poster un message de contact (public)
+
+```bash
+curl -X POST https://devfesttoulouse.fr/api/contact/send \
+  -H "Content-Type: application/json" \
+  -d '{
+    "firstName": "Jane",
+    "lastName": "Doe",
+    "email": "jane@example.com",
+    "category": "sponsoring",
+    "message": "Bonjour, je souhaite sponsoriser l'\''édition 2026."
+  }'
+```
+
+---
+
+## Codes HTTP
+
+| Code | Signification |
+|------|---------------|
+| `200` | Succès |
+| `201` | Ressource créée |
+| `400` | Requête invalide (validation body / query) |
+| `401` | Non authentifié (aucun cookie ni Bearer valide) |
+| `403` | Authentifié mais droits insuffisants |
+| `404` | Ressource inexistante |
+| `429` | Rate-limit atteint |
+| `500` | Erreur serveur |
+
+Les réponses d'erreur suivent le schéma :
+```json
+{ "error": "code_court", "message": "description optionnelle" }
+```
+
+---
+
+## Bonnes pratiques
+
+- **Ne versionnez pas vos jetons** dans un dépôt Git public. Traitez-les comme un mot de passe.
+- **Rotez-les régulièrement** — créez-en un nouveau, basculez vos clients, révoquez l'ancien.
+- **Préférez un jeton par application** (un pour le site, un pour le script d'import, etc.) pour pouvoir révoquer ponctuellement.
+- **Utilisez la date d'expiration** pour les jetons courts (CI, scripts temporaires).
+- **Ne loggez pas la valeur** d'un jeton dans vos systèmes d'observabilité.
+
+---
+
+## Liens utiles
+
+- Documentation OpenAPI interactive : [`/api/docs`](https://devfesttoulouse.fr/api/docs)
+- Plan de construction de l'API : [`docs/plan-api-publique-et-jetons.md`](plan-api-publique-et-jetons.md)
+- Spécification métier du projet : [`docs/modele-donnees-metier.md`](modele-donnees-metier.md)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,8 +195,31 @@ model User {
 
   sessions         Session[]
   accounts         Account[]
+  apiKeys          ApiKey[]
 
   @@map("user")
+}
+
+// --- API Keys ---
+// Personal API tokens. Inherit their owner's role dynamically (no scopes in v1).
+// The raw key is shown once at creation, then only its argon2 hash is stored.
+
+model ApiKey {
+  id          String    @id @default(cuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name        String
+  prefix      String    @unique
+  hashedKey   String
+  lastUsedAt  DateTime?
+  expiresAt   DateTime?
+  revokedAt   DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([userId])
+  @@index([prefix])
+  @@map("api_key")
 }
 
 model Session {

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -21,6 +21,8 @@
     "@fastify/multipart": "^9.0.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^8.2.0",
+    "@fastify/swagger": "^9.7.0",
+    "@fastify/swagger-ui": "^5.2.5",
     "@prisma/client": "6",
     "better-auth": "^1.5.6",
     "fastify": "^5.8.4",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -23,6 +23,7 @@
     "@fastify/static": "^8.2.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.5",
+    "@node-rs/argon2": "^2.0.2",
     "@prisma/client": "6",
     "better-auth": "^1.5.6",
     "fastify": "^5.8.4",

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -26,12 +26,18 @@ importers:
       '@fastify/static':
         specifier: ^8.2.0
         version: 8.3.0
+      '@fastify/swagger':
+        specifier: ^9.7.0
+        version: 9.7.0
+      '@fastify/swagger-ui':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@prisma/client':
         specifier: '6'
         version: 6.19.2(prisma@6.19.2(typescript@6.0.2))(typescript@6.0.2)
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@6.19.2(prisma@6.19.2(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(pg@8.20.0)(prisma@6.19.2(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@6.19.2(prisma@6.19.2(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(pg@8.20.0)(prisma@6.19.2(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       fastify:
         specifier: ^5.8.4
         version: 5.8.4
@@ -56,7 +62,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -347,6 +353,15 @@ packages:
 
   '@fastify/static@8.3.0':
     resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
+
+  '@fastify/static@9.1.1':
+    resolution: {integrity: sha512-LHxFea3qdwe0Pbbkh/yux7/k6nFNLGTNcbLKVYgmRDB6LdDE/8TFSO7qWZ0IzM/nF6iwR8W03oFlwe4v79R1Ow==}
+
+  '@fastify/swagger-ui@5.2.5':
+    resolution: {integrity: sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==}
+
+  '@fastify/swagger@9.7.0':
+    resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -712,6 +727,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -725,6 +744,15 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   deepmerge-ts@7.1.5:
     resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
@@ -867,6 +895,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   helmet@8.1.0:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
@@ -911,6 +943,10 @@ packages:
 
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1023,6 +1059,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   mysql2@3.15.3:
     resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
     engines: {node: '>= 8.0'}
@@ -1064,6 +1103,9 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -1484,6 +1526,11 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -1717,6 +1764,33 @@ snapshots:
       fastq: 1.20.1
       glob: 11.1.0
 
+  '@fastify/static@9.1.1':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.1.0
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
+  '@fastify/swagger-ui@5.2.5':
+    dependencies:
+      '@fastify/static': 9.1.1
+      fastify-plugin: 5.1.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.3
+
+  '@fastify/swagger@9.7.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@isaacs/cliui@9.0.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -1862,13 +1936,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -1927,7 +2001,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@6.19.2(prisma@6.19.2(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(pg@8.20.0)(prisma@6.19.2(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(@prisma/client@6.19.2(prisma@6.19.2(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(pg@8.20.0)(prisma@6.19.2(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
@@ -1953,7 +2027,7 @@ snapshots:
       prisma: 6.19.2(typescript@6.0.2)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
+      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -2013,6 +2087,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
@@ -2024,6 +2100,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   deepmerge-ts@7.1.5: {}
 
@@ -2204,6 +2284,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   helmet@8.1.0: {}
 
   http-errors@2.0.1:
@@ -2243,6 +2329,14 @@ snapshots:
   json-schema-ref-resolver@3.0.0:
     dependencies:
       dequal: 2.0.3
+
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.3
+      fast-uri: 3.1.0
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   json-schema-traverse@1.0.0: {}
 
@@ -2325,6 +2419,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  ms@2.1.3: {}
+
   mysql2@3.15.3:
     dependencies:
       aws-ssl-profiles: 1.1.2
@@ -2366,6 +2462,8 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openapi-types@12.1.3: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -2694,7 +2792,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0):
+  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2707,14 +2805,15 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
+      yaml: 2.8.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -2731,7 +2830,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -2751,5 +2850,7 @@ snapshots:
   wrappy@1.0.2: {}
 
   xtend@4.0.2: {}
+
+  yaml@2.8.3: {}
 
   zod@4.3.6: {}

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^5.2.5
         version: 5.2.5
+      '@node-rs/argon2':
+        specifier: ^2.0.2
+        version: 2.0.2
       '@prisma/client':
         specifier: '6'
         version: 6.19.2(prisma@6.19.2(typescript@6.0.2))(typescript@6.0.2)
@@ -374,6 +377,9 @@ packages:
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
     peerDependencies:
@@ -387,6 +393,93 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    resolution: {integrity: sha512-DV/H8p/jt40lrao5z5g6nM9dPNPGEHL+aK6Iy/og+dbL503Uj0AHLqj1Hk9aVUSCNnsDdUEKp4TVMi0YakDYKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    resolution: {integrity: sha512-1LKwskau+8O1ktKx7TbK7jx1oMOMt4YEXZOdSNIar1TQKxm6isZ0cRXgHLibPHEcNHgYRsJWDE9zvDGBB17QDg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    resolution: {integrity: sha512-3TTNL/7wbcpNju5YcqUrCgXnXUSbD7ogeAKatzBVHsbpjZQbNb1NDxDjqqrWoTt6XL3z9mJUMGwbAk7zQltHtA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    resolution: {integrity: sha512-vNPfkLj5Ij5111UTiYuwgxMqE7DRbOS2y58O2DIySzSHbcnu+nipmRKg+P0doRq6eKIJStyBK8dQi5Ic8pFyDw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    resolution: {integrity: sha512-M8vQZk01qojQfCqQU0/O1j1a4zPPrz93zc9fSINY7Q/6RhQRBCYwDw7ltDCZXg5JRGlSaeS8cUXWyhPGar3cGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    resolution: {integrity: sha512-7EmmEPHLzcu0G2GDh30L6G48CH38roFC2dqlQJmtRCxs6no3tTE/pvgBGatTp/o2n2oyOJcfmgndVFcUpwMnww==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    resolution: {integrity: sha512-6lsYh3Ftbk+HAIZ7wNuRF4SZDtxtFTfK+HYFAQQyW7Ig3LHqasqwfUKRXVSV5tJ+xTnxjqgKzvZSUJCAyIfHew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    resolution: {integrity: sha512-Eisd7/NM0m23ijrGr6xI2iMocdOuyl6gO27gfMfya4C5BODbUSP7ljKJ7LrA0teqZMdYHesRDzx36Js++/vhiQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    resolution: {integrity: sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    resolution: {integrity: sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/argon2@2.0.2':
+    resolution: {integrity: sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg==}
+    engines: {node: '>= 10'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -1797,6 +1890,13 @@ snapshots:
 
   '@lukeed/ms@2.0.2': {}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
       '@emnapi/core': 1.9.1
@@ -1807,6 +1907,67 @@ snapshots:
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2@2.0.2':
+    optionalDependencies:
+      '@node-rs/argon2-android-arm-eabi': 2.0.2
+      '@node-rs/argon2-android-arm64': 2.0.2
+      '@node-rs/argon2-darwin-arm64': 2.0.2
+      '@node-rs/argon2-darwin-x64': 2.0.2
+      '@node-rs/argon2-freebsd-x64': 2.0.2
+      '@node-rs/argon2-linux-arm-gnueabihf': 2.0.2
+      '@node-rs/argon2-linux-arm64-gnu': 2.0.2
+      '@node-rs/argon2-linux-arm64-musl': 2.0.2
+      '@node-rs/argon2-linux-x64-gnu': 2.0.2
+      '@node-rs/argon2-linux-x64-musl': 2.0.2
+      '@node-rs/argon2-wasm32-wasi': 2.0.2
+      '@node-rs/argon2-win32-arm64-msvc': 2.0.2
+      '@node-rs/argon2-win32-ia32-msvc': 2.0.2
+      '@node-rs/argon2-win32-x64-msvc': 2.0.2
 
   '@opentelemetry/api@1.9.1': {}
 

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -6,6 +6,8 @@ import rateLimit from "@fastify/rate-limit";
 import multipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import { auth } from "./lib/auth.js";
+import { registerSwagger } from "./plugins/swagger.js";
+import { registerCommonSchemas } from "./schemas/common.js";
 import editionRoutes from "./routes/editions.js";
 import articleRoutes from "./routes/articles.js";
 import settingsRoutes from "./routes/settings.js";
@@ -61,6 +63,11 @@ await app.register(fastifyStatic, {
   prefix: "/uploads/",
   decorateReply: false,
 });
+
+// OpenAPI / Swagger — must be registered before routes so it can capture their schemas.
+// Exposes /api/docs (UI) and /api/docs/json (raw spec).
+await registerSwagger(app);
+registerCommonSchemas(app);
 
 // Health check
 app.get("/api/health", async () => {

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -8,6 +8,7 @@ import fastifyStatic from "@fastify/static";
 import { auth } from "./lib/auth.js";
 import { registerSwagger } from "./plugins/swagger.js";
 import { registerCommonSchemas } from "./schemas/common.js";
+import { registerApiKeySchemas } from "./schemas/api-key.js";
 import editionRoutes from "./routes/editions.js";
 import articleRoutes from "./routes/articles.js";
 import settingsRoutes from "./routes/settings.js";
@@ -69,14 +70,44 @@ await app.register(fastifyStatic, {
 // Exposes /api/docs (UI) and /api/docs/json (raw spec).
 await registerSwagger(app);
 registerCommonSchemas(app);
+registerApiKeySchemas(app);
 
 // Health check
-app.get("/api/health", async () => {
+app.get("/api/health", {
+  schema: {
+    tags: ["health"],
+    summary: "Sonde de santé du service",
+    response: {
+      200: {
+        type: "object",
+        properties: {
+          status: { type: "string", enum: ["ok"] },
+          timestamp: { type: "string", format: "date-time" },
+        },
+        required: ["status", "timestamp"],
+      },
+    },
+  },
+}, async () => {
   return { status: "ok", timestamp: new Date().toISOString() };
 });
 
 // Auth providers availability
-app.get("/api/auth/providers", async () => {
+app.get("/api/auth/providers", {
+  schema: {
+    tags: ["auth"],
+    summary: "Fournisseurs OAuth activés",
+    response: {
+      200: {
+        type: "object",
+        properties: {
+          google: { type: "boolean" },
+          github: { type: "boolean" },
+        },
+      },
+    },
+  },
+}, async () => {
   return {
     google: !!(process.env.OAUTH_GOOGLE_CLIENT_ID && process.env.OAUTH_GOOGLE_CLIENT_SECRET),
     github: !!(process.env.OAUTH_GITHUB_CLIENT_ID && process.env.OAUTH_GITHUB_CLIENT_SECRET),

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -13,6 +13,7 @@ import articleRoutes from "./routes/articles.js";
 import settingsRoutes from "./routes/settings.js";
 import pageRoutes from "./routes/pages.js";
 import contactRoutes from "./routes/contact.js";
+import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
 const port = Number(process.env.PORT) || 4000;
@@ -142,6 +143,9 @@ await app.register(articleRoutes, { prefix: "/api" });
 await app.register(settingsRoutes, { prefix: "/api" });
 await app.register(pageRoutes, { prefix: "/api" });
 await app.register(contactRoutes, { prefix: "/api" });
+
+// Per-user routes (any authenticated back-office user — own resources only)
+await app.register(myApiKeysRoutes, { prefix: "/api/me" });
 
 // Admin routes (protected by requireAdmin hook)
 await app.register(adminRoutes, { prefix: "/api/admin" });

--- a/src/backend/src/lib/admin-guard.ts
+++ b/src/backend/src/lib/admin-guard.ts
@@ -1,67 +1,39 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
-import { fromNodeHeaders } from "better-auth/node";
-import { auth } from "./auth.js";
-import { prisma } from "./prisma.js";
+
+import { getAuthContext, type AuthContext } from "./auth-context.js";
 
 // Source of truth for back-office access: the user.role column in DB.
 // ADMIN_EMAILS is only used at bootstrap (prisma/seed.ts) to create the very
 // first admin account. After that, admins grant / revoke access through the
 // back-office (Utilisateurs page) which writes to user.role.
-async function getSessionUser(request: FastifyRequest) {
-  request.log.debug({ authPhase: "guard.enter", url: request.url, method: request.method, hasCookie: !!request.headers.cookie });
-
-  const session = await auth.api.getSession({
-    headers: fromNodeHeaders(request.headers),
-  });
-
-  request.log.debug({
-    authPhase: "guard.session",
-    session: session ? { userId: session.user.id, email: session.user.email } : null,
-  });
-
-  if (!session) return null;
-
-  const user = await prisma.user.findUnique({
-    where: { email: session.user.email },
-    select: { role: true, banned: true },
-  });
-
-  request.log.debug({ authPhase: "guard.dbUser", user });
-
-  if (!user || user.banned) {
-    request.log.debug({ authPhase: "guard.reject", reason: !user ? "no_user" : "banned" });
-    return null;
-  }
-  if (user.role !== "ADMIN" && user.role !== "EDITOR") {
-    request.log.debug({ authPhase: "guard.reject", reason: "bad_role", role: user.role });
-    return null;
-  }
-
-  request.log.debug({ authPhase: "guard.accept", role: user.role });
-  return {
-    ...session.user,
-    role: user.role,
-  };
-}
+//
+// Auth can come from either a Better Auth session cookie (browser back-office)
+// or an API key sent as `Authorization: Bearer <token>` (external clients).
+// `getAuthContext` handles both paths and returns the resolved user + source.
 
 /** Requires any authenticated back-office user (ADMIN or EDITOR) */
 export async function requireAdmin(request: FastifyRequest, reply: FastifyReply) {
-  const user = await getSessionUser(request);
-  if (!user) {
+  const ctx = await getAuthContext(request);
+  if (!ctx) {
     request.log.debug({ authPhase: "requireAdmin.deny" });
     reply.status(403).send({ error: "Forbidden" });
     return;
   }
-  (request as FastifyRequest & { adminUser?: typeof user }).adminUser = user;
+  if (ctx.user.role !== "ADMIN" && ctx.user.role !== "EDITOR") {
+    request.log.debug({ authPhase: "requireAdmin.deny", reason: "bad_role", role: ctx.user.role });
+    reply.status(403).send({ error: "Forbidden" });
+    return;
+  }
+  (request as FastifyRequest & { adminUser?: AuthContext["user"] }).adminUser = ctx.user;
 }
 
 /** Requires ADMIN role specifically (not EDITOR) */
 export async function requireAdminRole(request: FastifyRequest, reply: FastifyReply) {
-  const user = await getSessionUser(request);
-  if (!user || user.role !== "ADMIN") {
-    request.log.debug({ authPhase: "requireAdminRole.deny", role: user?.role ?? null });
+  const ctx = await getAuthContext(request);
+  if (!ctx || ctx.user.role !== "ADMIN") {
+    request.log.debug({ authPhase: "requireAdminRole.deny", role: ctx?.user.role ?? null });
     reply.status(403).send({ error: "Forbidden — admin only" });
     return;
   }
-  (request as FastifyRequest & { adminUser?: typeof user }).adminUser = user;
+  (request as FastifyRequest & { adminUser?: AuthContext["user"] }).adminUser = ctx.user;
 }

--- a/src/backend/src/lib/api-key.test.ts
+++ b/src/backend/src/lib/api-key.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+
+import { generateApiKey, verifyApiKey, extractPrefix, resolveApiKeyEnv } from "./api-key.js";
+
+describe("generateApiKey", () => {
+  it("produces a key matching the expected shape", async () => {
+    const { raw, prefix, hashedKey } = await generateApiKey("dev");
+    expect(raw.startsWith("dft_dev_")).toBe(true);
+    expect(raw.length).toBeGreaterThan(32);
+    expect(prefix).toBe(raw.slice(0, "dft_dev_".length + 12));
+    expect(hashedKey.startsWith("$argon2id$")).toBe(true);
+  });
+
+  it("produces distinct keys on each call", async () => {
+    const a = await generateApiKey("dev");
+    const b = await generateApiKey("dev");
+    expect(a.raw).not.toBe(b.raw);
+    expect(a.hashedKey).not.toBe(b.hashedKey);
+  });
+
+  it("respects the requested environment segment", async () => {
+    const live = await generateApiKey("live");
+    const beta = await generateApiKey("beta");
+    expect(live.raw.startsWith("dft_live_")).toBe(true);
+    expect(beta.raw.startsWith("dft_beta_")).toBe(true);
+  });
+});
+
+describe("verifyApiKey", () => {
+  it("accepts the matching raw key", async () => {
+    const { raw, hashedKey } = await generateApiKey("dev");
+    expect(await verifyApiKey(raw, hashedKey)).toBe(true);
+  });
+
+  it("rejects a different raw key", async () => {
+    const { hashedKey } = await generateApiKey("dev");
+    const { raw: otherRaw } = await generateApiKey("dev");
+    expect(await verifyApiKey(otherRaw, hashedKey)).toBe(false);
+  });
+
+  it("rejects a tampered key without throwing", async () => {
+    const { raw, hashedKey } = await generateApiKey("dev");
+    const tampered = raw.slice(0, -4) + "XXXX";
+    expect(await verifyApiKey(tampered, hashedKey)).toBe(false);
+  });
+});
+
+describe("extractPrefix", () => {
+  it("returns the public prefix of a well-formed key", async () => {
+    const { raw, prefix } = await generateApiKey("dev");
+    expect(extractPrefix(raw)).toBe(prefix);
+  });
+
+  it("returns null for malformed keys", () => {
+    expect(extractPrefix("not-a-key")).toBeNull();
+    expect(extractPrefix("dft_live_")).toBeNull();
+    expect(extractPrefix("dft_staging_abc")).toBeNull();
+  });
+});
+
+describe("resolveApiKeyEnv", () => {
+  it("returns dev outside of production", () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    expect(resolveApiKeyEnv()).toBe("dev");
+    process.env.NODE_ENV = prev;
+  });
+
+  it("returns beta when BASE_URL contains beta.", () => {
+    const prevNode = process.env.NODE_ENV;
+    const prevBase = process.env.BASE_URL;
+    process.env.NODE_ENV = "production";
+    process.env.BASE_URL = "https://beta.site.devfesttoulouse.fr";
+    expect(resolveApiKeyEnv()).toBe("beta");
+    process.env.NODE_ENV = prevNode;
+    process.env.BASE_URL = prevBase;
+  });
+
+  it("returns live in production otherwise", () => {
+    const prevNode = process.env.NODE_ENV;
+    const prevBase = process.env.BASE_URL;
+    process.env.NODE_ENV = "production";
+    process.env.BASE_URL = "https://devfesttoulouse.fr";
+    expect(resolveApiKeyEnv()).toBe("live");
+    process.env.NODE_ENV = prevNode;
+    process.env.BASE_URL = prevBase;
+  });
+});

--- a/src/backend/src/lib/api-key.ts
+++ b/src/backend/src/lib/api-key.ts
@@ -1,0 +1,68 @@
+import { randomBytes } from "node:crypto";
+import { hash, verify, Algorithm } from "@node-rs/argon2";
+
+// The prefix that visually identifies a DevFest Toulouse API key.
+// Format: dft_<env>_<random>. The <env> segment mirrors the deployment
+// environment (live, beta, dev) so a leaked key is immediately traceable.
+const KEY_PREFIX = "dft";
+
+// First N characters of the raw key that we also store in plaintext for
+// identification/lookup. 12 characters give enough entropy to make the
+// index lookup virtually collision-free while still hiding the full secret.
+const PREFIX_LOOKUP_LENGTH = 12;
+
+// argon2id is the recommended profile for secrets with high entropy (like
+// random tokens). Default parameters are safe; we pin them explicitly so a
+// library upgrade can't silently weaken hashes at rest.
+const ARGON2_OPTIONS = {
+  algorithm: Algorithm.Argon2id,
+  memoryCost: 19456, // 19 MiB
+  timeCost: 2,
+  parallelism: 1,
+} as const;
+
+export type ApiKeyEnv = "live" | "beta" | "dev";
+
+export interface GeneratedApiKey {
+  /** Full plaintext key — returned once to the user, never stored. */
+  raw: string;
+  /** Indexed lookup prefix stored as-is in DB. */
+  prefix: string;
+  /** Argon2 hash of the full raw key. */
+  hashedKey: string;
+}
+
+/**
+ * Resolve the env segment baked into newly generated keys from the runtime
+ * context. Production keys have `live`, the beta environment uses `beta`,
+ * and every other case (dev-j, local, tests) falls back to `dev`.
+ */
+export function resolveApiKeyEnv(): ApiKeyEnv {
+  if (process.env.NODE_ENV !== "production") return "dev";
+  const baseUrl = process.env.BASE_URL ?? "";
+  if (baseUrl.includes("beta.")) return "beta";
+  return "live";
+}
+
+export async function generateApiKey(env: ApiKeyEnv): Promise<GeneratedApiKey> {
+  const random = randomBytes(32).toString("base64url");
+  const raw = `${KEY_PREFIX}_${env}_${random}`;
+  const prefix = raw.slice(0, KEY_PREFIX.length + 1 + env.length + 1 + PREFIX_LOOKUP_LENGTH);
+  const hashedKey = await hash(raw, ARGON2_OPTIONS);
+  return { raw, prefix, hashedKey };
+}
+
+export function extractPrefix(raw: string): string | null {
+  const match = raw.match(/^dft_(live|beta|dev)_[A-Za-z0-9_-]+$/);
+  if (!match) return null;
+  const envLen = match[1].length;
+  return raw.slice(0, KEY_PREFIX.length + 1 + envLen + 1 + PREFIX_LOOKUP_LENGTH);
+}
+
+export async function verifyApiKey(raw: string, hashedKey: string): Promise<boolean> {
+  try {
+    return await verify(hashedKey, raw);
+  } catch {
+    return false;
+  }
+}

--- a/src/backend/src/lib/auth-context.ts
+++ b/src/backend/src/lib/auth-context.ts
@@ -1,0 +1,138 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import type { UserRole } from "@prisma/client";
+import { fromNodeHeaders } from "better-auth/node";
+
+import { auth } from "./auth.js";
+import { prisma } from "./prisma.js";
+import { extractPrefix, verifyApiKey } from "./api-key.js";
+
+// Update `lastUsedAt` at most once per minute to avoid spamming the DB on
+// high-traffic keys. Good enough for "seen recently" UI hints.
+const LAST_USED_THROTTLE_MS = 60_000;
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  name: string | null;
+  role: UserRole;
+}
+
+export interface AuthContext {
+  user: AuthenticatedUser;
+  source: "session" | "apiKey";
+}
+
+async function resolveSession(request: FastifyRequest): Promise<AuthenticatedUser | null> {
+  request.log.debug({ authPhase: "auth-context.session.try", hasCookie: !!request.headers.cookie });
+
+  const session = await auth.api.getSession({
+    headers: fromNodeHeaders(request.headers),
+  });
+  if (!session) return null;
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { id: true, email: true, name: true, role: true, banned: true },
+  });
+  if (!user || user.banned) {
+    request.log.debug({ authPhase: "auth-context.session.reject", reason: !user ? "no_user" : "banned" });
+    return null;
+  }
+  request.log.debug({ authPhase: "auth-context.session.ok", role: user.role });
+  return { id: user.id, email: user.email, name: user.name, role: user.role };
+}
+
+async function resolveBearer(request: FastifyRequest): Promise<AuthenticatedUser | null> {
+  const authHeader = request.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+
+  const raw = authHeader.slice("Bearer ".length).trim();
+  if (!raw) return null;
+
+  const prefix = extractPrefix(raw);
+  if (!prefix) {
+    request.log.debug({ authPhase: "auth-context.bearer.reject", reason: "bad_format" });
+    return null;
+  }
+
+  const apiKey = await prisma.apiKey.findUnique({
+    where: { prefix },
+    include: {
+      user: { select: { id: true, email: true, name: true, role: true, banned: true } },
+    },
+  });
+  if (!apiKey) {
+    request.log.debug({ authPhase: "auth-context.bearer.reject", reason: "unknown_prefix" });
+    return null;
+  }
+  if (apiKey.revokedAt) {
+    request.log.debug({ authPhase: "auth-context.bearer.reject", reason: "revoked", keyId: apiKey.id });
+    return null;
+  }
+  if (apiKey.expiresAt && apiKey.expiresAt <= new Date()) {
+    request.log.debug({ authPhase: "auth-context.bearer.reject", reason: "expired", keyId: apiKey.id });
+    return null;
+  }
+  if (apiKey.user.banned) {
+    request.log.debug({ authPhase: "auth-context.bearer.reject", reason: "user_banned", keyId: apiKey.id });
+    return null;
+  }
+
+  const ok = await verifyApiKey(raw, apiKey.hashedKey);
+  if (!ok) {
+    request.log.debug({ authPhase: "auth-context.bearer.reject", reason: "bad_hash", keyId: apiKey.id });
+    return null;
+  }
+
+  // Throttled lastUsedAt refresh.
+  const now = Date.now();
+  const lastUsed = apiKey.lastUsedAt?.getTime() ?? 0;
+  if (now - lastUsed > LAST_USED_THROTTLE_MS) {
+    await prisma.apiKey.update({
+      where: { id: apiKey.id },
+      data: { lastUsedAt: new Date(now) },
+    });
+  }
+
+  request.log.debug({ authPhase: "auth-context.bearer.ok", keyId: apiKey.id, role: apiKey.user.role });
+  return {
+    id: apiKey.user.id,
+    email: apiKey.user.email,
+    name: apiKey.user.name,
+    role: apiKey.user.role,
+  };
+}
+
+/**
+ * Resolve the current caller by trying (in order): a Better Auth session
+ * cookie, then an `Authorization: Bearer <api-key>` header. Returns null
+ * if neither succeeds. The caller's role reflects the DB state at request
+ * time, so API tokens always mirror their owner's current role.
+ */
+export async function getAuthContext(request: FastifyRequest): Promise<AuthContext | null> {
+  const sessionUser = await resolveSession(request);
+  if (sessionUser) return { user: sessionUser, source: "session" };
+
+  const apiKeyUser = await resolveBearer(request);
+  if (apiKeyUser) return { user: apiKeyUser, source: "apiKey" };
+
+  return null;
+}
+
+/**
+ * preHandler that requires ANY authenticated back-office user (ADMIN or
+ * EDITOR). Used for per-user routes such as `/api/me/*` where ownership
+ * is enforced inside the handler.
+ */
+export async function requireAnyAuthenticated(request: FastifyRequest, reply: FastifyReply) {
+  const ctx = await getAuthContext(request);
+  if (!ctx) {
+    reply.status(401).send({ error: "Unauthenticated" });
+    return;
+  }
+  if (ctx.user.role !== "ADMIN" && ctx.user.role !== "EDITOR") {
+    reply.status(403).send({ error: "Forbidden" });
+    return;
+  }
+  (request as FastifyRequest & { authContext?: AuthContext }).authContext = ctx;
+}

--- a/src/backend/src/plugins/swagger.ts
+++ b/src/backend/src/plugins/swagger.ts
@@ -1,0 +1,77 @@
+import type { FastifyInstance } from "fastify";
+import swagger from "@fastify/swagger";
+import swaggerUi from "@fastify/swagger-ui";
+
+// Hardcoded API version. Bump alongside `package.json#version` on breaking
+// changes. Reading the file dynamically would tie us to where node started
+// (different in dev/build/prod) and add filesystem coupling for one number.
+const apiVersion = "0.1.0";
+
+const apiTags = [
+  { name: "health", description: "Sondes de santé du service" },
+  { name: "editions", description: "Éditions du DevFest (lecture publique)" },
+  { name: "articles", description: "Articles du blog (lecture publique)" },
+  { name: "pages", description: "Pages de contenu (CGU, mentions légales, etc.)" },
+  { name: "settings", description: "Paramètres publics du site" },
+  { name: "contact", description: "Formulaire de contact" },
+  { name: "auth", description: "Authentification (Better Auth) — proxy non documenté ici" },
+  { name: "api-keys", description: "Jetons d'API personnels" },
+  { name: "admin-editions", description: "Administration des éditions" },
+  { name: "admin-articles", description: "Administration des articles" },
+  { name: "admin-pages", description: "Administration des pages de contenu" },
+  { name: "admin-users", description: "Administration des utilisateurs" },
+  { name: "admin-settings", description: "Administration des paramètres" },
+  { name: "admin-contact", description: "Administration des messages de contact" },
+  { name: "admin-tickets", description: "Administration des tarifs de billetterie" },
+  { name: "admin-sponsor-plans", description: "Administration des offres de sponsoring" },
+  { name: "admin-images", description: "Administration des fichiers" },
+  { name: "admin-cache", description: "Invalidation du cache HTTP" },
+  { name: "admin-api-keys", description: "Vue d'ensemble admin des jetons d'API" },
+];
+
+export async function registerSwagger(app: FastifyInstance) {
+  await app.register(swagger, {
+    openapi: {
+      info: {
+        title: "DevFest Toulouse 2026 — API",
+        description:
+          "API REST publique du site DevFest Toulouse 2026. " +
+          "Authentification : cookie de session (Better Auth, via `/api/auth/*`) " +
+          "ou jeton Bearer (`Authorization: Bearer dft_…`) généré depuis " +
+          "le back-office (page Profil > Mes jetons d'API).",
+        version: apiVersion,
+        contact: { email: "contact@devfesttoulouse.fr" },
+      },
+      servers: [
+        { url: "/", description: "Serveur courant" },
+      ],
+      tags: apiTags,
+      components: {
+        securitySchemes: {
+          bearerAuth: {
+            type: "http",
+            scheme: "bearer",
+            bearerFormat: "Token",
+            description: "Jeton d'API au format `dft_<env>_<random>`. À placer dans l'en-tête `Authorization: Bearer <token>`.",
+          },
+          cookieAuth: {
+            type: "apiKey",
+            in: "cookie",
+            name: "better-auth.session_token",
+            description: "Cookie de session Better Auth (positionné automatiquement après login depuis le back-office).",
+          },
+        },
+      },
+    },
+  });
+
+  await app.register(swaggerUi, {
+    routePrefix: "/api/docs",
+    uiConfig: {
+      docExpansion: "list",
+      deepLinking: true,
+      persistAuthorization: true,
+    },
+    staticCSP: true,
+  });
+}

--- a/src/backend/src/routes/admin/api-keys.ts
+++ b/src/backend/src/routes/admin/api-keys.ts
@@ -1,0 +1,65 @@
+import type { FastifyInstance } from "fastify";
+
+import { prisma } from "../../lib/prisma.js";
+
+interface ListQuery {
+  userId?: string;
+  status?: "active" | "revoked" | "all";
+  page?: string;
+  limit?: string;
+}
+
+export default async function adminApiKeysRoutes(app: FastifyInstance) {
+  // GET /api/admin/api-keys — global list with filters
+  app.get<{ Querystring: ListQuery }>("/api-keys", async (request) => {
+    const { userId, status = "all" } = request.query;
+    const page = Math.max(1, Number(request.query.page) || 1);
+    const limit = Math.min(100, Math.max(1, Number(request.query.limit) || 20));
+
+    const where: Record<string, unknown> = {};
+    if (userId) where.userId = userId;
+    if (status === "active") where.revokedAt = null;
+    else if (status === "revoked") where.revokedAt = { not: null };
+
+    const [total, items] = await Promise.all([
+      prisma.apiKey.count({ where }),
+      prisma.apiKey.findMany({
+        where,
+        include: {
+          user: { select: { id: true, email: true, name: true, role: true } },
+        },
+        orderBy: [{ createdAt: "desc" }],
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+    ]);
+
+    return {
+      page,
+      limit,
+      total,
+      items: items.map((k) => ({
+        id: k.id,
+        name: k.name,
+        prefix: k.prefix,
+        lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
+        expiresAt: k.expiresAt?.toISOString() ?? null,
+        revokedAt: k.revokedAt?.toISOString() ?? null,
+        createdAt: k.createdAt.toISOString(),
+        user: k.user,
+      })),
+    };
+  });
+
+  // DELETE /api/admin/api-keys/:id — revoke any key
+  app.delete<{ Params: { id: string } }>("/api-keys/:id", async (request, reply) => {
+    const key = await prisma.apiKey.findUnique({ where: { id: request.params.id } });
+    if (!key) return reply.status(404).send({ error: "not_found" });
+    if (key.revokedAt) return reply.send({ ok: true, alreadyRevoked: true });
+    await prisma.apiKey.update({
+      where: { id: key.id },
+      data: { revokedAt: new Date() },
+    });
+    return { ok: true };
+  });
+}

--- a/src/backend/src/routes/admin/api-keys.ts
+++ b/src/backend/src/routes/admin/api-keys.ts
@@ -11,7 +11,35 @@ interface ListQuery {
 
 export default async function adminApiKeysRoutes(app: FastifyInstance) {
   // GET /api/admin/api-keys — global list with filters
-  app.get<{ Querystring: ListQuery }>("/api-keys", async (request) => {
+  app.get<{ Querystring: ListQuery }>("/api-keys", {
+    schema: {
+      tags: ["admin-api-keys"],
+      summary: "Vue d'ensemble admin des jetons (tous utilisateurs)",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      querystring: {
+        type: "object",
+        properties: {
+          userId: { type: "string" },
+          status: { type: "string", enum: ["active", "revoked", "all"] },
+          page: { type: "string" },
+          limit: { type: "string" },
+        },
+      },
+      response: {
+        200: {
+          type: "object",
+          required: ["page", "limit", "total", "items"],
+          properties: {
+            page: { type: "integer" },
+            limit: { type: "integer" },
+            total: { type: "integer" },
+            items: { type: "array", items: { $ref: "ApiKeyWithUser#" } },
+          },
+        },
+        403: { $ref: "Error#" },
+      },
+    },
+  }, async (request) => {
     const { userId, status = "all" } = request.query;
     const page = Math.max(1, Number(request.query.page) || 1);
     const limit = Math.min(100, Math.max(1, Number(request.query.limit) || 20));
@@ -52,7 +80,26 @@ export default async function adminApiKeysRoutes(app: FastifyInstance) {
   });
 
   // DELETE /api/admin/api-keys/:id — revoke any key
-  app.delete<{ Params: { id: string } }>("/api-keys/:id", async (request, reply) => {
+  app.delete<{ Params: { id: string } }>("/api-keys/:id", {
+    schema: {
+      tags: ["admin-api-keys"],
+      summary: "Révoquer n'importe quelle clé (ADMIN)",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      params: {
+        type: "object",
+        required: ["id"],
+        properties: { id: { type: "string" } },
+      },
+      response: {
+        200: {
+          type: "object",
+          properties: { ok: { type: "boolean" }, alreadyRevoked: { type: "boolean" } },
+        },
+        403: { $ref: "Error#" },
+        404: { $ref: "Error#" },
+      },
+    },
+  }, async (request, reply) => {
     const key = await prisma.apiKey.findUnique({ where: { id: request.params.id } });
     if (!key) return reply.status(404).send({ error: "not_found" });
     if (key.revokedAt) return reply.send({ ok: true, alreadyRevoked: true });

--- a/src/backend/src/routes/admin/auth.ts
+++ b/src/backend/src/routes/admin/auth.ts
@@ -1,61 +1,43 @@
-import type { FastifyInstance, FastifyRequest } from "fastify";
-import { fromNodeHeaders } from "better-auth/node";
-import { auth } from "../../lib/auth.js";
-import { prisma } from "../../lib/prisma.js";
+import type { FastifyInstance } from "fastify";
 
-// Helper — same rule as admin-guard: rely on user.role in DB, not on the
-// ADMIN_EMAILS env var (which is only used at bootstrap).
-async function getSessionWithRole(request: FastifyRequest) {
-  request.log.debug({ authPhase: "adminAuth.enter", url: request.url, hasCookie: !!request.headers.cookie });
-  const session = await auth.api.getSession({ headers: fromNodeHeaders(request.headers) });
-  request.log.debug({
-    authPhase: "adminAuth.session",
-    session: session ? { userId: session.user.id, email: session.user.email } : null,
-  });
-  if (!session) return null;
-  const user = await prisma.user.findUnique({
-    where: { email: session.user.email },
-    select: { role: true, banned: true },
-  });
-  request.log.debug({ authPhase: "adminAuth.dbUser", user });
-  if (!user || user.banned) {
-    request.log.debug({ authPhase: "adminAuth.reject", reason: !user ? "no_user" : "banned" });
-    return null;
-  }
-  if (user.role !== "ADMIN" && user.role !== "EDITOR") {
-    request.log.debug({ authPhase: "adminAuth.reject", reason: "bad_role", role: user.role });
-    return null;
-  }
-  request.log.debug({ authPhase: "adminAuth.accept", role: user.role });
-  return { session, role: user.role };
-}
+import { prisma } from "../../lib/prisma.js";
+import { getAuthContext } from "../../lib/auth-context.js";
+
+// /api/admin/auth — self-check for the current caller (session cookie or API key).
+// Anyone with a valid back-office identity (ADMIN or EDITOR) can read it.
 
 export default async function adminAuthRoutes(app: FastifyInstance) {
-  // GET /api/admin/session — returns current back-office session info with role
+  // GET /api/admin/session — returns current back-office identity with role
   app.get("/session", async (request, reply) => {
-    const ctx = await getSessionWithRole(request);
+    const ctx = await getAuthContext(request);
     if (!ctx) return reply.status(403).send({ error: "Forbidden" });
+    if (ctx.user.role !== "ADMIN" && ctx.user.role !== "EDITOR") {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
 
     return {
       user: {
-        id: ctx.session.user.id,
-        email: ctx.session.user.email,
-        name: ctx.session.user.name,
-        image: ctx.session.user.image,
-        role: ctx.role,
+        id: ctx.user.id,
+        email: ctx.user.email,
+        name: ctx.user.name,
+        role: ctx.user.role,
       },
+      source: ctx.source,
     };
   });
 
   // PUT /api/admin/profile — update current user's name
   app.put<{ Body: { name?: string } }>("/profile", async (request, reply) => {
-    const ctx = await getSessionWithRole(request);
+    const ctx = await getAuthContext(request);
     if (!ctx) return reply.status(403).send({ error: "Forbidden" });
+    if (ctx.user.role !== "ADMIN" && ctx.user.role !== "EDITOR") {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
 
     const { name } = request.body;
 
     const updated = await prisma.user.update({
-      where: { id: ctx.session.user.id },
+      where: { id: ctx.user.id },
       data: {
         ...(name !== undefined && { name: name.trim() || null }),
       },

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -11,6 +11,7 @@ import adminContactRoutes from "./contact.js";
 import adminImageRoutes from "./images.js";
 import adminUserRoutes from "./users.js";
 import adminSponsorPlanRoutes from "./sponsor-plans.js";
+import adminApiKeyRoutes from "./api-keys.js";
 
 export default async function adminRoutes(app: FastifyInstance) {
   // Auth check route (does its own auth check internally)
@@ -34,5 +35,6 @@ export default async function adminRoutes(app: FastifyInstance) {
     await adminApp.register(adminSettingsRoutes);
     await adminApp.register(adminUserRoutes);
     await adminApp.register(adminSponsorPlanRoutes);
+    await adminApp.register(adminApiKeyRoutes);
   });
 }

--- a/src/backend/src/routes/me/api-keys.ts
+++ b/src/backend/src/routes/me/api-keys.ts
@@ -47,7 +47,18 @@ export default async function myApiKeysRoutes(app: FastifyInstance) {
   app.addHook("preHandler", requireAnyAuthenticated);
 
   // GET /api/me/api-keys — list caller's own keys (never exposes raw/hash)
-  app.get("/api-keys", async (request) => {
+  app.get("/api-keys", {
+    schema: {
+      tags: ["api-keys"],
+      summary: "Lister ses propres jetons d'API",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      response: {
+        200: { type: "array", items: { $ref: "ApiKey#" } },
+        401: { $ref: "Error#" },
+        403: { $ref: "Error#" },
+      },
+    },
+  }, async (request) => {
     const user = getCurrentUser(request);
     const keys = await prisma.apiKey.findMany({
       where: { userId: user.id },
@@ -57,7 +68,33 @@ export default async function myApiKeysRoutes(app: FastifyInstance) {
   });
 
   // POST /api/me/api-keys — create a new key. The raw value is returned ONCE.
-  app.post<{ Body: CreateApiKeyBody }>("/api-keys", async (request, reply) => {
+  app.post<{ Body: CreateApiKeyBody }>("/api-keys", {
+    schema: {
+      tags: ["api-keys"],
+      summary: "Créer un nouveau jeton d'API",
+      description: "La valeur complète de la clé (`key`) n'est retournée qu'à la création. Stockez-la immédiatement.",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      body: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", minLength: 1, maxLength: 80, description: "Nom libre identifiant la clé" },
+          expiresAt: {
+            type: "string",
+            format: "date-time",
+            nullable: true,
+            description: "Date d'expiration ISO 8601 (optionnelle)",
+          },
+        },
+      },
+      response: {
+        201: { $ref: "CreatedApiKey#" },
+        400: { $ref: "Error#" },
+        401: { $ref: "Error#" },
+        403: { $ref: "Error#" },
+      },
+    },
+  }, async (request, reply) => {
     const user = getCurrentUser(request);
     const { name, expiresAt } = request.body ?? {};
 
@@ -107,7 +144,27 @@ export default async function myApiKeysRoutes(app: FastifyInstance) {
   });
 
   // DELETE /api/me/api-keys/:id — revoke caller's own key
-  app.delete<{ Params: { id: string } }>("/api-keys/:id", async (request, reply) => {
+  app.delete<{ Params: { id: string } }>("/api-keys/:id", {
+    schema: {
+      tags: ["api-keys"],
+      summary: "Révoquer un de ses propres jetons",
+      security: [{ bearerAuth: [] }, { cookieAuth: [] }],
+      params: {
+        type: "object",
+        required: ["id"],
+        properties: { id: { type: "string" } },
+      },
+      response: {
+        200: {
+          type: "object",
+          properties: { ok: { type: "boolean" }, alreadyRevoked: { type: "boolean" } },
+        },
+        401: { $ref: "Error#" },
+        403: { $ref: "Error#" },
+        404: { $ref: "Error#" },
+      },
+    },
+  }, async (request, reply) => {
     const user = getCurrentUser(request);
     const key = await prisma.apiKey.findUnique({ where: { id: request.params.id } });
     if (!key || key.userId !== user.id) {

--- a/src/backend/src/routes/me/api-keys.ts
+++ b/src/backend/src/routes/me/api-keys.ts
@@ -1,0 +1,125 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+
+import { prisma } from "../../lib/prisma.js";
+import {
+  requireAnyAuthenticated,
+  type AuthContext,
+} from "../../lib/auth-context.js";
+import { generateApiKey, resolveApiKeyEnv } from "../../lib/api-key.js";
+
+// Soft cap on active keys per user. Meant as a sanity safeguard, not a
+// security boundary — an admin can raise/lower it in code as the usage
+// pattern solidifies. Revoked keys do not count.
+const MAX_ACTIVE_KEYS_PER_USER = 20;
+
+interface CreateApiKeyBody {
+  name?: string;
+  expiresAt?: string | null;
+}
+
+function getCurrentUser(request: FastifyRequest) {
+  const ctx = (request as FastifyRequest & { authContext?: AuthContext }).authContext;
+  if (!ctx) throw new Error("authContext missing — requireAnyAuthenticated must run first");
+  return ctx.user;
+}
+
+function serializeApiKey(k: {
+  id: string;
+  name: string;
+  prefix: string;
+  lastUsedAt: Date | null;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+}) {
+  return {
+    id: k.id,
+    name: k.name,
+    prefix: k.prefix,
+    lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
+    expiresAt: k.expiresAt?.toISOString() ?? null,
+    revokedAt: k.revokedAt?.toISOString() ?? null,
+    createdAt: k.createdAt.toISOString(),
+  };
+}
+
+export default async function myApiKeysRoutes(app: FastifyInstance) {
+  app.addHook("preHandler", requireAnyAuthenticated);
+
+  // GET /api/me/api-keys — list caller's own keys (never exposes raw/hash)
+  app.get("/api-keys", async (request) => {
+    const user = getCurrentUser(request);
+    const keys = await prisma.apiKey.findMany({
+      where: { userId: user.id },
+      orderBy: [{ revokedAt: "asc" }, { createdAt: "desc" }],
+    });
+    return keys.map(serializeApiKey);
+  });
+
+  // POST /api/me/api-keys — create a new key. The raw value is returned ONCE.
+  app.post<{ Body: CreateApiKeyBody }>("/api-keys", async (request, reply) => {
+    const user = getCurrentUser(request);
+    const { name, expiresAt } = request.body ?? {};
+
+    if (!name || !name.trim()) {
+      return reply.status(400).send({ error: "name_required" });
+    }
+    const trimmed = name.trim().slice(0, 80);
+
+    let expiresAtDate: Date | null = null;
+    if (expiresAt) {
+      const parsed = new Date(expiresAt);
+      if (Number.isNaN(parsed.getTime())) {
+        return reply.status(400).send({ error: "invalid_expires_at" });
+      }
+      if (parsed.getTime() <= Date.now()) {
+        return reply.status(400).send({ error: "expires_at_in_past" });
+      }
+      expiresAtDate = parsed;
+    }
+
+    const activeCount = await prisma.apiKey.count({
+      where: { userId: user.id, revokedAt: null },
+    });
+    if (activeCount >= MAX_ACTIVE_KEYS_PER_USER) {
+      return reply.status(400).send({ error: "too_many_active_keys" });
+    }
+
+    const { raw, prefix, hashedKey } = await generateApiKey(resolveApiKeyEnv());
+
+    const created = await prisma.apiKey.create({
+      data: {
+        userId: user.id,
+        name: trimmed,
+        prefix,
+        hashedKey,
+        expiresAt: expiresAtDate,
+      },
+    });
+
+    reply.status(201);
+    return {
+      ...serializeApiKey(created),
+      // The raw secret. Client must store it now; the server will never
+      // expose it again.
+      key: raw,
+    };
+  });
+
+  // DELETE /api/me/api-keys/:id — revoke caller's own key
+  app.delete<{ Params: { id: string } }>("/api-keys/:id", async (request, reply) => {
+    const user = getCurrentUser(request);
+    const key = await prisma.apiKey.findUnique({ where: { id: request.params.id } });
+    if (!key || key.userId !== user.id) {
+      return reply.status(404).send({ error: "not_found" });
+    }
+    if (key.revokedAt) {
+      return reply.status(200).send({ ok: true, alreadyRevoked: true });
+    }
+    await prisma.apiKey.update({
+      where: { id: key.id },
+      data: { revokedAt: new Date() },
+    });
+    return { ok: true };
+  });
+}

--- a/src/backend/src/schemas/api-key.ts
+++ b/src/backend/src/schemas/api-key.ts
@@ -1,0 +1,62 @@
+import type { FastifyInstance } from "fastify";
+
+export function registerApiKeySchemas(app: FastifyInstance) {
+  app.addSchema({
+    $id: "ApiKey",
+    type: "object",
+    required: ["id", "name", "prefix", "createdAt"],
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      prefix: { type: "string", description: "Préfixe public de la clé (12 caractères après dft_<env>_)" },
+      lastUsedAt: { type: "string", format: "date-time", nullable: true },
+      expiresAt: { type: "string", format: "date-time", nullable: true },
+      revokedAt: { type: "string", format: "date-time", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+    },
+  });
+
+  app.addSchema({
+    $id: "ApiKeyWithUser",
+    type: "object",
+    required: ["id", "name", "prefix", "createdAt", "user"],
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      prefix: { type: "string" },
+      lastUsedAt: { type: "string", format: "date-time", nullable: true },
+      expiresAt: { type: "string", format: "date-time", nullable: true },
+      revokedAt: { type: "string", format: "date-time", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+      user: {
+        type: "object",
+        required: ["id", "email", "role"],
+        properties: {
+          id: { type: "string" },
+          email: { type: "string", format: "email" },
+          name: { type: "string", nullable: true },
+          role: { type: "string", enum: ["ADMIN", "EDITOR"] },
+        },
+      },
+    },
+  });
+
+  app.addSchema({
+    $id: "CreatedApiKey",
+    type: "object",
+    required: ["id", "name", "prefix", "key", "createdAt"],
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      prefix: { type: "string" },
+      key: {
+        type: "string",
+        description: "Valeur complète de la clé au format `dft_<env>_<random>`. N'est retournée qu'à la création.",
+      },
+      lastUsedAt: { type: "string", format: "date-time", nullable: true },
+      expiresAt: { type: "string", format: "date-time", nullable: true },
+      revokedAt: { type: "string", format: "date-time", nullable: true },
+      createdAt: { type: "string", format: "date-time" },
+    },
+  });
+}

--- a/src/backend/src/schemas/common.ts
+++ b/src/backend/src/schemas/common.ts
@@ -1,0 +1,24 @@
+import type { FastifyInstance } from "fastify";
+
+export function registerCommonSchemas(app: FastifyInstance) {
+  app.addSchema({
+    $id: "Error",
+    type: "object",
+    required: ["error"],
+    properties: {
+      error: { type: "string", description: "Code ou message court d'erreur" },
+      message: { type: "string", description: "Message détaillé (optionnel)" },
+    },
+  });
+
+  app.addSchema({
+    $id: "Pagination",
+    type: "object",
+    required: ["page", "limit", "total"],
+    properties: {
+      page: { type: "integer", minimum: 1 },
+      limit: { type: "integer", minimum: 1 },
+      total: { type: "integer", minimum: 0 },
+    },
+  });
+}

--- a/src/frontend/next.config.ts
+++ b/src/frontend/next.config.ts
@@ -27,6 +27,18 @@ const nextConfig: NextConfig = {
         destination: `${backendUrl}/api/editions/:path*`,
       },
       {
+        source: "/api/me/:path*",
+        destination: `${backendUrl}/api/me/:path*`,
+      },
+      {
+        source: "/api/docs",
+        destination: `${backendUrl}/api/docs/`,
+      },
+      {
+        source: "/api/docs/:path*",
+        destination: `${backendUrl}/api/docs/:path*`,
+      },
+      {
         source: "/uploads/:path*",
         destination: `${backendUrl}/uploads/:path*`,
       },

--- a/src/frontend/src/app/admin/api-keys/page.tsx
+++ b/src/frontend/src/app/admin/api-keys/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+import {
+  adminListApiKeys,
+  adminRevokeApiKey,
+  type AdminApiKeysList,
+  type ApiKeyWithUser,
+} from "@/lib/admin-api";
+
+function formatDate(iso: string | null, placeholder = "—") {
+  if (!iso) return placeholder;
+  return new Date(iso).toLocaleString("fr-FR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+function statusLabel(key: ApiKeyWithUser): { label: string; className: string } {
+  if (key.revokedAt) return { label: "Révoquée", className: "bg-gris/10 text-gris" };
+  if (key.expiresAt && new Date(key.expiresAt) <= new Date()) {
+    return { label: "Expirée", className: "bg-gris/10 text-gris" };
+  }
+  return { label: "Active", className: "bg-malachite/10 text-malachite" };
+}
+
+export default function AdminApiKeysPage() {
+  const [list, setList] = useState<AdminApiKeysList | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"all" | "active" | "revoked">("active");
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError("");
+    const data = await adminListApiKeys({ status: statusFilter, page, limit: 20 });
+    if (!data) setError("Impossible de charger les clés");
+    setList(data);
+    setIsLoading(false);
+  }, [statusFilter, page]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleRevoke(id: string) {
+    if (!confirm("Révoquer cette clé ? Le propriétaire ne pourra plus l'utiliser.")) return;
+    const ok = await adminRevokeApiKey(id);
+    if (!ok) setError("Révocation impossible");
+    await load();
+  }
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-noir mb-2">Clés API</h1>
+      <p className="text-gris mb-6">
+        Vue d&apos;ensemble de toutes les clés d&apos;API. Vous pouvez révoquer n&apos;importe quelle clé à tout moment.
+      </p>
+
+      <div className="flex items-center gap-3 mb-4">
+        <label className="text-sm text-noir">Statut :</label>
+        <select
+          value={statusFilter}
+          onChange={(e) => {
+            setStatusFilter(e.target.value as "all" | "active" | "revoked");
+            setPage(1);
+          }}
+          className="rounded-lg border border-gris/30 px-3 py-1.5 text-sm bg-blanc"
+        >
+          <option value="active">Actives</option>
+          <option value="revoked">Révoquées</option>
+          <option value="all">Toutes</option>
+        </select>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm text-gris py-12 text-center">Chargement...</p>
+      ) : !list || list.items.length === 0 ? (
+        <div className="bg-blanc rounded-xl shadow-card p-12 text-center text-gris">
+          Aucune clé correspondant aux critères.
+        </div>
+      ) : (
+        <div className="bg-blanc rounded-xl shadow-card overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b border-gris/20">
+                <th className="py-3 px-4 text-noir font-medium">Propriétaire</th>
+                <th className="py-3 px-4 text-noir font-medium">Nom</th>
+                <th className="py-3 px-4 text-noir font-medium">Préfixe</th>
+                <th className="py-3 px-4 text-noir font-medium">Statut</th>
+                <th className="py-3 px-4 text-noir font-medium">Dernière utilisation</th>
+                <th className="py-3 px-4 text-noir font-medium">Expiration</th>
+                <th className="py-3 px-4 text-noir font-medium">Créée le</th>
+                <th className="py-3 px-4 text-right text-noir font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.items.map((k) => {
+                const status = statusLabel(k);
+                return (
+                  <tr key={k.id} className="border-b border-gris/10 last:border-b-0">
+                    <td className="py-3 px-4">
+                      <div className="text-noir">{k.user.name ?? k.user.email}</div>
+                      {k.user.name && <div className="text-xs text-gris">{k.user.email}</div>}
+                      <div className="text-xs text-gris mt-0.5">
+                        {k.user.role === "ADMIN" ? "Administrateur" : "Éditeur"}
+                      </div>
+                    </td>
+                    <td className="py-3 px-4 text-noir">{k.name}</td>
+                    <td className="py-3 px-4">
+                      <code className="text-xs font-mono text-gris">{k.prefix}…</code>
+                    </td>
+                    <td className="py-3 px-4">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${status.className}`}>
+                        {status.label}
+                      </span>
+                    </td>
+                    <td className="py-3 px-4 text-gris">{formatDate(k.lastUsedAt, "Jamais")}</td>
+                    <td className="py-3 px-4 text-gris">{formatDate(k.expiresAt)}</td>
+                    <td className="py-3 px-4 text-gris">{formatDate(k.createdAt)}</td>
+                    <td className="py-3 px-4 text-right">
+                      {!k.revokedAt && (
+                        <button
+                          type="button"
+                          onClick={() => handleRevoke(k.id)}
+                          className="text-terre-cuite hover:underline text-sm"
+                        >
+                          Révoquer
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {list && list.total > list.limit && (
+        <div className="flex items-center justify-between mt-4">
+          <span className="text-sm text-gris">
+            {(list.page - 1) * list.limit + 1}–{Math.min(list.page * list.limit, list.total)} sur {list.total}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={list.page <= 1}
+              className="px-3 py-1.5 text-sm bg-blanc border border-gris/30 rounded-lg disabled:opacity-40"
+            >
+              Précédent
+            </button>
+            <button
+              type="button"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={list.page * list.limit >= list.total}
+              className="px-3 py-1.5 text-sm bg-blanc border border-gris/30 rounded-lg disabled:opacity-40"
+            >
+              Suivant
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/profile/page.tsx
+++ b/src/frontend/src/app/admin/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { adminFetch, getAdminSession } from "@/lib/admin-api";
+import ApiKeysSection from "@/components/admin/ApiKeysSection";
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "";
 
@@ -172,6 +173,11 @@ export default function ProfilePage() {
           </div>
         </div>
       </form>
+
+      {/* API keys */}
+      <div className="mb-6">
+        <ApiKeysSection />
+      </div>
 
       {/* Password change */}
       <form onSubmit={handleChangePassword}>

--- a/src/frontend/src/components/admin/AdminSidebar.tsx
+++ b/src/frontend/src/components/admin/AdminSidebar.tsx
@@ -12,6 +12,7 @@ import {
   faEnvelope,
   faUsers,
   faGear,
+  faKey,
 } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
@@ -38,6 +39,7 @@ const iconMap: Record<string, IconDefinition> = {
   mail: faEnvelope,
   users: faUsers,
   settings: faGear,
+  key: faKey,
 };
 
 export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSidebarProps) {

--- a/src/frontend/src/components/admin/ApiKeysSection.tsx
+++ b/src/frontend/src/components/admin/ApiKeysSection.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+import {
+  listMyApiKeys,
+  createApiKey,
+  revokeMyApiKey,
+  type ApiKey,
+  type CreatedApiKey,
+} from "@/lib/admin-api";
+
+function formatDate(iso: string | null, placeholder = "—") {
+  if (!iso) return placeholder;
+  return new Date(iso).toLocaleString("fr-FR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+function statusLabel(key: ApiKey): { label: string; className: string } {
+  if (key.revokedAt) return { label: "Révoquée", className: "bg-gris/10 text-gris" };
+  if (key.expiresAt && new Date(key.expiresAt) <= new Date()) {
+    return { label: "Expirée", className: "bg-gris/10 text-gris" };
+  }
+  return { label: "Active", className: "bg-malachite/10 text-malachite" };
+}
+
+export default function ApiKeysSection() {
+  const [keys, setKeys] = useState<ApiKey[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // Creation form
+  const [isCreating, setIsCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newExpiresAt, setNewExpiresAt] = useState("");
+  const [created, setCreated] = useState<CreatedApiKey | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [copyFeedback, setCopyFeedback] = useState("");
+
+  async function load() {
+    setIsLoading(true);
+    setError("");
+    try {
+      setKeys(await listMyApiKeys());
+    } catch {
+      setError("Impossible de charger les clés");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (!newName.trim()) {
+      setError("Le nom est obligatoire");
+      return;
+    }
+    setIsSaving(true);
+    const { data, status } = await createApiKey(newName.trim(), newExpiresAt || null);
+    setIsSaving(false);
+    if (!data) {
+      if (status === 400) setError("Requête invalide (nom, date d'expiration ou quota dépassé)");
+      else if (status === 401 || status === 403) setError("Session expirée, reconnectez-vous");
+      else setError("Erreur serveur");
+      return;
+    }
+    setCreated(data);
+    setNewName("");
+    setNewExpiresAt("");
+    setIsCreating(false);
+    await load();
+  }
+
+  async function handleRevoke(id: string) {
+    if (!confirm("Révoquer cette clé ? Les requêtes utilisant cette clé échoueront immédiatement.")) return;
+    const ok = await revokeMyApiKey(id);
+    if (!ok) setError("Révocation impossible");
+    await load();
+  }
+
+  async function handleCopy() {
+    if (!created) return;
+    try {
+      await navigator.clipboard.writeText(created.key);
+      setCopyFeedback("Copiée !");
+      setTimeout(() => setCopyFeedback(""), 2000);
+    } catch {
+      setCopyFeedback("Copie manuelle requise");
+    }
+  }
+
+  return (
+    <div className="bg-blanc rounded-xl shadow-card p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-bold text-noir">Mes jetons d&apos;API</h2>
+        {!isCreating && !created && (
+          <button
+            type="button"
+            onClick={() => setIsCreating(true)}
+            className="px-3 py-1.5 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+          >
+            Nouveau jeton
+          </button>
+        )}
+      </div>
+
+      <p className="text-sm text-gris mb-4">
+        Un jeton d&apos;API vous permet d&apos;accéder à l&apos;API depuis un client externe (script,
+        application mobile, etc.). Les jetons héritent de vos droits courants. La valeur complète
+        n&apos;est affichée qu&apos;une seule fois, à la création.
+      </p>
+
+      {/* Creation form */}
+      {isCreating && (
+        <form onSubmit={handleCreate} className="mb-6 p-4 bg-blanc-casse rounded-lg">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+            <div>
+              <label className="block text-sm font-medium text-noir mb-1">Nom du jeton</label>
+              <input
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Mon app mobile"
+                required
+                maxLength={80}
+                className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-noir mb-1">
+                Date d&apos;expiration <span className="text-gris text-xs">(optionnelle)</span>
+              </label>
+              <input
+                type="datetime-local"
+                value={newExpiresAt}
+                onChange={(e) => setNewExpiresAt(e.target.value)}
+                className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+            >
+              {isSaving ? "Création..." : "Créer le jeton"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setIsCreating(false);
+                setNewName("");
+                setNewExpiresAt("");
+                setError("");
+              }}
+              className="px-4 py-2 text-sm font-medium text-gris hover:text-noir"
+            >
+              Annuler
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Created key one-shot display */}
+      {created && (
+        <div className="mb-6 p-4 border-2 border-malachite rounded-lg bg-malachite/5">
+          <h3 className="text-sm font-bold text-malachite mb-2">Nouveau jeton créé : {created.name}</h3>
+          <p className="text-sm text-noir mb-3">
+            <strong>Copiez cette clé maintenant.</strong> Elle ne sera plus jamais affichée.
+          </p>
+          <div className="flex items-stretch gap-2 mb-3">
+            <code className="flex-1 px-3 py-2 bg-blanc border border-gris/30 rounded text-xs font-mono break-all">
+              {created.key}
+            </code>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="px-3 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 whitespace-nowrap"
+            >
+              Copier
+            </button>
+          </div>
+          {copyFeedback && <p className="text-xs text-malachite mb-3">{copyFeedback}</p>}
+          <button
+            type="button"
+            onClick={() => setCreated(null)}
+            className="text-sm font-medium text-gris hover:text-noir"
+          >
+            J&apos;ai copié la clé, fermer
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
+      )}
+
+      {/* Keys list */}
+      {isLoading ? (
+        <p className="text-sm text-gris py-6">Chargement...</p>
+      ) : !keys || keys.length === 0 ? (
+        <p className="text-sm text-gris py-6">Aucun jeton pour le moment.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b border-gris/20">
+                <th className="py-2 pr-4 text-noir font-medium">Nom</th>
+                <th className="py-2 pr-4 text-noir font-medium">Préfixe</th>
+                <th className="py-2 pr-4 text-noir font-medium">Statut</th>
+                <th className="py-2 pr-4 text-noir font-medium">Dernière utilisation</th>
+                <th className="py-2 pr-4 text-noir font-medium">Expiration</th>
+                <th className="py-2 pr-4 text-noir font-medium">Créée le</th>
+                <th className="py-2 text-right text-noir font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => {
+                const status = statusLabel(k);
+                return (
+                  <tr key={k.id} className="border-b border-gris/10">
+                    <td className="py-3 pr-4 text-noir">{k.name}</td>
+                    <td className="py-3 pr-4">
+                      <code className="text-xs font-mono text-gris">{k.prefix}…</code>
+                    </td>
+                    <td className="py-3 pr-4">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${status.className}`}>
+                        {status.label}
+                      </span>
+                    </td>
+                    <td className="py-3 pr-4 text-gris">{formatDate(k.lastUsedAt, "Jamais")}</td>
+                    <td className="py-3 pr-4 text-gris">{formatDate(k.expiresAt)}</td>
+                    <td className="py-3 pr-4 text-gris">{formatDate(k.createdAt)}</td>
+                    <td className="py-3 text-right">
+                      {!k.revokedAt && (
+                        <button
+                          type="button"
+                          onClick={() => handleRevoke(k.id)}
+                          className="text-terre-cuite hover:underline text-sm"
+                        >
+                          Révoquer
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -15,6 +15,7 @@ export const adminNavItems: AdminNavItem[] = [
   { label: "Fichiers", path: "/admin/images", icon: "image", roles: ["ADMIN", "EDITOR"] },
   { label: "Messages", path: "/admin/contact/messages", icon: "mail", roles: ["ADMIN", "EDITOR"] },
   { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
+  { label: "Clés API", path: "/admin/api-keys", icon: "key", roles: ["ADMIN"] },
   { label: "Paramètres", path: "/admin/settings", icon: "settings", roles: ["ADMIN"] },
 ];
 

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -98,3 +98,86 @@ export async function forgotPassword(email: string): Promise<{ success: boolean;
     return { success: false, error: "Impossible de contacter le serveur" };
   }
 }
+
+// --- API Keys ---
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+export interface ApiKeyWithUser extends ApiKey {
+  user: { id: string; email: string; name: string | null; role: "ADMIN" | "EDITOR" };
+}
+
+export interface CreatedApiKey extends ApiKey {
+  key: string;
+}
+
+async function meFetch<T>(path: string, options: RequestInit = {}): Promise<{ data: T | null; status: number }> {
+  try {
+    const headers: Record<string, string> = {};
+    if (options.body && !(options.body instanceof FormData)) {
+      headers["Content-Type"] = "application/json";
+    }
+    const res = await fetch(`${BACKEND_URL}/api/me${path}`, {
+      credentials: "include",
+      headers: { ...headers, ...options.headers },
+      ...options,
+    });
+    if (!res.ok) return { data: null, status: res.status };
+    const data = await res.json();
+    return { data, status: res.status };
+  } catch {
+    return { data: null, status: 0 };
+  }
+}
+
+export async function listMyApiKeys(): Promise<ApiKey[]> {
+  const { data } = await meFetch<ApiKey[]>("/api-keys");
+  return data ?? [];
+}
+
+export async function createApiKey(name: string, expiresAt?: string | null): Promise<{ data: CreatedApiKey | null; status: number }> {
+  return meFetch<CreatedApiKey>("/api-keys", {
+    method: "POST",
+    body: JSON.stringify({ name, expiresAt: expiresAt ?? null }),
+  });
+}
+
+export async function revokeMyApiKey(id: string): Promise<boolean> {
+  const { status } = await meFetch(`/api-keys/${id}`, { method: "DELETE" });
+  return status === 200;
+}
+
+export interface AdminApiKeysList {
+  page: number;
+  limit: number;
+  total: number;
+  items: ApiKeyWithUser[];
+}
+
+export async function adminListApiKeys(params: {
+  userId?: string;
+  status?: "active" | "revoked" | "all";
+  page?: number;
+  limit?: number;
+} = {}): Promise<AdminApiKeysList | null> {
+  const q = new URLSearchParams();
+  if (params.userId) q.set("userId", params.userId);
+  if (params.status) q.set("status", params.status);
+  if (params.page) q.set("page", String(params.page));
+  if (params.limit) q.set("limit", String(params.limit));
+  const { data } = await adminFetch<AdminApiKeysList>(`/api-keys${q.toString() ? `?${q}` : ""}`);
+  return data;
+}
+
+export async function adminRevokeApiKey(id: string): Promise<boolean> {
+  const { status } = await adminFetch(`/api-keys/${id}`, { method: "DELETE" });
+  return status === 200;
+}


### PR DESCRIPTION
## Summary

Ouverture de l'API REST aux consommateurs externes : doc OpenAPI/Swagger + jetons d'API par utilisateur.

**Authentification unifiée** : toutes les routes protégées acceptent indifféremment un cookie de session Better Auth OU un header \`Authorization: Bearer dft_…\`. Les jetons héritent dynamiquement du rôle de leur propriétaire.

## PRs intégrées

- #6 — feat(backend): Swagger + UI sur \`/api/docs\` et \`/api/docs/json\`
- #7 — feat(auth): unified auth context (session OR Bearer)
- #8 — feat(api): CRUD endpoints \`/api/me/api-keys\` + \`/api/admin/api-keys\`
- #9 — feat(admin-ui): API keys management — section profile + admin overview
- #10 — feat(openapi): annotations api-keys + health (autres routes en backlog)
- #11 — docs(api): user-facing API guide

## Architecture

- **Modèle Prisma \`ApiKey\`** : prefix indexé (lookup), hash argon2id, expiresAt, revokedAt.
- **Format clé** : \`dft_<env>_<32 bytes base64url>\`. \`<env>\` ∈ {live, beta, dev}.
- **Hash argon2id** via \`@node-rs/argon2\` (binaire natif, supporte Alpine).
- **Throttle lastUsedAt** : 1/min max pour éviter de spammer la DB.
- **UI back-office** : section dans \`/admin/profile\` (perso) + page \`/admin/api-keys\` (admin global).

## Test plan complet

- [x] Setup Swagger : \`/api/docs/json\` répond avec OpenAPI 3.0.3 valide
- [x] Modèle ApiKey créé en DB (\`prisma db push\` au boot)
- [x] Tests unitaires argon2id : 11/11 ✅
- [x] \`/api/admin/session\` sans auth → 403
- [x] \`/api/me/api-keys\` sans auth → 401
- [x] \`/api/admin/api-keys\` sans auth → 403
- [ ] Login admin via UI → création d'un jeton → utilisation en Bearer sur \`/api/admin/editions\` → 200 (à tester sur dev-j après deploy)
- [ ] Login editor → création d'un jeton → utilisation en Bearer sur \`/api/admin/editions\` → 403 (admin-only)
- [ ] Page \`/admin/api-keys\` : admin voit toutes les clés ; editor → "Accès réservé"
- [ ] Révocation : la clé devient inutilisable immédiatement
- [ ] Swagger UI : "Try it out" + "Authorize" Bearer fonctionnent

## Backlog explicite

- Annoter les 25+ autres routes en OpenAPI (editions, articles, pages, settings, contact, admin-*)
- Exposition filtrée de la doc (PR 6 reportée)
- Rate-limit par clé (au lieu de par IP)
- Scopes granulaires (au-delà du rôle)
- Audit log complet d'usage par clé
- IP allowlist par clé
- SDK clients TypeScript/Python générés depuis l'OpenAPI

## Deploy notes

- **Aucune nouvelle variable d'environnement** requise.
- **Migration auto** : \`prisma db push\` au démarrage applique le nouveau modèle ApiKey.
- **\`@node-rs/argon2\`** : binaire natif, le rebuild Docker prendra 1-2 min de plus la première fois.
- À tester sur dev-j avant beta/prod (cf. \`docs/deployer-nouvel-environnement.md\`).

## Documents

- Plan : [\`docs/plan-api-publique-et-jetons.md\`](https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/blob/feature/public-api/docs/plan-api-publique-et-jetons.md)
- Guide utilisateur : [\`docs/api-publique.md\`](https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/blob/feature/public-api/docs/api-publique.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)