### PR TITLE
feat(frontend): sponsor contact form + brochure/webhook admin fields

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -196,7 +196,10 @@
     "ctaDownload": "Receive sponsorship package",
     "noPlans": "Sponsorship packages will be available soon.",
     "visible": "Visible",
-    "hidden": "Hidden"
+    "hidden": "Hidden",
+    "formTitle": "Contact us",
+    "formIntro": "Fill out the form below and we will send you our sponsorship brochure. We will get back to you shortly.",
+    "formSubmit": "Receive the sponsorship brochure"
   },
   "codeOfConduct": {
     "title": "Code of Conduct",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -196,7 +196,10 @@
     "ctaDownload": "Recevoir le dossier de sponsoring",
     "noPlans": "Les formules de sponsoring seront bientôt disponibles.",
     "visible": "Visible",
-    "hidden": "Masqué"
+    "hidden": "Masqué",
+    "formTitle": "Contactez-nous",
+    "formIntro": "Remplissez le formulaire ci-dessous et nous vous enverrons notre dossier de sponsoring. Nous reviendrons vers vous dans les plus brefs délais.",
+    "formSubmit": "Recevoir le dossier de sponsoring"
   },
   "codeOfConduct": {
     "title": "Code de conduite",

--- a/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
+++ b/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
-import { getCurrentEdition, getSponsorPlans } from "@/lib/api";
+import { getCurrentEdition, getSponsorPlans, getContactCategories } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
-import { Link } from "@/i18n/navigation";
+import ContactForm from "@/components/ContactForm";
 
 function localizedField(
   obj: Record<string, unknown>,
@@ -30,10 +30,13 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function SponsorPage() {
   const locale = await getLocale();
   const t = await getTranslations("sponsor");
-  const [edition, plans] = await Promise.all([
+  const [edition, plans, categories] = await Promise.all([
     getCurrentEdition(),
     getSponsorPlans(),
+    getContactCategories(),
   ]);
+
+  const sponsoringCategory = categories.find((c) => c.slug === "sponsoring");
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },
@@ -175,13 +178,13 @@ export default async function SponsorPage() {
 
                       {/* CTA button */}
                       <div className="px-6 pb-6">
-                        <Link
-                          href="/contact"
+                        <a
+                          href="#contact"
                           className="block w-full text-center py-3 rounded-lg font-bold text-blanc transition-opacity hover:opacity-90"
                           style={{ backgroundColor: plan.color }}
                         >
                           {t("ctaContact")}
-                        </Link>
+                        </a>
                       </div>
                     </div>
                   );
@@ -190,15 +193,25 @@ export default async function SponsorPage() {
             )}
           </div>
 
-          {/* Bottom CTA */}
-          <div className="mt-16 text-center">
-            <Link
-              href="/contact"
-              className="inline-block px-8 py-4 rounded-[12px] bg-bleu text-blanc font-bold text-xl hover:bg-bleu/90 transition-colors"
-            >
-              {t("ctaContact")}
-            </Link>
-          </div>
+          {/* Contact form */}
+          {sponsoringCategory && (
+            <div id="contact" className="mt-16 scroll-mt-8">
+              <h2 className="text-2xl lg:text-4xl font-bold text-noir">
+                {t("formTitle")}
+              </h2>
+              <p className="mt-4 text-gris leading-relaxed max-w-3xl">
+                {t("formIntro")}
+              </p>
+              <div className="mt-8 max-w-2xl">
+                <ContactForm
+                  categories={categories}
+                  locale={locale}
+                  forceCategoryId={sponsoringCategory.id}
+                  submitLabel={t("formSubmit")}
+                />
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/frontend/src/components/ContactForm.tsx
+++ b/src/frontend/src/components/ContactForm.tsx
@@ -9,11 +9,13 @@ import type { ContactCategory } from "@/lib/types";
 interface ContactFormProps {
   categories: ContactCategory[];
   locale: string;
+  forceCategoryId?: number;
+  submitLabel?: string;
 }
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "";
 
-export default function ContactForm({ categories, locale }: ContactFormProps) {
+export default function ContactForm({ categories, locale, forceCategoryId, submitLabel }: ContactFormProps) {
   const t = useTranslations("contact.form");
 
   const [formData, setFormData] = useState({
@@ -35,7 +37,7 @@ export default function ContactForm({ categories, locale }: ContactFormProps) {
     if (!formData.lastName.trim()) errs.lastName = t("lastNameError");
     if (!formData.email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email))
       errs.email = t("emailError");
-    if (categories.length > 0 && !formData.categoryId) errs.categoryId = t("categoryError");
+    if (!forceCategoryId && categories.length > 0 && !formData.categoryId) errs.categoryId = t("categoryError");
     if (!formData.message.trim() || formData.message.trim().length < 10)
       errs.message = t("messageError");
     return errs;
@@ -49,6 +51,7 @@ export default function ContactForm({ categories, locale }: ContactFormProps) {
 
     setStatus("sending");
     try {
+      const categoryId = forceCategoryId ?? (formData.categoryId ? Number(formData.categoryId) : undefined);
       const res = await fetch(`${BACKEND_URL}/api/contact/send`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -57,8 +60,9 @@ export default function ContactForm({ categories, locale }: ContactFormProps) {
           lastName: formData.lastName,
           email: formData.email,
           phone: formData.phone || undefined,
-          categoryId: formData.categoryId ? Number(formData.categoryId) : undefined,
+          categoryId,
           message: formData.message,
+          locale,
           website: formData.website, // honeypot
         }),
       });
@@ -172,8 +176,8 @@ export default function ContactForm({ categories, locale }: ContactFormProps) {
         />
       </div>
 
-      {/* Category */}
-      {categories.length > 0 && (
+      {/* Category — hidden when forceCategoryId is set */}
+      {!forceCategoryId && categories.length > 0 && (
         <div>
           <label htmlFor="categoryId" className="block text-sm font-bold text-noir mb-1">
             {t("category")} *
@@ -226,7 +230,7 @@ export default function ContactForm({ categories, locale }: ContactFormProps) {
         disabled={status === "sending"}
         className="px-8 py-3 rounded-[12px] bg-bleu text-blanc font-bold text-lg hover:bg-bleu/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        {status === "sending" ? t("sending") : t("submit")}
+        {status === "sending" ? t("sending") : (submitLabel || t("submit"))}
       </button>
 
       {/* Status messages */}

--- a/src/frontend/src/components/admin/ContactCategories.tsx
+++ b/src/frontend/src/components/admin/ContactCategories.tsx
@@ -13,19 +13,44 @@ interface ContactCategory {
   emailRecipients: string;
   sortOrder: number;
   isActive: boolean;
+  slug: string | null;
+  isSystem: boolean;
+  confirmationSubjectFr: string | null;
+  confirmationSubjectEn: string | null;
+  confirmationBodyFr: string | null;
+  confirmationBodyEn: string | null;
   messagesCount: number;
 }
 
-const emptyCategory = { nameFr: "", nameEn: "", emailRecipients: "", sortOrder: "0", isActive: true };
+interface FormState {
+  nameFr: string;
+  nameEn: string;
+  emailRecipients: string;
+  sortOrder: string;
+  isActive: boolean;
+  slug: string;
+  confirmationSubjectFr: string;
+  confirmationSubjectEn: string;
+  confirmationBodyFr: string;
+  confirmationBodyEn: string;
+}
+
+const emptyForm: FormState = {
+  nameFr: "", nameEn: "", emailRecipients: "", sortOrder: "0", isActive: true,
+  slug: "", confirmationSubjectFr: "", confirmationSubjectEn: "",
+  confirmationBodyFr: "", confirmationBodyEn: "",
+};
 
 export default function ContactCategories() {
   const [categories, setCategories] = useState<ContactCategory[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
-  const [form, setForm] = useState(emptyCategory);
+  const [editingIsSystem, setEditingIsSystem] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyForm);
   const [isSaving, setIsSaving] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<ContactCategory | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   async function loadCategories() {
     setIsLoading(true);
@@ -40,19 +65,36 @@ export default function ContactCategories() {
 
   function startEdit(cat: ContactCategory) {
     setEditingId(cat.id);
-    setForm({ nameFr: cat.nameFr, nameEn: cat.nameEn, emailRecipients: cat.emailRecipients, sortOrder: String(cat.sortOrder), isActive: cat.isActive });
+    setEditingIsSystem(cat.isSystem);
+    setForm({
+      nameFr: cat.nameFr, nameEn: cat.nameEn, emailRecipients: cat.emailRecipients,
+      sortOrder: String(cat.sortOrder), isActive: cat.isActive, slug: cat.slug || "",
+      confirmationSubjectFr: cat.confirmationSubjectFr || "",
+      confirmationSubjectEn: cat.confirmationSubjectEn || "",
+      confirmationBodyFr: cat.confirmationBodyFr || "",
+      confirmationBodyEn: cat.confirmationBodyEn || "",
+    });
     setShowForm(true);
   }
 
   function startNew() {
     setEditingId(null);
-    setForm(emptyCategory);
+    setEditingIsSystem(false);
+    setForm(emptyForm);
     setShowForm(true);
   }
 
   async function handleSave() {
     setIsSaving(true);
-    const payload = { nameFr: form.nameFr, nameEn: form.nameEn, emailRecipients: form.emailRecipients, sortOrder: Number(form.sortOrder), isActive: form.isActive };
+    const payload = {
+      nameFr: form.nameFr, nameEn: form.nameEn, emailRecipients: form.emailRecipients,
+      sortOrder: Number(form.sortOrder), isActive: form.isActive,
+      slug: form.slug || undefined,
+      confirmationSubjectFr: form.confirmationSubjectFr || undefined,
+      confirmationSubjectEn: form.confirmationSubjectEn || undefined,
+      confirmationBodyFr: form.confirmationBodyFr || undefined,
+      confirmationBodyEn: form.confirmationBodyEn || undefined,
+    };
 
     if (editingId) {
       await adminFetch(`/contact/categories/${editingId}`, { method: "PUT", body: JSON.stringify(payload) });
@@ -67,7 +109,12 @@ export default function ContactCategories() {
 
   async function handleDelete() {
     if (!deleteTarget) return;
-    await adminFetch(`/contact/categories/${deleteTarget.id}`, { method: "DELETE" });
+    setDeleteError(null);
+    const { status } = await adminFetch(`/contact/categories/${deleteTarget.id}`, { method: "DELETE" });
+    if (status === 409) {
+      setDeleteError("Les catégories système ne peuvent pas être supprimées.");
+      return;
+    }
     setDeleteTarget(null);
     loadCategories();
   }
@@ -86,12 +133,29 @@ export default function ContactCategories() {
           <BilingualInput label="Nom" nameFr="nameFr" nameEn="nameEn" valueFr={form.nameFr} valueEn={form.nameEn} onChangeFr={(v) => setForm({ ...form, nameFr: v })} onChangeEn={(v) => setForm({ ...form, nameEn: v })} required />
           <FormField label="Destinataires (emails séparés par virgule)" name="emailRecipients" value={form.emailRecipients} onChange={(v) => setForm({ ...form, emailRecipients: v })} required />
           <div className="grid grid-cols-2 gap-4">
+            <FormField label="Slug" name="slug" value={form.slug} onChange={(v) => setForm({ ...form, slug: v })} helpText="Identifiant stable (ex: sponsoring, cfp)" disabled={editingIsSystem} />
             <FormField label="Ordre" name="sortOrder" type="number" value={form.sortOrder} onChange={(v) => setForm({ ...form, sortOrder: v })} />
-            <div className="flex items-center gap-2 pt-6">
-              <input type="checkbox" checked={form.isActive} onChange={(e) => setForm({ ...form, isActive: e.target.checked })} className="rounded border-gris/30" />
-              <span className="text-sm text-noir">Active</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <input type="checkbox" checked={form.isActive} onChange={(e) => setForm({ ...form, isActive: e.target.checked })} className="rounded border-gris/30" />
+            <span className="text-sm text-noir">Active</span>
+          </div>
+
+          {/* Confirmation email template */}
+          <div className="pt-4 border-t border-gris/20">
+            <h3 className="text-sm font-bold text-noir mb-3">Email de confirmation (envoyé à l&apos;expéditeur du formulaire)</h3>
+            <p className="text-xs text-gris mb-3">Variables disponibles : <code className="bg-blanc-casse px-1 rounded">{"{firstName}"}</code> <code className="bg-blanc-casse px-1 rounded">{"{lastName}"}</code> <code className="bg-blanc-casse px-1 rounded">{"{brochureUrl}"}</code></p>
+            <BilingualInput label="Objet" nameFr="confirmationSubjectFr" nameEn="confirmationSubjectEn" valueFr={form.confirmationSubjectFr} valueEn={form.confirmationSubjectEn} onChangeFr={(v) => setForm({ ...form, confirmationSubjectFr: v })} onChangeEn={(v) => setForm({ ...form, confirmationSubjectEn: v })} />
+            <div className="mt-3">
+              <label className="block text-sm font-medium text-noir mb-1">Contenu FR</label>
+              <textarea rows={5} value={form.confirmationBodyFr} onChange={(e) => setForm({ ...form, confirmationBodyFr: e.target.value })} className="w-full px-3 py-2 rounded-lg border border-gris/30 text-noir text-sm focus:outline-none focus:ring-2 focus:ring-malachite/50" placeholder="Bonjour {firstName} {lastName},..." />
+            </div>
+            <div className="mt-3">
+              <label className="block text-sm font-medium text-noir mb-1">Contenu EN</label>
+              <textarea rows={5} value={form.confirmationBodyEn} onChange={(e) => setForm({ ...form, confirmationBodyEn: e.target.value })} className="w-full px-3 py-2 rounded-lg border border-gris/30 text-noir text-sm focus:outline-none focus:ring-2 focus:ring-malachite/50" placeholder="Hello {firstName} {lastName},..." />
             </div>
           </div>
+
           <div className="flex gap-3 justify-end">
             <button onClick={() => setShowForm(false)} className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse">Annuler</button>
             <button onClick={handleSave} disabled={isSaving} className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50">{isSaving ? "Sauvegarde..." : "Sauvegarder"}</button>
@@ -104,22 +168,31 @@ export default function ContactCategories() {
           <thead>
             <tr className="bg-blanc-casse/60 border-b border-gris/20">
               <th className="text-left px-4 py-3 font-medium text-gris">Nom (FR)</th>
+              <th className="text-left px-4 py-3 font-medium text-gris">Slug</th>
               <th className="text-left px-4 py-3 font-medium text-gris">Destinataires</th>
               <th className="text-left px-4 py-3 font-medium text-gris">Messages</th>
               <th className="text-left px-4 py-3 font-medium text-gris">Active</th>
+              <th className="text-left px-4 py-3 font-medium text-gris">Confirmation</th>
               <th className="text-right px-4 py-3 font-medium text-gris">Actions</th>
             </tr>
           </thead>
           <tbody>
             {categories.map((cat) => (
               <tr key={cat.id} className="border-b border-gris/10 hover:bg-blanc-casse/50">
-                <td className="px-4 py-3 text-noir font-medium">{cat.nameFr}</td>
+                <td className="px-4 py-3 text-noir font-medium">
+                  {cat.nameFr}
+                  {cat.isSystem && <span className="ml-2 text-[10px] bg-bleu/10 text-bleu px-1.5 py-0.5 rounded">système</span>}
+                </td>
+                <td className="px-4 py-3 text-gris text-xs font-mono">{cat.slug || "—"}</td>
                 <td className="px-4 py-3 text-gris text-xs">{cat.emailRecipients}</td>
                 <td className="px-4 py-3 text-noir">{cat.messagesCount}</td>
                 <td className="px-4 py-3">{cat.isActive ? <span className="text-malachite">Oui</span> : <span className="text-gris">Non</span>}</td>
+                <td className="px-4 py-3">{cat.confirmationSubjectFr ? <span className="text-malachite text-xs">✓ configurée</span> : <span className="text-gris text-xs">—</span>}</td>
                 <td className="px-4 py-3 text-right space-x-2">
                   <button onClick={() => startEdit(cat)} className="text-bleu hover:underline text-sm">Modifier</button>
-                  <button onClick={() => setDeleteTarget(cat)} className="text-terre-cuite hover:underline text-sm">Supprimer</button>
+                  {!cat.isSystem && (
+                    <button onClick={() => setDeleteTarget(cat)} className="text-terre-cuite hover:underline text-sm">Supprimer</button>
+                  )}
                 </td>
               </tr>
             ))}
@@ -127,7 +200,15 @@ export default function ContactCategories() {
         </table>
       </div>
 
-      <ConfirmDialog isOpen={!!deleteTarget} title="Supprimer la catégorie" message={`Supprimer "${deleteTarget?.nameFr}" ?`} confirmLabel="Supprimer" variant="danger" onConfirm={handleDelete} onCancel={() => setDeleteTarget(null)} />
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="Supprimer la catégorie"
+        message={deleteError || `Supprimer "${deleteTarget?.nameFr}" ?`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => { setDeleteTarget(null); setDeleteError(null); }}
+      />
     </div>
   );
 }

--- a/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
@@ -19,6 +19,8 @@ interface EditionData {
   aftermovieUrl: string | null;
   galleryUrl: string | null;
   archivedSiteUrl: string | null;
+  sponsorBrochureUrl: string | null;
+  contactWebhookUrl: string | null;
 }
 
 const STATUS_OPTIONS = [
@@ -44,10 +46,14 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
     aftermovieUrl: edition.aftermovieUrl || "",
     galleryUrl: edition.galleryUrl || "",
     archivedSiteUrl: edition.archivedSiteUrl || "",
+    sponsorBrochureUrl: edition.sponsorBrochureUrl || "",
+    contactWebhookUrl: edition.contactWebhookUrl || "",
   });
   const [isSaving, setIsSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
+  const [isBrochurePickerOpen, setIsBrochurePickerOpen] = useState(false);
+  const [webhookTestResult, setWebhookTestResult] = useState<string | null>(null);
 
   async function handleSave() {
     setIsSaving(true);
@@ -65,6 +71,8 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
         aftermovieUrl: form.aftermovieUrl || undefined,
         galleryUrl: form.galleryUrl || undefined,
         archivedSiteUrl: form.archivedSiteUrl || undefined,
+        sponsorBrochureUrl: form.sponsorBrochureUrl || undefined,
+        contactWebhookUrl: form.contactWebhookUrl || undefined,
       }),
     });
     setIsSaving(false);
@@ -132,6 +140,67 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
       </div>
 
       <FormField label="URL formulaire partenaire" name="partnerFormUrl" type="url" value={form.partnerFormUrl} onChange={(v) => setForm({ ...form, partnerFormUrl: v })} />
+
+      {/* Sponsor brochure */}
+      <div>
+        <label className="block text-sm font-medium text-noir mb-1">Plaquette sponsors (PDF)</label>
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => setIsBrochurePickerOpen(true)}
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+          >
+            {form.sponsorBrochureUrl ? "Changer le fichier" : "Choisir un fichier"}
+          </button>
+          {form.sponsorBrochureUrl && (
+            <button
+              type="button"
+              onClick={() => setForm({ ...form, sponsorBrochureUrl: "" })}
+              className="text-sm text-terre-cuite hover:underline"
+            >
+              Supprimer
+            </button>
+          )}
+        </div>
+        {form.sponsorBrochureUrl && (
+          <p className="text-xs text-gris mt-1">{form.sponsorBrochureUrl}</p>
+        )}
+        <ImagePickerDialog
+          open={isBrochurePickerOpen}
+          onClose={() => setIsBrochurePickerOpen(false)}
+          onSelect={(url) => setForm({ ...form, sponsorBrochureUrl: url })}
+        />
+      </div>
+
+      {/* Webhook */}
+      <div>
+        <FormField label="URL webhook contact" name="contactWebhookUrl" type="url" value={form.contactWebhookUrl} onChange={(v) => setForm({ ...form, contactWebhookUrl: v })} helpText="URL appelée en POST à chaque soumission de formulaire de contact (toutes catégories)." />
+        {form.contactWebhookUrl && (
+          <div className="mt-2 flex items-center gap-3">
+            <button
+              type="button"
+              onClick={async () => {
+                setWebhookTestResult(null);
+                const { data } = await adminFetch<{ status: string; responseStatus?: number; responseBody?: string }>(`/editions/${edition.id}/test-webhook`, { method: "POST" });
+                if (data) {
+                  setWebhookTestResult(data.status === "sent" ? `✓ ${data.responseStatus}` : `✗ ${data.responseBody?.slice(0, 100)}`);
+                } else {
+                  setWebhookTestResult("✗ Erreur");
+                }
+                setTimeout(() => setWebhookTestResult(null), 5000);
+              }}
+              className="px-3 py-1 text-xs rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+            >
+              Tester le webhook
+            </button>
+            {webhookTestResult && (
+              <span className={`text-xs ${webhookTestResult.startsWith("✓") ? "text-malachite" : "text-terre-cuite"}`}>
+                {webhookTestResult}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <FormField label="Aftermovie URL" name="aftermovieUrl" type="url" value={form.aftermovieUrl} onChange={(v) => setForm({ ...form, aftermovieUrl: v })} />

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -125,6 +125,7 @@ export interface ContactCategory {
   id: number;
   nameFr: string;
   nameEn: string;
+  slug: string | null;
 }
 
 export interface ContactFormData {


### PR DESCRIPTION
## Summary

Frontend de la feature formulaire sponsor :

- **ContactForm** : prop \`forceCategoryId\` (cache le select + force la catégorie), prop \`submitLabel\`, envoi de \`locale\` au backend
- **Page \`/devenir-sponsor\`** : charge la catégorie sponsoring par slug, affiche le formulaire en bas de page avec CTA personnalisé, boutons plans scrollent vers \`#contact\`
- **GeneralTab** (admin édition) : champs \`sponsorBrochureUrl\` (file picker) + \`contactWebhookUrl\` (input + bouton "Tester le webhook")
- **ContactCategories** (admin) : slug (read-only système), badge "système", templates de confirmation FR/EN, suppression bloquée pour catégories système
- **i18n** : \`sponsor.formTitle\`, \`formIntro\`, \`formSubmit\` (FR + EN)
- **types.ts** : \`ContactCategory.slug\` ajouté

## Test plan

- [ ] Build Docker frontend OK
- [ ] Page \`/fr/devenir-sponsor\` affiche le formulaire en bas (pas de sélecteur de catégorie)
- [ ] Soumission → email de confirmation dans MailHog (dev-j)
- [ ] Admin > Éditions > Général : champs plaquette + webhook visibles
- [ ] Admin > Messages > Catégories : templates de confirmation modifiables, badge "système" sur Sponsoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)