### PR TITLE
chore(admin): rename /admin/images -> /admin/files

### DIFF
--- a/src/backend/src/routes/admin/files.ts
+++ b/src/backend/src/routes/admin/files.ts
@@ -19,9 +19,9 @@ const ALLOWED_MIMES = [
 ];
 const MAX_FILE_SIZE = 20_000_000; // 20 MB
 
-export default async function adminImageRoutes(app: FastifyInstance) {
-  // POST /api/admin/images — upload a single image
-  app.post("/images", async (request, reply) => {
+export default async function adminFileRoutes(app: FastifyInstance) {
+  // POST /api/admin/files — upload a single file (image or document)
+  app.post("/files", async (request, reply) => {
     const data = await request.file({
       limits: { fileSize: MAX_FILE_SIZE },
     });
@@ -62,8 +62,8 @@ export default async function adminImageRoutes(app: FastifyInstance) {
     };
   });
 
-  // GET /api/admin/images — list all uploaded files
-  app.get("/images", async () => {
+  // GET /api/admin/files — list all uploaded files (images and documents)
+  app.get("/files", async () => {
     await fs.promises.mkdir(UPLOADS_DIR, { recursive: true });
 
     const IMAGE_EXTS = [".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg"];
@@ -92,9 +92,9 @@ export default async function adminImageRoutes(app: FastifyInstance) {
     return items;
   });
 
-  // DELETE /api/admin/images/:filename — delete an image
+  // DELETE /api/admin/files/:filename — delete a file
   app.delete<{ Params: { filename: string } }>(
-    "/images/:filename",
+    "/files/:filename",
     async (request, reply) => {
       const { filename } = request.params;
 

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -8,7 +8,7 @@ import adminTicketRoutes from "./tickets.js";
 import adminSettingsRoutes from "./settings.js";
 import adminPageRoutes from "./pages.js";
 import adminContactRoutes from "./contact.js";
-import adminImageRoutes from "./images.js";
+import adminFileRoutes from "./files.js";
 import adminUserRoutes from "./users.js";
 import adminSponsorPlanRoutes from "./sponsor-plans.js";
 import adminApiKeyRoutes from "./api-keys.js";
@@ -23,7 +23,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminArticleRoutes);
     await editorApp.register(adminPageRoutes);
     await editorApp.register(adminContactRoutes);
-    await editorApp.register(adminImageRoutes);
+    await editorApp.register(adminFileRoutes);
   });
 
   // Routes restricted to ADMIN only

--- a/src/frontend/src/app/admin/files/page.tsx
+++ b/src/frontend/src/app/admin/files/page.tsx
@@ -56,7 +56,7 @@ export default function FilesAdminPage() {
 
   async function loadFiles() {
     setIsLoading(true);
-    const { data } = await adminFetch<FileInfo[]>("/images");
+    const { data } = await adminFetch<FileInfo[]>("/files");
     if (data) setFiles(data);
     setIsLoading(false);
   }
@@ -73,7 +73,7 @@ export default function FilesAdminPage() {
     formData.append("file", file);
 
     try {
-      const res = await fetch(`${BACKEND_URL}/api/admin/images`, {
+      const res = await fetch(`${BACKEND_URL}/api/admin/files`, {
         method: "POST",
         credentials: "include",
         body: formData,
@@ -108,7 +108,7 @@ export default function FilesAdminPage() {
 
   async function handleDelete() {
     if (!deleteTarget) return;
-    await adminFetch(`/images/${deleteTarget}`, { method: "DELETE" });
+    await adminFetch(`/files/${deleteTarget}`, { method: "DELETE" });
     setDeleteTarget(null);
     loadFiles();
   }

--- a/src/frontend/src/components/admin/ImagePickerDialog.tsx
+++ b/src/frontend/src/components/admin/ImagePickerDialog.tsx
@@ -37,7 +37,7 @@ export default function ImagePickerDialog({ open, onClose, onSelect }: ImagePick
 
   async function loadImages() {
     setIsLoading(true);
-    const { data } = await adminFetch<ImageInfo[]>("/images");
+    const { data } = await adminFetch<ImageInfo[]>("/files");
     if (data) setImages(data);
     setIsLoading(false);
   }
@@ -50,7 +50,7 @@ export default function ImagePickerDialog({ open, onClose, onSelect }: ImagePick
     formData.append("file", file);
 
     try {
-      const { data, status } = await adminFetch<{ url: string }>("/images", {
+      const { data, status } = await adminFetch<{ url: string }>("/files", {
         method: "POST",
         body: formData,
       });
@@ -185,7 +185,7 @@ export default function ImagePickerDialog({ open, onClose, onSelect }: ImagePick
                     onChange={handleFileChange}
                     className="hidden"
                   />
-                  <p className="text-xs text-gris mt-3">JPEG, PNG, WebP, GIF — max 5 Mo</p>
+                  <p className="text-xs text-gris mt-3">JPEG, PNG, WebP, GIF — max 20 Mo</p>
                 </>
               )}
             </div>

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -12,7 +12,7 @@ export const adminNavItems: AdminNavItem[] = [
   { label: "Éditions", path: "/admin/editions", icon: "calendar", roles: ["ADMIN"] },
   { label: "Articles", path: "/admin/articles", icon: "file-text", roles: ["ADMIN", "EDITOR"] },
   { label: "Pages", path: "/admin/pages", icon: "book", roles: ["ADMIN", "EDITOR"] },
-  { label: "Fichiers", path: "/admin/images", icon: "image", roles: ["ADMIN", "EDITOR"] },
+  { label: "Fichiers", path: "/admin/files", icon: "image", roles: ["ADMIN", "EDITOR"] },
   { label: "Messages", path: "/admin/contact/messages", icon: "mail", roles: ["ADMIN", "EDITOR"] },
   { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
   { label: "Clés API", path: "/admin/api-keys", icon: "key", roles: ["ADMIN"] },


### PR DESCRIPTION
La page "Fichiers" admin acceptait déjà images + documents (PDF, PPT, DOC, XLS). On aligne URL/route avec le nom.

Renommage pur :
- Backend : `routes/admin/images.ts` → `routes/admin/files.ts`, paths `/api/admin/files{,/:filename}`
- Frontend : `app/admin/images/` → `app/admin/files/`, `ImagePickerDialog` et `nav-items.ts` à jour
- Bonus : `ImagePickerDialog` affichait "max 5 Mo" alors que le backend autorise 20 Mo → corrigé

## Test plan

- [x] Build Docker backend + frontend OK
- [x] `/admin/files` → 200 (page accessible)
- [x] `/admin/images` → 404 (ancienne URL bien partie)
- [x] `/api/admin/files` → 403 (auth requise — endpoint existe)
- [x] `/api/admin/images` → 404 (ancienne route disparue)
- [ ] Coolify dev-j : login admin, navigation Fichiers, upload PDF, picker dans GeneralTab/RichTextEditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)