### PR TITLE
fix: home/sponsor/footer/ticketing UI polish

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -52,7 +52,8 @@
       "viewAll": "View all tickets"
     },
     "replay": {
-      "title": "Last year's recap",
+      "title": "Relive the {year} edition in 2 minutes!",
+      "titleFallback": "Relive the last edition in 2 minutes!",
       "viewGallery": "View the photo gallery",
       "viewEdition": "View the {year} edition"
     }

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -52,7 +52,8 @@
       "viewAll": "Voir la billetterie"
     },
     "replay": {
-      "title": "Résumé de l'année dernière",
+      "title": "Revivez l'édition {year} en 2 minutes !",
+      "titleFallback": "Revivez la dernière édition en 2 minutes !",
       "viewGallery": "Voir l'album photo",
       "viewEdition": "Voir l'édition {year}"
     }

--- a/src/frontend/src/app/[locale]/billetterie/page.tsx
+++ b/src/frontend/src/app/[locale]/billetterie/page.tsx
@@ -47,7 +47,18 @@ export default async function TicketingPage() {
               <p className="mt-6 text-lg font-bold text-rouge">{t("allSoldOut")}</p>
             )}
 
-            <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div
+              className={`mt-10 grid grid-cols-1 ${
+                tiers.length === 1 ? "sm:grid-cols-1" : "sm:grid-cols-2"
+              } ${
+                tiers.length === 1
+                  ? "lg:grid-cols-1"
+                  : tiers.length === 2
+                    ? "lg:grid-cols-2"
+                    : "lg:grid-cols-3"
+              } gap-8 justify-center mx-auto`}
+              style={{ maxWidth: tiers.length < 3 ? `${tiers.length * 380}px` : undefined }}
+            >
               {tiers.map((tier) => {
                 const name = localizedField(tier, "name", locale);
                 const isAvailable = tier.status === "AVAILABLE";

--- a/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
+++ b/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
@@ -99,13 +99,13 @@ export default async function SponsorPage() {
             </h1>
           )}
 
-          <p className="mt-6 text-lg text-gris leading-relaxed max-w-3xl">
+          <p className="mt-6 text-lg text-gris leading-relaxed">
             {t("intro")}
           </p>
 
           {/* Sold-out callout — short and ends the page */}
           {showSoldOut && (
-            <div className="mt-12 p-8 rounded-xl bg-blanc shadow-card max-w-3xl">
+            <div className="mt-12 p-8 rounded-xl bg-blanc shadow-card">
               <h2 className="text-2xl lg:text-3xl font-bold text-noir">
                 {t("soldOutTitle")}
               </h2>
@@ -149,7 +149,7 @@ export default async function SponsorPage() {
 
           {/* Pre-announcement message */}
           {showPreAnnouncementMessage && (
-            <div className="mt-16 p-8 rounded-xl bg-blanc shadow-card max-w-3xl">
+            <div className="mt-16 p-8 rounded-xl bg-blanc shadow-card">
               <h2 className="text-2xl lg:text-3xl font-bold text-noir">
                 {t("preAnnouncementTitle")}
               </h2>
@@ -282,13 +282,13 @@ export default async function SponsorPage() {
           {/* Integrated contact form (OPEN mode only) */}
           {showIntegratedForm && sponsoringCategory && (
             <div id="contact" className="mt-16 scroll-mt-8">
-              <h2 className="text-2xl lg:text-4xl font-bold text-noir">
+              <h2 className="text-2xl lg:text-4xl font-bold text-noir text-center">
                 {t("formTitle")}
               </h2>
-              <p className="mt-4 text-gris leading-relaxed max-w-3xl">
+              <p className="mt-4 text-gris leading-relaxed text-center">
                 {t("formIntro")}
               </p>
-              <div className="mt-8 max-w-2xl">
+              <div className="mt-8 mx-auto max-w-2xl">
                 <ContactForm
                   categories={categories}
                   locale={locale}

--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -148,7 +148,10 @@ export default async function HomePage() {
 
       {/* SEE_YOU_NEXT_YEAR: bilan + aftermovie + gallery + news */}
       {isSeeYouNextYear && edition?.aftermovieUrl && (
-        <ReplaySection aftermovieUrl={edition.aftermovieUrl} />
+        <ReplaySection
+          aftermovieUrl={edition.aftermovieUrl}
+          editionYear={edition.year}
+        />
       )}
 
       {isSeeYouNextYear && edition?.galleryUrl && (

--- a/src/frontend/src/components/Footer.tsx
+++ b/src/frontend/src/components/Footer.tsx
@@ -51,7 +51,7 @@ export default async function Footer() {
       <div className="mx-auto max-w-[1440px] px-6 py-8 lg:px-[84px] lg:py-8">
         <div className="flex flex-col lg:flex-row lg:justify-between gap-8">
           {/* Left column — Logo + socials + CTA */}
-          <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-6 items-start">
             <Image
               src={logoUrl}
               alt="DevFest Toulouse"
@@ -60,9 +60,9 @@ export default async function Footer() {
               className="h-auto"
             />
 
-            <div>
+            <div className="w-full">
               <p className="text-blanc text-sm mb-2">{tFooter("followUs")}</p>
-              <SocialIcons size={48} className="text-blanc" links={socialLinks} />
+              <SocialIcons size={48} className="text-blanc justify-start flex-wrap" links={socialLinks} />
             </div>
 
             <Link

--- a/src/frontend/src/components/home/KeyFiguresSection.tsx
+++ b/src/frontend/src/components/home/KeyFiguresSection.tsx
@@ -42,7 +42,7 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
             {figures.map((figure) => (
               <div
                 key={figure.icon}
-                className="flex flex-col items-center text-center p-6 rounded-xl bg-blanc"
+                className="flex flex-col items-center text-center p-6 rounded-xl"
               >
                 <StatIcon name={figure.icon} className="text-4xl lg:text-[56px]" />
                 <span className="mt-3 text-4xl lg:text-[56px] lg:leading-[140%] font-bold text-noir">

--- a/src/frontend/src/components/home/ReplaySection.tsx
+++ b/src/frontend/src/components/home/ReplaySection.tsx
@@ -21,7 +21,7 @@ export default function ReplaySection({
     <section className="px-6 py-16 lg:py-24">
       <div className="mx-auto max-w-4xl">
         <h2 className="text-3xl lg:text-5xl font-bold text-noir text-center mb-10">
-          {t("title")}
+          {editionYear ? t("title", { year: editionYear }) : t("titleFallback")}
         </h2>
         <YouTubeFacade videoUrl={aftermovieUrl} title="DevFest Toulouse Aftermovie" />
         {hasCtas && (

--- a/src/frontend/src/components/home/TicketingSection.tsx
+++ b/src/frontend/src/components/home/TicketingSection.tsx
@@ -15,6 +15,14 @@ export default function TicketingSection({ tiers, locale }: TicketingSectionProp
 
   const billetwebUrl = tiers.find((t) => t.externalUrl)?.externalUrl || null;
 
+  // When the row isn't full, cap the column count so the cards stay
+  // centred instead of clinging to the left edge of a 3-column grid.
+  // Cards are also given a fixed max-width so the centred row keeps
+  // the same card size as a full row.
+  const lgCols =
+    tiers.length === 1 ? "lg:grid-cols-1" : tiers.length === 2 ? "lg:grid-cols-2" : "lg:grid-cols-3";
+  const smCols = tiers.length === 1 ? "sm:grid-cols-1" : "sm:grid-cols-2";
+
   return (
     <section className="px-6 py-16 lg:py-24 bg-blanc-casse">
       <div className="mx-auto max-w-6xl text-center">
@@ -22,7 +30,10 @@ export default function TicketingSection({ tiers, locale }: TicketingSectionProp
           {t("title")}
         </h2>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-10">
+        <div
+          className={`grid grid-cols-1 ${smCols} ${lgCols} gap-6 mb-10 justify-center mx-auto`}
+          style={{ maxWidth: tiers.length < 3 ? `${tiers.length * 360}px` : undefined }}
+        >
           {tiers.map((tier) => {
             const name = localizedField(tier, "name", locale);
             const isAvailable = tier.status === "AVAILABLE";


### PR DESCRIPTION
## Summary

5 fixes UX/UI accumulés sur `dev-j` après les PRs #54 et #55.

- **Replay section title** — nomme l'année de l'édition (`Revivez l'édition {year} en 2 minutes !` / `Relive the {year} edition in 2 minutes!`) au lieu de "Résumé de l'année dernière". Fallback générique si l'année n'est pas disponible.
- **Ticketing rows centred** — quand moins de 3 tarifs sont visibles (1 ou 2), la rangée se centre horizontalement au lieu de coller à gauche dans la grille 3-colonnes. Patch appliqué à la fois dans la `TicketingSection` du home et la page `/billetterie`.
- **Footer social icons** — ancrées à gauche sous "Suivez l'aventure en ligne" via `items-start` + `flex-wrap`. Plus de dérive vers le centre sur les viewports intermédiaires.
- **Key figure cards transparent** — l'illustration "La Grave" était masquée par le fond blanc des 4 cartes individuelles. Carte parent garde son `bg-blanc`, les enfants deviennent transparents pour laisser passer l'illustration `opacity-20`.
- **Sponsor page polish** — paragraphes intro + callouts (sold-out / pre-announcement) + form intro libérés du `max-w-3xl` (utilisent maintenant le full `max-w-6xl`). Formulaire intégré et son heading centrés (`mx-auto` + `text-center`).

## Test plan

- [ ] /fr (mode ANNOUNCEMENT) : la section replay affiche `Revivez l'édition 2025 en 2 minutes !`, l'illustration La Grave est visible derrière les key figures
- [ ] /fr/billetterie avec 1 tarif : carte centrée ; avec 2 tarifs : 2 cartes centrées ; avec 3+ tarifs : layout précédent inchangé
- [ ] Footer (mobile + desktop) : icônes sociales sous le heading, alignées à gauche
- [ ] /fr/devenir-sponsor : intro + callout occupent toute la largeur, formulaire centré sous son heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)