### PR TITLE
security(html): sanitize rich text on write + escape email template vars

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -28,7 +28,8 @@
     "better-auth": "^1.6.5",
     "fastify": "^5.8.4",
     "nodemailer": "^8.0.4",
-    "prisma": "6"
+    "prisma": "6",
+    "sanitize-html": "^2.17.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@types/node": "^25.5.0",
     "@types/nodemailer": "^7.0.11",
+    "@types/sanitize-html": "^2.16.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       prisma:
         specifier: '6'
         version: 6.19.2(typescript@5.9.3)
+      sanitize-html:
+        specifier: ^2.17.3
+        version: 2.17.3
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -57,6 +60,9 @@ importers:
       '@types/nodemailer':
         specifier: ^7.0.11
         version: 7.0.11
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -640,6 +646,9 @@ packages:
   '@types/nodemailer@7.0.11':
     resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
@@ -853,6 +862,10 @@ packages:
     resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
     engines: {node: '>=16.0.0'}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
@@ -875,6 +888,19 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -895,6 +921,14 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -905,6 +939,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -998,6 +1036,9 @@ packages:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -1015,6 +1056,10 @@ packages:
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
@@ -1204,6 +1249,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1404,6 +1452,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-html@2.17.3:
+    resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2092,6 +2143,10 @@ snapshots:
     dependencies:
       '@types/node': 25.5.0
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@vitest/expect@4.1.2':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2272,6 +2327,8 @@ snapshots:
 
   deepmerge-ts@7.1.5: {}
 
+  deepmerge@4.3.1: {}
+
   defu@6.1.4: {}
 
   denque@2.1.0:
@@ -2284,6 +2341,24 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv@16.6.1: {}
 
@@ -2311,6 +2386,10 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -2344,6 +2423,8 @@ snapshots:
       '@esbuild/win32-x64': 0.27.4
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -2457,6 +2538,13 @@ snapshots:
 
   helmet@8.1.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -2475,6 +2563,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ipaddr.js@2.3.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-property@1.0.2:
     optional: true
@@ -2631,6 +2721,8 @@ snapshots:
   openapi-types@12.1.3: {}
 
   package-json-from-dist@1.0.1: {}
+
+  parse-srcset@1.0.2: {}
 
   path-key@3.1.1: {}
 
@@ -2863,6 +2955,15 @@ snapshots:
 
   safer-buffer@2.1.2:
     optional: true
+
+  sanitize-html@2.17.3:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.8
 
   scheduler@0.27.0:
     optional: true

--- a/src/backend/src/lib/email.test.ts
+++ b/src/backend/src/lib/email.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { interpolate } from "./email.js";
+import { interpolate, interpolateHtml } from "./email.js";
 
 describe("interpolate", () => {
   it("replaces known tokens", () => {
@@ -26,5 +26,27 @@ describe("interpolate", () => {
 
   it("replaces multiple occurrences of the same token", () => {
     expect(interpolate("{name} and {name}", { name: "X" })).toBe("X and X");
+  });
+});
+
+describe("interpolateHtml", () => {
+  it("escapes HTML special chars in values", () => {
+    const result = interpolateHtml("Hello {firstName}", {
+      firstName: "<script>alert(1)</script>",
+    });
+    expect(result).toBe("Hello &lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("preserves HTML in the template itself", () => {
+    const tpl = '<p>Hi <strong>{name}</strong></p>';
+    expect(interpolateHtml(tpl, { name: "Jane" })).toBe("<p>Hi <strong>Jane</strong></p>");
+  });
+
+  it("escapes quotes and ampersands", () => {
+    expect(interpolateHtml("{x}", { x: 'A "B" & C' })).toBe("A &quot;B&quot; &amp; C");
+  });
+
+  it("leaves unknown tokens unchanged", () => {
+    expect(interpolateHtml("{unknown}", {})).toBe("{unknown}");
   });
 });

--- a/src/backend/src/lib/email.ts
+++ b/src/backend/src/lib/email.ts
@@ -42,7 +42,33 @@ export async function sendEmail({ to, subject, text, html }: SendEmailOptions) {
 /**
  * Simple string template interpolation: replaces `{key}` tokens with
  * the corresponding value from `vars`. Unknown tokens are left as-is.
+ * Use this for `text/plain` templates only — prefer `interpolateHtml`
+ * when the output is rendered as HTML.
  */
 export function interpolate(template: string, vars: Record<string, string>): string {
   return template.replace(/\{(\w+)\}/g, (match, key) => vars[key] ?? match);
+}
+
+/**
+ * HTML-safe variant of `interpolate`: values are HTML-escaped before
+ * substitution, so user-controlled input (firstName, lastName, email, etc.)
+ * can't inject arbitrary markup into the rendered email.
+ *
+ * The template itself is NOT escaped — it may contain anchors, line breaks,
+ * etc. This matches how the confirmation email bodies are authored.
+ */
+export function interpolateHtml(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const value = vars[key];
+    return value === undefined ? match : escapeHtml(value);
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }

--- a/src/backend/src/lib/sanitize.test.ts
+++ b/src/backend/src/lib/sanitize.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeRichHtml } from "./sanitize.js";
+
+describe("sanitizeRichHtml", () => {
+  it("keeps allowed formatting", () => {
+    const input = "<p>Hello <strong>world</strong></p><h2>Title</h2><ul><li>one</li></ul>";
+    expect(sanitizeRichHtml(input)).toBe(input);
+  });
+
+  it("strips <script> tags entirely", () => {
+    expect(sanitizeRichHtml("<p>ok</p><script>alert(1)</script>")).toBe("<p>ok</p>");
+  });
+
+  it("strips inline event handlers", () => {
+    expect(sanitizeRichHtml('<img src="x" onerror="alert(1)">')).toBe('<img src="x" />');
+  });
+
+  it("rejects javascript: and data: URLs on href/src", () => {
+    expect(sanitizeRichHtml('<a href="javascript:alert(1)">x</a>')).toBe('<a rel="noopener noreferrer">x</a>');
+    expect(sanitizeRichHtml('<img src="data:text/html,<script>">')).toBe('<img />');
+  });
+
+  it("adds rel=noopener on anchors", () => {
+    const output = sanitizeRichHtml('<a href="https://example.com" target="_blank">x</a>');
+    expect(output).toContain('rel="noopener noreferrer"');
+  });
+
+  it("strips style/iframe/form", () => {
+    expect(sanitizeRichHtml('<style>body{}</style><p>ok</p>')).toBe("<p>ok</p>");
+    expect(sanitizeRichHtml('<iframe src="https://evil"></iframe><p>ok</p>')).toBe("<p>ok</p>");
+    expect(sanitizeRichHtml('<form><input /></form><p>ok</p>')).toBe("<p>ok</p>");
+  });
+
+  it("returns empty string for null/undefined/empty", () => {
+    expect(sanitizeRichHtml(null)).toBe("");
+    expect(sanitizeRichHtml(undefined)).toBe("");
+    expect(sanitizeRichHtml("")).toBe("");
+  });
+});

--- a/src/backend/src/lib/sanitize.ts
+++ b/src/backend/src/lib/sanitize.ts
@@ -1,0 +1,47 @@
+import sanitizeHtml from "sanitize-html";
+
+/**
+ * Allowlist-based HTML sanitization for rich text stored from the admin UI
+ * (TipTap editor). Applied server-side before write so the database never
+ * holds anything unsafe — the front-office can then render with
+ * `dangerouslySetInnerHTML` without downstream sanitization.
+ *
+ * The allowlist intentionally tracks what TipTap produces by default
+ * (paragraphs, headings, lists, blockquote, code, links, images, hr, mark).
+ * Anything else (script, iframe, form, on* handlers, style, data URIs) is
+ * dropped. Links get rel=noopener noreferrer automatically.
+ */
+const OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    "p", "br", "strong", "em", "u", "s",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "ul", "ol", "li",
+    "blockquote", "code", "pre",
+    "a", "img",
+    "hr", "mark",
+    "span", "div",
+  ],
+  allowedAttributes: {
+    a: ["href", "title", "target"],
+    img: ["src", "alt", "title", "width", "height", "data-align"],
+    "*": ["class"],
+  },
+  // Only safe URL schemes for href/src. Blocks javascript:, data:, vbscript:
+  // and other exotic schemes that can carry executable content.
+  allowedSchemes: ["http", "https", "mailto", "tel"],
+  allowedSchemesByTag: {
+    img: ["http", "https"],
+  },
+  allowedSchemesAppliedToAttributes: ["href", "src"],
+  // Force target=_blank links to carry safe rel attributes.
+  transformTags: {
+    a: sanitizeHtml.simpleTransform("a", { rel: "noopener noreferrer" }, false),
+  },
+  // Strip entirely (don't keep text content) for clearly malicious tags.
+  nonTextTags: ["script", "style", "textarea", "option", "noscript"],
+};
+
+export function sanitizeRichHtml(html: string | null | undefined): string {
+  if (!html) return "";
+  return sanitizeHtml(html, OPTIONS);
+}

--- a/src/backend/src/routes/admin/articles.ts
+++ b/src/backend/src/routes/admin/articles.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateArticle } from "../../lib/revalidate.js";
+import { sanitizeRichHtml } from "../../lib/sanitize.js";
 
 interface ArticleBody {
   slug: string;
@@ -113,8 +114,8 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
         slug: body.slug.trim(),
         titleFr: body.titleFr.trim(),
         titleEn: body.titleEn.trim(),
-        contentFr: body.contentFr || "",
-        contentEn: body.contentEn || "",
+        contentFr: sanitizeRichHtml(body.contentFr),
+        contentEn: sanitizeRichHtml(body.contentEn),
         excerptFr: body.excerptFr?.trim() || null,
         excerptEn: body.excerptEn?.trim() || null,
         imageUrl: body.imageUrl?.trim() || null,
@@ -152,8 +153,8 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
         slug: body.slug?.trim() || existing.slug,
         titleFr: body.titleFr?.trim() || existing.titleFr,
         titleEn: body.titleEn?.trim() || existing.titleEn,
-        contentFr: body.contentFr ?? existing.contentFr,
-        contentEn: body.contentEn ?? existing.contentEn,
+        contentFr: body.contentFr !== undefined ? sanitizeRichHtml(body.contentFr) : existing.contentFr,
+        contentEn: body.contentEn !== undefined ? sanitizeRichHtml(body.contentEn) : existing.contentEn,
         excerptFr: body.excerptFr?.trim() ?? existing.excerptFr,
         excerptEn: body.excerptEn?.trim() ?? existing.excerptEn,
         imageUrl: body.imageUrl?.trim() ?? existing.imageUrl,

--- a/src/backend/src/routes/admin/pages.ts
+++ b/src/backend/src/routes/admin/pages.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
+import { sanitizeRichHtml } from "../../lib/sanitize.js";
 
 interface PageBody {
   slug: string;
@@ -54,8 +55,8 @@ export default async function adminPageRoutes(app: FastifyInstance) {
       data: {
         titleFr: body.titleFr?.trim() ?? existing.titleFr,
         titleEn: body.titleEn?.trim() ?? existing.titleEn,
-        contentFr: body.contentFr ?? existing.contentFr,
-        contentEn: body.contentEn ?? existing.contentEn,
+        contentFr: body.contentFr !== undefined ? sanitizeRichHtml(body.contentFr) : existing.contentFr,
+        contentEn: body.contentEn !== undefined ? sanitizeRichHtml(body.contentEn) : existing.contentEn,
       },
     });
 
@@ -78,8 +79,8 @@ export default async function adminPageRoutes(app: FastifyInstance) {
         slug: body.slug.trim(),
         titleFr: body.titleFr.trim(),
         titleEn: body.titleEn.trim(),
-        contentFr: body.contentFr || "",
-        contentEn: body.contentEn || "",
+        contentFr: sanitizeRichHtml(body.contentFr),
+        contentEn: sanitizeRichHtml(body.contentEn),
       },
     });
 

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
-import { sendEmail, interpolate } from "../lib/email.js";
+import { sendEmail, interpolate, interpolateHtml } from "../lib/email.js";
 import { validateWebhookUrl } from "../lib/webhook-url.js";
 import { getFeaturedEdition } from "./editions.js";
 
@@ -149,14 +149,18 @@ export default async function contactRoutes(app: FastifyInstance) {
             brochureUrl,
           };
 
+          // Subject is plain-text, use plain interpolation (values not HTML-escaped).
+          // Body has two renderings: plain-text for `text` (strip tags after
+          // interpolation) and HTML for `html` (escape values to avoid XSS).
           const renderedSubject = interpolate(tplSubject, vars);
-          const renderedBody = interpolate(tplBody, vars);
+          const renderedTextBody = interpolate(tplBody, vars).replace(/<[^>]+>/g, "");
+          const renderedHtmlBody = interpolateHtml(tplBody, vars).replace(/\n/g, "<br>");
 
           await sendEmail({
             to: [email.trim()],
             subject: renderedSubject,
-            text: renderedBody.replace(/<[^>]+>/g, ""),
-            html: renderedBody.replace(/\n/g, "<br>"),
+            text: renderedTextBody,
+            html: renderedHtmlBody,
           });
         } catch (err) {
           app.log.error("Failed to send confirmation email: %s", String(err));


### PR DESCRIPTION
VULN-002 (XSS stocké) + VULN-008 (template email injection).

- `sanitize-html` allowlist adapté à TipTap côté backend write : articles + pages (CoC/mentions) deviennent safe à rendre avec dangerouslySetInnerHTML
- Nouveau `interpolateHtml` qui échappe les vars du template email (firstName, lastName…) avant substitution
- Tests pour les deux modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)