### PR TITLE
feat(prisma): sponsor brochure, webhook, category email templates

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,26 +31,30 @@ enum UserRole {
 // --- Edition ---
 
 model Edition {
-  id               Int             @id @default(autoincrement())
-  year             Int             @unique
-  startDate        DateTime?
-  endDate          DateTime?
-  status           EditionStatus   @default(PREPARATION)
-  venueName        String?
-  venueAddress     String?
-  heroImageUrl     String?
-  cfpUrl           String?
-  partnerFormUrl   String?
-  aftermovieUrl    String?
-  galleryUrl       String?
-  archivedSiteUrl  String?
-  createdAt        DateTime        @default(now())
-  updatedAt        DateTime        @updatedAt
+  id                  Int             @id @default(autoincrement())
+  year                Int             @unique
+  startDate           DateTime?
+  endDate             DateTime?
+  status              EditionStatus   @default(PREPARATION)
+  venueName           String?
+  venueAddress        String?
+  heroImageUrl        String?
+  cfpUrl              String?
+  partnerFormUrl      String?
+  aftermovieUrl       String?
+  galleryUrl          String?
+  archivedSiteUrl     String?
+  // URL of the sponsor brochure PDF (stored under /uploads/, picked from /admin/files)
+  sponsorBrochureUrl  String?
+  // External URL POSTed when a contact message is submitted (any category)
+  contactWebhookUrl   String?
+  createdAt           DateTime        @default(now())
+  updatedAt           DateTime        @updatedAt
 
-  ticketTiers      TicketTier[]
-  articles         Article[]
-  keyFigures       KeyFigure[]
-  sponsorPlans     SponsorPlan[]
+  ticketTiers         TicketTier[]
+  articles            Article[]
+  keyFigures          KeyFigure[]
+  sponsorPlans        SponsorPlan[]
 }
 
 // --- Key Figures ---
@@ -141,16 +145,26 @@ model TicketTier {
 // --- Contact ---
 
 model ContactCategory {
-  id               Int       @id @default(autoincrement())
-  nameFr           String
-  nameEn           String
-  emailRecipients  String
-  sortOrder        Int       @default(0)
-  isActive         Boolean   @default(true)
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
+  id                     Int       @id @default(autoincrement())
+  nameFr                 String
+  nameEn                 String
+  emailRecipients        String
+  sortOrder              Int       @default(0)
+  isActive               Boolean   @default(true)
+  // Stable identifier used in code to target a specific category (e.g. "sponsoring")
+  slug                   String?   @unique
+  // System categories cannot be deleted from the admin UI
+  isSystem               Boolean   @default(false)
+  // Per-category confirmation email sent to the person who submitted the form.
+  // Templates support {firstName}, {lastName}, {brochureUrl} interpolation.
+  confirmationSubjectFr  String?
+  confirmationSubjectEn  String?
+  confirmationBodyFr     String?
+  confirmationBodyEn     String?
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
 
-  messages         ContactMessage[]
+  messages               ContactMessage[]
 }
 
 model ContactMessage {
@@ -161,6 +175,7 @@ model ContactMessage {
   phone            String?
   categoryLabel    String?
   message          String
+  locale           String?
   isRead           Boolean          @default(false)
   createdAt        DateTime         @default(now())
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -14,9 +14,17 @@ export async function seedBase() {
 
   // --- Contact Categories ---
   const contactCategories = [
-    { nameFr: "Sponsoring", nameEn: "Sponsoring", emailRecipients: "sponsors@devfesttoulouse.fr", sortOrder: 1 },
-    { nameFr: "Appel à conférences", nameEn: "Call for Papers", emailRecipients: "cfp@devfesttoulouse.fr", sortOrder: 2 },
-    { nameFr: "Presse / Média", nameEn: "Press / Media", emailRecipients: "presse@devfesttoulouse.fr", sortOrder: 3 },
+    {
+      nameFr: "Sponsoring", nameEn: "Sponsoring",
+      emailRecipients: "sponsors@devfesttoulouse.fr", sortOrder: 1,
+      slug: "sponsoring", isSystem: true,
+      confirmationSubjectFr: "[DevFest Toulouse 2026] Tenez vous prêt",
+      confirmationSubjectEn: "[DevFest Toulouse 2026] Get ready",
+      confirmationBodyFr: "Bonjour {firstName} {lastName},\n\nMerci de l'intérêt que vous portez au DevFest Toulouse.\n\nVous pouvez consulter la plaquette sponsor à <a href=\"{brochureUrl}\">cette adresse</a>.\n\nSi vous avez des questions, nous sommes là pour y répondre.\nNous vous recontacterons d'ici quelques jours pour étudier la meilleure formule pour vous.\n\nDevFestement,\nLes organisateurs du DevFest Toulouse",
+      confirmationBodyEn: "Hello {firstName} {lastName},\n\nThank you for your interest in DevFest Toulouse.\n\nYou can download the sponsor brochure at <a href=\"{brochureUrl}\">this link</a>.\n\nIf you have any questions, we are happy to help.\nWe will get back to you within a few days to find the best option for you.\n\nBest regards,\nThe DevFest Toulouse organizers",
+    },
+    { nameFr: "Appel à conférences", nameEn: "Call for Papers", emailRecipients: "cfp@devfesttoulouse.fr", sortOrder: 2, slug: "cfp" },
+    { nameFr: "Presse / Média", nameEn: "Press / Media", emailRecipients: "presse@devfesttoulouse.fr", sortOrder: 3, slug: "presse" },
   ];
 
   for (const cat of contactCategories) {
@@ -25,6 +33,21 @@ export async function seedBase() {
     });
     if (!existing) {
       await prisma.contactCategory.create({ data: cat });
+    } else {
+      // Backfill slug/isSystem on existing categories
+      await prisma.contactCategory.update({
+        where: { id: existing.id },
+        data: {
+          slug: cat.slug,
+          isSystem: cat.isSystem ?? false,
+          ...(cat.confirmationSubjectFr && !existing.confirmationSubjectFr ? {
+            confirmationSubjectFr: cat.confirmationSubjectFr,
+            confirmationSubjectEn: cat.confirmationSubjectEn,
+            confirmationBodyFr: cat.confirmationBodyFr,
+            confirmationBodyEn: cat.confirmationBodyEn,
+          } : {}),
+        },
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Changements schéma Prisma pour le formulaire sponsor :

**Edition** :
- \`sponsorBrochureUrl\` — URL du PDF plaquette (pickable depuis /admin/files)
- \`contactWebhookUrl\` — URL externe POSTée à chaque soumission de contact

**ContactCategory** :
- \`slug\` (unique) — identifiant stable pour cibler depuis le code (ex: "sponsoring")
- \`isSystem\` — empêche la suppression depuis l'admin
- \`confirmationSubject/BodyFr/En\` — template email de confirmation par catégorie, avec interpolation \`{firstName}\`, \`{lastName}\`, \`{brochureUrl}\`

**ContactMessage** :
- \`locale\` — langue de soumission pour traçabilité et webhook

**Seed** : backfill slug/isSystem sur les 3 catégories existantes, template par défaut FR/EN pour sponsoring.

## Test plan

- [ ] Build Docker backend OK (prisma generate + tsc)
- [ ] \`prisma db push\` applique sans erreur (les nouveaux champs sont tous optionnels)
- [ ] Seed backfills les slugs et templates sur les catégories existantes

🤖 Generated with [Claude Code](https://claude.com/claude-code)