### PR TITLE
fix(ci): drop pnpm version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -36,8 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
PR #16 a pin pnpm via `packageManager` dans `package.json`. Le `with: version: 9` du workflow CI entre en conflit avec ça (`ERR_PNPM_BAD_PM_VERSION`). On retire le `with:` — l'action utilisera `packageManager` automatiquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)