### PR TITLE
refactor(frontend): split @theme and @theme inline

### DIFF
--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -1,11 +1,17 @@
 @import "tailwindcss";
 
-@theme inline {
-  /* ========================================
-   * DevFest Toulouse 2026 — Design Tokens
-   * Source: docs/design-system.md
-   * ======================================== */
+/* ========================================
+ * DevFest Toulouse 2026 — Design Tokens
+ * Source: docs/design-system.md
+ *
+ * Literal tokens go in @theme so utilities like bg-noir compile to
+ * `background-color: var(--color-noir)` and stay themable at runtime.
+ * Tokens that reference other CSS variables (font stack pulled from
+ * the next/font className) need @theme inline so the resolved value
+ * is inlined into the utility.
+ * ======================================== */
 
+@theme {
   /* --- Colors: Primary --- */
   --color-bismarck: #B94420;
   --color-terre-cuite: #EC6839;
@@ -41,9 +47,6 @@
   --color-link: #703B27;
   --color-link-footer: #FDF0EB;
 
-  /* --- Typography --- */
-  --font-sans: var(--font-google-sans), system-ui, sans-serif;
-
   /* --- Shadows --- */
   --shadow-header: 0 4px 12px rgba(29, 29, 27, 0.10);
   --shadow-card: 0 12px 16px 4px rgba(29, 29, 27, 0.14);
@@ -59,6 +62,11 @@
   --radius-4xl: 40px;
   --radius-5xl: 56px;
   --radius-hero: 64px;
+}
+
+@theme inline {
+  /* --- Typography (references --font-google-sans set by next/font) --- */
+  --font-sans: var(--font-google-sans), system-ui, sans-serif;
 }
 
 /* --- Focus visible (accessibility) --- */


### PR DESCRIPTION
Tokens littéraux dans @theme (themable runtime), seul --font-sans dans @theme inline (référence à --font-google-sans).

## Test plan

- [x] Build frontend OK
- [x] Tokens `--color-malachite`, `--color-noir`, `--font-sans` présents dans la CSS générée
- [x] Classe `google_sans_*` injectée dans le HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)