### PR TITLE
feat(backend): confirmation email per category + contact webhook

### DIFF
--- a/src/backend/src/lib/email.test.ts
+++ b/src/backend/src/lib/email.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { interpolate } from "./email.js";
+
+describe("interpolate", () => {
+  it("replaces known tokens", () => {
+    const result = interpolate("Hello {firstName} {lastName}", {
+      firstName: "John",
+      lastName: "Doe",
+    });
+    expect(result).toBe("Hello John Doe");
+  });
+
+  it("leaves unknown tokens as-is", () => {
+    expect(interpolate("{unknown} token", {})).toBe("{unknown} token");
+  });
+
+  it("handles brochureUrl with HTML link", () => {
+    const tpl = 'Consultez la plaquette à <a href="{brochureUrl}">cette adresse</a>.';
+    const result = interpolate(tpl, { brochureUrl: "https://example.com/sponsor.pdf" });
+    expect(result).toBe('Consultez la plaquette à <a href="https://example.com/sponsor.pdf">cette adresse</a>.');
+  });
+
+  it("returns template unchanged when vars is empty", () => {
+    expect(interpolate("No tokens here", {})).toBe("No tokens here");
+  });
+
+  it("replaces multiple occurrences of the same token", () => {
+    expect(interpolate("{name} and {name}", { name: "X" })).toBe("X and X");
+  });
+});

--- a/src/backend/src/lib/email.ts
+++ b/src/backend/src/lib/email.ts
@@ -38,3 +38,11 @@ export async function sendEmail({ to, subject, text, html }: SendEmailOptions) {
     html,
   });
 }
+
+/**
+ * Simple string template interpolation: replaces `{key}` tokens with
+ * the corresponding value from `vars`. Unknown tokens are left as-is.
+ */
+export function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key) => vars[key] ?? match);
+}

--- a/src/backend/src/routes/admin/contact.ts
+++ b/src/backend/src/routes/admin/contact.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { requireAdminRole } from "../../lib/admin-guard.js";
 
@@ -8,6 +8,11 @@ interface ContactCategoryBody {
   emailRecipients: string;
   sortOrder?: number;
   isActive?: boolean;
+  slug?: string;
+  confirmationSubjectFr?: string;
+  confirmationSubjectEn?: string;
+  confirmationBodyFr?: string;
+  confirmationBodyEn?: string;
 }
 
 export default async function adminContactRoutes(app: FastifyInstance) {
@@ -25,6 +30,12 @@ export default async function adminContactRoutes(app: FastifyInstance) {
       emailRecipients: c.emailRecipients,
       sortOrder: c.sortOrder,
       isActive: c.isActive,
+      slug: c.slug,
+      isSystem: c.isSystem,
+      confirmationSubjectFr: c.confirmationSubjectFr,
+      confirmationSubjectEn: c.confirmationSubjectEn,
+      confirmationBodyFr: c.confirmationBodyFr,
+      confirmationBodyEn: c.confirmationBodyEn,
       messagesCount: c._count.messages,
     }));
   });
@@ -44,6 +55,11 @@ export default async function adminContactRoutes(app: FastifyInstance) {
         emailRecipients: body.emailRecipients.trim(),
         sortOrder: body.sortOrder ?? 0,
         isActive: body.isActive ?? true,
+        slug: body.slug?.trim() || null,
+        confirmationSubjectFr: body.confirmationSubjectFr?.trim() || null,
+        confirmationSubjectEn: body.confirmationSubjectEn?.trim() || null,
+        confirmationBodyFr: body.confirmationBodyFr?.trim() || null,
+        confirmationBodyEn: body.confirmationBodyEn?.trim() || null,
       },
     });
 
@@ -71,6 +87,11 @@ export default async function adminContactRoutes(app: FastifyInstance) {
         emailRecipients: body.emailRecipients?.trim() ?? existing.emailRecipients,
         sortOrder: body.sortOrder ?? existing.sortOrder,
         isActive: body.isActive ?? existing.isActive,
+        ...(existing.isSystem ? {} : { slug: body.slug !== undefined ? (body.slug?.trim() || null) : existing.slug }),
+        confirmationSubjectFr: body.confirmationSubjectFr !== undefined ? (body.confirmationSubjectFr?.trim() || null) : existing.confirmationSubjectFr,
+        confirmationSubjectEn: body.confirmationSubjectEn !== undefined ? (body.confirmationSubjectEn?.trim() || null) : existing.confirmationSubjectEn,
+        confirmationBodyFr: body.confirmationBodyFr !== undefined ? (body.confirmationBodyFr?.trim() || null) : existing.confirmationBodyFr,
+        confirmationBodyEn: body.confirmationBodyEn !== undefined ? (body.confirmationBodyEn?.trim() || null) : existing.confirmationBodyEn,
       },
     });
 
@@ -83,6 +104,13 @@ export default async function adminContactRoutes(app: FastifyInstance) {
   }>("/contact/categories/:id", { preHandler: [requireAdminRole] }, async (request, reply) => {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
+
+    const existing = await prisma.contactCategory.findUnique({ where: { id } });
+    if (!existing) return reply.status(404).send({ error: "Category not found" });
+
+    if (existing.isSystem) {
+      return reply.status(409).send({ error: "System categories cannot be deleted" });
+    }
 
     await prisma.contactCategory.delete({ where: { id } });
     return { success: true };
@@ -118,6 +146,7 @@ export default async function adminContactRoutes(app: FastifyInstance) {
         phone: m.phone,
         categoryLabel: m.category?.nameFr || m.categoryLabel,
         message: m.message,
+        locale: m.locale,
         isRead: m.isRead,
         createdAt: m.createdAt,
       })),

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -15,6 +15,8 @@ interface EditionBody {
   aftermovieUrl?: string;
   galleryUrl?: string;
   archivedSiteUrl?: string;
+  sponsorBrochureUrl?: string;
+  contactWebhookUrl?: string;
 }
 
 export default async function adminEditionRoutes(app: FastifyInstance) {
@@ -141,6 +143,8 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         aftermovieUrl: body.aftermovieUrl !== undefined ? (body.aftermovieUrl || null) : existing.aftermovieUrl,
         galleryUrl: body.galleryUrl !== undefined ? (body.galleryUrl || null) : existing.galleryUrl,
         archivedSiteUrl: body.archivedSiteUrl !== undefined ? (body.archivedSiteUrl || null) : existing.archivedSiteUrl,
+        sponsorBrochureUrl: body.sponsorBrochureUrl !== undefined ? (body.sponsorBrochureUrl || null) : existing.sponsorBrochureUrl,
+        contactWebhookUrl: body.contactWebhookUrl !== undefined ? (body.contactWebhookUrl || null) : existing.contactWebhookUrl,
       },
     });
 
@@ -283,4 +287,51 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       return { success: true, editionId };
     }
   );
+
+  // POST /api/admin/editions/:id/test-webhook — send a test payload to the contact webhook
+  app.post<{ Params: { id: string } }>("/editions/:id/test-webhook", async (request, reply) => {
+    const id = Number(request.params.id);
+    if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
+
+    const edition = await prisma.edition.findUnique({ where: { id } });
+    if (!edition) return reply.status(404).send({ error: "Edition not found" });
+    if (!edition.contactWebhookUrl) return reply.status(400).send({ error: "No webhook URL configured for this edition" });
+
+    const payload = {
+      id: `test_${Date.now()}`,
+      submittedAt: new Date().toISOString(),
+      data: {
+        firstName: "John",
+        lastName: "Doe",
+        email: "john.doe@example.com",
+        phone: "+33 6 00 00 00 00",
+        categoryId: null,
+        categorySlug: "sponsoring",
+        categoryLabel: "Sponsoring",
+        message: "Ceci est un message de test envoyé depuis le back-office pour vérifier la configuration du webhook.",
+        locale: "fr",
+      },
+    };
+
+    try {
+      const response = await fetch(edition.contactWebhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(10_000),
+      });
+      const responseBody = await response.text().catch(() => "");
+      return {
+        status: response.ok ? "sent" : "failed",
+        responseStatus: response.status,
+        responseBody: responseBody.slice(0, 500),
+      };
+    } catch (err) {
+      return {
+        status: "failed",
+        responseStatus: null,
+        responseBody: String(err),
+      };
+    }
+  });
 }

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
-import { sendEmail } from "../lib/email.js";
+import { sendEmail, interpolate } from "../lib/email.js";
+import { getFeaturedEdition } from "./editions.js";
 
 interface ContactBody {
   firstName: string;
@@ -9,6 +10,7 @@ interface ContactBody {
   phone?: string;
   categoryId?: number;
   message: string;
+  locale?: string;
   website?: string; // honeypot
 }
 
@@ -28,6 +30,7 @@ export default async function contactRoutes(app: FastifyInstance) {
       id: cat.id,
       nameFr: cat.nameFr,
       nameEn: cat.nameEn,
+      slug: cat.slug,
     }));
   });
 
@@ -41,11 +44,10 @@ export default async function contactRoutes(app: FastifyInstance) {
       },
     },
   }, async (request, reply) => {
-    const { firstName, lastName, email, phone, categoryId, message, website } = request.body;
+    const { firstName, lastName, email, phone, categoryId, message, locale, website } = request.body;
 
     // Honeypot check — bots fill this hidden field
     if (website) {
-      // Silently accept but don't process
       return { success: true };
     }
 
@@ -60,12 +62,13 @@ export default async function contactRoutes(app: FastifyInstance) {
       return reply.status(400).send({ success: false, errors });
     }
 
-    // Resolve email recipients
+    // Resolve category + recipients
     let recipients: string[] = [];
     let categoryLabel: string | null = null;
+    let category: Awaited<ReturnType<typeof prisma.contactCategory.findUnique>> = null;
 
     if (categoryId) {
-      const category = await prisma.contactCategory.findUnique({
+      category = await prisma.contactCategory.findUnique({
         where: { id: categoryId },
       });
       if (category) {
@@ -83,7 +86,7 @@ export default async function contactRoutes(app: FastifyInstance) {
     }
 
     // Store message in DB
-    await prisma.contactMessage.create({
+    const stored = await prisma.contactMessage.create({
       data: {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
@@ -91,11 +94,12 @@ export default async function contactRoutes(app: FastifyInstance) {
         phone: phone?.trim() || null,
         categoryLabel,
         message: message.trim(),
+        locale: locale || null,
         categoryId: categoryId || null,
       },
     });
 
-    // Send email
+    // --- Send notification email to recipients (existing behaviour) ---
     try {
       const subject = `Nouveau message de contact — ${firstName.trim()} ${lastName.trim()}`;
       const text = [
@@ -122,7 +126,74 @@ export default async function contactRoutes(app: FastifyInstance) {
       await sendEmail({ to: recipients, subject, text, html });
     } catch (err) {
       app.log.error("Failed to send contact email: %s", String(err));
-      // Message is saved in DB even if email fails
+    }
+
+    // --- Send confirmation email to the person who submitted the form ---
+    if (category) {
+      const lang = locale === "en" ? "en" : "fr";
+      const tplSubject = lang === "en" ? category.confirmationSubjectEn : category.confirmationSubjectFr;
+      const tplBody = lang === "en" ? category.confirmationBodyEn : category.confirmationBodyFr;
+
+      if (tplSubject && tplBody) {
+        try {
+          const edition = await getFeaturedEdition();
+          const baseUrl = process.env.BASE_URL || "http://localhost:3000";
+          const brochureUrl = edition?.sponsorBrochureUrl
+            ? `${baseUrl}${edition.sponsorBrochureUrl}`
+            : "";
+
+          const vars = {
+            firstName: firstName.trim(),
+            lastName: lastName.trim(),
+            brochureUrl,
+          };
+
+          const renderedSubject = interpolate(tplSubject, vars);
+          const renderedBody = interpolate(tplBody, vars);
+
+          await sendEmail({
+            to: [email.trim()],
+            subject: renderedSubject,
+            text: renderedBody.replace(/<[^>]+>/g, ""),
+            html: renderedBody.replace(/\n/g, "<br>"),
+          });
+        } catch (err) {
+          app.log.error("Failed to send confirmation email: %s", String(err));
+        }
+      }
+    }
+
+    // --- Fire webhook (async, fire-and-forget) ---
+    try {
+      const edition = await getFeaturedEdition();
+      if (edition?.contactWebhookUrl) {
+        const payload = {
+          id: stored.id,
+          submittedAt: stored.createdAt.toISOString(),
+          data: {
+            firstName: firstName.trim(),
+            lastName: lastName.trim(),
+            email: email.trim(),
+            phone: phone?.trim() || null,
+            categoryId: categoryId || null,
+            categorySlug: category?.slug || null,
+            categoryLabel: categoryLabel || null,
+            message: message.trim(),
+            locale: locale || null,
+          },
+        };
+
+        fetch(edition.contactWebhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(10_000),
+        }).catch((err) => {
+          app.log.warn("Contact webhook failed: %s", String(err));
+        });
+      }
+    } catch (err) {
+      app.log.warn("Contact webhook error: %s", String(err));
     }
 
     return { success: true };


### PR DESCRIPTION
## Summary

Backend de la feature formulaire sponsor :

- **Email de confirmation** au demandeur : template par catégorie (\`confirmationSubject/BodyFr/En\` sur \`ContactCategory\`), avec interpolation \`{firstName}\`, \`{lastName}\`, \`{brochureUrl}\` (lue depuis \`Edition.sponsorBrochureUrl\`)
- **Webhook sortant** : POST fire-and-forget à l'URL configurée sur l'édition à la une (\`contactWebhookUrl\`), pour TOUTES les soumissions de contact
- **Locale** : le frontend envoie désormais \`locale\` dans le body, persiste sur \`ContactMessage\`
- **Admin catégories** : expose slug, isSystem, templates de confirmation. Suppression bloquée si \`isSystem: true\` (409)
- **Admin éditions** : accepte \`sponsorBrochureUrl\` et \`contactWebhookUrl\` en update
- **Test webhook** : \`POST /api/admin/editions/:id/test-webhook\` envoie un payload fictif

## Test plan

- [ ] Build Docker backend OK
- [ ] \`interpolate()\` : 5 tests unitaires
- [ ] POST \`/api/contact/send\` avec \`categoryId\` sponsoring → email confirmation reçu dans MailHog
- [ ] Webhook reçu sur webhook.site
- [ ] DELETE catégorie isSystem → 409
- [ ] Test webhook → payload fictif reçu

🤖 Generated with [Claude Code](https://claude.com/claude-code)