### PR TITLE
fix(backend): drop null default from decorateRequest calls

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -32,11 +32,12 @@ const app = Fastify({
   trustProxy: true,
 });
 
-// Per-request decorations attached by auth middleware. Initialised to null
-// so Fastify's internal "shouldn't be undefined" check passes; the actual
-// types are declared in src/types/fastify.d.ts.
-app.decorateRequest("adminUser", null);
-app.decorateRequest("authContext", null);
+// Per-request decorations attached by auth middleware. Declared without a
+// default so Fastify treats them as optional getters (the typings live in
+// src/types/fastify.d.ts as `field?: T`). Reading them before the auth
+// preHandler runs returns undefined.
+app.decorateRequest("adminUser");
+app.decorateRequest("authContext");
 
 const corsOrigins = [
   process.env.FRONTEND_URL || "http://localhost:3000",


### PR DESCRIPTION
Coolify build cassait sur `tsc` parce que le default `null` ne matchait pas le type `AuthenticatedUser | undefined` augmenté dans `fastify.d.ts`. Drop le default — la decoration est set par l'auth middleware à chaque requête.

## Test plan

- [x] Build Docker backend `--no-cache` OK
- [ ] Coolify dev-j déploie sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)