### PR TITLE
feat(lot2): Speaker, Talk, Sponsor, Category models (#69)

### DIFF
--- a/src/backend/prisma/migrations/20260608195029_lot2_speakers_talks_sponsors_categories/migration.sql
+++ b/src/backend/prisma/migrations/20260608195029_lot2_speakers_talks_sponsors_categories/migration.sql
@@ -1,0 +1,162 @@
+-- CreateEnum
+CREATE TYPE "SponsorLevel" AS ENUM ('PLATINUM', 'GOLD', 'SILVER', 'SOUTIEN', 'COMMUNAUTE');
+
+-- CreateEnum
+CREATE TYPE "TalkFormat" AS ENUM ('CONFERENCE', 'QUICKIE', 'KEYNOTE');
+
+-- CreateEnum
+CREATE TYPE "TalkLevel" AS ENUM ('DEBUTANT', 'INTERMEDIAIRE', 'CONFIRME');
+
+-- AlterTable
+ALTER TABLE "Edition" ADD COLUMN     "openSponsorLevels" TEXT;
+
+-- CreateTable
+CREATE TABLE "Speaker" (
+    "id" SERIAL NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "photoUrl" TEXT,
+    "company" TEXT,
+    "city" TEXT,
+    "bioFr" TEXT,
+    "bioEn" TEXT,
+    "socialLinks" TEXT,
+    "isFeatured" BOOLEAN NOT NULL DEFAULT false,
+    "publicationStatus" "PublicationStatus" NOT NULL DEFAULT 'DRAFT',
+    "editToken" TEXT,
+    "editLinkLocked" BOOLEAN NOT NULL DEFAULT false,
+    "editTokenSentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "editionId" INTEGER NOT NULL,
+    "sponsorId" INTEGER,
+
+    CONSTRAINT "Speaker_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Talk" (
+    "id" SERIAL NOT NULL,
+    "slug" TEXT NOT NULL,
+    "titleFr" TEXT NOT NULL,
+    "titleEn" TEXT NOT NULL,
+    "descriptionFr" TEXT NOT NULL,
+    "descriptionEn" TEXT NOT NULL,
+    "format" "TalkFormat" NOT NULL,
+    "level" "TalkLevel",
+    "language" TEXT NOT NULL,
+    "publicationStatus" "PublicationStatus" NOT NULL DEFAULT 'DRAFT',
+    "room" TEXT,
+    "startsAt" TIMESTAMP(3),
+    "endsAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "editionId" INTEGER NOT NULL,
+    "categoryId" INTEGER,
+
+    CONSTRAINT "Talk_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Sponsor" (
+    "id" SERIAL NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "logoUrl" TEXT,
+    "level" "SponsorLevel" NOT NULL,
+    "websiteUrl" TEXT,
+    "descriptionFr" TEXT,
+    "descriptionEn" TEXT,
+    "socialLinks" TEXT,
+    "publicationStatus" "PublicationStatus" NOT NULL DEFAULT 'DRAFT',
+    "editToken" TEXT,
+    "editLinkLocked" BOOLEAN NOT NULL DEFAULT false,
+    "editTokenSentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "editionId" INTEGER NOT NULL,
+
+    CONSTRAINT "Sponsor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Category" (
+    "id" SERIAL NOT NULL,
+    "nameFr" TEXT NOT NULL,
+    "nameEn" TEXT NOT NULL,
+    "color" TEXT NOT NULL DEFAULT '#109E6E',
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "editionId" INTEGER NOT NULL,
+
+    CONSTRAINT "Category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_SpeakerToTalk" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_SpeakerToTalk_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Speaker_editToken_key" ON "Speaker"("editToken");
+
+-- CreateIndex
+CREATE INDEX "Speaker_editionId_idx" ON "Speaker"("editionId");
+
+-- CreateIndex
+CREATE INDEX "Speaker_sponsorId_idx" ON "Speaker"("sponsorId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Speaker_editionId_slug_key" ON "Speaker"("editionId", "slug");
+
+-- CreateIndex
+CREATE INDEX "Talk_editionId_idx" ON "Talk"("editionId");
+
+-- CreateIndex
+CREATE INDEX "Talk_categoryId_idx" ON "Talk"("categoryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Talk_editionId_slug_key" ON "Talk"("editionId", "slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Sponsor_editToken_key" ON "Sponsor"("editToken");
+
+-- CreateIndex
+CREATE INDEX "Sponsor_editionId_idx" ON "Sponsor"("editionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Sponsor_editionId_slug_key" ON "Sponsor"("editionId", "slug");
+
+-- CreateIndex
+CREATE INDEX "Category_editionId_idx" ON "Category"("editionId");
+
+-- CreateIndex
+CREATE INDEX "_SpeakerToTalk_B_index" ON "_SpeakerToTalk"("B");
+
+-- AddForeignKey
+ALTER TABLE "Speaker" ADD CONSTRAINT "Speaker_editionId_fkey" FOREIGN KEY ("editionId") REFERENCES "Edition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Speaker" ADD CONSTRAINT "Speaker_sponsorId_fkey" FOREIGN KEY ("sponsorId") REFERENCES "Sponsor"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Talk" ADD CONSTRAINT "Talk_editionId_fkey" FOREIGN KEY ("editionId") REFERENCES "Edition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Talk" ADD CONSTRAINT "Talk_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Sponsor" ADD CONSTRAINT "Sponsor_editionId_fkey" FOREIGN KEY ("editionId") REFERENCES "Edition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_editionId_fkey" FOREIGN KEY ("editionId") REFERENCES "Edition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_SpeakerToTalk" ADD CONSTRAINT "_SpeakerToTalk_A_fkey" FOREIGN KEY ("A") REFERENCES "Speaker"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_SpeakerToTalk" ADD CONSTRAINT "_SpeakerToTalk_B_fkey" FOREIGN KEY ("B") REFERENCES "Talk"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -41,6 +41,33 @@ enum UserRole {
   EDITOR
 }
 
+// ============================================
+// Lot 2 — Speakers, Sessions & Sponsors (enums)
+// ============================================
+
+// Sponsoring levels, ordered by decreasing importance (RG-221).
+enum SponsorLevel {
+  PLATINUM
+  GOLD
+  SILVER
+  SOUTIEN
+  COMMUNAUTE
+}
+
+// Talk formats (RG-211).
+enum TalkFormat {
+  CONFERENCE // 40 min
+  QUICKIE    // 15 min
+  KEYNOTE
+}
+
+// Talk difficulty levels (RG-212). Absence means "Tous niveaux".
+enum TalkLevel {
+  DEBUTANT
+  INTERMEDIAIRE
+  CONFIRME
+}
+
 // --- Edition ---
 
 model Edition {
@@ -65,6 +92,10 @@ model Edition {
   sponsorPageStatus        SponsorPageStatus @default(PRE_ANNOUNCEMENT)
   // External form URL used in PRE_ANNOUNCEMENT and TEMPORARY modes
   sponsorTemporaryFormUrl  String?
+  // Which SponsorLevel values are offered when creating a sponsor for this
+  // edition (US-245, RG-230). JSON array of SponsorLevel names; null/empty
+  // means all levels are allowed.
+  openSponsorLevels        String?
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
 
@@ -72,6 +103,10 @@ model Edition {
   articles            Article[]
   keyFigures          KeyFigure[]
   sponsorPlans        SponsorPlan[]
+  speakers            Speaker[]
+  talks               Talk[]
+  sponsors            Sponsor[]
+  categories          Category[]
 }
 
 // --- Key Figures ---
@@ -386,4 +421,144 @@ model FileMetadata {
   alt            String?   // Default alt text for accessibility
   updatedAt      DateTime  @updatedAt
   createdAt      DateTime  @default(now())
+}
+
+// ============================================
+// Lot 2 — Speakers, Sessions & Sponsors
+// ============================================
+
+// --- Speakers (RG-200 to RG-208) ---
+
+model Speaker {
+  id               Int               @id @default(autoincrement())
+  // Slug derived from the full name, unique per edition (RG-206).
+  slug             String
+  name             String
+  photoUrl         String?
+  company          String?
+  city             String?
+  bioFr            String?
+  bioEn            String?
+  // JSON object of social links, e.g. {"twitter":"...","github":"...","linkedin":"...","bluesky":"...","website":"..."}
+  socialLinks      String?
+  // Shown in the homepage "featured speakers" section (RG-202).
+  isFeatured       Boolean           @default(false)
+  publicationStatus PublicationStatus @default(DRAFT)
+
+  // Modification-link token infrastructure (issue #79, RG-242 to RG-251).
+  // Stored now to avoid a second migration. editToken is a crypto-random
+  // secret; editLinkLocked freezes editing without deleting the token.
+  editToken        String?           @unique
+  editLinkLocked   Boolean           @default(false)
+  editTokenSentAt  DateTime?
+
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+
+  editionId        Int
+  edition          Edition           @relation(fields: [editionId], references: [id], onDelete: Cascade)
+
+  // Manual association to a sponsor via the speaker's company (RG-204, RG-226).
+  sponsorId        Int?
+  sponsor          Sponsor?          @relation(fields: [sponsorId], references: [id], onDelete: SetNull)
+
+  talks            Talk[]
+
+  @@unique([editionId, slug])
+  @@index([editionId])
+  @@index([sponsorId])
+}
+
+// --- Talks / Sessions (RG-210 to RG-217) ---
+// Named Talk to avoid colliding with the Better Auth `Session` model.
+
+model Talk {
+  id               Int               @id @default(autoincrement())
+  // Slug derived from the title (RG-214). Unique per edition.
+  slug             String
+  titleFr          String
+  titleEn          String
+  descriptionFr    String
+  descriptionEn    String
+  format           TalkFormat
+  level            TalkLevel?
+  // Spoken language of the talk, e.g. "fr" | "en".
+  language         String
+  publicationStatus PublicationStatus @default(DRAFT)
+
+  // Room and time slot are assigned in Lot 3 (Programme) — optional here (RG-216).
+  room             String?
+  startsAt         DateTime?
+  endsAt           DateTime?
+
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+
+  editionId        Int
+  edition          Edition           @relation(fields: [editionId], references: [id], onDelete: Cascade)
+
+  // A talk belongs to one category/track (RG-213). Optional so a talk can be
+  // created before its track exists; SetNull keeps the talk if the track is removed.
+  categoryId       Int?
+  category         Category?         @relation(fields: [categoryId], references: [id], onDelete: SetNull)
+
+  speakers         Speaker[]
+
+  @@unique([editionId, slug])
+  @@index([editionId])
+  @@index([categoryId])
+}
+
+// --- Sponsors (RG-220 to RG-231) ---
+
+model Sponsor {
+  id               Int               @id @default(autoincrement())
+  // Slug derived from the name (RG-227). Unique per edition.
+  slug             String
+  name             String
+  logoUrl          String?
+  level            SponsorLevel
+  websiteUrl       String?
+  descriptionFr    String?
+  descriptionEn    String?
+  // JSON object of social links (same shape as Speaker.socialLinks).
+  socialLinks      String?
+  publicationStatus PublicationStatus @default(DRAFT)
+
+  // Modification-link token infrastructure (issue #79, RG-242 to RG-251).
+  editToken        String?           @unique
+  editLinkLocked   Boolean           @default(false)
+  editTokenSentAt  DateTime?
+
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+
+  editionId        Int
+  edition          Edition           @relation(fields: [editionId], references: [id], onDelete: Cascade)
+
+  // Speakers working for this sponsor's company (RG-226).
+  speakers         Speaker[]
+
+  @@unique([editionId, slug])
+  @@index([editionId])
+}
+
+// --- Categories / Tracks (RG-213, US-246) ---
+
+model Category {
+  id               Int       @id @default(autoincrement())
+  nameFr           String
+  nameEn           String
+  // Track colour used to tint the talk cards (hex string).
+  color            String    @default("#109E6E")
+  sortOrder        Int       @default(0)
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  editionId        Int
+  edition          Edition   @relation(fields: [editionId], references: [id], onDelete: Cascade)
+
+  talks            Talk[]
+
+  @@index([editionId])
 }

--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -289,6 +289,85 @@ async function seedDev() {
   await prisma.sponsorPlan.createMany({ data: sponsorPlans });
   console.log(`Sponsor plans created: ${sponsorPlans.length}`);
 
+  // --- Lot 2: Categories, Sponsors, Speakers, Talks (dev sample data) ---
+  // Wipe in dependency order so re-running the dev seed is idempotent.
+  await prisma.talk.deleteMany({ where: { editionId: edition.id } });
+  await prisma.speaker.deleteMany({ where: { editionId: edition.id } });
+  await prisma.sponsor.deleteMany({ where: { editionId: edition.id } });
+  await prisma.category.deleteMany({ where: { editionId: edition.id } });
+
+  const catCloud = await prisma.category.create({
+    data: { nameFr: "Cloud & DevOps", nameEn: "Cloud & DevOps", color: "#509EE3", sortOrder: 0, editionId: edition.id },
+  });
+  const catWeb = await prisma.category.create({
+    data: { nameFr: "Web & Mobile", nameEn: "Web & Mobile", color: "#EC6839", sortOrder: 1, editionId: edition.id },
+  });
+  console.log("Categories created: 2");
+
+  const sponsorOvh = await prisma.sponsor.create({
+    data: {
+      slug: "ovhcloud", name: "OVHcloud", level: "PLATINUM",
+      websiteUrl: "https://www.ovhcloud.com",
+      descriptionFr: "Leader européen du cloud.", descriptionEn: "European cloud leader.",
+      logoUrl: null, publicationStatus: "PUBLISHED", editionId: edition.id,
+    },
+  });
+  await prisma.sponsor.create({
+    data: {
+      slug: "google", name: "Google", level: "GOLD",
+      websiteUrl: "https://developers.google.com",
+      descriptionFr: "Partenaire historique du DevFest.", descriptionEn: "Long-time DevFest partner.",
+      publicationStatus: "PUBLISHED", editionId: edition.id,
+    },
+  });
+  console.log("Sponsors created: 2");
+
+  const speakerMarie = await prisma.speaker.create({
+    data: {
+      slug: "marie-dupont", name: "Marie Dupont", company: "OVHcloud", city: "Toulouse",
+      bioFr: "Ingénieure cloud passionnée de Kubernetes.", bioEn: "Cloud engineer passionate about Kubernetes.",
+      isFeatured: true, publicationStatus: "PUBLISHED", editionId: edition.id, sponsorId: sponsorOvh.id,
+      socialLinks: JSON.stringify({ github: "https://github.com/example", linkedin: "https://linkedin.com/in/example" }),
+    },
+  });
+  const speakerJean = await prisma.speaker.create({
+    data: {
+      slug: "jean-martin", name: "Jean Martin", company: "Freelance", city: "Bordeaux",
+      bioFr: "Développeur web fullstack.", bioEn: "Fullstack web developer.",
+      isFeatured: true, publicationStatus: "PUBLISHED", editionId: edition.id,
+    },
+  });
+  await prisma.speaker.create({
+    data: {
+      slug: "sophie-bernard", name: "Sophie Bernard", company: "Google", city: "Paris",
+      bioFr: "Developer advocate.", bioEn: "Developer advocate.",
+      publicationStatus: "DRAFT", editionId: edition.id,
+    },
+  });
+  console.log("Speakers created: 3");
+
+  await prisma.talk.create({
+    data: {
+      slug: "kubernetes-en-production", titleFr: "Kubernetes en production", titleEn: "Kubernetes in production",
+      descriptionFr: "Retour d'expérience sur l'exploitation de Kubernetes à grande échelle.",
+      descriptionEn: "Lessons learned running Kubernetes at scale.",
+      format: "CONFERENCE", level: "CONFIRME", language: "fr",
+      publicationStatus: "PUBLISHED", editionId: edition.id, categoryId: catCloud.id,
+      speakers: { connect: [{ id: speakerMarie.id }] },
+    },
+  });
+  await prisma.talk.create({
+    data: {
+      slug: "react-server-components", titleFr: "React Server Components", titleEn: "React Server Components",
+      descriptionFr: "Comprendre les Server Components et leur impact.",
+      descriptionEn: "Understanding Server Components and their impact.",
+      format: "QUICKIE", level: "INTERMEDIAIRE", language: "fr",
+      publicationStatus: "PUBLISHED", editionId: edition.id, categoryId: catWeb.id,
+      speakers: { connect: [{ id: speakerJean.id }] },
+    },
+  });
+  console.log("Talks created: 2");
+
   // --- Social Links ---
   const socialSettings = [
     { key: "social_linkedin", value: "https://www.linkedin.com/company/gdg-toulouse/" },


### PR DESCRIPTION
Closes #69. Fondation de données du Lot 2 — bloque tous les autres tickets Lot 2.

## Modèles ajoutés
- **Speaker** — nom, slug (unique/édition), photo, entreprise, ville, bio FR/EN, liens sociaux (JSON), `isFeatured`, brouillon/publié, FK Edition, FK Sponsor optionnel (lien entreprise manuel RG-204), N-N Talk.
- **Talk** (nommé ainsi pour éviter la collision avec le modèle `Session` de Better Auth) — titre + description bilingues, enums format/niveau, langue, slug, brouillon/publié, room/startsAt/endsAt optionnels (Lot 3, RG-216), FK Edition, FK Category optionnel, N-N speakers.
- **Sponsor** — nom, slug, logo, enum `SponsorLevel`, site web, description FR/EN, liens sociaux, brouillon/publié, FK Edition, relation speakers (RG-226).
- **Category** (track) — nom bilingue + couleur, FK Edition.
- `Edition.openSponsorLevels` (JSON) pour US-245.
- Speaker/Sponsor portent déjà `editToken`/`editLinkLocked`/`editTokenSentAt` pour éviter une 2e migration quand les liens de modification (#79) arriveront.
- Enums : `SponsorLevel`, `TalkFormat`, `TalkLevel`.

## Migration & seed
- Migration `20260608195029_lot2_speakers_talks_sponsors_categories`.
- Seed-dev : 2 catégories, 2 sponsors, 3 speakers, 2 talks avec relations câblées.

## Test plan
- `prisma validate` OK, `tsc` backend OK.
- `prisma migrate deploy` sur DB vierge applique toutes les migrations sans erreur (chemin du boot Docker).
- Seed-dev exécuté : relations vérifiées (talk→catégorie+speaker, speaker→sponsor).
- ⚠️ Note v7 : après `migrate dev`, il a fallu relancer `prisma generate` pour que le client expose les nouveaux modèles (quirk connu, le Dockerfile fait déjà un generate explicite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)