### PR TITLE
refactor: move webhook URL from Edition to SiteSetting (/admin/settings)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,8 +46,6 @@ model Edition {
   archivedSiteUrl     String?
   // URL of the sponsor brochure PDF (stored under /uploads/, picked from /admin/files)
   sponsorBrochureUrl  String?
-  // External URL POSTed when a contact message is submitted (any category)
-  contactWebhookUrl   String?
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
 

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -16,7 +16,6 @@ interface EditionBody {
   galleryUrl?: string;
   archivedSiteUrl?: string;
   sponsorBrochureUrl?: string;
-  contactWebhookUrl?: string;
 }
 
 export default async function adminEditionRoutes(app: FastifyInstance) {
@@ -144,7 +143,6 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         galleryUrl: body.galleryUrl !== undefined ? (body.galleryUrl || null) : existing.galleryUrl,
         archivedSiteUrl: body.archivedSiteUrl !== undefined ? (body.archivedSiteUrl || null) : existing.archivedSiteUrl,
         sponsorBrochureUrl: body.sponsorBrochureUrl !== undefined ? (body.sponsorBrochureUrl || null) : existing.sponsorBrochureUrl,
-        contactWebhookUrl: body.contactWebhookUrl !== undefined ? (body.contactWebhookUrl || null) : existing.contactWebhookUrl,
       },
     });
 
@@ -287,51 +285,4 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       return { success: true, editionId };
     }
   );
-
-  // POST /api/admin/editions/:id/test-webhook — send a test payload to the contact webhook
-  app.post<{ Params: { id: string } }>("/editions/:id/test-webhook", async (request, reply) => {
-    const id = Number(request.params.id);
-    if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
-
-    const edition = await prisma.edition.findUnique({ where: { id } });
-    if (!edition) return reply.status(404).send({ error: "Edition not found" });
-    if (!edition.contactWebhookUrl) return reply.status(400).send({ error: "No webhook URL configured for this edition" });
-
-    const payload = {
-      id: `test_${Date.now()}`,
-      submittedAt: new Date().toISOString(),
-      data: {
-        firstName: "John",
-        lastName: "Doe",
-        email: "john.doe@example.com",
-        phone: "+33 6 00 00 00 00",
-        categoryId: null,
-        categorySlug: "sponsoring",
-        categoryLabel: "Sponsoring",
-        message: "Ceci est un message de test envoyé depuis le back-office pour vérifier la configuration du webhook.",
-        locale: "fr",
-      },
-    };
-
-    try {
-      const response = await fetch(edition.contactWebhookUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(10_000),
-      });
-      const responseBody = await response.text().catch(() => "");
-      return {
-        status: response.ok ? "sent" : "failed",
-        responseStatus: response.status,
-        responseBody: responseBody.slice(0, 500),
-      };
-    } catch (err) {
-      return {
-        status: "failed",
-        responseStatus: null,
-        responseBody: String(err),
-      };
-    }
-  });
 }

--- a/src/backend/src/routes/admin/settings.ts
+++ b/src/backend/src/routes/admin/settings.ts
@@ -79,4 +79,49 @@ export default async function adminSettingsRoutes(app: FastifyInstance) {
     return { success: true };
   });
 
+  // POST /api/admin/settings/test-webhook — send a test payload to contact_webhook_url
+  app.post("/settings/test-webhook", async (_request, reply) => {
+    const setting = await prisma.siteSetting.findUnique({
+      where: { key: "contact_webhook_url" },
+    });
+    const webhookUrl = setting?.value;
+    if (!webhookUrl) return reply.status(400).send({ error: "No webhook URL configured (contact_webhook_url)" });
+
+    const payload = {
+      id: `test_${Date.now()}`,
+      submittedAt: new Date().toISOString(),
+      data: {
+        firstName: "John",
+        lastName: "Doe",
+        email: "john.doe@example.com",
+        phone: "+33 6 00 00 00 00",
+        categoryId: null,
+        categorySlug: "sponsoring",
+        categoryLabel: "Sponsoring",
+        message: "Ceci est un message de test envoyé depuis le back-office pour vérifier la configuration du webhook.",
+        locale: "fr",
+      },
+    };
+
+    try {
+      const response = await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(10_000),
+      });
+      const responseBody = await response.text().catch(() => "");
+      return {
+        status: response.ok ? "sent" : "failed",
+        responseStatus: response.status,
+        responseBody: responseBody.slice(0, 500),
+      };
+    } catch (err) {
+      return {
+        status: "failed",
+        responseStatus: null,
+        responseBody: String(err),
+      };
+    }
+  });
 }

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -165,8 +165,11 @@ export default async function contactRoutes(app: FastifyInstance) {
 
     // --- Fire webhook (async, fire-and-forget) ---
     try {
-      const edition = await getFeaturedEdition();
-      if (edition?.contactWebhookUrl) {
+      const webhookSetting = await prisma.siteSetting.findUnique({
+        where: { key: "contact_webhook_url" },
+      });
+      const webhookUrl = webhookSetting?.value;
+      if (webhookUrl) {
         const payload = {
           id: stored.id,
           submittedAt: stored.createdAt.toISOString(),
@@ -183,7 +186,7 @@ export default async function contactRoutes(app: FastifyInstance) {
           },
         };
 
-        fetch(edition.contactWebhookUrl, {
+        fetch(webhookUrl, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -26,7 +26,6 @@ interface EditionData {
   galleryUrl: string | null;
   archivedSiteUrl: string | null;
   sponsorBrochureUrl: string | null;
-  contactWebhookUrl: string | null;
   ticketTiersCount: number;
   articlesCount: number;
 }

--- a/src/frontend/src/app/admin/settings/page.tsx
+++ b/src/frontend/src/app/admin/settings/page.tsx
@@ -155,6 +155,7 @@ function ContactsTab({
 }) {
   const [form, setForm] = useState({
     contact_default_email: settings.contact_default_email || "",
+    contact_webhook_url: settings.contact_webhook_url || "",
     social_linkedin: settings.social_linkedin || "",
     social_youtube: settings.social_youtube || "",
     social_x: settings.social_x || "",
@@ -162,6 +163,7 @@ function ContactsTab({
   });
   const [isSaving, setIsSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [webhookTestResult, setWebhookTestResult] = useState<string | null>(null);
 
   function handleChange(key: string, value: string) {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -194,6 +196,45 @@ function ContactsTab({
           <p className="mt-1 text-xs text-gris">
             Utilisé quand aucune catégorie de contact n&apos;est définie ou n&apos;a de destinataire.
           </p>
+        </div>
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-noir mb-1">
+            URL webhook contact
+          </label>
+          <input
+            type="url"
+            value={form.contact_webhook_url}
+            onChange={(e) => handleChange("contact_webhook_url", e.target.value)}
+            placeholder="https://hooks.example.com/..."
+            className="w-full max-w-md rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+          />
+          <p className="mt-1 text-xs text-gris">
+            URL appelée en POST à chaque soumission de formulaire de contact (toutes catégories). Laissez vide pour désactiver.
+          </p>
+          {form.contact_webhook_url && (
+            <button
+              type="button"
+              onClick={async () => {
+                setWebhookTestResult(null);
+                const { adminFetch } = await import("@/lib/admin-api");
+                const { data } = await adminFetch<{ status: string; responseStatus?: number; responseBody?: string }>("/settings/test-webhook", { method: "POST" });
+                if (data) {
+                  setWebhookTestResult(data.status === "sent" ? `Envoyé (${data.responseStatus})` : `Échec : ${data.responseBody?.slice(0, 100)}`);
+                } else {
+                  setWebhookTestResult("Erreur");
+                }
+                setTimeout(() => setWebhookTestResult(null), 5000);
+              }}
+              className="mt-2 px-3 py-1 text-xs rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+            >
+              Tester le webhook
+            </button>
+          )}
+          {webhookTestResult && (
+            <p className={`mt-1 text-xs ${webhookTestResult.startsWith("Envoyé") ? "text-malachite" : "text-terre-cuite"}`}>
+              {webhookTestResult}
+            </p>
+          )}
         </div>
 
         <h2 className="text-lg font-bold text-noir mb-4">Réseaux sociaux</h2>

--- a/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
@@ -20,7 +20,6 @@ interface EditionData {
   galleryUrl: string | null;
   archivedSiteUrl: string | null;
   sponsorBrochureUrl: string | null;
-  contactWebhookUrl: string | null;
 }
 
 const STATUS_OPTIONS = [
@@ -47,13 +46,11 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
     galleryUrl: edition.galleryUrl || "",
     archivedSiteUrl: edition.archivedSiteUrl || "",
     sponsorBrochureUrl: edition.sponsorBrochureUrl || "",
-    contactWebhookUrl: edition.contactWebhookUrl || "",
   });
   const [isSaving, setIsSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
   const [isBrochurePickerOpen, setIsBrochurePickerOpen] = useState(false);
-  const [webhookTestResult, setWebhookTestResult] = useState<string | null>(null);
 
   async function handleSave() {
     setIsSaving(true);
@@ -72,7 +69,6 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
         galleryUrl: form.galleryUrl || undefined,
         archivedSiteUrl: form.archivedSiteUrl || undefined,
         sponsorBrochureUrl: form.sponsorBrochureUrl || undefined,
-        contactWebhookUrl: form.contactWebhookUrl || undefined,
       }),
     });
     setIsSaving(false);
@@ -170,36 +166,6 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
           onClose={() => setIsBrochurePickerOpen(false)}
           onSelect={(url) => setForm({ ...form, sponsorBrochureUrl: url })}
         />
-      </div>
-
-      {/* Webhook */}
-      <div>
-        <FormField label="URL webhook contact" name="contactWebhookUrl" type="url" value={form.contactWebhookUrl} onChange={(v) => setForm({ ...form, contactWebhookUrl: v })} helpText="URL appelée en POST à chaque soumission de formulaire de contact (toutes catégories)." />
-        {form.contactWebhookUrl && (
-          <div className="mt-2 flex items-center gap-3">
-            <button
-              type="button"
-              onClick={async () => {
-                setWebhookTestResult(null);
-                const { data } = await adminFetch<{ status: string; responseStatus?: number; responseBody?: string }>(`/editions/${edition.id}/test-webhook`, { method: "POST" });
-                if (data) {
-                  setWebhookTestResult(data.status === "sent" ? `✓ ${data.responseStatus}` : `✗ ${data.responseBody?.slice(0, 100)}`);
-                } else {
-                  setWebhookTestResult("✗ Erreur");
-                }
-                setTimeout(() => setWebhookTestResult(null), 5000);
-              }}
-              className="px-3 py-1 text-xs rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
-            >
-              Tester le webhook
-            </button>
-            {webhookTestResult && (
-              <span className={`text-xs ${webhookTestResult.startsWith("✓") ? "text-malachite" : "text-terre-cuite"}`}>
-                {webhookTestResult}
-              </span>
-            )}
-          </div>
-        )}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary

L'URL webhook n'est pas liée à une édition — elle sert pour tous les messages de contact. Déplacée dans `SiteSetting` (clé `contact_webhook_url`).

- **Prisma** : champ `contactWebhookUrl` retiré de `Edition`
- **Backend** : `contact.ts` lit depuis `SiteSetting`, `admin/settings.ts` expose le test-webhook endpoint, `admin/editions.ts` nettoyé
- **Frontend** : champ webhook + bouton test déplacé de `GeneralTab` (édition) vers la page `/admin/settings` (section "Email de contact")

## Test plan

- [ ] Frontend typecheck OK (vérifié localement)
- [ ] `/admin/settings` : champ webhook visible, bouton "Tester le webhook" fonctionnel
- [ ] Soumission contact → webhook déclenché
- [ ] `/admin/editions/:id` : plus de champ webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)