### PR TITLE
feat(sponsor): configurable page status with 4 modes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,14 @@ enum PublicationStatus {
   PUBLISHED
 }
 
+// Drives what /devenir-sponsor displays for the featured edition.
+enum SponsorPageStatus {
+  PRE_ANNOUNCEMENT  // Before the announcement: short message + CTA to a temporary external form (e.g. Google Form)
+  TEMPORARY         // Plans visible (if any) but contact still goes through the temporary external form
+  OPEN              // Full mode: plans + brochure download + integrated contact form
+  SOLD_OUT          // All slots taken: short message + link to /contact
+}
+
 
 enum UserRole {
   ADMIN
@@ -45,7 +53,11 @@ model Edition {
   galleryUrl          String?
   archivedSiteUrl     String?
   // URL of the sponsor brochure PDF (stored under /uploads/, picked from /admin/files)
-  sponsorBrochureUrl  String?
+  sponsorBrochureUrl       String?
+  // Controls the /devenir-sponsor page rendering (see SponsorPageStatus)
+  sponsorPageStatus        SponsorPageStatus @default(PRE_ANNOUNCEMENT)
+  // External form URL used in PRE_ANNOUNCEMENT and TEMPORARY modes
+  sponsorTemporaryFormUrl  String?
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
 

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
-import { revalidateHome, revalidateEdition } from "../../lib/revalidate.js";
+import { revalidateHome, revalidateEdition, revalidateSponsors } from "../../lib/revalidate.js";
 
 interface EditionBody {
   year: number;
@@ -16,6 +16,8 @@ interface EditionBody {
   galleryUrl?: string;
   archivedSiteUrl?: string;
   sponsorBrochureUrl?: string;
+  sponsorPageStatus?: "PRE_ANNOUNCEMENT" | "TEMPORARY" | "OPEN" | "SOLD_OUT";
+  sponsorTemporaryFormUrl?: string;
 }
 
 export default async function adminEditionRoutes(app: FastifyInstance) {
@@ -107,6 +109,9 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         aftermovieUrl: edition.aftermovieUrl,
         galleryUrl: edition.galleryUrl,
         archivedSiteUrl: edition.archivedSiteUrl,
+        sponsorBrochureUrl: edition.sponsorBrochureUrl,
+        sponsorPageStatus: edition.sponsorPageStatus,
+        sponsorTemporaryFormUrl: edition.sponsorTemporaryFormUrl,
         ticketTiersCount: edition._count.ticketTiers,
         articlesCount: edition._count.articles,
       };
@@ -143,12 +148,16 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         galleryUrl: body.galleryUrl !== undefined ? (body.galleryUrl || null) : existing.galleryUrl,
         archivedSiteUrl: body.archivedSiteUrl !== undefined ? (body.archivedSiteUrl || null) : existing.archivedSiteUrl,
         sponsorBrochureUrl: body.sponsorBrochureUrl !== undefined ? (body.sponsorBrochureUrl || null) : existing.sponsorBrochureUrl,
+        sponsorPageStatus: body.sponsorPageStatus ?? existing.sponsorPageStatus,
+        sponsorTemporaryFormUrl: body.sponsorTemporaryFormUrl !== undefined ? (body.sponsorTemporaryFormUrl || null) : existing.sponsorTemporaryFormUrl,
       },
     });
 
     // Revalidate the edition bilan page (both years if year changed) + home
     revalidateEdition(edition.year);
     if (existing.year !== edition.year) revalidateEdition(existing.year);
+    // Sponsor page depends on featured edition fields (status, brochure, etc.)
+    revalidateSponsors();
 
     return {
       id: edition.id,

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -132,6 +132,9 @@ export default async function editionRoutes(app: FastifyInstance) {
       previousAfterMovieUrl: previousEdition?.aftermovieUrl || null,
       galleryUrl: edition.galleryUrl,
       archivedSiteUrl: edition.archivedSiteUrl,
+      sponsorBrochureUrl: edition.sponsorBrochureUrl,
+      sponsorPageStatus: edition.sponsorPageStatus,
+      sponsorTemporaryFormUrl: edition.sponsorTemporaryFormUrl,
       // TODO: compute from actual data when Speaker/Session/Sponsor models exist
       isProgramPublished: false,
       hasSpeakers: false,

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -199,7 +199,15 @@
     "hidden": "Hidden",
     "formTitle": "Contact us",
     "formIntro": "Fill out the form below and we will send you our sponsorship brochure. We will get back to you shortly.",
-    "formSubmit": "Receive the sponsorship brochure"
+    "formSubmit": "Receive the sponsorship brochure",
+    "brochureCta": "Download the brochure",
+    "preAnnouncementTitle": "Coming soon",
+    "preAnnouncementMessage": "Sponsorships are opening soon. Sign up to be notified as soon as packages are available.",
+    "preAnnouncementCta": "Sign up to be notified",
+    "temporaryCta": "Receive the sponsorship brochure",
+    "soldOutTitle": "Fully booked",
+    "soldOutMessage": "All sponsor slots for this edition have been filled. See you next year! In the meantime, feel free to reach out with any questions.",
+    "soldOutCta": "Contact us"
   },
   "codeOfConduct": {
     "title": "Code of Conduct",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -199,7 +199,15 @@
     "hidden": "Masqué",
     "formTitle": "Contactez-nous",
     "formIntro": "Remplissez le formulaire ci-dessous et nous vous enverrons notre dossier de sponsoring. Nous reviendrons vers vous dans les plus brefs délais.",
-    "formSubmit": "Recevoir le dossier de sponsoring"
+    "formSubmit": "Recevoir le dossier de sponsoring",
+    "brochureCta": "Télécharger la plaquette",
+    "preAnnouncementTitle": "Bientôt disponible",
+    "preAnnouncementMessage": "Les sponsorings ouvrent prochainement. Inscrivez-vous pour être informé dès que les formules seront disponibles.",
+    "preAnnouncementCta": "S'inscrire pour être informé",
+    "temporaryCta": "Recevoir le dossier de sponsoring",
+    "soldOutTitle": "Sponsoring complet",
+    "soldOutMessage": "Tous les emplacements sponsors de cette édition sont attribués. Rendez-vous l'année prochaine ! En attendant, vous pouvez nous contacter pour toute question.",
+    "soldOutCta": "Nous contacter"
   },
   "codeOfConduct": {
     "title": "Code de conduite",

--- a/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
+++ b/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
@@ -4,6 +4,8 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { getCurrentEdition, getSponsorPlans, getContactCategories } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
 import ContactForm from "@/components/ContactForm";
+import { Link } from "@/i18n/navigation";
+import type { SponsorPageStatus } from "@/lib/types";
 
 function localizedField(
   obj: Record<string, unknown>,
@@ -44,6 +46,20 @@ export default async function SponsorPage() {
   ];
 
   const heroImageUrl = edition?.heroImageUrl || null;
+  const status: SponsorPageStatus = edition?.sponsorPageStatus ?? "PRE_ANNOUNCEMENT";
+  const tempUrl = edition?.sponsorTemporaryFormUrl || null;
+
+  // Sections to render depending on status:
+  // - "why" block always shown (gives context regardless of mode)
+  // - plans + brochure + integrated form: OPEN only
+  // - plans (without brochure/form, with external CTA): TEMPORARY
+  // - external CTA only: PRE_ANNOUNCEMENT
+  // - sold-out message: SOLD_OUT
+  const showPlans = status === "OPEN" || status === "TEMPORARY";
+  const showIntegratedForm = status === "OPEN" && Boolean(sponsoringCategory);
+  const showTemporaryCta = (status === "PRE_ANNOUNCEMENT" || status === "TEMPORARY") && Boolean(tempUrl);
+  const showSoldOut = status === "SOLD_OUT";
+  const showPreAnnouncementMessage = status === "PRE_ANNOUNCEMENT";
 
   return (
     <div>
@@ -80,121 +96,184 @@ export default async function SponsorPage() {
             {t("intro")}
           </p>
 
-          {/* Why become a sponsor */}
-          <div className="mt-16">
-            <h2 className="text-2xl lg:text-4xl font-bold text-noir">
-              {t("whyTitle")}
-            </h2>
-            <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-6">
-              {(["Visibility", "Brand", "Products", "Network"] as const).map(
-                (key) => (
-                  <div
-                    key={key}
-                    className="p-6 rounded-xl bg-blanc shadow-card"
-                  >
-                    <p className="text-lg font-bold text-noir">
-                      {t(`why${key}`)}
-                    </p>
-                    <p className="mt-2 text-sm text-gris leading-relaxed">
-                      {t(`why${key}Desc`)}
-                    </p>
-                  </div>
-                ),
+          {/* Sold-out callout — short and ends the page */}
+          {showSoldOut && (
+            <div className="mt-12 p-8 rounded-xl bg-blanc shadow-card max-w-3xl">
+              <h2 className="text-2xl lg:text-3xl font-bold text-noir">
+                {t("soldOutTitle")}
+              </h2>
+              <p className="mt-4 text-gris leading-relaxed">
+                {t("soldOutMessage")}
+              </p>
+              <Link
+                href="/contact"
+                className="mt-6 inline-block px-6 py-3 rounded-[12px] bg-bleu text-blanc font-bold hover:bg-bleu/90 transition-colors"
+              >
+                {t("soldOutCta")}
+              </Link>
+            </div>
+          )}
+
+          {/* Why become a sponsor — shown unless sold out */}
+          {!showSoldOut && (
+            <div className="mt-16">
+              <h2 className="text-2xl lg:text-4xl font-bold text-noir">
+                {t("whyTitle")}
+              </h2>
+              <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-6">
+                {(["Visibility", "Brand", "Products", "Network"] as const).map(
+                  (key) => (
+                    <div
+                      key={key}
+                      className="p-6 rounded-xl bg-blanc shadow-card"
+                    >
+                      <p className="text-lg font-bold text-noir">
+                        {t(`why${key}`)}
+                      </p>
+                      <p className="mt-2 text-sm text-gris leading-relaxed">
+                        {t(`why${key}Desc`)}
+                      </p>
+                    </div>
+                  ),
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Pre-announcement message */}
+          {showPreAnnouncementMessage && (
+            <div className="mt-16 p-8 rounded-xl bg-blanc shadow-card max-w-3xl">
+              <h2 className="text-2xl lg:text-3xl font-bold text-noir">
+                {t("preAnnouncementTitle")}
+              </h2>
+              <p className="mt-4 text-gris leading-relaxed">
+                {t("preAnnouncementMessage")}
+              </p>
+              {showTemporaryCta && tempUrl && (
+                <a
+                  href={tempUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-6 inline-block px-6 py-3 rounded-[12px] bg-bleu text-blanc font-bold hover:bg-bleu/90 transition-colors"
+                >
+                  {t("preAnnouncementCta")}
+                </a>
               )}
             </div>
-          </div>
+          )}
 
-          {/* Sponsor plans — pricing table style */}
-          <div className="mt-16">
-            <h2 className="text-2xl lg:text-4xl font-bold text-noir">
-              {t("plansTitle")}
-            </h2>
+          {/* Sponsor plans */}
+          {showPlans && (
+            <div className="mt-16">
+              <h2 className="text-2xl lg:text-4xl font-bold text-noir">
+                {t("plansTitle")}
+              </h2>
 
-            {plans.length === 0 ? (
-              <p className="mt-6 text-gris">{t("noPlans")}</p>
-            ) : (
-              <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0">
-                {plans.map((plan) => {
-                  const name = localizedField(plan as unknown as Record<string, unknown>, "name", locale);
-                  const subtitle = localizedField(plan as unknown as Record<string, unknown>, "subtitle", locale);
-                  const advantages = plan.advantages || [];
+              {plans.length === 0 ? (
+                <p className="mt-6 text-gris">{t("noPlans")}</p>
+              ) : (
+                <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0">
+                  {plans.map((plan) => {
+                    const name = localizedField(plan as unknown as Record<string, unknown>, "name", locale);
+                    const subtitle = localizedField(plan as unknown as Record<string, unknown>, "subtitle", locale);
+                    const advantages = plan.advantages || [];
 
-                  return (
-                    <div
-                      key={plan.id}
-                      className={`relative flex flex-col border border-gris/20 bg-blanc ${
-                        plan.isFeatured
-                          ? "lg:-my-4 lg:shadow-xl lg:z-10 lg:scale-[1.03] rounded-2xl"
-                          : "first:rounded-l-2xl last:rounded-r-2xl"
-                      }`}
-                    >
-                      {/* Color header */}
+                    // CTA target depends on the page mode
+                    const planCtaHref = status === "OPEN" ? "#contact" : (tempUrl || "#contact");
+                    const planCtaExternal = status !== "OPEN" && Boolean(tempUrl);
+
+                    return (
                       <div
-                        className={`px-6 py-4 text-center ${
-                          plan.isFeatured ? "rounded-t-2xl py-5" : "first:rounded-tl-2xl last:rounded-tr-2xl"
+                        key={plan.id}
+                        className={`relative flex flex-col border border-gris/20 bg-blanc ${
+                          plan.isFeatured
+                            ? "lg:-my-4 lg:shadow-xl lg:z-10 lg:scale-[1.03] rounded-2xl"
+                            : "first:rounded-l-2xl last:rounded-r-2xl"
                         }`}
-                        style={{ backgroundColor: plan.color }}
                       >
-                        <p className={`font-bold text-blanc ${plan.isFeatured ? "text-2xl" : "text-xl"}`}>
-                          {name}
-                        </p>
-                      </div>
-
-                      {/* Subtitle */}
-                      {subtitle && (
-                        <p className="text-center text-sm text-gris italic px-4 pt-4">
-                          {subtitle}
-                        </p>
-                      )}
-
-                      {/* Stand size */}
-                      {plan.standSize && (
-                        <p className="text-center text-3xl lg:text-4xl font-bold px-4 pt-4" style={{ color: plan.color }}>
-                          {plan.standSize}
-                        </p>
-                      )}
-
-                      {!plan.standSize && (
-                        <p className="text-center text-lg font-bold text-gris/50 px-4 pt-6">
-                          —
-                        </p>
-                      )}
-
-                      {/* Advantages */}
-                      <div className="flex-1 px-6 py-6">
-                        <ul className="space-y-3">
-                          {advantages.map(
-                            (adv: { fr: string; en: string }, i: number) => (
-                              <li
-                                key={i}
-                                className="text-sm text-noir text-center"
-                              >
-                                {locale === "en" ? adv.en : adv.fr}
-                              </li>
-                            ),
-                          )}
-                        </ul>
-                      </div>
-
-                      {/* CTA button */}
-                      <div className="px-6 pb-6">
-                        <a
-                          href="#contact"
-                          className="block w-full text-center py-3 rounded-lg font-bold text-blanc transition-opacity hover:opacity-90"
+                        {/* Color header */}
+                        <div
+                          className={`px-6 py-4 text-center ${
+                            plan.isFeatured ? "rounded-t-2xl py-5" : "first:rounded-tl-2xl last:rounded-tr-2xl"
+                          }`}
                           style={{ backgroundColor: plan.color }}
                         >
-                          {t("ctaContact")}
-                        </a>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+                          <p className={`font-bold text-blanc ${plan.isFeatured ? "text-2xl" : "text-xl"}`}>
+                            {name}
+                          </p>
+                        </div>
 
-          {/* Contact form */}
-          {sponsoringCategory && (
+                        {/* Subtitle */}
+                        {subtitle && (
+                          <p className="text-center text-sm text-gris italic px-4 pt-4">
+                            {subtitle}
+                          </p>
+                        )}
+
+                        {/* Stand size */}
+                        {plan.standSize && (
+                          <p className="text-center text-3xl lg:text-4xl font-bold px-4 pt-4" style={{ color: plan.color }}>
+                            {plan.standSize}
+                          </p>
+                        )}
+
+                        {!plan.standSize && (
+                          <p className="text-center text-lg font-bold text-gris/50 px-4 pt-6">
+                            —
+                          </p>
+                        )}
+
+                        {/* Advantages */}
+                        <div className="flex-1 px-6 py-6">
+                          <ul className="space-y-3">
+                            {advantages.map(
+                              (adv: { fr: string; en: string }, i: number) => (
+                                <li
+                                  key={i}
+                                  className="text-sm text-noir text-center"
+                                >
+                                  {locale === "en" ? adv.en : adv.fr}
+                                </li>
+                              ),
+                            )}
+                          </ul>
+                        </div>
+
+                        {/* CTA button */}
+                        <div className="px-6 pb-6">
+                          <a
+                            href={planCtaHref}
+                            {...(planCtaExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                            className="block w-full text-center py-3 rounded-lg font-bold text-blanc transition-opacity hover:opacity-90"
+                            style={{ backgroundColor: plan.color }}
+                          >
+                            {t("ctaContact")}
+                          </a>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Temporary CTA below plans (TEMPORARY mode) */}
+          {status === "TEMPORARY" && showTemporaryCta && tempUrl && (
+            <div className="mt-16 text-center">
+              <a
+                href={tempUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block px-8 py-4 rounded-[12px] bg-bleu text-blanc font-bold text-xl hover:bg-bleu/90 transition-colors"
+              >
+                {t("temporaryCta")}
+              </a>
+            </div>
+          )}
+
+          {/* Integrated contact form (OPEN mode only) */}
+          {showIntegratedForm && sponsoringCategory && (
             <div id="contact" className="mt-16 scroll-mt-8">
               <h2 className="text-2xl lg:text-4xl font-bold text-noir">
                 {t("formTitle")}
@@ -202,6 +281,16 @@ export default async function SponsorPage() {
               <p className="mt-4 text-gris leading-relaxed max-w-3xl">
                 {t("formIntro")}
               </p>
+              {edition?.sponsorBrochureUrl && (
+                <a
+                  href={edition.sponsorBrochureUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-4 inline-block px-5 py-2 rounded-[12px] border-2 border-bleu text-bleu font-bold hover:bg-bleu/10 transition-colors"
+                >
+                  {t("brochureCta")}
+                </a>
+              )}
               <div className="mt-8 max-w-2xl">
                 <ContactForm
                   categories={categories}

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -25,7 +25,6 @@ interface EditionData {
   aftermovieUrl: string | null;
   galleryUrl: string | null;
   archivedSiteUrl: string | null;
-  sponsorBrochureUrl: string | null;
   ticketTiersCount: number;
   articlesCount: number;
 }

--- a/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
@@ -19,7 +19,6 @@ interface EditionData {
   aftermovieUrl: string | null;
   galleryUrl: string | null;
   archivedSiteUrl: string | null;
-  sponsorBrochureUrl: string | null;
 }
 
 const STATUS_OPTIONS = [
@@ -45,12 +44,10 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
     aftermovieUrl: edition.aftermovieUrl || "",
     galleryUrl: edition.galleryUrl || "",
     archivedSiteUrl: edition.archivedSiteUrl || "",
-    sponsorBrochureUrl: edition.sponsorBrochureUrl || "",
   });
   const [isSaving, setIsSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
-  const [isBrochurePickerOpen, setIsBrochurePickerOpen] = useState(false);
 
   async function handleSave() {
     setIsSaving(true);
@@ -68,7 +65,6 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
         aftermovieUrl: form.aftermovieUrl || undefined,
         galleryUrl: form.galleryUrl || undefined,
         archivedSiteUrl: form.archivedSiteUrl || undefined,
-        sponsorBrochureUrl: form.sponsorBrochureUrl || undefined,
       }),
     });
     setIsSaving(false);
@@ -136,37 +132,6 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
       </div>
 
       <FormField label="URL formulaire partenaire" name="partnerFormUrl" type="url" value={form.partnerFormUrl} onChange={(v) => setForm({ ...form, partnerFormUrl: v })} />
-
-      {/* Sponsor brochure */}
-      <div>
-        <label className="block text-sm font-medium text-noir mb-1">Plaquette sponsors (PDF)</label>
-        <div className="flex items-center gap-4">
-          <button
-            type="button"
-            onClick={() => setIsBrochurePickerOpen(true)}
-            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
-          >
-            {form.sponsorBrochureUrl ? "Changer le fichier" : "Choisir un fichier"}
-          </button>
-          {form.sponsorBrochureUrl && (
-            <button
-              type="button"
-              onClick={() => setForm({ ...form, sponsorBrochureUrl: "" })}
-              className="text-sm text-terre-cuite hover:underline"
-            >
-              Supprimer
-            </button>
-          )}
-        </div>
-        {form.sponsorBrochureUrl && (
-          <p className="text-xs text-gris mt-1">{form.sponsorBrochureUrl}</p>
-        )}
-        <ImagePickerDialog
-          open={isBrochurePickerOpen}
-          onClose={() => setIsBrochurePickerOpen(false)}
-          onSelect={(url) => setForm({ ...form, sponsorBrochureUrl: url })}
-        />
-      </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <FormField label="Aftermovie URL" name="aftermovieUrl" type="url" value={form.aftermovieUrl} onChange={(v) => setForm({ ...form, aftermovieUrl: v })} />

--- a/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
@@ -5,6 +5,22 @@ import { adminFetch } from "@/lib/admin-api";
 import FormField from "@/components/admin/FormField";
 import BilingualInput from "@/components/admin/BilingualInput";
 import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
+
+type SponsorPageStatus = "PRE_ANNOUNCEMENT" | "TEMPORARY" | "OPEN" | "SOLD_OUT";
+
+interface EditionSettings {
+  sponsorPageStatus: SponsorPageStatus;
+  sponsorTemporaryFormUrl: string | null;
+  sponsorBrochureUrl: string | null;
+}
+
+const STATUS_OPTIONS: { value: SponsorPageStatus; label: string; hint: string }[] = [
+  { value: "PRE_ANNOUNCEMENT", label: "Avant annonce", hint: "Affiche un message + CTA vers le formulaire temporaire (formulaire externe)." },
+  { value: "TEMPORARY", label: "Annoncé (formulaire temporaire)", hint: "Affiche les plans + CTA vers le formulaire externe (la plaquette n'est pas encore prête)." },
+  { value: "OPEN", label: "Ouvert (formulaire intégré)", hint: "Affiche tout : plans, plaquette téléchargeable, formulaire intégré." },
+  { value: "SOLD_OUT", label: "Sponsoring complet", hint: "Affiche un message « tout est vendu » avec un lien vers /contact." },
+];
 
 interface SponsorPlan {
   id: number;
@@ -61,6 +77,44 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
   const [isSaving, setIsSaving] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<SponsorPlan | null>(null);
 
+  // Page settings (status, temporary form URL, brochure URL) — separate
+  // from the plans list because they live on Edition, not on SponsorPlan.
+  const [settings, setSettings] = useState<EditionSettings>({
+    sponsorPageStatus: "PRE_ANNOUNCEMENT",
+    sponsorTemporaryFormUrl: null,
+    sponsorBrochureUrl: null,
+  });
+  const [isSettingsSaving, setIsSettingsSaving] = useState(false);
+  const [settingsSaved, setSettingsSaved] = useState(false);
+  const [isBrochurePickerOpen, setIsBrochurePickerOpen] = useState(false);
+
+  async function loadSettings() {
+    const { data } = await adminFetch<EditionSettings>(`/editions/${editionId}`);
+    if (data) {
+      setSettings({
+        sponsorPageStatus: data.sponsorPageStatus ?? "PRE_ANNOUNCEMENT",
+        sponsorTemporaryFormUrl: data.sponsorTemporaryFormUrl ?? null,
+        sponsorBrochureUrl: data.sponsorBrochureUrl ?? null,
+      });
+    }
+  }
+
+  async function saveSettings() {
+    setIsSettingsSaving(true);
+    setSettingsSaved(false);
+    await adminFetch(`/editions/${editionId}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        sponsorPageStatus: settings.sponsorPageStatus,
+        sponsorTemporaryFormUrl: settings.sponsorTemporaryFormUrl ?? "",
+        sponsorBrochureUrl: settings.sponsorBrochureUrl ?? "",
+      }),
+    });
+    setIsSettingsSaving(false);
+    setSettingsSaved(true);
+    setTimeout(() => setSettingsSaved(false), 3000);
+  }
+
   async function loadPlans() {
     setIsLoading(true);
     const { data } = await adminFetch<SponsorPlan[]>(
@@ -72,6 +126,7 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
 
   useEffect(() => {
     loadPlans();
+    loadSettings();
   }, [editionId]);
 
   function startNew() {
@@ -169,8 +224,87 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
 
   if (isLoading) return <p className="text-gris text-sm">Chargement...</p>;
 
+  const currentStatusOption = STATUS_OPTIONS.find((o) => o.value === settings.sponsorPageStatus);
+  const showTempUrl = settings.sponsorPageStatus === "PRE_ANNOUNCEMENT" || settings.sponsorPageStatus === "TEMPORARY";
+  const showBrochure = settings.sponsorPageStatus === "OPEN";
+
   return (
     <div>
+      {/* Page settings */}
+      <div className="bg-blanc-casse/50 rounded-xl p-6 mb-6 space-y-4">
+        <h3 className="text-lg font-bold text-noir">Statut de la page « Devenir sponsor »</h3>
+        <div>
+          <label className="block text-sm font-medium text-noir mb-1">Statut</label>
+          <select
+            value={settings.sponsorPageStatus}
+            onChange={(e) => setSettings({ ...settings, sponsorPageStatus: e.target.value as SponsorPageStatus })}
+            className="w-full max-w-md rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+          >
+            {STATUS_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+          {currentStatusOption && (
+            <p className="mt-1 text-xs text-gris">{currentStatusOption.hint}</p>
+          )}
+        </div>
+
+        {showTempUrl && (
+          <FormField
+            label="URL formulaire temporaire (Google Form, etc.)"
+            name="sponsorTemporaryFormUrl"
+            type="url"
+            value={settings.sponsorTemporaryFormUrl || ""}
+            onChange={(v) => setSettings({ ...settings, sponsorTemporaryFormUrl: v || null })}
+            helpText="Lien externe affiché en CTA tant que la plaquette n'est pas finalisée."
+          />
+        )}
+
+        {showBrochure && (
+          <div>
+            <label className="block text-sm font-medium text-noir mb-1">Plaquette sponsors (PDF)</label>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => setIsBrochurePickerOpen(true)}
+                className="px-3 py-1.5 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+              >
+                {settings.sponsorBrochureUrl ? "Changer le fichier" : "Choisir un fichier"}
+              </button>
+              {settings.sponsorBrochureUrl && (
+                <button
+                  type="button"
+                  onClick={() => setSettings({ ...settings, sponsorBrochureUrl: null })}
+                  className="text-sm text-terre-cuite hover:underline"
+                >
+                  Supprimer
+                </button>
+              )}
+            </div>
+            {settings.sponsorBrochureUrl && (
+              <p className="mt-1 text-xs text-gris">{settings.sponsorBrochureUrl}</p>
+            )}
+            <ImagePickerDialog
+              open={isBrochurePickerOpen}
+              onClose={() => setIsBrochurePickerOpen(false)}
+              onSelect={(url) => setSettings({ ...settings, sponsorBrochureUrl: url })}
+            />
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={saveSettings}
+            disabled={isSettingsSaving}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {isSettingsSaving ? "Sauvegarde..." : "Enregistrer le statut"}
+          </button>
+          {settingsSaved && <span className="text-sm text-malachite">Enregistré !</span>}
+        </div>
+      </div>
+
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-bold text-noir">Formules de sponsoring</h3>
         <button

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -1,3 +1,5 @@
+export type SponsorPageStatus = "PRE_ANNOUNCEMENT" | "TEMPORARY" | "OPEN" | "SOLD_OUT";
+
 export interface Edition {
   id: number;
   year: number;
@@ -13,6 +15,9 @@ export interface Edition {
   previousAfterMovieUrl: string | null;
   galleryUrl: string | null;
   archivedSiteUrl: string | null;
+  sponsorBrochureUrl: string | null;
+  sponsorPageStatus: SponsorPageStatus;
+  sponsorTemporaryFormUrl: string | null;
   isProgramPublished: boolean;
   hasSpeakers: boolean;
   hasSponsors: boolean;


### PR DESCRIPTION
## Summary

La page \`/devenir-sponsor\` s'adapte désormais à la phase de vente du sponsoring via un nouvel enum sur \`Edition\` :

| Statut | Affichage |
|---|---|
| \`PRE_ANNOUNCEMENT\` | Message court + CTA vers le formulaire temporaire (Google Form) |
| \`TEMPORARY\` | Plans visibles + CTA vers le formulaire temporaire (la plaquette n'est pas encore prête) |
| \`OPEN\` | Plans + plaquette téléchargeable + formulaire intégré |
| \`SOLD_OUT\` | Message « complet » + lien vers \`/contact\` |

**Admin** : statut + URL temporaire + sélecteur de plaquette dans l'onglet Sponsoring de l'édition (la plaquette a été déplacée depuis GeneralTab pour regrouper tous les réglages sponsor).

## Risque

Toutes les éditions existantes basculent en \`PRE_ANNOUNCEMENT\` au déploiement (default Prisma). L'admin doit basculer manuellement en \`OPEN\` ou \`TEMPORARY\` après déploiement.

## Test plan

- [ ] Build Coolify OK (frontend tsc + backend tsc + prisma db push)
- [ ] Admin > Éditions > Sponsoring : bloc « Statut de la page » visible
- [ ] PRE_ANNOUNCEMENT : page sponsor affiche le message + CTA externe
- [ ] TEMPORARY : page sponsor affiche les plans + CTA externe
- [ ] OPEN : page sponsor affiche les plans + plaquette + formulaire intégré
- [ ] SOLD_OUT : page sponsor affiche le message « complet » + lien /contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)