### PR TITLE
fix(admin): brochure upload always visible in Sponsoring tab

### DIFF
--- a/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
@@ -232,7 +232,9 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
 
   const currentStatusOption = STATUS_OPTIONS.find((o) => o.value === settings.sponsorPageStatus);
   const showTempUrl = settings.sponsorPageStatus === "PRE_ANNOUNCEMENT" || settings.sponsorPageStatus === "TEMPORARY";
-  const showBrochure = settings.sponsorPageStatus === "OPEN";
+  // Brochure is always editable — admins typically upload it before flipping
+  // the page to OPEN, and the sponsor-brochure email template needs it
+  // available regardless of the public page status.
 
   return (
     <div>
@@ -312,38 +314,36 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
           />
         </div>
 
-        {showBrochure && (
-          <div>
-            <label className="block text-sm font-medium text-noir mb-1">Plaquette sponsors (PDF)</label>
-            <div className="flex items-center gap-3">
+        <div>
+          <label className="block text-sm font-medium text-noir mb-1">Plaquette sponsors (PDF)</label>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setIsBrochurePickerOpen(true)}
+              className="px-3 py-1.5 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+            >
+              {settings.sponsorBrochureUrl ? "Changer le fichier" : "Choisir un fichier"}
+            </button>
+            {settings.sponsorBrochureUrl && (
               <button
                 type="button"
-                onClick={() => setIsBrochurePickerOpen(true)}
-                className="px-3 py-1.5 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+                onClick={() => setSettings({ ...settings, sponsorBrochureUrl: null })}
+                className="text-sm text-terre-cuite hover:underline"
               >
-                {settings.sponsorBrochureUrl ? "Changer le fichier" : "Choisir un fichier"}
+                Supprimer
               </button>
-              {settings.sponsorBrochureUrl && (
-                <button
-                  type="button"
-                  onClick={() => setSettings({ ...settings, sponsorBrochureUrl: null })}
-                  className="text-sm text-terre-cuite hover:underline"
-                >
-                  Supprimer
-                </button>
-              )}
-            </div>
-            {settings.sponsorBrochureUrl && (
-              <p className="mt-1 text-xs text-gris">{settings.sponsorBrochureUrl}</p>
             )}
-            <FilePickerDialog
-              open={isBrochurePickerOpen}
-              onClose={() => setIsBrochurePickerOpen(false)}
-              onSelect={(url) => setSettings({ ...settings, sponsorBrochureUrl: url })}
-              title="Bibliothèque de plaquettes"
-            />
           </div>
-        )}
+          {settings.sponsorBrochureUrl && (
+            <p className="mt-1 text-xs text-gris">{settings.sponsorBrochureUrl}</p>
+          )}
+          <FilePickerDialog
+            open={isBrochurePickerOpen}
+            onClose={() => setIsBrochurePickerOpen(false)}
+            onSelect={(url) => setSettings({ ...settings, sponsorBrochureUrl: url })}
+            title="Bibliothèque de plaquettes"
+          />
+        </div>
 
         <div className="flex items-center gap-3">
           <button


### PR DESCRIPTION
## Summary

Follow-up au fix PDF picker (PR #53) — le champ "Plaquette sponsors" était caché tant que le statut de la page sponsor n'était pas `OPEN`. Problème : les admins chargent en général la plaquette avant de flipper la page en `OPEN`, pour que le template email `sponsor-brochure` ait une URL valide dès qu'un demandeur est capturé.

## Changements

- [SponsoringTab.tsx](src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx) : retire la condition `showBrochure === "OPEN"` ; le champ plaquette est désormais visible dans tous les statuts (`PRE_ANNOUNCEMENT`, `TEMPORARY`, `OPEN`, `SOLD_OUT`).

Le picker reste `FilePickerDialog` (filtrage `.pdf`, pas de preview, pas d'alt) déjà mergé dans PR #53.

## Test plan

- [ ] Statut "Avant annonce" → le champ "Plaquette sponsors (PDF)" est visible et fonctionnel
- [ ] Statut "Temporaire" → idem
- [ ] Statut "Ouvert" → idem (comportement précédent)
- [ ] Statut "Complet" → idem
- [ ] Upload d'un PDF → ajouté en bibliothèque, sélectionnable
- [ ] Le dialog montre bien "Bibliothèque de plaquettes" et pas "Bibliothèque d'images"

🤖 Generated with [Claude Code](https://claude.com/claude-code)