### PR TITLE
fix(frontend): add missing EditionData fields (build fix)

### DIFF
--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -25,6 +25,8 @@ interface EditionData {
   aftermovieUrl: string | null;
   galleryUrl: string | null;
   archivedSiteUrl: string | null;
+  sponsorBrochureUrl: string | null;
+  contactWebhookUrl: string | null;
   ticketTiersCount: number;
   articlesCount: number;
 }


### PR DESCRIPTION
Le type `EditionData` dans `editions/[id]/page.tsx` n'avait pas les 2 nouveaux champs (`sponsorBrochureUrl`, `contactWebhookUrl`) ajoutés en PR #27. Le frontend ne compilait plus sur Coolify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)