### PR TITLE
fix(lot1): spec-compliance quick wins (pagination, SEO, footer, confirmations)

### DIFF
--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -35,7 +35,7 @@ export default async function editionRoutes(app: FastifyInstance) {
   app.get("/editions", async () => {
     const editions = await prisma.edition.findMany({
       orderBy: { year: "desc" },
-      select: { id: true, year: true, status: true, archivedSiteUrl: true },
+      select: { id: true, year: true, status: true, archivedSiteUrl: true, startDate: true },
     });
     return editions;
   });

--- a/src/frontend/src/app/[locale]/actualites/page.tsx
+++ b/src/frontend/src/app/[locale]/actualites/page.tsx
@@ -29,7 +29,7 @@ export default async function ArticlesPage({
   const { page: pageParam } = await searchParams;
   const page = Math.max(Number(pageParam) || 1, 1);
 
-  const { articles, totalPages } = await getArticles(page, 8);
+  const { articles, totalPages } = await getArticles(page, 9);
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },

--- a/src/frontend/src/app/[locale]/actualites/tag/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/actualites/tag/[slug]/page.tsx
@@ -36,7 +36,7 @@ export default async function TagPage({
   const { page: pageParam } = await searchParams;
   const page = Math.max(Number(pageParam) || 1, 1);
 
-  const { articles, totalPages } = await getArticles(page, 8, slug);
+  const { articles, totalPages } = await getArticles(page, 9, slug);
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },

--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -3,6 +3,7 @@ import { getLocale } from "next-intl/server";
 import {
   getCfpSettings,
   getCurrentEdition,
+  getEditions,
   getLatestArticles,
   getCurrentTicketTiers,
   getKeyFigures,
@@ -25,6 +26,7 @@ function buildEventJsonLd(
     venueAddress: string | null;
   },
   tiers: { nameFr: string; price: number; status: string; externalUrl: string | null }[],
+  previousStartDates: string[] = [],
 ) {
   // Dedup offers by (name, price, status) — protects Schema.org output from
   // accidental duplicates in seed data or admin double-imports, which
@@ -79,6 +81,11 @@ function buildEventJsonLd(
       name: "DevFest",
       url: "https://developers.google.com/community/devfest",
     },
+    // Past edition start dates signal the event's recurrence to search engines.
+    ...(previousStartDates.length > 0 && {
+      previousStartDate:
+        previousStartDates.length === 1 ? previousStartDates[0] : previousStartDates,
+    }),
     ...(offers.length > 0 && { offers }),
   };
 }
@@ -86,14 +93,20 @@ function buildEventJsonLd(
 export default async function HomePage() {
   const locale = await getLocale();
 
-  const [edition, tiers, figures, cfp] = await Promise.all([
+  const [edition, tiers, figures, cfp, editions] = await Promise.all([
     getCurrentEdition(),
     getCurrentTicketTiers(),
     getKeyFigures(),
     getCfpSettings(),
+    getEditions(),
   ]);
 
   const articles = await getLatestArticles(4, edition?.id);
+
+  // Past editions' start dates (YYYY-MM-DD) for Schema.org previousStartDate.
+  const previousStartDates = editions
+    .filter((e) => e.year < (edition?.year ?? Infinity) && e.startDate)
+    .map((e) => e.startDate!.split("T")[0]);
 
   const isPreparation = edition?.status === "PREPARATION";
   const isAnnouncement = edition?.status === "ANNOUNCEMENT";
@@ -105,7 +118,7 @@ export default async function HomePage() {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(buildEventJsonLd(edition, tiers)),
+            __html: JSON.stringify(buildEventJsonLd(edition, tiers, previousStartDates)),
           }}
         />
       )}

--- a/src/frontend/src/app/admin/settings/page.tsx
+++ b/src/frontend/src/app/admin/settings/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import { adminFetch } from "@/lib/admin-api";
 import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 
 const TABS = [
   { key: "identity", label: "Identité" },
@@ -32,6 +33,7 @@ function CacheTab() {
   const [customPath, setCustomPath] = useState("");
   const [isPurging, setIsPurging] = useState(false);
   const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [confirmScope, setConfirmScope] = useState<"selection" | "all" | null>(null);
 
   function togglePath(path: string) {
     setSelectedPaths((prev) =>
@@ -39,15 +41,19 @@ function CacheTab() {
     );
   }
 
-  async function handlePurge() {
+  function requestPurge() {
     const paths = [...selectedPaths];
-    if (customPath.trim()) {
-      paths.push(customPath.trim());
-    }
+    if (customPath.trim()) paths.push(customPath.trim());
     if (paths.length === 0) {
       setResult({ success: false, message: "Sélectionnez au moins un chemin" });
       return;
     }
+    setConfirmScope("selection");
+  }
+
+  async function purgeSelection() {
+    const paths = [...selectedPaths];
+    if (customPath.trim()) paths.push(customPath.trim());
 
     setIsPurging(true);
     setResult(null);
@@ -68,7 +74,7 @@ function CacheTab() {
     }
   }
 
-  async function handlePurgeAll() {
+  async function purgeAll() {
     setIsPurging(true);
     setResult(null);
 
@@ -118,14 +124,14 @@ function CacheTab() {
 
         <div className="flex gap-3">
           <button
-            onClick={handlePurge}
+            onClick={requestPurge}
             disabled={isPurging}
             className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
           >
             {isPurging ? "Purge en cours..." : "Purger la sélection"}
           </button>
           <button
-            onClick={handlePurgeAll}
+            onClick={() => setConfirmScope("all")}
             disabled={isPurging}
             className="px-4 py-2 bg-terre-cuite text-blanc rounded-lg text-sm font-medium hover:bg-terre-cuite/90 disabled:opacity-50"
           >
@@ -143,6 +149,26 @@ function CacheTab() {
           {result.message}
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={confirmScope !== null}
+        title={confirmScope === "all" ? "Purger tout le cache ?" : "Purger les pages sélectionnées ?"}
+        message={
+          confirmScope === "all"
+            ? "Tout le cache des pages publiques sera régénéré. Les visiteurs verront du contenu frais (re-rendu au prochain accès)."
+            : "Les pages sélectionnées seront purgées et régénérées au prochain accès."
+        }
+        confirmLabel="Purger"
+        cancelLabel="Annuler"
+        variant="danger"
+        onConfirm={() => {
+          const scope = confirmScope;
+          setConfirmScope(null);
+          if (scope === "all") void purgeAll();
+          else void purgeSelection();
+        }}
+        onCancel={() => setConfirmScope(null)}
+      />
     </>
   );
 }

--- a/src/frontend/src/components/Footer.tsx
+++ b/src/frontend/src/components/Footer.tsx
@@ -35,8 +35,6 @@ export default async function Footer() {
   // Footer sits on a dark green background — pick the white variant.
   const logoUrl = getLogoUrl(identity, "white");
 
-  const isAnnouncement = edition?.status === "ANNOUNCEMENT";
-
   const previousEditions = edition
     ? editions
         .filter((e) => e.year < edition.year)
@@ -46,7 +44,7 @@ export default async function Footer() {
   return (
     <footer
       role="contentinfo"
-      className="bg-[#0B7350] rounded-3xl shadow-section mx-4 mb-4 mt-8 overflow-hidden"
+      className="bg-malachite rounded-3xl shadow-section mx-4 mb-4 mt-8 overflow-hidden"
     >
       <div className="mx-auto max-w-[1440px] px-6 py-8 lg:px-[84px] lg:py-8">
         <div className="flex flex-col lg:flex-row lg:justify-between gap-8">
@@ -75,8 +73,9 @@ export default async function Footer() {
 
           {/* Right columns */}
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-8">
-            {/* Navigation — only when edition is in ANNOUNCEMENT */}
-            {isAnnouncement && (() => {
+            {/* Navigation — always shown; links appear as their content goes
+                live (Actus is always available). */}
+            {(() => {
               const footerLinks = NAV_LINKS.filter((link) => {
                 if (link.key === "program" && !edition?.isProgramPublished) return false;
                 if (link.key === "speakers" && !edition?.hasSpeakers) return false;

--- a/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { adminFetch } from "@/lib/admin-api";
 import FormField from "@/components/admin/FormField";
 import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 
 interface EditionData {
   id: number;
@@ -47,8 +48,12 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
   const [isSaving, setIsSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
+  const [isStatusConfirmOpen, setIsStatusConfirmOpen] = useState(false);
 
-  async function handleSave() {
+  const statusLabel = (value: string) =>
+    STATUS_OPTIONS.find((o) => o.value === value)?.label ?? value;
+
+  async function persist() {
     setIsSaving(true);
     setSaved(false);
     await adminFetch(`/editions/${edition.id}`, {
@@ -70,6 +75,16 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
     setSaved(true);
     setTimeout(() => setSaved(false), 3000);
     onSaved();
+  }
+
+  // Changing the annual status reshapes the whole public homepage, so it needs
+  // an explicit confirmation (US-191). Other edits save straight away.
+  function handleSave() {
+    if (form.status !== edition.status) {
+      setIsStatusConfirmOpen(true);
+      return;
+    }
+    void persist();
   }
 
   return (
@@ -148,6 +163,19 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
         </button>
         {saved && <span className="text-sm text-malachite">Sauvegardé !</span>}
       </div>
+
+      <ConfirmDialog
+        isOpen={isStatusConfirmOpen}
+        title="Changer le statut de l'édition ?"
+        message={`Le statut passera de « ${statusLabel(edition.status)} » à « ${statusLabel(form.status)} ». Cela modifie le contenu affiché sur la page d'accueil et purge son cache.`}
+        confirmLabel="Changer le statut"
+        cancelLabel="Annuler"
+        onConfirm={() => {
+          setIsStatusConfirmOpen(false);
+          void persist();
+        }}
+        onCancel={() => setIsStatusConfirmOpen(false)}
+      />
     </div>
   );
 }

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -30,6 +30,7 @@ export interface EditionSummary {
   year: number;
   status: "PREPARATION" | "ANNOUNCEMENT" | "SEE_YOU_NEXT_YEAR";
   archivedSiteUrl: string | null;
+  startDate: string | null;
 }
 
 export interface SocialLinks {


### PR DESCRIPTION
Quick wins de conformité Lot 1 (issus de l'audit spec `docs/specs/lot-1-fondations.md`).

## Changements
- **RG-098** — liste d'actualités paginée à **9** articles/page (au lieu de 8), sur `/actualites` et la liste filtrée par tag.
- **RG-017** — le Schema.org `Event` de la home inclut désormais `previousStartDate` (dates de début des éditions passées) pour signaler la récurrence. `/api/editions` expose `startDate`.
- **US-111** — footer : utilise le token `malachite` et affiche **toujours** la colonne Navigation (les liens apparaissent au fur et à mesure que leur contenu est publié ; Actus toujours présent). ⚠️ La couleur reste `#0B7350` (nuance ajustée WCAG AA) plutôt que le `#109E6E` de la spec, qui échoue le ratio AA sous texte blanc (RG-043) — conflit spec interne tranché en faveur de l'accessibilité.
- **US-191** — la bascule du statut annuel d'une édition demande une **confirmation** (elle remodèle la home + purge son cache).
- **US-196** — la purge du cache (sélection et purge totale) demande une **confirmation**.

## Test plan
- ESLint : OK (1 warning préexistante sur un `<img>` non touché).
- `tsc` front + back : OK.
- Vérifié en local (Docker) :
  - `/api/editions` renvoie `startDate`
  - home `/fr` rend, le JSON-LD contient `previousStartDate: "2025-11-06"`
  - `/fr/actualites` rend (pagination 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)