### PR TITLE
fix(sponsor): Header/Hero CTAs follow sponsorPageStatus

### DIFF
--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -22,7 +22,9 @@ export default function Header() {
   const tHeader = useTranslations("header");
   const edition = useEdition();
 
-  const partnerUrl = edition?.partnerFormUrl || null;
+  // Show "Become a sponsor" CTA whenever the page is meant to receive
+  // visitors (i.e. anything but the sold-out state).
+  const showSponsorCta = edition && edition.sponsorPageStatus !== "SOLD_OUT";
   const cfpUrl = edition?.cfpUrl || null;
 
   const navLinks = ALL_NAV_LINKS.filter((link) => {
@@ -70,7 +72,7 @@ export default function Header() {
         {/* Desktop actions */}
         <div className="hidden lg:flex items-center gap-4">
           <SocialIcons size={20} className="text-gris" />
-          {partnerUrl && (
+          {showSponsorCta && (
             <Link
               href="/devenir-sponsor"
               className="rounded-[12px] border-2 border-bleu px-[18px] py-1.5 text-base font-bold text-bleu hover:bg-bleu hover:text-blanc transition-colors"
@@ -127,8 +129,8 @@ export default function Header() {
                 {t(link.key)}
               </Link>
             ))}
-            {(partnerUrl || cfpUrl) && <hr className="border-gray-100" />}
-            {partnerUrl && (
+            {(showSponsorCta || cfpUrl) && <hr className="border-gray-100" />}
+            {showSponsorCta && (
               <Link
                 href="/devenir-sponsor"
                 className="rounded-[12px] border-2 border-bleu px-[18px] py-3 text-base font-bold text-bleu text-center"

--- a/src/frontend/src/components/home/HeroSection.tsx
+++ b/src/frontend/src/components/home/HeroSection.tsx
@@ -26,7 +26,9 @@ export default function HeroSection({ edition, locale }: HeroSectionProps) {
       ? `${edition.venueName}, ${edition.venueAddress}`
       : edition?.venueName || null;
 
-  const partnerUrl = edition?.partnerFormUrl || null;
+  // Show "Become a sponsor" CTA whenever the page is meant to receive
+  // visitors (i.e. anything but the sold-out state).
+  const showSponsorCta = edition && edition.sponsorPageStatus !== "SOLD_OUT";
   const cfpUrl = edition?.cfpUrl || null;
 
   const backgroundImage = heroImageUrl
@@ -110,9 +112,9 @@ export default function HeroSection({ edition, locale }: HeroSectionProps) {
             )}
 
             {/* Buttons */}
-            {(partnerUrl || cfpUrl) && (
+            {(showSponsorCta || cfpUrl) && (
               <div className="mt-16 pl-8 lg:pl-[225px] flex flex-col sm:flex-row gap-4">
-                {partnerUrl && (
+                {showSponsorCta && (
                   <Link
                     href="/devenir-sponsor"
                     className="px-8 py-5 rounded-[12px] border-3 border-bleu bg-blanc text-bleu font-bold text-2xl hover:bg-bleu hover:text-blanc transition-colors text-center"


### PR DESCRIPTION
Le CTA "Devenir sponsor" du Header et du Hero était conditionné par l'ancien champ `partnerFormUrl`. Maintenant qu'on a `sponsorPageStatus`, on l'utilise : CTA visible sauf en `SOLD_OUT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)