### PR TITLE
chore(infra): use Coolify standalone Postfix instead of bundled service

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,31 +37,30 @@ services:
       - OAUTH_GITHUB_CLIENT_ID=${OAUTH_GITHUB_CLIENT_ID:-}
       - OAUTH_GITHUB_CLIENT_SECRET=${OAUTH_GITHUB_CLIENT_SECRET:-}
       - ADMIN_EMAILS=${ADMIN_EMAILS}
-      - SMTP_HOST=postfix
-      - SMTP_PORT=25
+      # SMTP relayed through the standalone `postfix` service deployed at
+      # the Coolify level (shared by all projects). Reachable via the
+      # `coolify` network — see the `networks:` section below.
+      - SMTP_HOST=${SMTP_HOST:-postfix}
+      - SMTP_PORT=${SMTP_PORT:-25}
+      - SMTP_SECURE=${SMTP_SECURE:-false}
+      - SMTP_AUTH=${SMTP_AUTH:-false}
       - SMTP_FROM=${SMTP_FROM:-contact@devfesttoulouse.fr}
       - BILLETWEB_USER=${BILLETWEB_USER:-}
       - BILLETWEB_KEY=${BILLETWEB_KEY:-}
     depends_on:
       db:
         condition: service_healthy
-      postfix:
-        condition: service_started
-    # Intentionally NOT on the shared `coolify` network. The backend isn't
-    # exposed via Traefik — the frontend proxies /api/* to it through the
-    # Next.js rewrites. Joining `coolify` would put it side-by-side with the
-    # backend of every other Coolify project that uses the same service name,
-    # and Docker DNS would round-robin between them.
-    #
-    # Network alias gives the backend a unique, env-scoped hostname inside
-    # the project's `default` network. The frontend points BACKEND_URL at
-    # this alias instead of the bare `backend` to avoid resolving against
-    # other projects' backends through the shared `coolify` network (Coolify
-    # ignores `container_name` so we can't rely on that).
+    # The backend itself is NOT exposed via Traefik (the frontend proxies
+    # /api/* to it through the Next.js rewrites). It joins the shared
+    # `coolify` network only to reach the standalone `postfix` service
+    # deployed at the Coolify level. Inbound resolution from other projects
+    # is mitigated by the env-scoped network alias on `default` —
+    # `BACKEND_URL` points at that alias, never at the bare `backend` name.
     networks:
       default:
         aliases:
           - devfest-${ENV_NAME:-local}-backend
+      coolify:
 
   db:
     image: postgres:16-alpine
@@ -76,13 +75,6 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-
-  postfix:
-    image: boky/postfix:latest
-    environment:
-      - ALLOWED_SENDER_DOMAINS=${SMTP_DOMAIN:-devfesttoulouse.fr}
-    networks:
-      - default
 
 networks:
   coolify:

--- a/docs/variables-environnement.md
+++ b/docs/variables-environnement.md
@@ -55,9 +55,15 @@ Utilisé pour le formulaire de contact (Lot 1) et l'envoi des liens de modificat
 
 | Variable | Obligatoire | Description | Exemple |
 |----------|:-----------:|-------------|---------|
-| `SMTP_HOST` | oui | Hôte du serveur SMTP | `postfix` (container Docker) ou `localhost` |
+| `SMTP_HOST` | oui | Hôte du serveur SMTP. En prod/beta : nom DNS du service Postfix Coolify standalone (ex. `postfix`). En dev : `mailhog`. | `postfix` |
 | `SMTP_PORT` | non | Port SMTP (défaut : `25`) | `25` |
+| `SMTP_SECURE` | non | `true` pour forcer TLS au handshake (port 465). Défaut `false`. | `false` |
+| `SMTP_AUTH` | non | `true` pour activer l'auth SMTP via `SMTP_USER` / `SMTP_PASSWORD`. Défaut `false`. | `false` |
+| `SMTP_USER` | si `SMTP_AUTH=true` | Identifiant SMTP | `noreply@devfesttoulouse.fr` |
+| `SMTP_PASSWORD` | si `SMTP_AUTH=true` | Mot de passe SMTP | `…` |
 | `SMTP_FROM` | oui | Adresse expéditeur des emails | `contact@devfesttoulouse.fr` |
+
+> ⚠️ **Prod/beta** : le service `postfix` n'est plus défini dans `docker-compose.prod.yml`. Il est désormais déployé en **service standalone Coolify** au niveau de l'instance, partagé par tous les projets. Le backend doit être joint au réseau `coolify` (configuré dans `docker-compose.prod.yml`) pour résoudre `postfix`.
 
 ## API tierces (backend uniquement)
 

--- a/src/backend/src/lib/email.ts
+++ b/src/backend/src/lib/email.ts
@@ -1,9 +1,23 @@
 import nodemailer from "nodemailer";
 
+// SMTP_SECURE = true forces a TLS handshake on connect (port 465 typical).
+// SMTP_AUTH = true enables plain SMTP auth via SMTP_USER / SMTP_PASSWORD.
+// Default profile (secure=false, auth=false) matches the standalone
+// Postfix relay we deploy through Coolify, which accepts any sender on
+// the internal network without authentication.
+const useSecure = process.env.SMTP_SECURE === "true";
+const useAuth = process.env.SMTP_AUTH === "true";
+
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST || "localhost",
   port: Number(process.env.SMTP_PORT) || 1025,
-  secure: false,
+  secure: useSecure,
+  ...(useAuth && {
+    auth: {
+      user: process.env.SMTP_USER || "",
+      pass: process.env.SMTP_PASSWORD || "",
+    },
+  }),
 });
 
 const FROM = process.env.SMTP_FROM || "contact@devfesttoulouse.fr";


### PR DESCRIPTION
## Summary

Retire le service \`postfix\` du \`docker-compose.prod.yml\`. Le backend utilise désormais le service **Postfix standalone Coolify** déployé au niveau de l'instance, partagé entre tous les projets.

Pour atteindre ce service, le backend rejoint le réseau \`coolify\` partagé. L'isolation inter-projets reste assurée par l'alias réseau \`devfest-\${ENV_NAME}-backend\` sur le réseau \`default\` du projet (le \`BACKEND_URL\` du frontend pointe sur cet alias, jamais sur \`backend\` qui résoudrait via \`coolify\`).

\`SMTP_SECURE\` et \`SMTP_AUTH\` deviennent configurables dans \`email.ts\` (défaut \`false/false\` qui matche le relais Postfix Coolify, sans TLS et sans auth en interne).

## ⚠️ Variables Coolify à configurer

Sur chaque environnement (dev-j, beta, prod) — runtime, pas buildtime :

\`\`\`
SMTP_HOST=postfix
SMTP_PORT=25
SMTP_SECURE=false
SMTP_AUTH=false
\`\`\`

## Test plan

- [x] Build Docker backend OK
- [ ] Coolify déploie sans erreur sur dev-j
- [ ] Test email : reset password depuis \`/admin\` → email reçu (vérifier dans la boîte mail réelle de l'utilisateur, pas dans MailHog qui est déjà configuré pour dev local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)