### PR TITLE
refactor(backend): use decorateRequest + module augmentation

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -32,6 +32,12 @@ const app = Fastify({
   trustProxy: true,
 });
 
+// Per-request decorations attached by auth middleware. Initialised to null
+// so Fastify's internal "shouldn't be undefined" check passes; the actual
+// types are declared in src/types/fastify.d.ts.
+app.decorateRequest("adminUser", null);
+app.decorateRequest("authContext", null);
+
 const corsOrigins = [
   process.env.FRONTEND_URL || "http://localhost:3000",
   process.env.BASE_URL || "http://localhost:3000",

--- a/src/backend/src/lib/admin-guard.ts
+++ b/src/backend/src/lib/admin-guard.ts
@@ -1,6 +1,6 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
 
-import { getAuthContext, type AuthContext } from "./auth-context.js";
+import { getAuthContext } from "./auth-context.js";
 
 // Source of truth for back-office access: the user.role column in DB.
 // ADMIN_EMAILS is only used at bootstrap (prisma/seed.ts) to create the very
@@ -24,7 +24,7 @@ export async function requireAdmin(request: FastifyRequest, reply: FastifyReply)
     reply.status(403).send({ error: "Forbidden" });
     return;
   }
-  (request as FastifyRequest & { adminUser?: AuthContext["user"] }).adminUser = ctx.user;
+  request.adminUser = ctx.user;
 }
 
 /** Requires ADMIN role specifically (not EDITOR) */
@@ -35,5 +35,5 @@ export async function requireAdminRole(request: FastifyRequest, reply: FastifyRe
     reply.status(403).send({ error: "Forbidden — admin only" });
     return;
   }
-  (request as FastifyRequest & { adminUser?: AuthContext["user"] }).adminUser = ctx.user;
+  request.adminUser = ctx.user;
 }

--- a/src/backend/src/lib/auth-context.ts
+++ b/src/backend/src/lib/auth-context.ts
@@ -134,5 +134,5 @@ export async function requireAnyAuthenticated(request: FastifyRequest, reply: Fa
     reply.status(403).send({ error: "Forbidden" });
     return;
   }
-  (request as FastifyRequest & { authContext?: AuthContext }).authContext = ctx;
+  request.authContext = ctx;
 }

--- a/src/backend/src/routes/admin/users.ts
+++ b/src/backend/src/routes/admin/users.ts
@@ -125,9 +125,7 @@ export default async function adminUserRoutes(app: FastifyInstance) {
     "/users/:id/ban",
     async (request, reply) => {
       const { id } = request.params;
-      const adminUser = (request as unknown as { adminUser: { id: string } }).adminUser;
-
-      if (adminUser.id === id) {
+      if (request.adminUser?.id === id) {
         return reply.code(400).send({ error: "You cannot ban yourself" });
       }
 
@@ -153,9 +151,7 @@ export default async function adminUserRoutes(app: FastifyInstance) {
     "/users/:id",
     async (request, reply) => {
       const { id } = request.params;
-      const adminUser = (request as unknown as { adminUser: { id: string } }).adminUser;
-
-      if (adminUser.id === id) {
+      if (request.adminUser?.id === id) {
         return reply.code(400).send({ error: "You cannot delete your own account" });
       }
 

--- a/src/backend/src/routes/me/api-keys.ts
+++ b/src/backend/src/routes/me/api-keys.ts
@@ -1,10 +1,7 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
 
 import { prisma } from "../../lib/prisma.js";
-import {
-  requireAnyAuthenticated,
-  type AuthContext,
-} from "../../lib/auth-context.js";
+import { requireAnyAuthenticated } from "../../lib/auth-context.js";
 import { generateApiKey, resolveApiKeyEnv } from "../../lib/api-key.js";
 
 // Soft cap on active keys per user. Meant as a sanity safeguard, not a
@@ -18,7 +15,7 @@ interface CreateApiKeyBody {
 }
 
 function getCurrentUser(request: FastifyRequest) {
-  const ctx = (request as FastifyRequest & { authContext?: AuthContext }).authContext;
+  const ctx = request.authContext;
   if (!ctx) throw new Error("authContext missing — requireAnyAuthenticated must run first");
   return ctx.user;
 }

--- a/src/backend/src/types/fastify.d.ts
+++ b/src/backend/src/types/fastify.d.ts
@@ -1,0 +1,13 @@
+// Module augmentation: extend Fastify's request typings with the
+// per-request decorations attached by our auth middleware. Keeps route
+// handlers free of `as` casts when reading request.adminUser /
+// request.authContext.
+
+import type { AuthContext } from "../lib/auth-context.js";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    adminUser?: AuthContext["user"];
+    authContext?: AuthContext;
+  }
+}


### PR DESCRIPTION
Pattern Fastify 5 officiel pour les decorations request. Plus de `(request as ...)` casts.

## Test plan

- [x] Build Docker backend OK
- [x] /api/admin/users sans auth → 403 (auth flow non cassé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)