### PR TITLE
fix(webhook): test against the form's URL, not the saved one

### DIFF
--- a/src/backend/src/routes/admin/settings.ts
+++ b/src/backend/src/routes/admin/settings.ts
@@ -79,13 +79,19 @@ export default async function adminSettingsRoutes(app: FastifyInstance) {
     return { success: true };
   });
 
-  // POST /api/admin/settings/test-webhook — send a test payload to contact_webhook_url
-  app.post("/settings/test-webhook", async (_request, reply) => {
-    const setting = await prisma.siteSetting.findUnique({
-      where: { key: "contact_webhook_url" },
-    });
-    const webhookUrl = setting?.value;
-    if (!webhookUrl) return reply.status(400).send({ error: "No webhook URL configured (contact_webhook_url)" });
+  // POST /api/admin/settings/test-webhook — send a test payload to a webhook URL
+  // Body { url? }: when set, tests this URL directly (lets the admin probe a
+  // candidate URL without saving). Falls back to the stored contact_webhook_url
+  // if no body URL is provided.
+  app.post<{ Body: { url?: string } }>("/settings/test-webhook", async (request, reply) => {
+    let webhookUrl = request.body?.url?.trim();
+    if (!webhookUrl) {
+      const setting = await prisma.siteSetting.findUnique({
+        where: { key: "contact_webhook_url" },
+      });
+      webhookUrl = setting?.value;
+    }
+    if (!webhookUrl) return reply.status(400).send({ error: "No webhook URL provided" });
 
     const payload = {
       id: `test_${Date.now()}`,

--- a/src/frontend/src/app/admin/settings/page.tsx
+++ b/src/frontend/src/app/admin/settings/page.tsx
@@ -217,13 +217,16 @@ function ContactsTab({
               onClick={async () => {
                 setWebhookTestResult(null);
                 const { adminFetch } = await import("@/lib/admin-api");
-                const { data } = await adminFetch<{ status: string; responseStatus?: number; responseBody?: string }>("/settings/test-webhook", { method: "POST" });
+                const { data } = await adminFetch<{ status: string; responseStatus?: number; responseBody?: string }>(
+                  "/settings/test-webhook",
+                  { method: "POST", body: JSON.stringify({ url: form.contact_webhook_url }) }
+                );
                 if (data) {
                   setWebhookTestResult(data.status === "sent" ? `Envoyé (${data.responseStatus})` : `Échec : ${data.responseBody?.slice(0, 100)}`);
                 } else {
                   setWebhookTestResult("Erreur");
                 }
-                setTimeout(() => setWebhookTestResult(null), 5000);
+                setTimeout(() => setWebhookTestResult(null), 8000);
               }}
               className="mt-2 px-3 py-1 text-xs rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
             >


### PR DESCRIPTION
Avant : il fallait Enregistrer avant de Tester (le backend lisait depuis SiteSetting). Contre-intuitif.

Maintenant : le bouton envoie l'URL du formulaire au backend, qui l'utilise directement. Plus besoin d'enregistrer pour tester.

Le backend garde un fallback sur `SiteSetting` si le body est vide (utile pour appels programmatiques).

🤖 Generated with [Claude Code](https://claude.com/claude-code)