### PR TITLE
chore(infra): pin pnpm to 9.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "devfest-toulouse-2026",
   "private": true,
   "description": "DevFest Toulouse 2026 — monorepo root",
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "db:generate": "prisma generate --schema prisma/schema.prisma"
   },

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 COPY src/backend/package.json src/backend/pnpm-lock.yaml ./
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 COPY src/frontend/package.json src/frontend/pnpm-lock.yaml ./
 


### PR DESCRIPTION
Évite la dérive de versions pnpm entre contributeurs/builds. Épinglage dans `packageManager` (racine) + `corepack prepare` explicite dans les deux Dockerfiles.

## Test plan

- [x] Build Docker backend OK
- [ ] Build Docker frontend OK (sera testé au déploiement Coolify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)