### PR TITLE
feat: editions, brochure tracking, webhook retry, honeypot fix, key purge

### DIFF
--- a/docs/variables-environnement.md
+++ b/docs/variables-environnement.md
@@ -26,6 +26,7 @@ Un fichier `.env.example` est fourni à la racine du projet avec des valeurs fic
 | `LOG_LEVEL` | non | Niveau du logger Pino/Fastify (`fatal\|error\|warn\|info\|debug\|trace`). Défaut `info`. Passer à `debug` pour activer les traces verbeuses (auth guards, proxy, etc.) lors d'un diagnostic. | `debug` |
 | `SWAGGER_PUBLIC` | non | `true` pour exposer la doc OpenAPI sur `/api/docs` en production. Défaut désactivé en prod, activé en dev. | `false` |
 | `REVALIDATE_SECRET` | oui en prod | Secret partagé entre backend et frontend pour invalider le cache Next via `POST /api/revalidate`. Si absent, la revalidation est désactivée (le cache reste statique jusqu'au TTL `s-maxage`). | (32+ caractères aléatoires) |
+| `BROCHURE_TOKEN_SECRET` | oui en prod | Secret HMAC utilisé pour signer les liens de téléchargement de la plaquette envoyés par email. Si absent, le mail de confirmation tombe sur l'URL brute (sans tracking). | (32+ caractères aléatoires) |
 
 ## Base de données (backend uniquement)
 

--- a/prisma/migrations/20260418100000_brochure_tracking/migration.sql
+++ b/prisma/migrations/20260418100000_brochure_tracking/migration.sql
@@ -1,0 +1,5 @@
+-- Track per-message brochure downloads (Option A from the plan):
+-- the public /api/brochure/:token redirector increments these.
+ALTER TABLE "ContactMessage"
+  ADD COLUMN "brochureDownloadCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "brochureDownloadedAt" TIMESTAMP(3);

--- a/prisma/migrations/20260418110000_webhook_status/migration.sql
+++ b/prisma/migrations/20260418110000_webhook_status/migration.sql
@@ -1,0 +1,6 @@
+-- Track the outcome of the contact_webhook_url POST per message so the
+-- admin can see failures and retry them.
+ALTER TABLE "ContactMessage"
+  ADD COLUMN "webhookStatus" TEXT NOT NULL DEFAULT 'not_attempted',
+  ADD COLUMN "webhookAttemptedAt" TIMESTAMP(3),
+  ADD COLUMN "webhookError" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -189,6 +189,11 @@ model ContactMessage {
   isRead           Boolean          @default(false)
   createdAt        DateTime         @default(now())
 
+  // Tracks how many times the per-message brochure link has been opened.
+  // Populated by the public /api/brochure/:token redirector.
+  brochureDownloadCount Int        @default(0)
+  brochureDownloadedAt  DateTime?
+
   categoryId       Int?
   category         ContactCategory? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,6 +194,17 @@ model ContactMessage {
   brochureDownloadCount Int        @default(0)
   brochureDownloadedAt  DateTime?
 
+  // Outcome of the last contact_webhook_url POST attempt for this message.
+  // Status string (avoids a Postgres enum so we can add new states without
+  // a migration): "not_attempted" | "success" | "failed" | "skipped".
+  // - skipped: no URL configured, or URL failed SSRF validation.
+  // - failed: HTTP error / network error / non-2xx response.
+  // - success: 2xx received from the webhook target.
+  // webhookError stores the last error string (truncated) when status=failed.
+  webhookStatus    String           @default("not_attempted")
+  webhookAttemptedAt DateTime?
+  webhookError     String?
+
   categoryId       Int?
   category         ContactCategory? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
 }

--- a/scripts/import-archived-editions.py
+++ b/scripts/import-archived-editions.py
@@ -1,0 +1,196 @@
+"""
+One-shot import: populate archived editions (2016, 2017, 2018, 2019) using
+data scraped from the legacy per-year sites:
+  - https://2016.devfesttoulouse.fr/data/{sessions,speakers}.json
+  - https://2017.devfesttoulouse.fr/data/{sessions,speakers}.json
+  - https://2018.devfesttoulouse.fr/data/{sessions,speakers}.json
+  - 2019: stats hardcoded (HTML-only, no data API on that site)
+
+For each year we upsert the Edition (date, venue, archivedSiteUrl) and
+its KeyFigures (sessions count, speakers count). The Speaker/Session
+entities themselves can't be imported — there is no schema for them yet.
+
+Usage:
+    DFT_API_URL=https://beta.site.devfesttoulouse.fr \
+    DFT_API_TOKEN=dft_dev_xxx \
+    python scripts/import-archived-editions.py
+"""
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+
+API_URL = os.environ.get("DFT_API_URL", "https://dev-j.site.devfesttoulouse.fr").rstrip("/")
+API_TOKEN = os.environ["DFT_API_TOKEN"]
+
+
+def api(method, path, body=None):
+    req = urllib.request.Request(
+        f"{API_URL}{path}",
+        method=method,
+        headers={
+            "Authorization": f"Bearer {API_TOKEN}",
+            "Content-Type": "application/json",
+        },
+    )
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    try:
+        with urllib.request.urlopen(req, data=data) as r:
+            text = r.read().decode("utf-8")
+            return json.loads(text) if text else None
+    except urllib.error.HTTPError as e:
+        print(f"  ! {method} {path} -> {e.code}: {e.read().decode('utf-8')[:300]}", file=sys.stderr)
+        return None
+
+
+def fetch_json(url):
+    try:
+        with urllib.request.urlopen(url) as r:
+            return json.loads(r.read().decode("utf-8"))
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError) as e:
+        print(f"  ! could not fetch {url}: {e}")
+        return None
+
+
+def count_items(data, key=None):
+    """Count entries in a JSON file that may be a list or a dict-of-objects."""
+    if data is None:
+        return 0
+    if isinstance(data, list):
+        return len(data)
+    if isinstance(data, dict):
+        if key and key in data:
+            return count_items(data[key])
+        return len(data)
+    return 0
+
+
+def count_real_sessions(sessions_data, speakers_data):
+    """Filter out break/lunch entries (no speaker assigned) so the count
+    reflects actual talks, not schedule slots."""
+    items = sessions_data
+    if isinstance(sessions_data, dict) and "sessions" in sessions_data:
+        items = sessions_data["sessions"]
+    if isinstance(items, dict):
+        items = list(items.values())
+    if not isinstance(items, list):
+        return 0
+    def has_speaker_or_track(s):
+        if s.get("speakers"):
+            return True
+        track = s.get("track")
+        if track:
+            return True
+        return False
+    talks = [s for s in items if not s.get("isBreak") and has_speaker_or_track(s)]
+    # Fallback: if the heuristic kills everything, take total minus obvious breaks
+    if len(talks) < 5:
+        talks = [s for s in items if not s.get("isBreak")]
+    return len(talks)
+
+
+# Static facts collected from the archived sites
+EDITIONS = [
+    {
+        "year": 2016,
+        "startDate": "2016-11-03T00:00:00.000Z",
+        "venueName": "Centre de Congrès Pierre Baudis",
+        "venueAddress": "Toulouse",
+        "archivedSiteUrl": "https://2016.devfesttoulouse.fr/",
+        "sessions_url": "https://2016.devfesttoulouse.fr/data/sessions.json",
+        "speakers_url": "https://2016.devfesttoulouse.fr/data/speakers.json",
+    },
+    {
+        "year": 2017,
+        "startDate": "2017-09-28T00:00:00.000Z",
+        "venueName": "Centre de Congrès Pierre Baudis",
+        "venueAddress": "Toulouse",
+        "archivedSiteUrl": "https://2017.devfesttoulouse.fr/",
+        "sessions_url": "https://2017.devfesttoulouse.fr/data/sessions.json",
+        "speakers_url": "https://2017.devfesttoulouse.fr/data/speakers.json",
+    },
+    {
+        "year": 2018,
+        "startDate": "2018-11-08T00:00:00.000Z",
+        "venueName": "Centre de Congrès Pierre Baudis",
+        "venueAddress": "Toulouse",
+        "archivedSiteUrl": "https://2018.devfesttoulouse.fr/",
+        "sessions_url": "https://2018.devfesttoulouse.fr/data/sessions.json",
+        "speakers_url": "https://2018.devfesttoulouse.fr/data/speakers.json",
+    },
+    {
+        "year": 2019,
+        "startDate": "2019-10-03T00:00:00.000Z",
+        "venueName": "Centre de Congrès Pierre Baudis",
+        "venueAddress": "Toulouse",
+        "archivedSiteUrl": "https://2019.devfesttoulouse.fr/",
+        # No machine-readable data feed for this year — values left null below.
+        "sessions_url": None,
+        "speakers_url": None,
+    },
+]
+
+
+def upsert_edition(year, fields):
+    existing = api("GET", "/api/admin/editions") or []
+    match = next((e for e in existing if e["year"] == year), None)
+    body = {
+        "status": "SEE_YOU_NEXT_YEAR",
+        "startDate": fields["startDate"],
+        "venueName": fields["venueName"],
+        "venueAddress": fields["venueAddress"],
+        "archivedSiteUrl": fields["archivedSiteUrl"],
+    }
+    if match:
+        print(f"  . edition {year} exists (id={match['id']}), updating")
+        api("PUT", f"/api/admin/editions/{match['id']}", body)
+        return match["id"]
+    print(f"  + edition {year}, creating")
+    res = api("POST", "/api/admin/editions", {"year": year, **body})
+    return res["id"] if res else None
+
+
+def set_key_figures(edition_id, sessions_count, speakers_count):
+    figures = []
+    if speakers_count:
+        figures.append({
+            "icon": "microphone",
+            "value": str(speakers_count),
+            "labelFr": "Conférenciers",
+            "labelEn": "Speakers",
+        })
+    if sessions_count:
+        figures.append({
+            "icon": "calendar",
+            "value": str(sessions_count),
+            "labelFr": "Sessions",
+            "labelEn": "Sessions",
+        })
+    if not figures:
+        print(f"    no key figures available for this year")
+        return
+    res = api("PUT", f"/api/admin/editions/{edition_id}/key-figures", figures)
+    print(f"    key figures set: {sessions_count} sessions, {speakers_count} speakers")
+
+
+print("## Archived editions (2016 to 2019)\n")
+
+for ed in EDITIONS:
+    year = ed["year"]
+    print(f"[{year}]")
+    edition_id = upsert_edition(year, ed)
+    if edition_id is None:
+        print(f"  ! upsert failed, skipping key figures")
+        continue
+
+    sessions = fetch_json(ed["sessions_url"]) if ed["sessions_url"] else None
+    speakers = fetch_json(ed["speakers_url"]) if ed["speakers_url"] else None
+    sessions_count = count_real_sessions(sessions, speakers) if sessions else 0
+    speakers_count = count_items(speakers, key="speakers")
+
+    set_key_figures(edition_id, sessions_count, speakers_count)
+    print()
+
+print("Done.")

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -14,6 +14,7 @@ import articleRoutes from "./routes/articles.js";
 import settingsRoutes from "./routes/settings.js";
 import pageRoutes from "./routes/pages.js";
 import contactRoutes from "./routes/contact.js";
+import brochureRoutes from "./routes/brochure.js";
 import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
@@ -191,6 +192,7 @@ await app.register(articleRoutes, { prefix: "/api" });
 await app.register(settingsRoutes, { prefix: "/api" });
 await app.register(pageRoutes, { prefix: "/api" });
 await app.register(contactRoutes, { prefix: "/api" });
+await app.register(brochureRoutes, { prefix: "/api" });
 
 // Per-user routes (any authenticated back-office user — own resources only)
 await app.register(myApiKeysRoutes, { prefix: "/api/me" });

--- a/src/backend/src/lib/brochure-token.test.ts
+++ b/src/backend/src/lib/brochure-token.test.ts
@@ -1,0 +1,33 @@
+// Vitest sees the test file before the lib resets ENV, so we lock the secret
+// at module-import time.
+process.env.BROCHURE_TOKEN_SECRET = "test-secret-123";
+
+import { describe, it, expect } from "vitest";
+import { makeToken, verifyToken } from "./brochure-token.js";
+
+describe("brochure-token", () => {
+  it("round-trips a valid token", () => {
+    const token = makeToken(42);
+    expect(token).not.toBeNull();
+    expect(verifyToken(token!)).toBe(42);
+  });
+
+  it("rejects a token signed with a different id (signature mismatch)", () => {
+    const token = makeToken(42)!;
+    const tampered = token.replace(/^42\./, "43.");
+    expect(verifyToken(tampered)).toBeNull();
+  });
+
+  it("rejects a token with garbage signature", () => {
+    expect(verifyToken("42.not-a-real-signature")).toBeNull();
+  });
+
+  it("rejects malformed input", () => {
+    expect(verifyToken("")).toBeNull();
+    expect(verifyToken("nodot")).toBeNull();
+    expect(verifyToken(".justasig")).toBeNull();
+    expect(verifyToken("abc.sig")).toBeNull();
+    expect(verifyToken("0.sig")).toBeNull();
+    expect(verifyToken("-1.sig")).toBeNull();
+  });
+});

--- a/src/backend/src/lib/brochure-token.ts
+++ b/src/backend/src/lib/brochure-token.ts
@@ -1,0 +1,54 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// Per-message brochure links carry a token of the form `<id>.<sig>` where
+// `sig` is base64url(HMAC-SHA256(secret, "brochure:<id>")).
+//
+// The id alone would let anyone iterate /api/brochure/1, /api/brochure/2…
+// and rack up download counts for messages they never sent. The HMAC binds
+// each id to a secret only the server knows, so guessing is infeasible.
+//
+// The secret is BROCHURE_TOKEN_SECRET. We refuse to mint or verify tokens
+// when it's missing — better to break the email flow than to ship signed
+// URLs with an empty key.
+
+// Read at call time so tests can set the env var before invoking — a
+// module-level constant would lock to whatever was set at import time.
+function getSecret(): string {
+  return process.env.BROCHURE_TOKEN_SECRET || "";
+}
+
+function sign(id: number, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(`brochure:${id}`)
+    .digest("base64url");
+}
+
+export function isEnabled(): boolean {
+  return getSecret().length > 0;
+}
+
+export function makeToken(messageId: number): string | null {
+  const secret = getSecret();
+  if (!secret) return null;
+  return `${messageId}.${sign(messageId, secret)}`;
+}
+
+export function verifyToken(token: string): number | null {
+  const secret = getSecret();
+  if (!secret) return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+  const idPart = token.slice(0, dot);
+  const sigPart = token.slice(dot + 1);
+  const id = Number(idPart);
+  if (!Number.isInteger(id) || id <= 0) return null;
+  const expected = sign(id, secret);
+  // Length check first to keep timingSafeEqual happy.
+  if (expected.length !== sigPart.length) return null;
+  try {
+    if (!timingSafeEqual(Buffer.from(expected), Buffer.from(sigPart))) return null;
+  } catch {
+    return null;
+  }
+  return id;
+}

--- a/src/backend/src/lib/contact-webhook.ts
+++ b/src/backend/src/lib/contact-webhook.ts
@@ -1,0 +1,134 @@
+import { prisma } from "./prisma.js";
+import { validateWebhookUrl } from "./webhook-url.js";
+
+// Common shape of the JSON sent to the configured webhook URL.
+// Mirrors what the form already POSTed before this refactor — keep
+// stable, consumers (n8n, Zapier, Make…) parse these field names.
+export interface ContactWebhookPayload {
+  id: number;
+  submittedAt: string;
+  data: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string | null;
+    categoryId: number | null;
+    categorySlug: string | null;
+    categoryLabel: string | null;
+    message: string;
+    locale: string | null;
+  };
+}
+
+const TIMEOUT_MS = 10_000;
+const ERROR_MAX_LEN = 500;
+
+function truncateError(err: unknown): string {
+  const text = err instanceof Error ? err.message : String(err);
+  return text.length > ERROR_MAX_LEN ? `${text.slice(0, ERROR_MAX_LEN)}…` : text;
+}
+
+async function recordOutcome(
+  messageId: number,
+  status: "success" | "failed" | "skipped",
+  error: string | null,
+): Promise<void> {
+  try {
+    await prisma.contactMessage.update({
+      where: { id: messageId },
+      data: {
+        webhookStatus: status,
+        webhookAttemptedAt: new Date(),
+        webhookError: error,
+      },
+    });
+  } catch {
+    // The bookkeeping update failing shouldn't bubble — the original
+    // request has already returned to the caller by now.
+  }
+}
+
+interface SendOptions {
+  /** Override the URL stored in SiteSetting (used by the /retry endpoint
+   *  if we ever want to test a candidate URL). Defaults to the saved one. */
+  urlOverride?: string;
+}
+
+/**
+ * Posts the payload to the configured webhook URL and updates the
+ * matching ContactMessage with the outcome. Never throws — all errors
+ * are recorded as `failed` / `skipped` and returned via the result.
+ */
+export async function sendContactWebhook(
+  payload: ContactWebhookPayload,
+  opts: SendOptions = {},
+): Promise<{ status: "success" | "failed" | "skipped"; error: string | null; httpStatus?: number }> {
+  let url = opts.urlOverride;
+  if (!url) {
+    const setting = await prisma.siteSetting.findUnique({
+      where: { key: "contact_webhook_url" },
+    });
+    url = setting?.value || undefined;
+  }
+
+  if (!url) {
+    await recordOutcome(payload.id, "skipped", "No webhook URL configured");
+    return { status: "skipped", error: "No webhook URL configured" };
+  }
+
+  try {
+    await validateWebhookUrl(url);
+  } catch (err) {
+    const msg = `Invalid URL: ${truncateError(err)}`;
+    await recordOutcome(payload.id, "skipped", msg);
+    return { status: "skipped", error: msg };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      redirect: "manual",
+    });
+  } catch (err) {
+    const msg = truncateError(err);
+    await recordOutcome(payload.id, "failed", msg);
+    return { status: "failed", error: msg };
+  }
+
+  if (!response.ok) {
+    const msg = `HTTP ${response.status} ${response.statusText}`;
+    await recordOutcome(payload.id, "failed", msg);
+    return { status: "failed", error: msg, httpStatus: response.status };
+  }
+
+  await recordOutcome(payload.id, "success", null);
+  return { status: "success", error: null, httpStatus: response.status };
+}
+
+/** Build the payload from a stored ContactMessage (used by the retry endpoint). */
+export async function buildPayloadFromStored(messageId: number): Promise<ContactWebhookPayload | null> {
+  const m = await prisma.contactMessage.findUnique({
+    where: { id: messageId },
+    include: { category: true },
+  });
+  if (!m) return null;
+  return {
+    id: m.id,
+    submittedAt: m.createdAt.toISOString(),
+    data: {
+      firstName: m.firstName,
+      lastName: m.lastName,
+      email: m.email,
+      phone: m.phone,
+      categoryId: m.categoryId,
+      categorySlug: m.category?.slug ?? null,
+      categoryLabel: m.category?.nameFr || m.categoryLabel,
+      message: m.message,
+      locale: m.locale,
+    },
+  };
+}

--- a/src/backend/src/routes/admin/contact.ts
+++ b/src/backend/src/routes/admin/contact.ts
@@ -149,6 +149,8 @@ export default async function adminContactRoutes(app: FastifyInstance) {
         locale: m.locale,
         isRead: m.isRead,
         createdAt: m.createdAt,
+        brochureDownloadCount: m.brochureDownloadCount,
+        brochureDownloadedAt: m.brochureDownloadedAt,
       })),
       total,
       page,

--- a/src/backend/src/routes/admin/contact.ts
+++ b/src/backend/src/routes/admin/contact.ts
@@ -151,6 +151,9 @@ export default async function adminContactRoutes(app: FastifyInstance) {
         createdAt: m.createdAt,
         brochureDownloadCount: m.brochureDownloadCount,
         brochureDownloadedAt: m.brochureDownloadedAt,
+        webhookStatus: m.webhookStatus,
+        webhookAttemptedAt: m.webhookAttemptedAt,
+        webhookError: m.webhookError,
       })),
       total,
       page,
@@ -225,5 +228,21 @@ export default async function adminContactRoutes(app: FastifyInstance) {
     } catch {
       return reply.status(500).send({ error: "Failed to send email" });
     }
+  });
+
+  // POST /api/admin/contact/messages/:id/retry-webhook — re-fire the
+  // contact webhook for a stored message. Useful when the original POST
+  // failed (target down, bad URL set then fixed, etc.). Returns the
+  // outcome synchronously so the admin sees success/failure immediately.
+  app.post<{ Params: { id: string } }>("/contact/messages/:id/retry-webhook", async (request, reply) => {
+    const id = Number(request.params.id);
+    if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
+
+    const { buildPayloadFromStored, sendContactWebhook } = await import("../../lib/contact-webhook.js");
+    const payload = await buildPayloadFromStored(id);
+    if (!payload) return reply.status(404).send({ error: "Message not found" });
+
+    const result = await sendContactWebhook(payload);
+    return result;
   });
 }

--- a/src/backend/src/routes/brochure.ts
+++ b/src/backend/src/routes/brochure.ts
@@ -1,0 +1,48 @@
+import type { FastifyInstance } from "fastify";
+
+import { prisma } from "../lib/prisma.js";
+import { verifyToken } from "../lib/brochure-token.js";
+import { getFeaturedEdition } from "./editions.js";
+
+// GET /api/brochure/:token — public redirector that:
+//   1. validates the HMAC-signed token (id is bound to a server secret),
+//   2. atomically increments the brochure download counter on the matching
+//      ContactMessage,
+//   3. issues a 302 to the current edition's sponsorBrochureUrl.
+//
+// We intentionally use a 302 (not 301) — the brochure URL can change between
+// sponsor cycles, and we don't want intermediaries to cache the redirect.
+//
+// The endpoint is unauthenticated. The HMAC binding is what gates access:
+// without the secret, an attacker can't mint a token for an arbitrary id.
+export default async function brochureRoutes(app: FastifyInstance) {
+  app.get<{ Params: { token: string } }>("/brochure/:token", async (request, reply) => {
+    const id = verifyToken(request.params.token);
+    if (id === null) {
+      return reply.status(404).send({ error: "Not found" });
+    }
+
+    const featured = await getFeaturedEdition();
+
+    if (!featured?.sponsorBrochureUrl) {
+      // Nothing to redirect to — treat as gone.
+      return reply.status(404).send({ error: "Brochure unavailable" });
+    }
+
+    // Best-effort: a missing/already-deleted message just skips the bookkeeping
+    // but still serves the file (the email was legitimate when it was sent).
+    try {
+      await prisma.contactMessage.update({
+        where: { id },
+        data: {
+          brochureDownloadCount: { increment: 1 },
+          brochureDownloadedAt: new Date(),
+        },
+      });
+    } catch (err) {
+      request.log.warn({ err, id }, "[brochure] could not update download counter");
+    }
+
+    return reply.redirect(featured.sponsorBrochureUrl, 302);
+  });
+}

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { sendEmail, interpolate, interpolateHtml } from "../lib/email.js";
 import { makeToken } from "../lib/brochure-token.js";
-import { validateWebhookUrl } from "../lib/webhook-url.js";
+import { sendContactWebhook } from "../lib/contact-webhook.js";
 import { getFeaturedEdition } from "./editions.js";
 
 interface ContactBody {
@@ -176,51 +176,26 @@ export default async function contactRoutes(app: FastifyInstance) {
     }
 
     // --- Fire webhook (async, fire-and-forget) ---
-    try {
-      const webhookSetting = await prisma.siteSetting.findUnique({
-        where: { key: "contact_webhook_url" },
-      });
-      const webhookUrl = webhookSetting?.value;
-      if (webhookUrl) {
-        // Validate against SSRF: protocol + private IP check. Skip the webhook
-        // if validation fails — better to miss the event than leak internal
-        // endpoints to whichever URL an admin accidentally set.
-        try {
-          await validateWebhookUrl(webhookUrl);
-        } catch (err) {
-          app.log.warn("Contact webhook skipped (invalid URL: %s)", String(err));
-          return { success: true };
-        }
-
-        const payload = {
-          id: stored.id,
-          submittedAt: stored.createdAt.toISOString(),
-          data: {
-            firstName: firstName.trim(),
-            lastName: lastName.trim(),
-            email: email.trim(),
-            phone: phone?.trim() || null,
-            categoryId: categoryId || null,
-            categorySlug: category?.slug || null,
-            categoryLabel: categoryLabel || null,
-            message: message.trim(),
-            locale: locale || null,
-          },
-        };
-
-        fetch(webhookUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-          signal: AbortSignal.timeout(10_000),
-          redirect: "manual",
-        }).catch((err) => {
-          app.log.warn("Contact webhook failed: %s", String(err));
-        });
-      }
-    } catch (err) {
-      app.log.warn("Contact webhook error: %s", String(err));
-    }
+    // sendContactWebhook records the outcome on the ContactMessage so the
+    // admin can see failures and retry them. We don't await — the form
+    // response shouldn't block on a slow third-party endpoint.
+    sendContactWebhook({
+      id: stored.id,
+      submittedAt: stored.createdAt.toISOString(),
+      data: {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        email: email.trim(),
+        phone: phone?.trim() || null,
+        categoryId: categoryId || null,
+        categorySlug: category?.slug || null,
+        categoryLabel: categoryLabel || null,
+        message: message.trim(),
+        locale: locale || null,
+      },
+    }).catch((err) => {
+      app.log.warn("Contact webhook helper crashed: %s", String(err));
+    });
 
     return { success: true };
   });

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -51,25 +51,39 @@ export default async function contactRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { firstName, lastName, email, phone, categoryId, message, locale, confirmUrl, website } = request.body;
 
-    // Honeypot check — bots fill this hidden field. We silently succeed
-    // (200 OK) so bots can't tell they were caught, but we log on the
-    // server so legitimate users trapped by aggressive autofill show up
-    // in the logs instead of "my message vanished without a trace".
-    const honeypotValue = confirmUrl || website;
-    if (honeypotValue) {
-      request.log.warn(
-        { ip: request.ip, email, honeypotValue: honeypotValue.slice(0, 80) },
-        "[contact] honeypot tripped — submission silently dropped",
-      );
-      return { success: true };
-    }
-
-    // Server-side validation
+    // Server-side validation first, so we can tell "honeypot + bot-like
+    // payload" (drop silently) apart from "honeypot + real user with
+    // aggressive autofill" (show a helpful error). A real bot rarely
+    // fills all four required fields cleanly before triggering the trap;
+    // a human whose password-manager polluted the hidden input does.
     const errors: Record<string, string> = {};
     if (!firstName?.trim()) errors.firstName = "required";
     if (!lastName?.trim()) errors.lastName = "required";
     if (!email?.trim() || !validateEmail(email)) errors.email = "invalid";
     if (!message?.trim() || message.trim().length < 10) errors.message = "too_short";
+
+    const honeypotValue = confirmUrl || website;
+    if (honeypotValue) {
+      if (Object.keys(errors).length === 0) {
+        // All required fields are valid AND the honeypot was touched —
+        // this looks like autofill on a legitimate user. Tell them so
+        // they know their message didn't vanish.
+        request.log.warn(
+          { ip: request.ip, email, honeypotValue: honeypotValue.slice(0, 80) },
+          "[contact] honeypot tripped on well-formed payload — surfacing error to user",
+        );
+        return reply.status(400).send({
+          success: false,
+          errors: { honeypot: "autofill_detected" },
+        });
+      }
+      // Missing/bad required fields + honeypot => classic bot. Drop silently.
+      request.log.warn(
+        { ip: request.ip, email, honeypotValue: honeypotValue.slice(0, 80) },
+        "[contact] honeypot tripped on bot-like payload — silently dropped",
+      );
+      return { success: true };
+    }
 
     if (Object.keys(errors).length > 0) {
       return reply.status(400).send({ success: false, errors });

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -13,7 +13,10 @@ interface ContactBody {
   categoryId?: number;
   message: string;
   locale?: string;
-  website?: string; // honeypot
+  // Honeypot. Accepts both the new `confirmUrl` (current front) and the
+  // old `website` field in case a cached build is still out there.
+  confirmUrl?: string;
+  website?: string;
 }
 
 function validateEmail(email: string): boolean {
@@ -46,10 +49,18 @@ export default async function contactRoutes(app: FastifyInstance) {
       },
     },
   }, async (request, reply) => {
-    const { firstName, lastName, email, phone, categoryId, message, locale, website } = request.body;
+    const { firstName, lastName, email, phone, categoryId, message, locale, confirmUrl, website } = request.body;
 
-    // Honeypot check — bots fill this hidden field
-    if (website) {
+    // Honeypot check — bots fill this hidden field. We silently succeed
+    // (200 OK) so bots can't tell they were caught, but we log on the
+    // server so legitimate users trapped by aggressive autofill show up
+    // in the logs instead of "my message vanished without a trace".
+    const honeypotValue = confirmUrl || website;
+    if (honeypotValue) {
+      request.log.warn(
+        { ip: request.ip, email, honeypotValue: honeypotValue.slice(0, 80) },
+        "[contact] honeypot tripped — submission silently dropped",
+      );
       return { success: true };
     }
 

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { sendEmail, interpolate, interpolateHtml } from "../lib/email.js";
+import { makeToken } from "../lib/brochure-token.js";
 import { validateWebhookUrl } from "../lib/webhook-url.js";
 import { getFeaturedEdition } from "./editions.js";
 
@@ -139,8 +140,14 @@ export default async function contactRoutes(app: FastifyInstance) {
         try {
           const edition = await getFeaturedEdition();
           const baseUrl = process.env.BASE_URL || "http://localhost:3000";
+          // Per-message tracked link if both the brochure and the signing
+          // secret are configured; falls back to the raw URL otherwise so
+          // the email stays useful in dev.
+          const brochureToken = makeToken(stored.id);
           const brochureUrl = edition?.sponsorBrochureUrl
-            ? `${baseUrl}${edition.sponsorBrochureUrl}`
+            ? brochureToken
+              ? `${baseUrl}/api/brochure/${brochureToken}`
+              : `${baseUrl}${edition.sponsorBrochureUrl}`
             : "";
 
           const vars = {

--- a/src/backend/src/routes/me/api-keys.ts
+++ b/src/backend/src/routes/me/api-keys.ts
@@ -140,22 +140,41 @@ export default async function myApiKeysRoutes(app: FastifyInstance) {
     };
   });
 
-  // DELETE /api/me/api-keys/:id — revoke caller's own key
-  app.delete<{ Params: { id: string } }>("/api-keys/:id", {
+  // DELETE /api/me/api-keys/:id — revoke caller's own key (soft-delete).
+  // With ?purge=true, physically delete an already-revoked key. We refuse
+  // to hard-delete an active key: revoking first creates a paper trail
+  // (the admin can tell the user "yes I revoked this one") before the row
+  // disappears for good.
+  app.delete<{ Params: { id: string }; Querystring: { purge?: string } }>("/api-keys/:id", {
     schema: {
       tags: ["api-keys"],
-      summary: "Révoquer un de ses propres jetons",
+      summary: "Révoquer (ou supprimer définitivement) un de ses propres jetons",
       security: [{ bearerAuth: [] }, { cookieAuth: [] }],
       params: {
         type: "object",
         required: ["id"],
         properties: { id: { type: "string" } },
       },
+      querystring: {
+        type: "object",
+        properties: {
+          purge: {
+            type: "string",
+            enum: ["true", "false"],
+            description: "`true` pour supprimer physiquement une clé déjà révoquée",
+          },
+        },
+      },
       response: {
         200: {
           type: "object",
-          properties: { ok: { type: "boolean" }, alreadyRevoked: { type: "boolean" } },
+          properties: {
+            ok: { type: "boolean" },
+            alreadyRevoked: { type: "boolean" },
+            purged: { type: "boolean" },
+          },
         },
+        400: { $ref: "Error#" },
         401: { $ref: "Error#" },
         403: { $ref: "Error#" },
         404: { $ref: "Error#" },
@@ -167,6 +186,16 @@ export default async function myApiKeysRoutes(app: FastifyInstance) {
     if (!key || key.userId !== user.id) {
       return reply.status(404).send({ error: "not_found" });
     }
+
+    const wantPurge = request.query.purge === "true";
+    if (wantPurge) {
+      if (!key.revokedAt) {
+        return reply.status(400).send({ error: "key_still_active" });
+      }
+      await prisma.apiKey.delete({ where: { id: key.id } });
+      return { ok: true, purged: true };
+    }
+
     if (key.revokedAt) {
       return reply.status(200).send({ ok: true, alreadyRevoked: true });
     }

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -172,7 +172,9 @@
     "date": "Date",
     "archivedSite": "View archived site",
     "noEdition": "No edition found for this year.",
-    "allEditions": "All editions"
+    "allEditions": "All editions",
+    "previousEdition": "Previous edition",
+    "nextEdition": "Next edition"
   },
   "sponsor": {
     "pageTitle": "Become a sponsor",

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -151,7 +151,8 @@
       "submit": "Send",
       "sending": "Sending...",
       "success": "Thank you! We received your message and will respond as soon as possible.",
-      "error": "An error occurred. Please try again."
+      "error": "An error occurred. Please try again.",
+      "honeypotError": "Your browser (or password manager) filled a hidden field we use to filter out bots. Try again in a private window, or temporarily disable autofill, then resubmit."
     },
     "sidebar": {
       "responseTime": "We are volunteers, thank you for your patience. We do our best to respond within 48 hours.",

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -202,7 +202,6 @@
     "formTitle": "Contact us",
     "formIntro": "Fill out the form below and we will send you our sponsorship brochure. We will get back to you shortly.",
     "formSubmit": "Receive the sponsorship brochure",
-    "brochureCta": "Download the brochure",
     "preAnnouncementTitle": "Coming soon",
     "preAnnouncementMessage": "Sponsorships are opening soon. Sign up to be notified as soon as packages are available.",
     "preAnnouncementCta": "Sign up to be notified",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -202,7 +202,6 @@
     "formTitle": "Contactez-nous",
     "formIntro": "Remplissez le formulaire ci-dessous et nous vous enverrons notre dossier de sponsoring. Nous reviendrons vers vous dans les plus brefs délais.",
     "formSubmit": "Recevoir le dossier de sponsoring",
-    "brochureCta": "Télécharger la plaquette",
     "preAnnouncementTitle": "Bientôt disponible",
     "preAnnouncementMessage": "Les sponsorings ouvrent prochainement. Inscrivez-vous pour être informé dès que les formules seront disponibles.",
     "preAnnouncementCta": "S'inscrire pour être informé",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -172,7 +172,9 @@
     "date": "Date",
     "archivedSite": "Voir le site archivé",
     "noEdition": "Aucune édition trouvée pour cette année.",
-    "allEditions": "Toutes les éditions"
+    "allEditions": "Toutes les éditions",
+    "previousEdition": "Édition précédente",
+    "nextEdition": "Édition suivante"
   },
   "sponsor": {
     "pageTitle": "Devenir sponsor",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -151,7 +151,8 @@
       "submit": "Envoyer",
       "sending": "Envoi en cours...",
       "success": "Merci ! Nous avons reçu votre message et vous répondrons dans les meilleurs délais.",
-      "error": "Une erreur s'est produite. Veuillez réessayer."
+      "error": "Une erreur s'est produite. Veuillez réessayer.",
+      "honeypotError": "Votre navigateur (ou votre gestionnaire de mots de passe) a rempli un champ caché qui nous sert à filtrer les robots. Essayez en navigation privée, ou désactivez temporairement l'auto-remplissage, puis soumettez à nouveau."
     },
     "sidebar": {
       "responseTime": "Nous sommes bénévoles, merci pour votre patience. Nous faisons de notre mieux pour répondre sous 48h.",

--- a/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
+++ b/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
@@ -281,16 +281,6 @@ export default async function SponsorPage() {
               <p className="mt-4 text-gris leading-relaxed max-w-3xl">
                 {t("formIntro")}
               </p>
-              {edition?.sponsorBrochureUrl && (
-                <a
-                  href={edition.sponsorBrochureUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-4 inline-block px-5 py-2 rounded-[12px] border-2 border-bleu text-bleu font-bold hover:bg-bleu/10 transition-colors"
-                >
-                  {t("brochureCta")}
-                </a>
-              )}
               <div className="mt-8 max-w-2xl">
                 <ContactForm
                   categories={categories}

--- a/src/frontend/src/app/[locale]/editions/[year]/page.tsx
+++ b/src/frontend/src/app/[locale]/editions/[year]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 
-import { getEditionByYear } from "@/lib/api";
+import { getEditionByYear, getEditions } from "@/lib/api";
 import { localizedField } from "@/lib/i18n-helpers";
 import Breadcrumb from "@/components/Breadcrumb";
 import YouTubeFacade from "@/components/YouTubeFacade";
@@ -44,8 +44,21 @@ export default async function BilanPage({ params }: PageProps) {
   const locale = await getLocale();
   const t = await getTranslations("bilan");
 
-  const edition = await getEditionByYear(Number(year));
+  const [edition, allEditions] = await Promise.all([
+    getEditionByYear(Number(year)),
+    getEditions(),
+  ]);
   if (!edition) notFound();
+
+  // Prev/next navigation across archived editions only — going forward
+  // from a recap to the upcoming edition would be jarring.
+  const archivedYears = allEditions
+    .filter((e) => e.status === "SEE_YOU_NEXT_YEAR")
+    .map((e) => e.year)
+    .sort((a, b) => a - b);
+  const idx = archivedYears.indexOf(edition.year);
+  const previousYear = idx > 0 ? archivedYears[idx - 1] : null;
+  const nextYear = idx >= 0 && idx < archivedYears.length - 1 ? archivedYears[idx + 1] : null;
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },
@@ -199,6 +212,45 @@ export default async function BilanPage({ params }: PageProps) {
                 {t("archivedSite")}
               </a>
             </section>
+          )}
+
+          {/* Prev/next archived edition */}
+          {(previousYear || nextYear) && (
+            <nav
+              aria-label={t("editions")}
+              className="mt-16 flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-4 border-t border-gris/20 pt-8"
+            >
+              <div className="flex-1">
+                {previousYear && (
+                  <Link
+                    href={`/editions/${previousYear}`}
+                    rel="prev"
+                    className="group flex items-center gap-3 px-5 py-3 rounded-[12px] border border-gris/30 hover:border-bleu hover:bg-bleu/5 transition-colors"
+                  >
+                    <span aria-hidden="true" className="text-bleu text-xl group-hover:-translate-x-1 transition-transform">←</span>
+                    <span className="flex flex-col leading-tight">
+                      <span className="text-xs uppercase tracking-wide text-gris">{t("previousEdition")}</span>
+                      <span className="text-noir font-bold">DevFest Toulouse {previousYear}</span>
+                    </span>
+                  </Link>
+                )}
+              </div>
+              <div className="flex-1 sm:text-right">
+                {nextYear && (
+                  <Link
+                    href={`/editions/${nextYear}`}
+                    rel="next"
+                    className="group flex items-center justify-end gap-3 px-5 py-3 rounded-[12px] border border-gris/30 hover:border-bleu hover:bg-bleu/5 transition-colors"
+                  >
+                    <span className="flex flex-col leading-tight text-right">
+                      <span className="text-xs uppercase tracking-wide text-gris">{t("nextEdition")}</span>
+                      <span className="text-noir font-bold">DevFest Toulouse {nextYear}</span>
+                    </span>
+                    <span aria-hidden="true" className="text-bleu text-xl group-hover:translate-x-1 transition-transform">→</span>
+                  </Link>
+                )}
+              </div>
+            </nav>
           )}
         </div>
       </div>

--- a/src/frontend/src/app/admin/contact/messages/page.tsx
+++ b/src/frontend/src/app/admin/contact/messages/page.tsx
@@ -16,6 +16,8 @@ interface Message {
   message: string;
   isRead: boolean;
   createdAt: string;
+  brochureDownloadCount: number;
+  brochureDownloadedAt: string | null;
 }
 
 interface MessagesResponse {
@@ -268,6 +270,19 @@ export default function ContactMessagesPage() {
                 {selected.phone && <p><span className="text-gris">Téléphone :</span> {selected.phone}</p>}
                 {selected.categoryLabel && <p><span className="text-gris">Catégorie :</span> <StatusBadge status={selected.categoryLabel} variant="blue" /></p>}
                 <p><span className="text-gris">Date :</span> {new Date(selected.createdAt).toLocaleString("fr-FR")}</p>
+                <p>
+                  <span className="text-gris">Plaquette :</span>{" "}
+                  {selected.brochureDownloadCount > 0 ? (
+                    <span className="text-noir">
+                      {selected.brochureDownloadCount} téléchargement{selected.brochureDownloadCount > 1 ? "s" : ""}
+                      {selected.brochureDownloadedAt && (
+                        <span className="text-gris"> · dernier le {new Date(selected.brochureDownloadedAt).toLocaleDateString("fr-FR")}</span>
+                      )}
+                    </span>
+                  ) : (
+                    <span className="text-gris">Pas encore téléchargée</span>
+                  )}
+                </p>
               </div>
 
               {showForward && (

--- a/src/frontend/src/app/admin/contact/messages/page.tsx
+++ b/src/frontend/src/app/admin/contact/messages/page.tsx
@@ -6,6 +6,8 @@ import StatusBadge from "@/components/admin/StatusBadge";
 import ConfirmDialog from "@/components/admin/ConfirmDialog";
 import ContactCategories from "@/components/admin/ContactCategories";
 
+type WebhookStatus = "not_attempted" | "success" | "failed" | "skipped";
+
 interface Message {
   id: number;
   firstName: string;
@@ -18,6 +20,9 @@ interface Message {
   createdAt: string;
   brochureDownloadCount: number;
   brochureDownloadedAt: string | null;
+  webhookStatus: WebhookStatus;
+  webhookAttemptedAt: string | null;
+  webhookError: string | null;
 }
 
 interface MessagesResponse {
@@ -75,6 +80,7 @@ export default function ContactMessagesPage() {
     setSelected(msg);
     setShowForward(false);
     setForwardSuccess(false);
+    setWebhookRetryFeedback(null);
     if (!msg.isRead) {
       await adminFetch(`/contact/messages/${msg.id}/read`, { method: "PUT" });
       setMessages((prev) => prev.map((m) => (m.id === msg.id ? { ...m, isRead: true } : m)));
@@ -102,6 +108,31 @@ export default function ContactMessagesPage() {
       setForwardEmails("");
       setShowForward(false);
     }
+  }
+
+  const [isRetryingWebhook, setIsRetryingWebhook] = useState(false);
+  const [webhookRetryFeedback, setWebhookRetryFeedback] = useState<string | null>(null);
+
+  async function handleRetryWebhook() {
+    if (!selected) return;
+    setIsRetryingWebhook(true);
+    setWebhookRetryFeedback(null);
+    const { data, status } = await adminFetch<{ status: WebhookStatus; error: string | null; httpStatus?: number }>(
+      `/contact/messages/${selected.id}/retry-webhook`,
+      { method: "POST" },
+    );
+    if (status !== 200 || !data) {
+      setWebhookRetryFeedback("Erreur réseau lors de la relance.");
+    } else if (data.status === "success") {
+      setWebhookRetryFeedback("Webhook relancé avec succès.");
+    } else {
+      setWebhookRetryFeedback(`Échec : ${data.error ?? "raison inconnue"}`);
+    }
+    setIsRetryingWebhook(false);
+    // Refresh the list to update the badge.
+    await loadMessages(page);
+    // Re-pick the selected message from the refreshed list.
+    setSelected((prev) => (prev ? { ...prev, ...data } as Message : prev));
   }
 
   // Client-side filtering
@@ -283,6 +314,58 @@ export default function ContactMessagesPage() {
                     <span className="text-gris">Pas encore téléchargée</span>
                   )}
                 </p>
+                <p className="sm:col-span-2">
+                  <span className="text-gris">Webhook :</span>{" "}
+                  {selected.webhookStatus === "success" && (
+                    <span className="text-malachite font-medium">
+                      Envoyé avec succès
+                      {selected.webhookAttemptedAt && (
+                        <span className="text-gris font-normal"> · le {new Date(selected.webhookAttemptedAt).toLocaleString("fr-FR")}</span>
+                      )}
+                    </span>
+                  )}
+                  {selected.webhookStatus === "failed" && (
+                    <>
+                      <span className="text-rouge font-medium">
+                        Échec
+                        {selected.webhookAttemptedAt && (
+                          <span className="text-gris font-normal"> · le {new Date(selected.webhookAttemptedAt).toLocaleString("fr-FR")}</span>
+                        )}
+                      </span>
+                      {selected.webhookError && (
+                        <span className="block text-xs text-gris mt-0.5">{selected.webhookError}</span>
+                      )}
+                    </>
+                  )}
+                  {selected.webhookStatus === "skipped" && (
+                    <>
+                      <span className="text-gris font-medium">Ignoré</span>
+                      {selected.webhookError && (
+                        <span className="block text-xs text-gris mt-0.5">{selected.webhookError}</span>
+                      )}
+                    </>
+                  )}
+                  {selected.webhookStatus === "not_attempted" && (
+                    <span className="text-gris">Pas encore tenté</span>
+                  )}
+                </p>
+                {(selected.webhookStatus === "failed" || selected.webhookStatus === "skipped" || selected.webhookStatus === "not_attempted") && (
+                  <p className="sm:col-span-2 -mt-2">
+                    <button
+                      type="button"
+                      onClick={handleRetryWebhook}
+                      disabled={isRetryingWebhook}
+                      className="text-sm px-3 py-1.5 rounded border border-bleu text-bleu hover:bg-bleu/10 disabled:opacity-50"
+                    >
+                      {isRetryingWebhook ? "Relance en cours…" : "Relancer le webhook"}
+                    </button>
+                    {webhookRetryFeedback && (
+                      <span className={`ml-3 text-xs ${webhookRetryFeedback.startsWith("Échec") || webhookRetryFeedback.startsWith("Erreur") ? "text-rouge" : "text-malachite"}`}>
+                        {webhookRetryFeedback}
+                      </span>
+                    )}
+                  </p>
+                )}
               </div>
 
               {showForward && (

--- a/src/frontend/src/components/ContactForm.tsx
+++ b/src/frontend/src/components/ContactForm.tsx
@@ -242,7 +242,7 @@ export default function ContactForm({ categories, locale, forceCategoryId, submi
       )}
       {status === "error" && (
         <p role="alert" className="mt-4 p-4 rounded-m bg-rouge/10 text-rouge font-bold">
-          {t("error")}
+          {errors.honeypot === "autofill_detected" ? t("honeypotError") : t("error")}
         </p>
       )}
     </form>

--- a/src/frontend/src/components/ContactForm.tsx
+++ b/src/frontend/src/components/ContactForm.tsx
@@ -23,7 +23,7 @@ export default function ContactForm({ categories, locale, forceCategoryId, submi
     phone: "",
     categoryId: "",
     message: "",
-    website: "", // honeypot
+    confirmUrl: "", // honeypot
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -61,7 +61,7 @@ export default function ContactForm({ categories, locale, forceCategoryId, submi
           categoryId,
           message: formData.message,
           locale,
-          website: formData.website, // honeypot
+          confirmUrl: formData.confirmUrl, // honeypot
         }),
       });
 
@@ -73,7 +73,7 @@ export default function ContactForm({ categories, locale, forceCategoryId, submi
       }
 
       setStatus("success");
-      setFormData({ firstName: "", lastName: "", email: "", phone: "", categoryId: "", message: "", website: "" });
+      setFormData({ firstName: "", lastName: "", email: "", phone: "", categoryId: "", message: "", confirmUrl: "" });
       setErrors({});
     } catch {
       setStatus("error");
@@ -87,15 +87,18 @@ export default function ContactForm({ categories, locale, forceCategoryId, submi
 
   return (
     <form onSubmit={handleSubmit} noValidate className="space-y-6">
-      {/* Honeypot — hidden from users */}
-      <div aria-hidden="true" className="absolute -left-[9999px] opacity-0">
+      {/* Honeypot — hidden from users. Name is intentionally neutral
+          (not "website"/"url"/"company") so Chrome/password-managers
+          don't auto-fill it. We kept a legit-looking type and autoComplete
+          value so bots that blindly fill every text field still trip it. */}
+      <div aria-hidden="true" className="absolute -left-[9999px] opacity-0 pointer-events-none">
         <input
           type="text"
-          name="website"
+          name="confirm_url"
           tabIndex={-1}
-          autoComplete="off"
-          value={formData.website}
-          onChange={(e) => handleChange("website", e.target.value)}
+          autoComplete="new-password"
+          value={formData.confirmUrl}
+          onChange={(e) => handleChange("confirmUrl", e.target.value)}
         />
       </div>
 

--- a/src/frontend/src/components/admin/ApiKeysSection.tsx
+++ b/src/frontend/src/components/admin/ApiKeysSection.tsx
@@ -6,6 +6,7 @@ import {
   listMyApiKeys,
   createApiKey,
   revokeMyApiKey,
+  purgeMyApiKey,
   type ApiKey,
   type CreatedApiKey,
 } from "@/lib/admin-api";
@@ -82,6 +83,13 @@ export default function ApiKeysSection() {
     if (!confirm("Révoquer cette clé ? Les requêtes utilisant cette clé échoueront immédiatement.")) return;
     const ok = await revokeMyApiKey(id);
     if (!ok) setError("Révocation impossible");
+    await load();
+  }
+
+  async function handlePurge(id: string, name: string) {
+    if (!confirm(`Supprimer définitivement la clé « ${name} » ? Cette action est irréversible.`)) return;
+    const ok = await purgeMyApiKey(id);
+    if (!ok) setError("Suppression impossible");
     await load();
   }
 
@@ -240,7 +248,16 @@ export default function ApiKeysSection() {
                     <td className="py-3 pr-4 text-gris">{formatDate(k.expiresAt)}</td>
                     <td className="py-3 pr-4 text-gris">{formatDate(k.createdAt)}</td>
                     <td className="py-3 text-right">
-                      {!k.revokedAt && (
+                      {k.revokedAt ? (
+                        <button
+                          type="button"
+                          onClick={() => handlePurge(k.id, k.name)}
+                          className="text-terre-cuite hover:underline text-sm"
+                          title="La clé est déjà révoquée ; cette action la supprime définitivement."
+                        >
+                          Supprimer définitivement
+                        </button>
+                      ) : (
                         <button
                           type="button"
                           onClick={() => handleRevoke(k.id)}

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -155,6 +155,13 @@ export async function revokeMyApiKey(id: string): Promise<boolean> {
   return status === 200;
 }
 
+// Hard-delete a key that has already been revoked. Returns false if the
+// key is still active (the backend refuses to purge unrevoked keys).
+export async function purgeMyApiKey(id: string): Promise<boolean> {
+  const { status } = await meFetch(`/api-keys/${id}?purge=true`, { method: "DELETE" });
+  return status === 200;
+}
+
 export interface AdminApiKeysList {
   page: number;
   limit: number;


### PR DESCRIPTION
## Summary

8 commits on dev-j to promote to beta:

### 1. Import script for archived editions
- Creates editions 2016-2019 via the admin API.
- Pulls session/speaker counts from legacy per-year sites' static JSON feeds.
- 2019 has no machine-readable feed — key figures left empty for manual entry.
- Already executed against beta.

### 2. Prev/next navigation on /editions/[year]
- Footer nav block linking to previous and next archived editions.
- Adds rel="prev"/rel="next" hints for crawlers.

### 3. Drop standalone brochure download button
- The CTA bypassed the contact form. Removing it makes the filled form the single path to the brochure.

### 4. Per-message tracked brochure link
- Confirmation email now contains a tracked URL signed with HMAC.
- The redirector increments `brochureDownloadCount` + `brochureDownloadedAt` then 302s to the brochure.
- New env var: `BROCHURE_TOKEN_SECRET` (documented).
- Admin Messages view shows the counter + date of the latest download.

### 5. Webhook outcome tracking + retry button
- Each attempt records `webhookStatus` (success/failed/skipped/not_attempted), `webhookAttemptedAt`, `webhookError`.
- Admin Messages detail panel surfaces the status with timestamp and error text.
- "Relancer le webhook" button on failed/skipped/not_attempted messages → POST /api/admin/contact/messages/:id/retry-webhook.

### 6. Honeypot rename + clear error
- Hidden field renamed `website` → `confirm_url` with `autoComplete="new-password"` so Chrome/password-managers stop auto-filling it.
- When the honeypot is tripped on a payload that's otherwise fully valid (= legitimate user with autofill), the API returns `400 errors.honeypot=autofill_detected` and the form shows a dedicated bilingual message.
- Bot-like payloads keep the silent 200 OK behaviour.

### 7. API keys: user-driven hard-delete
- Once revoked (by the user or an admin), users can now permanently remove a key from their list via "Supprimer définitivement".
- Backend: `DELETE /api/me/api-keys/:id?purge=true` is accepted only on already-revoked keys (refuses active keys → guarantees a paper trail).
- Tested locally end-to-end (Chrome DevTools MCP).

## Schema changes
```sql
-- 20260418100000_brochure_tracking
ALTER TABLE "ContactMessage"
  ADD COLUMN "brochureDownloadCount" INTEGER NOT NULL DEFAULT 0,
  ADD COLUMN "brochureDownloadedAt" TIMESTAMP(3);

-- 20260418110000_webhook_status
ALTER TABLE "ContactMessage"
  ADD COLUMN "webhookStatus" TEXT NOT NULL DEFAULT 'not_attempted',
  ADD COLUMN "webhookAttemptedAt" TIMESTAMP(3),
  ADD COLUMN "webhookError" TEXT;
```

## Test plan
- [x] Backend + frontend typecheck green (CI 4/4).
- [x] `pnpm test src/lib/brochure-token.test.ts` passes (4/4).
- [x] Local: full create → revoke → purge flow validated, plus backend guard against purging an active key (returns 400).
- [x] Local: contact form submitted via Chrome DevTools MCP arrives in DB and webhook fires.
- [ ] Beta: set `BROCHURE_TOKEN_SECRET` in Coolify env (32+ chars random).
- [ ] Beta smoke test: contact form, brochure link in email, retry button on a failed webhook, profile → revoke + purge an API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)