### PR TITLE
refactor(frontend): middleware.ts -> proxy.ts (Next.js 16)

### DIFF
--- a/src/frontend/src/proxy.ts
+++ b/src/frontend/src/proxy.ts
@@ -4,7 +4,7 @@ import { routing } from "./i18n/routing";
 
 const intlMiddleware = createMiddleware(routing);
 
-export default function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Admin is mono-language: bypass i18n routing but forward the pathname


### PR DESCRIPTION
## Summary

Next.js 16 a déprécié la convention \`middleware.js/ts\` au profit de \`proxy.js/ts\` et renomme l'export par défaut en \`proxy\`. Appliqué via le codemod officiel \`@next/codemod middleware-to-proxy\`.

## Test plan

- [ ] Déploiement dev-j : login admin fonctionne
- [ ] Page FR (\`/fr\`) et EN (\`/en\`) s'affichent, routing i18n OK
- [ ] \`/admin\` n'est pas redirigé vers \`/fr/admin\`
- [ ] Header \`x-pathname\` toujours injecté pour les routes admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)