### PR TITLE
refactor(admin): extract parseIdParam + notFound + pickPartial helpers

### DIFF
--- a/src/backend/src/lib/admin-helpers.test.ts
+++ b/src/backend/src/lib/admin-helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { pickPartial } from "./admin-helpers.js";
+
+describe("pickPartial", () => {
+  const existing = { name: "old", count: 5, description: "old desc" };
+
+  it("keeps existing fields when body omits them", () => {
+    const out = pickPartial(existing, { name: "new" }, ["name", "count", "description"] as const);
+    expect(out).toEqual({ name: "new" });
+  });
+
+  it("trims string values", () => {
+    const out = pickPartial(existing, { name: "  new  " }, ["name"] as const);
+    expect(out.name).toBe("new");
+  });
+
+  it("coerces empty strings to null", () => {
+    const out = pickPartial(existing, { description: "" }, ["description"] as const);
+    expect(out.description).toBeNull();
+  });
+
+  it("passes non-string values through", () => {
+    const out = pickPartial(existing, { count: 42 }, ["count"] as const);
+    expect(out.count).toBe(42);
+  });
+
+  it("ignores fields not in the allowlist (no mass assignment)", () => {
+    // @ts-expect-error — intentionally passing an extra field
+    const out = pickPartial(existing, { name: "x", hacked: true }, ["name"] as const);
+    expect(out).toEqual({ name: "x" });
+    expect("hacked" in out).toBe(false);
+  });
+});

--- a/src/backend/src/lib/admin-helpers.ts
+++ b/src/backend/src/lib/admin-helpers.ts
@@ -1,0 +1,68 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+/**
+ * Helpers that factor out boilerplate shared by most `/api/admin/*` routes:
+ *
+ *  - `parseIdParam(request)` : coerces `:id` to a positive integer and
+ *    sends a 400 `{ error: "Invalid ID" }` if it isn't one. Returns `null`
+ *    in that case so the caller can `return` early.
+ *
+ *  - `notFound(reply, resource)` : one-line 404 `{ error: "<resource> not found" }`.
+ *
+ *  - `pickPartial(existing, body, fields)` : builds a Prisma `data` object
+ *    that applies only the fields present in `body`, falling back to the
+ *    existing row for every field omitted. Coerces empty strings to `null`
+ *    so an admin UI form that sends `""` to clear an optional field works
+ *    as expected.
+ *
+ * The goal is to shrink the per-route CRUD boilerplate from ~25 lines to
+ * ~10, without forcing a full routing framework on top of Fastify.
+ */
+
+export async function parseIdParam(
+  request: FastifyRequest<{ Params: { id: string } }>,
+  reply: FastifyReply,
+): Promise<number | null> {
+  const id = Number(request.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    reply.status(400).send({ error: "Invalid ID" });
+    return null;
+  }
+  return id;
+}
+
+export function notFound(reply: FastifyReply, resource = "Resource") {
+  return reply.status(404).send({ error: `${resource} not found` });
+}
+
+type PartialFields<T> = {
+  [K in keyof T]?: T[K] | null | undefined;
+};
+
+/**
+ * Build a Prisma-friendly update payload from a REST body. For every field
+ * in `fields`:
+ *   - if `body[f]` is undefined → keep `existing[f]`
+ *   - if `body[f]` is a trimmed string that's empty → null
+ *   - otherwise use the value (trimmed for strings)
+ *
+ * Intentionally strict: fields not listed are ignored (no mass assignment).
+ */
+export function pickPartial<T extends Record<string, unknown>>(
+  existing: T,
+  body: PartialFields<T>,
+  fields: readonly (keyof T)[],
+): Partial<T> {
+  const out: Partial<T> = {};
+  for (const f of fields) {
+    const raw = body[f];
+    if (raw === undefined) continue; // not provided → keep existing
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      out[f] = (trimmed === "" ? null : trimmed) as T[typeof f];
+    } else {
+      out[f] = raw as T[typeof f];
+    }
+  }
+  return out;
+}

--- a/src/backend/src/routes/admin/pages.ts
+++ b/src/backend/src/routes/admin/pages.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { sanitizeRichHtml } from "../../lib/sanitize.js";
+import { parseIdParam, notFound } from "../../lib/admin-helpers.js";
 
 interface PageBody {
   slug: string;
@@ -28,11 +29,11 @@ export default async function adminPageRoutes(app: FastifyInstance) {
 
   // GET /api/admin/pages/:id
   app.get<{ Params: { id: string } }>("/pages/:id", async (request, reply) => {
-    const id = Number(request.params.id);
-    if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
+    const id = await parseIdParam(request, reply);
+    if (id === null) return;
 
     const page = await prisma.contentPage.findUnique({ where: { id } });
-    if (!page) return reply.status(404).send({ error: "Page not found" });
+    if (!page) return notFound(reply, "Page");
 
     return page;
   });
@@ -42,11 +43,11 @@ export default async function adminPageRoutes(app: FastifyInstance) {
     Params: { id: string };
     Body: PageBody;
   }>("/pages/:id", async (request, reply) => {
-    const id = Number(request.params.id);
-    if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
+    const id = await parseIdParam(request, reply);
+    if (id === null) return;
 
     const existing = await prisma.contentPage.findUnique({ where: { id } });
-    if (!existing) return reply.status(404).send({ error: "Page not found" });
+    if (!existing) return notFound(reply, "Page");
 
     const body = request.body;
 


### PR DESCRIPTION
Démarre la chasse à la duplication CRUD admin. Migre `routes/admin/pages.ts` comme premier consommateur — les autres seront migrées au fur et à mesure des évolutions de fonctionnalités, pas en big-bang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)