### PR TITLE
feat(lot2): sponsors CRUD admin + REST API (#70)

### DIFF
--- a/src/backend/src/lib/slug.ts
+++ b/src/backend/src/lib/slug.ts
@@ -1,0 +1,19 @@
+// Derive a URL-safe slug from a free-text name: lowercase, strip accents,
+// collapse non-alphanumerics into single hyphens, trim edge hyphens.
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// Make `base` unique against an existing set by appending -2, -3, ... until free
+// (RG-206/RG-227: slugs are unique per edition; duplicates are deduplicated).
+export function uniqueSlug(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  let n = 2;
+  while (taken.has(`${base}-${n}`)) n++;
+  return `${base}-${n}`;
+}

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -18,6 +18,8 @@ interface EditionBody {
   sponsorHeroImageUrl?: string;
   sponsorPageStatus?: "PRE_ANNOUNCEMENT" | "TEMPORARY" | "OPEN" | "SOLD_OUT";
   sponsorTemporaryFormUrl?: string;
+  // SponsorLevel names offered when creating a sponsor for this edition (US-245).
+  openSponsorLevels?: string[];
 }
 
 export default async function adminEditionRoutes(app: FastifyInstance) {
@@ -110,6 +112,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         sponsorHeroImageUrl: edition.sponsorHeroImageUrl,
         sponsorPageStatus: edition.sponsorPageStatus,
         sponsorTemporaryFormUrl: edition.sponsorTemporaryFormUrl,
+        openSponsorLevels: edition.openSponsorLevels ? JSON.parse(edition.openSponsorLevels) : [],
         ticketTiersCount: edition._count.ticketTiers,
         articlesCount: edition._count.articles,
       };
@@ -148,6 +151,9 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         sponsorHeroImageUrl: body.sponsorHeroImageUrl !== undefined ? (body.sponsorHeroImageUrl || null) : existing.sponsorHeroImageUrl,
         sponsorPageStatus: body.sponsorPageStatus ?? existing.sponsorPageStatus,
         sponsorTemporaryFormUrl: body.sponsorTemporaryFormUrl !== undefined ? (body.sponsorTemporaryFormUrl || null) : existing.sponsorTemporaryFormUrl,
+        openSponsorLevels: body.openSponsorLevels !== undefined
+          ? (body.openSponsorLevels.length > 0 ? JSON.stringify(body.openSponsorLevels) : null)
+          : existing.openSponsorLevels,
       },
     });
 

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -11,6 +11,7 @@ import adminContactRoutes from "./contact.js";
 import adminFileRoutes from "./files.js";
 import adminUserRoutes from "./users.js";
 import adminSponsorPlanRoutes from "./sponsor-plans.js";
+import adminSponsorRoutes from "./sponsors.js";
 import adminApiKeyRoutes from "./api-keys.js";
 import adminTranslateRoutes from "./translate.js";
 
@@ -26,6 +27,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminContactRoutes);
     await editorApp.register(adminFileRoutes);
     await editorApp.register(adminTranslateRoutes);
+    await editorApp.register(adminSponsorRoutes);
   });
 
   // Routes restricted to ADMIN only

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -1,0 +1,136 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../lib/prisma.js";
+import { revalidateSponsors } from "../../lib/revalidate.js";
+import { slugify, uniqueSlug } from "../../lib/slug.js";
+
+const SPONSOR_LEVELS = ["PLATINUM", "GOLD", "SILVER", "SOUTIEN", "COMMUNAUTE"] as const;
+type SponsorLevel = (typeof SPONSOR_LEVELS)[number];
+
+interface SponsorCreateBody {
+  editionId: number;
+  name: string;
+  level: SponsorLevel;
+  logoUrl?: string;
+  websiteUrl?: string;
+  descriptionFr?: string;
+  descriptionEn?: string;
+  socialLinks?: Record<string, string>;
+  publicationStatus?: "DRAFT" | "PUBLISHED";
+}
+
+type SponsorUpdateBody = Partial<Omit<SponsorCreateBody, "editionId">>;
+
+interface SponsorIdParams {
+  id: string;
+}
+
+interface SponsorListQuery {
+  editionId?: string;
+}
+
+function serialize(s: {
+  socialLinks: string | null;
+  [k: string]: unknown;
+}) {
+  return { ...s, socialLinks: s.socialLinks ? JSON.parse(s.socialLinks) : {} };
+}
+
+export default async function adminSponsorRoutes(app: FastifyInstance) {
+  // GET /api/admin/sponsors?editionId=X
+  app.get<{ Querystring: SponsorListQuery }>("/sponsors", {
+    schema: {
+      querystring: { type: "object", properties: { editionId: { type: "string" } } },
+    },
+  }, async (request, reply) => {
+    const { editionId } = request.query;
+    if (!editionId) return reply.code(400).send({ error: "editionId required" });
+
+    const sponsors = await prisma.sponsor.findMany({
+      where: { editionId: Number(editionId) },
+      orderBy: [{ level: "asc" }, { name: "asc" }],
+    });
+    return sponsors.map(serialize);
+  });
+
+  // POST /api/admin/sponsors
+  app.post<{ Body: SponsorCreateBody }>("/sponsors", async (request, reply) => {
+    const body = request.body;
+
+    if (!body.editionId || !body.name?.trim() || !body.level) {
+      return reply.code(400).send({ error: "editionId, name and level are required" });
+    }
+    if (!SPONSOR_LEVELS.includes(body.level)) {
+      return reply.code(422).send({ error: `Invalid level. Allowed: ${SPONSOR_LEVELS.join(", ")}` });
+    }
+
+    // Build a slug unique within the edition.
+    const existing = await prisma.sponsor.findMany({
+      where: { editionId: body.editionId },
+      select: { slug: true },
+    });
+    const slug = uniqueSlug(slugify(body.name), new Set(existing.map((e) => e.slug)));
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        editionId: body.editionId,
+        slug,
+        name: body.name.trim(),
+        level: body.level,
+        logoUrl: body.logoUrl || null,
+        websiteUrl: body.websiteUrl || null,
+        descriptionFr: body.descriptionFr || null,
+        descriptionEn: body.descriptionEn || null,
+        socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+        publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
+      },
+    });
+
+    revalidateSponsors();
+    return reply.code(201).send(serialize(sponsor));
+  });
+
+  // PUT /api/admin/sponsors/:id
+  app.put<{ Params: SponsorIdParams; Body: SponsorUpdateBody }>("/sponsors/:id", {
+    schema: {
+      params: { type: "object", required: ["id"], properties: { id: { type: "string" } } },
+    },
+  }, async (request, reply) => {
+    const { id } = request.params;
+    const body = request.body;
+
+    if (body.level !== undefined && !SPONSOR_LEVELS.includes(body.level)) {
+      return reply.code(422).send({ error: `Invalid level. Allowed: ${SPONSOR_LEVELS.join(", ")}` });
+    }
+
+    const sponsor = await prisma.sponsor.update({
+      where: { id: Number(id) },
+      data: {
+        ...(body.name !== undefined && { name: body.name.trim() }),
+        ...(body.level !== undefined && { level: body.level }),
+        ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
+        ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
+        ...(body.descriptionFr !== undefined && { descriptionFr: body.descriptionFr || null }),
+        ...(body.descriptionEn !== undefined && { descriptionEn: body.descriptionEn || null }),
+        ...(body.socialLinks !== undefined && {
+          socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+        }),
+        ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
+      },
+    });
+
+    revalidateSponsors();
+    return serialize(sponsor);
+  });
+
+  // DELETE /api/admin/sponsors/:id
+  app.delete<{ Params: SponsorIdParams }>("/sponsors/:id", {
+    schema: {
+      params: { type: "object", required: ["id"], properties: { id: { type: "string" } } },
+    },
+  }, async (request, reply) => {
+    const { id } = request.params;
+    await prisma.sponsor.delete({ where: { id: Number(id) } });
+    revalidateSponsors();
+    return reply.code(204).send();
+  });
+}

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -10,6 +10,7 @@ import TicketingTab from "@/components/admin/edition-detail/TicketingTab";
 import CfpTab from "@/components/admin/edition-detail/CfpTab";
 import KeyFiguresTab from "@/components/admin/edition-detail/KeyFiguresTab";
 import SponsoringTab from "@/components/admin/edition-detail/SponsoringTab";
+import SponsorsTab from "@/components/admin/edition-detail/SponsorsTab";
 
 interface EditionData {
   id: number;
@@ -39,7 +40,7 @@ const TABS = [
   { key: "ticketing", label: "Billetterie" },
   { key: "speakers", label: "Speakers (0)" },
   { key: "conferences", label: "Conférences (0)" },
-  { key: "sponsors", label: "Sponsors (0)" },
+  { key: "sponsors", label: "Sponsors" },
   { key: "sponsoring", label: "Sponsoring" },
   { key: "cfp", label: "CFP" },
   { key: "key-figures", label: "Chiffres clés" },
@@ -108,10 +109,7 @@ export default function EditionDetailPage() {
           </div>
         )}
         {activeTab === "sponsors" && (
-          <div className="py-12 text-center text-gris">
-            <p className="text-lg font-medium">Sponsors</p>
-            <p className="mt-2 text-sm">Fonctionnalité à venir — gestion des sponsors de l&apos;édition.</p>
-          </div>
+          <SponsorsTab editionId={edition.id} />
         )}
         {activeTab === "sponsoring" && (
           <SponsoringTab editionId={edition.id} />

--- a/src/frontend/src/components/admin/edition-detail/SponsorsTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SponsorsTab.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Sponsor, SponsorLevel } from "@/lib/types";
+import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+
+const LEVELS: { value: SponsorLevel; label: string }[] = [
+  { value: "PLATINUM", label: "Platinum" },
+  { value: "GOLD", label: "Gold" },
+  { value: "SILVER", label: "Silver" },
+  { value: "SOUTIEN", label: "Soutien" },
+  { value: "COMMUNAUTE", label: "Communauté" },
+];
+
+const emptyForm = {
+  name: "",
+  level: "PLATINUM" as SponsorLevel,
+  logoUrl: "",
+  websiteUrl: "",
+  descriptionFr: "",
+  descriptionEn: "",
+  linkedin: "",
+  twitter: "",
+  publicationStatus: "DRAFT" as "DRAFT" | "PUBLISHED",
+};
+
+interface SponsorsTabProps {
+  editionId: number;
+}
+
+export default function SponsorsTab({ editionId }: SponsorsTabProps) {
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [openLevels, setOpenLevels] = useState<SponsorLevel[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState(emptyForm);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Sponsor | null>(null);
+  const [levelsSaved, setLevelsSaved] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    const [{ data: list }, { data: edition }] = await Promise.all([
+      adminFetch<Sponsor[]>(`/sponsors?editionId=${editionId}`),
+      adminFetch<{ openSponsorLevels: SponsorLevel[] }>(`/editions/${editionId}`),
+    ]);
+    if (list) setSponsors(list);
+    if (edition) setOpenLevels(edition.openSponsorLevels ?? []);
+    setIsLoading(false);
+  }, [editionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function openCreate() {
+    setEditingId(null);
+    setForm(emptyForm);
+    setShowForm(true);
+  }
+
+  function openEdit(s: Sponsor) {
+    setEditingId(s.id);
+    setForm({
+      name: s.name,
+      level: s.level,
+      logoUrl: s.logoUrl || "",
+      websiteUrl: s.websiteUrl || "",
+      descriptionFr: s.descriptionFr || "",
+      descriptionEn: s.descriptionEn || "",
+      linkedin: s.socialLinks?.linkedin || "",
+      twitter: s.socialLinks?.twitter || "",
+      publicationStatus: s.publicationStatus,
+    });
+    setShowForm(true);
+  }
+
+  async function handleSave() {
+    if (!form.name.trim()) return;
+    setIsSaving(true);
+    const socialLinks: Record<string, string> = {};
+    if (form.linkedin.trim()) socialLinks.linkedin = form.linkedin.trim();
+    if (form.twitter.trim()) socialLinks.twitter = form.twitter.trim();
+
+    const payload = {
+      editionId,
+      name: form.name.trim(),
+      level: form.level,
+      logoUrl: form.logoUrl || undefined,
+      websiteUrl: form.websiteUrl || undefined,
+      descriptionFr: form.descriptionFr || undefined,
+      descriptionEn: form.descriptionEn || undefined,
+      socialLinks,
+      publicationStatus: form.publicationStatus,
+    };
+
+    if (editingId) {
+      await adminFetch(`/sponsors/${editingId}`, { method: "PUT", body: JSON.stringify(payload) });
+    } else {
+      await adminFetch("/sponsors", { method: "POST", body: JSON.stringify(payload) });
+    }
+    setIsSaving(false);
+    setShowForm(false);
+    void load();
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await adminFetch(`/sponsors/${deleteTarget.id}`, { method: "DELETE" });
+    setDeleteTarget(null);
+    void load();
+  }
+
+  function toggleOpenLevel(level: SponsorLevel) {
+    setOpenLevels((prev) =>
+      prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level],
+    );
+  }
+
+  async function saveOpenLevels() {
+    await adminFetch(`/editions/${editionId}`, {
+      method: "PUT",
+      body: JSON.stringify({ openSponsorLevels: openLevels }),
+    });
+    setLevelsSaved(true);
+    setTimeout(() => setLevelsSaved(false), 3000);
+  }
+
+  if (isLoading) return <p className="py-12 text-center text-gris">Chargement…</p>;
+
+  return (
+    <div className="space-y-8">
+      {/* US-245 — open sponsoring levels for this edition */}
+      <div className="bg-blanc rounded-xl shadow-card p-6">
+        <h2 className="text-lg font-bold text-noir mb-1">Niveaux de sponsoring ouverts</h2>
+        <p className="text-sm text-gris mb-4">
+          Seuls les niveaux cochés sont proposés à la création d&apos;un sponsor.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          {LEVELS.map((l) => (
+            <label key={l.value} className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={openLevels.includes(l.value)}
+                onChange={() => toggleOpenLevel(l.value)}
+                className="rounded border-gris/30 text-malachite focus:ring-malachite"
+              />
+              <span className="text-sm text-noir">{l.label}</span>
+            </label>
+          ))}
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <button
+            onClick={saveOpenLevels}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+          >
+            Enregistrer les niveaux
+          </button>
+          {levelsSaved && <span className="text-sm text-malachite">Enregistré !</span>}
+        </div>
+      </div>
+
+      {/* Sponsor list + form */}
+      <div className="bg-blanc rounded-xl shadow-card p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-noir">Sponsors ({sponsors.length})</h2>
+          {!showForm && (
+            <button
+              onClick={openCreate}
+              className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+            >
+              + Ajouter un sponsor
+            </button>
+          )}
+        </div>
+
+        {showForm && (
+          <div className="border border-gris/20 rounded-lg p-4 mb-6 space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <label className="block">
+                <span className="block text-sm font-medium text-noir mb-1">Nom *</span>
+                <input
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                />
+              </label>
+              <label className="block">
+                <span className="block text-sm font-medium text-noir mb-1">Niveau *</span>
+                <select
+                  value={form.level}
+                  onChange={(e) => setForm({ ...form, level: e.target.value as SponsorLevel })}
+                  className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                >
+                  {LEVELS.filter((l) => openLevels.length === 0 || openLevels.includes(l.value)).map((l) => (
+                    <option key={l.value} value={l.value}>{l.label}</option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <div>
+              <span className="block text-sm font-medium text-noir mb-1">Logo</span>
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  onClick={() => setIsImagePickerOpen(true)}
+                  className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+                >
+                  {form.logoUrl ? "Changer le logo" : "Choisir un logo"}
+                </button>
+                {form.logoUrl && (
+                  <>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={form.logoUrl} alt="Logo" className="h-12 rounded object-contain" />
+                    <button
+                      type="button"
+                      onClick={() => setForm({ ...form, logoUrl: "" })}
+                      className="text-sm text-terre-cuite hover:underline"
+                    >
+                      Retirer
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Site web</span>
+              <input
+                type="url"
+                value={form.websiteUrl}
+                onChange={(e) => setForm({ ...form, websiteUrl: e.target.value })}
+                className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              />
+            </label>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <label className="block">
+                <span className="block text-sm font-medium text-noir mb-1">Description (FR)</span>
+                <textarea
+                  value={form.descriptionFr}
+                  onChange={(e) => setForm({ ...form, descriptionFr: e.target.value })}
+                  rows={3}
+                  className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                />
+              </label>
+              <label className="block">
+                <span className="block text-sm font-medium text-noir mb-1">Description (EN)</span>
+                <textarea
+                  value={form.descriptionEn}
+                  onChange={(e) => setForm({ ...form, descriptionEn: e.target.value })}
+                  rows={3}
+                  className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                />
+              </label>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <label className="block">
+                <span className="block text-sm font-medium text-noir mb-1">LinkedIn</span>
+                <input
+                  type="url"
+                  value={form.linkedin}
+                  onChange={(e) => setForm({ ...form, linkedin: e.target.value })}
+                  className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                />
+              </label>
+              <label className="block">
+                <span className="block text-sm font-medium text-noir mb-1">X / Twitter</span>
+                <input
+                  type="url"
+                  value={form.twitter}
+                  onChange={(e) => setForm({ ...form, twitter: e.target.value })}
+                  className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                />
+              </label>
+            </div>
+
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={form.publicationStatus === "PUBLISHED"}
+                onChange={(e) =>
+                  setForm({ ...form, publicationStatus: e.target.checked ? "PUBLISHED" : "DRAFT" })
+                }
+                className="rounded border-gris/30 text-malachite focus:ring-malachite"
+              />
+              <span className="text-sm text-noir">Publié (visible sur le site)</span>
+            </label>
+
+            <div className="flex items-center gap-3 pt-2">
+              <button
+                onClick={handleSave}
+                disabled={isSaving || !form.name.trim()}
+                className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+              >
+                {isSaving ? "Enregistrement…" : "Enregistrer"}
+              </button>
+              <button
+                onClick={() => setShowForm(false)}
+                className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+              >
+                Annuler
+              </button>
+            </div>
+          </div>
+        )}
+
+        {sponsors.length === 0 ? (
+          <p className="py-8 text-center text-gris text-sm">Aucun sponsor pour cette édition.</p>
+        ) : (
+          <ul className="divide-y divide-gris/10">
+            {sponsors.map((s) => (
+              <li key={s.id} className="flex items-center gap-4 py-3">
+                <span className="w-24 text-xs font-bold text-gris uppercase">{s.level}</span>
+                <span className="flex-1 text-noir">{s.name}</span>
+                <span
+                  className={`text-xs px-2 py-0.5 rounded-full ${
+                    s.publicationStatus === "PUBLISHED"
+                      ? "bg-malachite/10 text-malachite"
+                      : "bg-gris/10 text-gris"
+                  }`}
+                >
+                  {s.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+                </span>
+                <button onClick={() => openEdit(s)} className="text-sm text-bleu hover:underline">
+                  Éditer
+                </button>
+                <button
+                  onClick={() => setDeleteTarget(s)}
+                  className="text-sm text-terre-cuite hover:underline"
+                >
+                  Supprimer
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ImagePickerDialog
+        open={isImagePickerOpen}
+        onClose={() => setIsImagePickerOpen(false)}
+        onSelect={(url) => setForm((f) => ({ ...f, logoUrl: url }))}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        title="Supprimer ce sponsor ?"
+        message={`« ${deleteTarget?.name} » sera définitivement supprimé.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -118,6 +118,22 @@ export interface SponsorPlan {
   isFeatured: boolean;
 }
 
+export type SponsorLevel = "PLATINUM" | "GOLD" | "SILVER" | "SOUTIEN" | "COMMUNAUTE";
+
+export interface Sponsor {
+  id: number;
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  level: SponsorLevel;
+  websiteUrl: string | null;
+  descriptionFr: string | null;
+  descriptionEn: string | null;
+  socialLinks: Record<string, string>;
+  publicationStatus: "DRAFT" | "PUBLISHED";
+  editionId: number;
+}
+
 export interface EditionDetail {
   id: number;
   year: number;


### PR DESCRIPTION
Closes #70. Gestion admin des sponsors d'une édition (US-242, US-244, US-245). Dépend de #69 (modèles).

## Backend
- `admin/sponsors.ts` : `GET/POST/PUT/DELETE /api/admin/sponsors`, edition-scoped, scope ADMIN+EDITOR (contenu éditorial, comme les articles).
- Slug auto dérivé du nom, dédupliqué par édition (`lib/slug.ts`, réutilisable pour speakers/talks — RG-227).
- Niveau validé contre l'enum `SponsorLevel` (422 si invalide).
- `socialLinks` stocké en JSON, renvoyé parsé.
- **US-245** : `Edition.openSponsorLevels` exposé au GET détail et modifiable via `PUT /api/admin/editions/:id` ; le formulaire ne propose que les niveaux ouverts.
- `revalidateSponsors()` sur chaque mutation.

## Frontend
- Types `Sponsor` + `SponsorLevel`.
- `SponsorsTab` : cases à cocher des niveaux ouverts (US-245) + liste + formulaire create/edit (nom, niveau, logo via image picker, site, description bilingue, réseaux, brouillon/publié) + confirmation de suppression.
- Branché dans la page édition admin (remplace le placeholder).

## Test plan
- `tsc` back + front : OK (erreurs uniquement dans `.next/dev/` généré, non liées).
- Route montée et protégée : `GET /api/admin/sponsors` → **403** sans auth.
- Logique CRUD validée via script Prisma : slugify (accents/`&`), dédup slug (`google` → `google-2`), create/update/delete, socialLinks JSON.

Suite : #71 (pages publiques sponsors), #72 (section home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)