### PR TITLE
feat(lot2): public sponsors pages — list + detail (#71)

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -15,6 +15,7 @@ import settingsRoutes from "./routes/settings.js";
 import pageRoutes from "./routes/pages.js";
 import contactRoutes from "./routes/contact.js";
 import brochureRoutes from "./routes/brochure.js";
+import sponsorRoutes from "./routes/sponsors.js";
 import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
@@ -193,6 +194,7 @@ await app.register(settingsRoutes, { prefix: "/api" });
 await app.register(pageRoutes, { prefix: "/api" });
 await app.register(contactRoutes, { prefix: "/api" });
 await app.register(brochureRoutes, { prefix: "/api" });
+await app.register(sponsorRoutes, { prefix: "/api" });
 
 // Per-user routes (any authenticated back-office user — own resources only)
 await app.register(myApiKeysRoutes, { prefix: "/api/me" });

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -1,0 +1,81 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { getFeaturedEdition } from "./editions.js";
+
+// Decreasing importance order (RG-221), used to sort levels for display.
+const LEVEL_ORDER: Record<string, number> = {
+  PLATINUM: 0,
+  GOLD: 1,
+  SILVER: 2,
+  SOUTIEN: 3,
+  COMMUNAUTE: 4,
+};
+
+function parseSocial(raw: string | null): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export default async function sponsorRoutes(app: FastifyInstance) {
+  // GET /api/sponsors — published sponsors of the featured edition, ordered by level.
+  app.get("/sponsors", async (_request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+
+    const sponsors = await prisma.sponsor.findMany({
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+    });
+
+    return sponsors
+      .map((s) => ({
+        id: s.id,
+        slug: s.slug,
+        name: s.name,
+        logoUrl: s.logoUrl,
+        level: s.level,
+        websiteUrl: s.websiteUrl,
+      }))
+      .sort((a, b) => (LEVEL_ORDER[a.level] - LEVEL_ORDER[b.level]) || a.name.localeCompare(b.name));
+  });
+
+  // GET /api/sponsors/:slug — detail of a published sponsor + its speakers (RG-226).
+  app.get<{ Params: { slug: string } }>("/sponsors/:slug", {
+    schema: {
+      params: { type: "object", required: ["slug"], properties: { slug: { type: "string" } } },
+    },
+  }, async (request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+
+    const sponsor = await prisma.sponsor.findFirst({
+      where: { editionId: edition.id, slug: request.params.slug, publicationStatus: "PUBLISHED" },
+      include: {
+        speakers: {
+          where: { publicationStatus: "PUBLISHED" },
+          select: { slug: true, name: true, photoUrl: true, company: true },
+          orderBy: { name: "asc" },
+        },
+      },
+    });
+
+    if (!sponsor) return reply.status(404).send({ error: "Sponsor not found" });
+
+    return {
+      id: sponsor.id,
+      slug: sponsor.slug,
+      name: sponsor.name,
+      logoUrl: sponsor.logoUrl,
+      level: sponsor.level,
+      websiteUrl: sponsor.websiteUrl,
+      descriptionFr: sponsor.descriptionFr,
+      descriptionEn: sponsor.descriptionEn,
+      socialLinks: parseSocial(sponsor.socialLinks),
+      speakers: sponsor.speakers,
+    };
+  });
+}

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -255,6 +255,16 @@
     "comingSoonTitle": "Sponsors will be announced soon",
     "comingSoonBody": "The DevFest Toulouse {year} sponsor list will be published here. Does your company want to support the Toulouse tech ecosystem?",
     "becomeSponsorCta": "Become a sponsor",
-    "home": "Home"
+    "home": "Home",
+    "empty": "Sponsors will be announced soon.",
+    "visitWebsite": "Visit website",
+    "speakersOf": "Speakers from {name}",
+    "level": {
+      "PLATINUM": "Platinum",
+      "GOLD": "Gold",
+      "SILVER": "Silver",
+      "SOUTIEN": "Supporter",
+      "COMMUNAUTE": "Community"
+    }
   }
 }

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -255,6 +255,16 @@
     "comingSoonTitle": "Les sponsors seront annoncés prochainement",
     "comingSoonBody": "La liste des sponsors du DevFest Toulouse {year} sera publiée ici. Votre entreprise souhaite soutenir l'écosystème tech toulousain ?",
     "becomeSponsorCta": "Devenir sponsor",
-    "home": "Accueil"
+    "home": "Accueil",
+    "empty": "Les sponsors seront annoncés prochainement.",
+    "visitWebsite": "Visiter le site",
+    "speakersOf": "Speakers de {name}",
+    "level": {
+      "PLATINUM": "Platinum",
+      "GOLD": "Gold",
+      "SILVER": "Silver",
+      "SOUTIEN": "Soutien",
+      "COMMUNAUTE": "Communauté"
+    }
   }
 }

--- a/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
@@ -1,0 +1,162 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { getSponsorBySlug } from "@/lib/api";
+import { localizedField } from "@/lib/i18n-helpers";
+import Breadcrumb from "@/components/Breadcrumb";
+import { Link } from "@/i18n/navigation";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const sponsor = await getSponsorBySlug(slug);
+
+  if (!sponsor) return { title: "Sponsor not found" };
+
+  const description = localizedField(sponsor, "description", locale) || sponsor.name;
+
+  return {
+    title: sponsor.name,
+    description,
+    alternates: {
+      canonical: `/${locale}/sponsors/${slug}`,
+      languages: {
+        fr: `/fr/sponsors/${slug}`,
+        en: `/en/sponsors/${slug}`,
+        "x-default": `/fr/sponsors/${slug}`,
+      },
+    },
+    // OG image = sponsor logo (RG-229).
+    openGraph: {
+      title: sponsor.name,
+      description,
+      ...(sponsor.logoUrl ? { images: [{ url: sponsor.logoUrl }] } : {}),
+    },
+  };
+}
+
+export default async function SponsorDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const t = await getTranslations("sponsors");
+  const sponsor = await getSponsorBySlug(slug);
+
+  if (!sponsor) notFound();
+
+  const description = localizedField(sponsor, "description", locale);
+
+  const breadcrumbItems = [
+    { label: t("home"), href: `/${locale}` },
+    { label: t("title"), href: `/${locale}/sponsors` },
+    { label: sponsor.name, href: `/${locale}/sponsors/${slug}` },
+  ];
+
+  const orgJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: sponsor.name,
+    ...(sponsor.logoUrl ? { logo: sponsor.logoUrl } : {}),
+    ...(sponsor.websiteUrl ? { url: sponsor.websiteUrl } : {}),
+    ...(Object.values(sponsor.socialLinks).length > 0
+      ? { sameAs: Object.values(sponsor.socialLinks) }
+      : {}),
+  };
+
+  return (
+    <div className="px-6 py-8 lg:py-12">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
+      />
+      <div className="mx-auto max-w-6xl">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <h1 className="mt-6 text-3xl lg:text-5xl font-bold text-noir">{sponsor.name}</h1>
+
+        <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px]">
+          {/* Left: description */}
+          <div>
+            {description ? (
+              <p className="text-lg leading-relaxed text-noir whitespace-pre-line">{description}</p>
+            ) : null}
+          </div>
+
+          {/* Right: logo + links */}
+          <aside className="space-y-6">
+            {sponsor.logoUrl && (
+              <div className="relative h-40 w-full rounded-2xl bg-blanc p-6 shadow-card">
+                <Image src={sponsor.logoUrl} alt={sponsor.name} fill className="object-contain p-6" sizes="320px" />
+              </div>
+            )}
+            {sponsor.websiteUrl && (
+              <a
+                href={sponsor.websiteUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block rounded-[12px] bg-bleu px-6 py-3 text-center font-bold text-blanc transition-colors hover:bg-bleu/90"
+              >
+                {t("visitWebsite")}
+              </a>
+            )}
+            {Object.entries(sponsor.socialLinks).length > 0 && (
+              <ul className="flex flex-wrap gap-4">
+                {Object.entries(sponsor.socialLinks).map(([key, url]) => (
+                  <li key={key}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-bleu hover:underline capitalize"
+                    >
+                      {key}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </aside>
+        </div>
+
+        {/* Speakers of this sponsor (RG-226) */}
+        {sponsor.speakers.length > 0 && (
+          <section className="mt-14">
+            <h2 className="mb-6 text-2xl font-bold text-noir">
+              {t("speakersOf", { name: sponsor.name })}
+            </h2>
+            <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4">
+              {sponsor.speakers.map((sp) => (
+                <Link
+                  key={sp.slug}
+                  href={`/speakers/${sp.slug}`}
+                  className="group flex flex-col items-center gap-3 text-center"
+                >
+                  <div className="relative h-24 w-24 overflow-hidden rounded-full bg-blanc-casse">
+                    {sp.photoUrl ? (
+                      <Image src={sp.photoUrl} alt={sp.name} fill className="object-cover" sizes="96px" />
+                    ) : (
+                      <span className="flex h-full w-full items-center justify-center text-2xl font-bold text-gris">
+                        {sp.name.charAt(0)}
+                      </span>
+                    )}
+                  </div>
+                  <span className="font-bold text-noir group-hover:text-bleu">{sp.name}</span>
+                  {sp.company && <span className="text-sm text-gris">{sp.company}</span>}
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/[locale]/sponsors/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
-import { getCurrentEdition } from "@/lib/api";
+import { getCurrentEdition, getSponsors } from "@/lib/api";
+import type { SponsorLevel } from "@/lib/types";
 import Breadcrumb from "@/components/Breadcrumb";
+import SponsorCard from "@/components/sponsors/SponsorCard";
 import { Link } from "@/i18n/navigation";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -18,10 +20,12 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+const LEVEL_ORDER: SponsorLevel[] = ["PLATINUM", "GOLD", "SILVER", "SOUTIEN", "COMMUNAUTE"];
+
 export default async function SponsorsPage() {
   const locale = await getLocale();
   const t = await getTranslations("sponsors");
-  const edition = await getCurrentEdition();
+  const [edition, sponsors] = await Promise.all([getCurrentEdition(), getSponsors()]);
   const year = edition?.year ?? new Date().getFullYear();
 
   const breadcrumbItems = [
@@ -29,29 +33,51 @@ export default async function SponsorsPage() {
     { label: t("title"), href: `/${locale}/sponsors` },
   ];
 
+  // Group sponsors by level, keeping the importance order.
+  const byLevel = LEVEL_ORDER.map((level) => ({
+    level,
+    items: sponsors.filter((s) => s.level === level),
+  })).filter((g) => g.items.length > 0);
+
   return (
     <div className="px-6 py-8 lg:py-12">
-      <div className="mx-auto max-w-4xl">
+      <div className="mx-auto max-w-6xl">
         <Breadcrumb items={breadcrumbItems} />
 
-        <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
-          {t("heading", { year })}
-        </h1>
-
-        <div className="mt-8 p-8 rounded-3xl bg-blanc shadow-card">
-          <h2 className="text-2xl lg:text-3xl font-bold text-noir">
-            {t("comingSoonTitle")}
-          </h2>
-          <p className="mt-4 text-lg text-gris leading-relaxed">
-            {t("comingSoonBody", { year })}
-          </p>
+        <div className="mt-6 flex flex-wrap items-center justify-between gap-4">
+          <h1 className="text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
+            {t("heading", { year })}
+          </h1>
           <Link
             href="/devenir-sponsor"
-            className="mt-6 inline-block px-6 py-3 rounded-[12px] bg-bleu text-blanc font-bold hover:bg-bleu/90 transition-colors"
+            className="inline-block rounded-[12px] bg-bleu px-6 py-3 font-bold text-blanc transition-colors hover:bg-bleu/90"
           >
             {t("becomeSponsorCta")}
           </Link>
         </div>
+
+        {byLevel.length === 0 ? (
+          <p className="mt-12 text-lg text-gris">{t("empty")}</p>
+        ) : (
+          <div className="mt-10 space-y-12">
+            {byLevel.map(({ level, items }) => (
+              <section key={level}>
+                <h2 className="mb-6 text-2xl font-bold text-noir">{t(`level.${level}`)}</h2>
+                <div
+                  className={
+                    level === "PLATINUM"
+                      ? "grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+                      : "grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4"
+                  }
+                >
+                  {items.map((s) => (
+                    <SponsorCard key={s.id} sponsor={s} large={level === "PLATINUM"} />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/frontend/src/components/sponsors/SponsorCard.tsx
+++ b/src/frontend/src/components/sponsors/SponsorCard.tsx
@@ -1,0 +1,52 @@
+import Image from "next/image";
+import { Link } from "@/i18n/navigation";
+import type { SponsorPublic, SponsorLevel } from "@/lib/types";
+
+// Coloured banner per level (RG-224): Platinum → Émeraude, Gold → Jaune,
+// Silver/Soutien/Communauté → Rose.
+const LEVEL_BANNER: Record<SponsorLevel, string> = {
+  PLATINUM: "bg-emeraude",
+  GOLD: "bg-jaune",
+  SILVER: "bg-rose",
+  SOUTIEN: "bg-rose",
+  COMMUNAUTE: "bg-rose",
+};
+
+interface SponsorCardProps {
+  sponsor: SponsorPublic;
+  /** Platinum cards are larger (RG-223). */
+  large?: boolean;
+}
+
+export default function SponsorCard({ sponsor, large = false }: SponsorCardProps) {
+  return (
+    <Link
+      href={`/sponsors/${sponsor.slug}`}
+      className="group block overflow-hidden rounded-2xl bg-blanc shadow-card transition-transform hover:-translate-y-1"
+    >
+      <div className={`h-2 ${LEVEL_BANNER[sponsor.level]}`} />
+      <div className={`flex flex-col items-center justify-center gap-3 ${large ? "p-8" : "p-6"}`}>
+        <div className={`relative flex items-center justify-center ${large ? "h-32 w-full" : "h-20 w-full"}`}>
+          {sponsor.logoUrl ? (
+            <Image
+              src={sponsor.logoUrl}
+              alt={sponsor.name}
+              fill
+              className="object-contain"
+              sizes={large ? "267px" : "200px"}
+            />
+          ) : (
+            <span className={`font-bold text-noir ${large ? "text-3xl" : "text-xl"}`}>
+              {sponsor.name}
+            </span>
+          )}
+        </div>
+        {sponsor.logoUrl && (
+          <span className={`font-bold text-noir ${large ? "text-2xl" : "text-lg"}`}>
+            {sponsor.name}
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -13,6 +13,8 @@ import type {
   ContactCategory,
   PaginatedArticles,
   SponsorPlan,
+  SponsorPublic,
+  SponsorDetail,
   EcosystemPartner,
 } from "./types";
 
@@ -125,4 +127,12 @@ export async function getEcosystemPartners(): Promise<EcosystemPartner[]> {
 
 export async function getSponsorPlans(): Promise<SponsorPlan[]> {
   return (await fetchAPI<SponsorPlan[]>("/api/editions/current/sponsor-plans")) || [];
+}
+
+export async function getSponsors(): Promise<SponsorPublic[]> {
+  return (await fetchAPI<SponsorPublic[]>("/api/sponsors")) || [];
+}
+
+export async function getSponsorBySlug(slug: string): Promise<SponsorDetail | null> {
+  return fetchAPI<SponsorDetail>(`/api/sponsors/${slug}`);
 }

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -134,6 +134,36 @@ export interface Sponsor {
   editionId: number;
 }
 
+// Public list item (lighter than the admin Sponsor).
+export interface SponsorPublic {
+  id: number;
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  level: SponsorLevel;
+  websiteUrl: string | null;
+}
+
+export interface SponsorSpeakerRef {
+  slug: string;
+  name: string;
+  photoUrl: string | null;
+  company: string | null;
+}
+
+export interface SponsorDetail {
+  id: number;
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  level: SponsorLevel;
+  websiteUrl: string | null;
+  descriptionFr: string | null;
+  descriptionEn: string | null;
+  socialLinks: Record<string, string>;
+  speakers: SponsorSpeakerRef[];
+}
+
 export interface EditionDetail {
   id: number;
   year: number;


### PR DESCRIPTION
Closes #71. Pages publiques sponsors (US-210, US-211). Dépend de #69/#70.

## Backend
- `routes/sponsors.ts` (public) : `GET /api/sponsors` (publiés de l'édition featured, triés par niveau) + `GET /api/sponsors/:slug` (détail + speakers publiés associés, RG-226).

## Frontend
- `getSponsors` / `getSponsorBySlug` + types `SponsorPublic`/`SponsorDetail`/`SponsorSpeakerRef`.
- `SponsorCard` : bandeau coloré par niveau (Émeraude/Jaune/Rose — RG-224), Platinum agrandi (RG-223), logo ou placeholder nom.
- **Page liste `/sponsors`** : groupée par niveau (ordre d'importance), CTA « Devenir partenaire », breadcrumb, bilingue, état vide.
- **Page détail `/sponsors/[slug]`** : description localisée, logo, site + réseaux, section « Speakers de {nom} » (RG-226), Schema.org `Organization`, OG image = logo (RG-229).
- Clés i18n (niveaux, empty, visitWebsite, speakersOf).

## Test plan
- `tsc` back+front : OK.
- API vérifiée : liste triée par niveau, détail avec speaker associé (Marie Dupont → OVHcloud).
- Pages rendues avec données seedées après rebuild `.next` propre : liste (OVHcloud Platinum / Google Gold), détail (description + « Speakers de OVHcloud » + JSON-LD Organization). 200 sur liste et détail.

Suite : #72 (section sponsors page d'accueil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)