### PR TITLE
a11y(dialog): role=dialog + focus trap + Escape + focus restore

### DIFF
--- a/src/frontend/src/components/admin/ConfirmDialog.tsx
+++ b/src/frontend/src/components/admin/ConfirmDialog.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useId } from "react";
+import { useDialog } from "@/lib/use-dialog";
+
 interface ConfirmDialogProps {
   isOpen: boolean;
   title: string;
@@ -21,6 +24,12 @@ export default function ConfirmDialog({
   onCancel,
   variant = "default",
 }: ConfirmDialogProps) {
+  const titleId = useId();
+  const messageId = useId();
+  // Attach focus trap + Escape handling + focus restore even when isOpen
+  // transitions; hook handles the no-op case internally.
+  const containerRef = useDialog({ open: isOpen, onClose: onCancel });
+
   if (!isOpen) return null;
 
   const confirmButtonClass =
@@ -29,10 +38,18 @@ export default function ConfirmDialog({
       : "bg-malachite text-blanc hover:bg-malachite/90";
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-noir/50">
-      <div className="bg-blanc rounded-xl shadow-lg p-6 max-w-md w-full mx-4">
-        <h3 className="text-lg font-bold text-noir">{title}</h3>
-        <p className="mt-2 text-sm text-gris">{message}</p>
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-noir/50" onClick={onCancel}>
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={messageId}
+        className="bg-blanc rounded-xl shadow-lg p-6 max-w-md w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id={titleId} className="text-lg font-bold text-noir">{title}</h3>
+        <p id={messageId} className="mt-2 text-sm text-gris">{message}</p>
         <div className="mt-6 flex justify-end gap-3">
           <button
             onClick={onCancel}

--- a/src/frontend/src/components/admin/ImagePickerDialog.tsx
+++ b/src/frontend/src/components/admin/ImagePickerDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useId } from "react";
 import { adminFetch } from "@/lib/admin-api";
+import { useDialog } from "@/lib/use-dialog";
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "";
 
@@ -19,6 +20,9 @@ interface ImagePickerDialogProps {
 }
 
 export default function ImagePickerDialog({ open, onClose, onSelect }: ImagePickerDialogProps) {
+  const titleId = useId();
+  // Focus trap + Escape + focus restore — hook handles the open/close lifecycle.
+  const dialogRef = useDialog({ open, onClose });
   const [tab, setTab] = useState<"library" | "upload">("library");
   const [images, setImages] = useState<ImageInfo[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -93,12 +97,25 @@ export default function ImagePickerDialog({ open, onClose, onSelect }: ImagePick
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-noir/50">
-      <div className="bg-blanc rounded-xl shadow-card w-full max-w-2xl max-h-[80vh] flex flex-col">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-noir/50" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="bg-blanc rounded-xl shadow-card w-full max-w-2xl max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gris/20">
-          <h2 className="text-lg font-bold text-noir">Bibliothèque d&apos;images</h2>
-          <button onClick={onClose} className="text-gris hover:text-noir text-xl leading-none">&times;</button>
+          <h2 id={titleId} className="text-lg font-bold text-noir">Bibliothèque d&apos;images</h2>
+          <button
+            onClick={onClose}
+            aria-label="Fermer la boîte de dialogue"
+            className="text-gris hover:text-noir text-xl leading-none"
+          >
+            &times;
+          </button>
         </div>
 
         {/* Tabs */}

--- a/src/frontend/src/lib/use-dialog.ts
+++ b/src/frontend/src/lib/use-dialog.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Makes a dialog accessible: Escape to close, focus trapped inside while
+ * open, focus restored to the previously active element on close. Pair the
+ * returned ref with the dialog's outermost element (the backdrop or the
+ * dialog container itself), and give that element `role="dialog"`,
+ * `aria-modal="true"` and `aria-labelledby`.
+ *
+ * Usage:
+ *   const ref = useDialog({ open, onClose });
+ *   <div ref={ref} role="dialog" aria-modal="true" aria-labelledby="..."> ... </div>
+ */
+export function useDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Remember who had focus before the dialog opened so we can return
+    // there on close. This keeps keyboard users from losing their place.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    // Move focus inside the dialog — prefer the first focusable element,
+    // fall back to the container itself (which needs tabIndex=-1).
+    const focusables = container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusables[0] ?? container;
+    first.focus();
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "Tab" && focusables.length > 0) {
+        const firstEl = focusables[0];
+        const lastEl = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl.focus();
+        } else if (!e.shiftKey && document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      previouslyFocused?.focus?.();
+    };
+  }, [open, onClose]);
+
+  return containerRef;
+}


### PR DESCRIPTION
I1 de l'audit a11y. Nouveau hook `useDialog` : focus initial, trap Tab/Shift+Tab, Escape, restore focus. Appliqué à ConfirmDialog et ImagePickerDialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)