### PR TITLE
fix(auth): enable first-visit OAuth sign-in for allow-listed admins (#64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ The frontend calls the backend via HTTP (`http://backend:4000` in Docker, config
 | Layer | Technology |
 |-------|------------|
 | Frontend | Next.js 16 (App Router), Tailwind CSS v4, next-intl, pnpm |
-| Backend | Node.js (framework TBD: Fastify or Hono), Prisma, PostgreSQL |
-| Auth | Auth.js v5 (Google + GitHub OAuth) — admin only |
+| Backend | Node.js (Fastify), Prisma, PostgreSQL |
+| Auth | better-auth (email/password + Google + GitHub OAuth) — admin only |
 | Email | SMTP (Postfix or equivalent, MailHog in dev) |
 | Hosting | VPS + Coolify, Docker Compose |
 | CI/CD | GitHub Actions (lint, typecheck, tests) |

--- a/src/backend/src/lib/auth.ts
+++ b/src/backend/src/lib/auth.ts
@@ -68,15 +68,17 @@ export const auth = betterAuth({
     },
   },
   socialProviders: {
+    // Implicit sign-up stays enabled so an allow-listed admin can sign in via
+    // OAuth on their very first visit (no prior email/password account needed).
+    // Access is still gated: the databaseHooks.user.create.before hook below
+    // rejects any email that is not in ADMIN_EMAILS.
     google: {
       clientId: process.env.OAUTH_GOOGLE_CLIENT_ID || "",
       clientSecret: process.env.OAUTH_GOOGLE_CLIENT_SECRET || "",
-      disableImplicitSignUp: true,
     },
     github: {
       clientId: process.env.OAUTH_GITHUB_CLIENT_ID || "",
       clientSecret: process.env.OAUTH_GITHUB_CLIENT_SECRET || "",
-      disableImplicitSignUp: true,
     },
   },
   account: {


### PR DESCRIPTION
Refs #64.

## Constat
L'OAuth Google + GitHub était **déjà entièrement implémenté** (better-auth) : providers déclarés, endpoint `/api/auth/providers`, boutons UI conditionnels, allowlist `ADMIN_EMAILS`, schéma Account/Session. Il ne manquait que de la config (secrets) et un correctif de logique.

## Changements
- **fix(auth)** : retrait de `disableImplicitSignUp: true` sur Google/GitHub. Ce flag empêchait le **tout premier** login OAuth, même pour un email présent dans `ADMIN_EMAILS` — un admin sans compte email/password préalable ne pouvait jamais se connecter en OAuth. L'accès reste verrouillé par le hook `databaseHooks.user.create.before` (rejet de tout email hors `ADMIN_EMAILS`), donc l'implicit sign-up est sûr à réactiver et c'est lui qui fait fonctionner le flux « se connecter via Google/GitHub » du test plan.
- **docs** : correction de la table stack dans CLAUDE.md — `better-auth` (et non « Auth.js v5 ») + Fastify (et non « TBD Fastify or Hono »).

## Test plan
- `tsc` backend : OK.
- ⏳ **Test E2E reporté** : nécessite de vrais credentials OAuth + la config des redirect URIs dans les consoles Google/GitHub. À réaliser par un mainteneur :
  - Redirect URI Google : `{BASE_URL}/api/auth/callback/google`
  - Callback URL GitHub : `{BASE_URL}/api/auth/callback/github`
  - Renseigner `OAUTH_GOOGLE_CLIENT_ID/SECRET` + `OAUTH_GITHUB_CLIENT_ID/SECRET`
  - Vérifier : login Google OK pour un email dans `ADMIN_EMAILS`, login GitHub idem, **rejet** d'un email hors allowlist.

L'issue #64 reste ouverte pour ce test E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)