### PR TITLE
security(defense-in-depth): default role EDITOR + Swagger off in prod

### DIFF
--- a/docs/variables-environnement.md
+++ b/docs/variables-environnement.md
@@ -24,6 +24,8 @@ Un fichier `.env.example` est fourni à la racine du projet avec des valeurs fic
 | `BASE_URL` | oui | URL publique du site (utilisée pour les liens emails, liens de modification) | `https://devfesttoulouse.fr` |
 | `PORT` | non | Port d'écoute du backend (défaut : `4000`) | `4000` |
 | `LOG_LEVEL` | non | Niveau du logger Pino/Fastify (`fatal\|error\|warn\|info\|debug\|trace`). Défaut `info`. Passer à `debug` pour activer les traces verbeuses (auth guards, proxy, etc.) lors d'un diagnostic. | `debug` |
+| `SWAGGER_PUBLIC` | non | `true` pour exposer la doc OpenAPI sur `/api/docs` en production. Défaut désactivé en prod, activé en dev. | `false` |
+| `REVALIDATE_SECRET` | oui en prod | Secret partagé entre backend et frontend pour invalider le cache Next via `POST /api/revalidate`. Si absent, la revalidation est désactivée (le cache reste statique jusqu'au TTL `s-maxage`). | (32+ caractères aléatoires) |
 
 ## Base de données (backend uniquement)
 

--- a/prisma/migrations/20260417010000_default_role_editor/migration.sql
+++ b/prisma/migrations/20260417010000_default_role_editor/migration.sql
@@ -1,0 +1,4 @@
+-- Drop the previous default (ADMIN) and set EDITOR as the safe default.
+-- Existing rows keep their current role — this only affects INSERTs where
+-- the application doesn't explicitly set `role`.
+ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'EDITOR';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -213,7 +213,10 @@ model User {
   name             String?
   emailVerified    Boolean   @default(false)
   image            String?
-  role             UserRole  @default(ADMIN)
+  // Default to EDITOR so a leaked/forgotten user insertion path never
+  // elevates to ADMIN. Admins are explicitly promoted via the seed
+  // (from ADMIN_EMAILS) or by another admin through the back-office.
+  role             UserRole  @default(EDITOR)
   banned           Boolean   @default(false)
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -75,7 +75,17 @@ await app.register(fastifyStatic, {
 
 // OpenAPI / Swagger — must be registered before routes so it can capture their schemas.
 // Exposes /api/docs (UI) and /api/docs/json (raw spec).
-await registerSwagger(app);
+//
+// In production the docs list every admin endpoint (schema, query params,
+// auth scheme) which is great for internal use but also shortens the recon
+// loop for attackers. Gate the UI and spec behind SWAGGER_PUBLIC=true (or
+// non-production env) so the default prod deployment keeps them off.
+const swaggerPublic = process.env.SWAGGER_PUBLIC === "true" || process.env.NODE_ENV !== "production";
+if (swaggerPublic) {
+  await registerSwagger(app);
+} else {
+  app.log.info("[swagger] /api/docs disabled in production (set SWAGGER_PUBLIC=true to re-enable)");
+}
 registerCommonSchemas(app);
 registerApiKeySchemas(app);
 


### PR DESCRIPTION
VULN-004 + VULN-005.

- User.role default ADMIN → EDITOR (migration ne touche que le default, pas les rows existantes)
- /api/docs gated derrière SWAGGER_PUBLIC=true (off par défaut en prod, on en dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)