### PR TITLE
fix(db-boot): reliable table detection using PrismaClient

### DIFF
--- a/src/backend/scripts/db-boot.sh
+++ b/src/backend/scripts/db-boot.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 # Bootstrap the database before starting the backend:
-# 1. If the schema has never been migrated but the tables already exist
+# 1. If the schema has never been migrated but tables already exist
 #    (upgrading from the old `prisma db push` workflow), baseline the
 #    initial migration as already applied — no DDL runs.
 # 2. Otherwise apply pending migrations with `prisma migrate deploy`.
 # 3. Then run the seed and start the server.
-#
-# This replaces the previous `prisma db push --accept-data-loss` which
-# silently dropped columns/tables when the schema drifted.
 
 set -e
 
@@ -15,27 +12,40 @@ SCHEMA="prisma/schema.prisma"
 INIT_MIGRATION="20260417000000_init"
 SEED_SCRIPT="${SEED_SCRIPT:-prisma/seed.ts}"
 
-# Detect whether Prisma's migration bookkeeping table exists yet.
-# If `_prisma_migrations` is missing but the `user` table is present, we
-# are upgrading an environment that used `prisma db push` — baseline the
-# init migration as applied without re-running the SQL.
-HAS_PRISMA_TABLE=$(pnpm exec prisma db execute --schema "$SCHEMA" --stdin <<SQL 2>/dev/null || echo "error"
-SELECT 1 FROM information_schema.tables WHERE table_name = '_prisma_migrations';
-SQL
-)
+# Small Node helper that uses the generated Prisma client to check whether
+# a given table exists. Returns "yes", "no", or "check_failed" on stdout.
+# We avoided `prisma db execute --stdin` which produced unstable output in
+# earlier versions (no stable way to distinguish "found a row" vs. "empty
+# result set" from the CLI's textual output, leading to false negatives).
+has_table() {
+  table_name="$1"
+  node --input-type=module -e "
+    import { PrismaClient } from '@prisma/client';
+    const p = new PrismaClient();
+    try {
+      const r = await p.\$queryRawUnsafe(\"SELECT 1 AS found FROM information_schema.tables WHERE table_schema='public' AND table_name = '$table_name' LIMIT 1\");
+      process.stdout.write(r.length > 0 ? 'yes' : 'no');
+    } catch (e) {
+      process.stderr.write('check_failed: ' + e.message + '\\n');
+      process.exit(2);
+    } finally {
+      await p.\$disconnect();
+    }
+  " 2>/dev/null || echo "check_failed"
+}
 
-HAS_USER_TABLE=$(pnpm exec prisma db execute --schema "$SCHEMA" --stdin <<SQL 2>/dev/null || echo "error"
-SELECT 1 FROM information_schema.tables WHERE table_name = 'user';
-SQL
-)
+PRISMA_TABLE=$(has_table "_prisma_migrations")
+USER_TABLE=$(has_table "user")
 
-if ! echo "$HAS_PRISMA_TABLE" | grep -q "1"; then
-  if echo "$HAS_USER_TABLE" | grep -q "1"; then
-    echo "[db-boot] Existing tables detected without _prisma_migrations — baselining $INIT_MIGRATION as applied."
-    pnpm exec prisma migrate resolve --schema "$SCHEMA" --applied "$INIT_MIGRATION"
-  else
-    echo "[db-boot] Fresh database — migrations will run in order."
-  fi
+if [ "$PRISMA_TABLE" = "check_failed" ] || [ "$USER_TABLE" = "check_failed" ]; then
+  echo "[db-boot] Could not probe the database — letting migrate deploy decide."
+elif [ "$PRISMA_TABLE" = "no" ] && [ "$USER_TABLE" = "yes" ]; then
+  echo "[db-boot] Existing tables detected without _prisma_migrations — baselining $INIT_MIGRATION as applied."
+  pnpm exec prisma migrate resolve --schema "$SCHEMA" --applied "$INIT_MIGRATION"
+elif [ "$PRISMA_TABLE" = "no" ] && [ "$USER_TABLE" = "no" ]; then
+  echo "[db-boot] Fresh database — migrations will run in order."
+else
+  echo "[db-boot] Database already tracked by Prisma — applying pending migrations only."
 fi
 
 echo "[db-boot] Running migrate deploy..."


### PR DESCRIPTION
## Summary
- Replace unstable `prisma db execute --stdin` grep-based checks with a Node helper using `PrismaClient.\$queryRawUnsafe` against `information_schema.tables`.
- Prevents the P3009 restart-loop observed on dev-j after PR #42: the previous script read a populated database as "fresh", retried the init migration, crashed on existing objects, and left `_prisma_migrations` in a failed state.
- Deterministic `yes` / `no` / `check_failed` token makes the branching logic trivial to reason about.

## Test plan
- [x] Fix applied manually on dev-j DB via `UPDATE _prisma_migrations SET applied_steps_count = 1, finished_at = started_at WHERE migration_name = '20260417000000_init'` — backend restarted cleanly.
- [ ] Redeploy dev-j with this branch and confirm the boot logs show `Database already tracked by Prisma — applying pending migrations only.`
- [ ] Fresh-DB scenario (local): drop DB, redeploy, confirm `Fresh database — migrations will run in order.`
- [ ] Unmigrated-DB scenario (legacy `prisma db push`): simulate locally, confirm `Existing tables detected without _prisma_migrations — baselining ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)