### PR TITLE
feat(lot2): sponsors section on the home page (#72)

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -34,6 +34,11 @@
     "stats": {
       "title": "The largest <tech>tech</tech> conference in the <toulousain>Toulouse</toulousain> area"
     },
+    "sponsors": {
+      "title": "They support #DevFestToulouse",
+      "cta": "Become a partner",
+      "seeAll": "See all partners"
+    },
     "about": {
       "behindTitle": "Behind #DevFestToulouse",
       "gdgDescription": "DevFest Toulouse is organized by GDG Toulouse, a passionate developer community. Since 2016, we bring together the Toulouse tech community every year around talks, workshops, and networking.",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -34,6 +34,11 @@
     "stats": {
       "title": "La plus grande conférence <tech>tech</tech> du bassin <toulousain>Toulousain</toulousain>"
     },
+    "sponsors": {
+      "title": "Ils soutiennent le #DevFestToulouse",
+      "cta": "Devenir Partenaire",
+      "seeAll": "Voir tous les partenaires"
+    },
     "about": {
       "behindTitle": "Derrière le #DevFestToulouse",
       "gdgDescription": "Le DevFest Toulouse est organisé par le GDG Toulouse, une communauté de développeurs passionnés. Depuis 2016, nous rassemblons chaque année les acteurs de la tech toulousaine autour de conférences, de workshops et de moments de partage.",

--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -16,6 +16,7 @@ import ReplaySection from "@/components/home/ReplaySection";
 import LatestNewsSection from "@/components/home/LatestNewsSection";
 import AboutSection from "@/components/home/AboutSection";
 import EcosystemSection from "@/components/home/EcosystemSection";
+import SponsorsSection from "@/components/home/SponsorsSection";
 
 function buildEventJsonLd(
   edition: {
@@ -150,6 +151,8 @@ export default async function HomePage() {
           editionYear={edition.previousYear}
         />
       )}
+
+      {isAnnouncement && <SponsorsSection />}
 
       {isAnnouncement && articles.length > 0 && (
         <LatestNewsSection articles={articles} locale={locale} />

--- a/src/frontend/src/components/home/SponsorsSection.tsx
+++ b/src/frontend/src/components/home/SponsorsSection.tsx
@@ -1,0 +1,73 @@
+import { getTranslations } from "next-intl/server";
+
+import { getSponsors } from "@/lib/api";
+import type { SponsorLevel } from "@/lib/types";
+import { Link } from "@/i18n/navigation";
+import SponsorCard from "@/components/sponsors/SponsorCard";
+
+const LEVEL_ORDER: SponsorLevel[] = ["PLATINUM", "GOLD", "SILVER", "SOUTIEN", "COMMUNAUTE"];
+
+export default async function SponsorsSection() {
+  const [t, sponsors] = await Promise.all([
+    getTranslations("home.sponsors"),
+    getSponsors(),
+  ]);
+
+  // Hidden when no sponsor is published (US-212).
+  if (sponsors.length === 0) return null;
+
+  const byLevel = LEVEL_ORDER.map((level) => ({
+    level,
+    items: sponsors.filter((s) => s.level === level),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <section className="relative overflow-hidden px-6 py-10 lg:py-14">
+      {/* Croix occitane decoration (top-right). Placeholder geometric mark
+          until the brand asset is provided; kept subtle and decorative. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -right-10 -top-10 h-48 w-48 rotate-[22deg] opacity-[0.06]"
+      >
+        <svg viewBox="0 0 100 100" fill="currentColor" className="h-full w-full text-terre-cuite">
+          <path d="M40 0h20v40h40v20H60v40H40V60H0V40h40z" />
+        </svg>
+      </div>
+
+      <div className="relative mx-auto max-w-6xl">
+        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <h2 className="text-2xl font-bold text-noir lg:text-4xl">{t("title")}</h2>
+          <Link
+            href="/devenir-sponsor"
+            className="inline-block rounded-[12px] bg-bleu px-6 py-3 font-bold text-blanc transition-colors hover:bg-bleu/90"
+          >
+            {t("cta")}
+          </Link>
+        </div>
+
+        <div className="space-y-8">
+          {byLevel.map(({ level, items }) => (
+            <div
+              key={level}
+              className={
+                level === "PLATINUM"
+                  ? "grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+                  : "grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4"
+              }
+            >
+              {items.map((s) => (
+                <SponsorCard key={s.id} sponsor={s} large={level === "PLATINUM"} logoOnly />
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 text-center">
+          <Link href="/sponsors" className="font-bold text-bleu hover:underline">
+            {t("seeAll")}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/frontend/src/components/sponsors/SponsorCard.tsx
+++ b/src/frontend/src/components/sponsors/SponsorCard.tsx
@@ -16,9 +16,12 @@ interface SponsorCardProps {
   sponsor: SponsorPublic;
   /** Platinum cards are larger (RG-223). */
   large?: boolean;
+  /** On the homepage only the logo is shown, without the name (RG-223). */
+  logoOnly?: boolean;
 }
 
-export default function SponsorCard({ sponsor, large = false }: SponsorCardProps) {
+export default function SponsorCard({ sponsor, large = false, logoOnly = false }: SponsorCardProps) {
+  const showName = !logoOnly || !sponsor.logoUrl;
   return (
     <Link
       href={`/sponsors/${sponsor.slug}`}
@@ -41,7 +44,7 @@ export default function SponsorCard({ sponsor, large = false }: SponsorCardProps
             </span>
           )}
         </div>
-        {sponsor.logoUrl && (
+        {sponsor.logoUrl && showName && (
           <span className={`font-bold text-noir ${large ? "text-2xl" : "text-lg"}`}>
             {sponsor.name}
           </span>


### PR DESCRIPTION
Closes #72. Section Partenaires sur la page d'accueil (US-212), mode ANNOUNCEMENT.

## Livré
- `SponsorsSection` : titre « Ils soutiennent le #DevFestToulouse », CTA « Devenir Partenaire », sponsors groupés par niveau (Platinum agrandi), **cartes logo seul** (sans nom en home, RG-223), déco croix occitane en haut à droite, lien « Voir tous les partenaires ». Masquée si aucun sponsor publié.
- `SponsorCard` : variante `logoOnly`.
- Branchée dans la home entre replay et actualités (ANNOUNCEMENT).
- Clés i18n `home.sponsors` (fr/en).

Clôt le domaine **Sponsors** public : #70 (CRUD) + #71 (pages) + #72 (home).

## Test plan
- `tsc` + ESLint : OK.
- Rendu vérifié sur `/fr` (après rebuild `.next` propre) : titre, CTA, logo OVHcloud, lien « Voir tous les partenaires » présents.

## Note
La déco croix occitane est un placeholder SVG géométrique discret (opacity 6%) en attendant l'asset de marque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)