### PR TITLE
perf(frontend): drop force-dynamic from root layout

### DIFF
--- a/src/frontend/src/app/layout.tsx
+++ b/src/frontend/src/app/layout.tsx
@@ -9,10 +9,6 @@ const googleSans = Google_Sans({
   variable: "--font-google-sans",
 });
 
-// Root layout must render per-request so <html lang> reflects the locale
-// resolved by the next-intl middleware.
-export const dynamic = "force-dynamic";
-
 // The next-intl middleware forwards the resolved locale through the
 // X-NEXT-INTL-LOCALE request header (see next-intl source: shared/constants.js
 // exports HEADER_LOCALE_NAME = "X-NEXT-INTL-LOCALE"). Admin routes are


### PR DESCRIPTION
`await headers()` rend déjà le layout dynamique. La directive `export const dynamic = "force-dynamic"` est redondante et empêche les optimisations statiques sur les pages héritières.

## Test plan

- [ ] Coolify dev-j : pages publiques FR/EN OK, login admin OK
- [ ] `<html lang>` toujours correct selon la locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)