### PR TITLE
feat(lot2): speakers CRUD admin + REST API (#73)

### DIFF
--- a/src/backend/src/lib/revalidate.ts
+++ b/src/backend/src/lib/revalidate.ts
@@ -64,6 +64,14 @@ export function revalidateSponsors(): Promise<void> {
   return revalidatePaths([
     ...bilingualPaths(""),
     ...bilingualPaths("/devenir-sponsor"),
+    ...bilingualPaths("/sponsors"),
+  ]);
+}
+
+export function revalidateSpeakers(): Promise<void> {
+  return revalidatePaths([
+    ...bilingualPaths(""),
+    ...bilingualPaths("/speakers"),
   ]);
 }
 

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -12,6 +12,7 @@ import adminFileRoutes from "./files.js";
 import adminUserRoutes from "./users.js";
 import adminSponsorPlanRoutes from "./sponsor-plans.js";
 import adminSponsorRoutes from "./sponsors.js";
+import adminSpeakerRoutes from "./speakers.js";
 import adminApiKeyRoutes from "./api-keys.js";
 import adminTranslateRoutes from "./translate.js";
 
@@ -28,6 +29,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminFileRoutes);
     await editorApp.register(adminTranslateRoutes);
     await editorApp.register(adminSponsorRoutes);
+    await editorApp.register(adminSpeakerRoutes);
   });
 
   // Routes restricted to ADMIN only

--- a/src/backend/src/routes/admin/speakers.ts
+++ b/src/backend/src/routes/admin/speakers.ts
@@ -1,0 +1,121 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../lib/prisma.js";
+import { revalidateSpeakers } from "../../lib/revalidate.js";
+import { slugify, uniqueSlug } from "../../lib/slug.js";
+
+interface SpeakerCreateBody {
+  editionId: number;
+  name: string;
+  photoUrl?: string;
+  company?: string;
+  city?: string;
+  bioFr?: string;
+  bioEn?: string;
+  socialLinks?: Record<string, string>;
+  isFeatured?: boolean;
+  sponsorId?: number | null;
+  publicationStatus?: "DRAFT" | "PUBLISHED";
+}
+
+type SpeakerUpdateBody = Partial<Omit<SpeakerCreateBody, "editionId">>;
+
+interface SpeakerIdParams {
+  id: string;
+}
+
+interface SpeakerListQuery {
+  editionId?: string;
+}
+
+function serialize(s: { socialLinks: string | null; [k: string]: unknown }) {
+  return { ...s, socialLinks: s.socialLinks ? JSON.parse(s.socialLinks) : {} };
+}
+
+export default async function adminSpeakerRoutes(app: FastifyInstance) {
+  // GET /api/admin/speakers?editionId=X
+  app.get<{ Querystring: SpeakerListQuery }>("/speakers", {
+    schema: { querystring: { type: "object", properties: { editionId: { type: "string" } } } },
+  }, async (request, reply) => {
+    const { editionId } = request.query;
+    if (!editionId) return reply.code(400).send({ error: "editionId required" });
+
+    const speakers = await prisma.speaker.findMany({
+      where: { editionId: Number(editionId) },
+      orderBy: { name: "asc" },
+    });
+    return speakers.map(serialize);
+  });
+
+  // POST /api/admin/speakers
+  app.post<{ Body: SpeakerCreateBody }>("/speakers", async (request, reply) => {
+    const body = request.body;
+    if (!body.editionId || !body.name?.trim()) {
+      return reply.code(400).send({ error: "editionId and name are required" });
+    }
+
+    const existing = await prisma.speaker.findMany({
+      where: { editionId: body.editionId },
+      select: { slug: true },
+    });
+    const slug = uniqueSlug(slugify(body.name), new Set(existing.map((e) => e.slug)));
+
+    const speaker = await prisma.speaker.create({
+      data: {
+        editionId: body.editionId,
+        slug,
+        name: body.name.trim(),
+        photoUrl: body.photoUrl || null,
+        company: body.company || null,
+        city: body.city || null,
+        bioFr: body.bioFr || null,
+        bioEn: body.bioEn || null,
+        socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+        isFeatured: body.isFeatured ?? false,
+        sponsorId: body.sponsorId ?? null,
+        publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
+      },
+    });
+
+    revalidateSpeakers();
+    return reply.code(201).send(serialize(speaker));
+  });
+
+  // PUT /api/admin/speakers/:id
+  app.put<{ Params: SpeakerIdParams; Body: SpeakerUpdateBody }>("/speakers/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request) => {
+    const { id } = request.params;
+    const body = request.body;
+
+    const speaker = await prisma.speaker.update({
+      where: { id: Number(id) },
+      data: {
+        ...(body.name !== undefined && { name: body.name.trim() }),
+        ...(body.photoUrl !== undefined && { photoUrl: body.photoUrl || null }),
+        ...(body.company !== undefined && { company: body.company || null }),
+        ...(body.city !== undefined && { city: body.city || null }),
+        ...(body.bioFr !== undefined && { bioFr: body.bioFr || null }),
+        ...(body.bioEn !== undefined && { bioEn: body.bioEn || null }),
+        ...(body.socialLinks !== undefined && {
+          socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+        }),
+        ...(body.isFeatured !== undefined && { isFeatured: body.isFeatured }),
+        ...(body.sponsorId !== undefined && { sponsorId: body.sponsorId ?? null }),
+        ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
+      },
+    });
+
+    revalidateSpeakers();
+    return serialize(speaker);
+  });
+
+  // DELETE /api/admin/speakers/:id
+  app.delete<{ Params: SpeakerIdParams }>("/speakers/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const { id } = request.params;
+    await prisma.speaker.delete({ where: { id: Number(id) } });
+    revalidateSpeakers();
+    return reply.code(204).send();
+  });
+}

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -11,6 +11,7 @@ import CfpTab from "@/components/admin/edition-detail/CfpTab";
 import KeyFiguresTab from "@/components/admin/edition-detail/KeyFiguresTab";
 import SponsoringTab from "@/components/admin/edition-detail/SponsoringTab";
 import SponsorsTab from "@/components/admin/edition-detail/SponsorsTab";
+import SpeakersTab from "@/components/admin/edition-detail/SpeakersTab";
 
 interface EditionData {
   id: number;
@@ -38,7 +39,7 @@ const STATUS_LABELS: Record<string, { label: string; variant: "green" | "orange"
 const TABS = [
   { key: "general", label: "Général" },
   { key: "ticketing", label: "Billetterie" },
-  { key: "speakers", label: "Speakers (0)" },
+  { key: "speakers", label: "Speakers" },
   { key: "conferences", label: "Conférences (0)" },
   { key: "sponsors", label: "Sponsors" },
   { key: "sponsoring", label: "Sponsoring" },
@@ -97,10 +98,7 @@ export default function EditionDetailPage() {
           <TicketingTab editionId={edition.id} />
         )}
         {activeTab === "speakers" && (
-          <div className="py-12 text-center text-gris">
-            <p className="text-lg font-medium">Speakers</p>
-            <p className="mt-2 text-sm">Fonctionnalité à venir — gestion des speakers de l&apos;édition.</p>
-          </div>
+          <SpeakersTab editionId={edition.id} />
         )}
         {activeTab === "conferences" && (
           <div className="py-12 text-center text-gris">

--- a/src/frontend/src/components/admin/edition-detail/SpeakersTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SpeakersTab.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Speaker, Sponsor } from "@/lib/types";
+import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+
+const emptyForm = {
+  name: "",
+  photoUrl: "",
+  company: "",
+  city: "",
+  bioFr: "",
+  bioEn: "",
+  linkedin: "",
+  twitter: "",
+  github: "",
+  website: "",
+  isFeatured: false,
+  sponsorId: "" as string,
+  publicationStatus: "DRAFT" as "DRAFT" | "PUBLISHED",
+};
+
+interface SpeakersTabProps {
+  editionId: number;
+}
+
+export default function SpeakersTab({ editionId }: SpeakersTabProps) {
+  const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState(emptyForm);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Speaker | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    const [{ data: list }, { data: spList }] = await Promise.all([
+      adminFetch<Speaker[]>(`/speakers?editionId=${editionId}`),
+      adminFetch<Sponsor[]>(`/sponsors?editionId=${editionId}`),
+    ]);
+    if (list) setSpeakers(list);
+    if (spList) setSponsors(spList);
+    setIsLoading(false);
+  }, [editionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function openCreate() {
+    setEditingId(null);
+    setForm(emptyForm);
+    setShowForm(true);
+  }
+
+  function openEdit(s: Speaker) {
+    setEditingId(s.id);
+    setForm({
+      name: s.name,
+      photoUrl: s.photoUrl || "",
+      company: s.company || "",
+      city: s.city || "",
+      bioFr: s.bioFr || "",
+      bioEn: s.bioEn || "",
+      linkedin: s.socialLinks?.linkedin || "",
+      twitter: s.socialLinks?.twitter || "",
+      github: s.socialLinks?.github || "",
+      website: s.socialLinks?.website || "",
+      isFeatured: s.isFeatured,
+      sponsorId: s.sponsorId ? String(s.sponsorId) : "",
+      publicationStatus: s.publicationStatus,
+    });
+    setShowForm(true);
+  }
+
+  async function handleSave() {
+    if (!form.name.trim()) return;
+    setIsSaving(true);
+    const socialLinks: Record<string, string> = {};
+    if (form.linkedin.trim()) socialLinks.linkedin = form.linkedin.trim();
+    if (form.twitter.trim()) socialLinks.twitter = form.twitter.trim();
+    if (form.github.trim()) socialLinks.github = form.github.trim();
+    if (form.website.trim()) socialLinks.website = form.website.trim();
+
+    const payload = {
+      editionId,
+      name: form.name.trim(),
+      photoUrl: form.photoUrl || undefined,
+      company: form.company || undefined,
+      city: form.city || undefined,
+      bioFr: form.bioFr || undefined,
+      bioEn: form.bioEn || undefined,
+      socialLinks,
+      isFeatured: form.isFeatured,
+      sponsorId: form.sponsorId ? Number(form.sponsorId) : null,
+      publicationStatus: form.publicationStatus,
+    };
+
+    if (editingId) {
+      await adminFetch(`/speakers/${editingId}`, { method: "PUT", body: JSON.stringify(payload) });
+    } else {
+      await adminFetch("/speakers", { method: "POST", body: JSON.stringify(payload) });
+    }
+    setIsSaving(false);
+    setShowForm(false);
+    void load();
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await adminFetch(`/speakers/${deleteTarget.id}`, { method: "DELETE" });
+    setDeleteTarget(null);
+    void load();
+  }
+
+  if (isLoading) return <p className="py-12 text-center text-gris">Chargement…</p>;
+
+  const inputClass =
+    "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+  return (
+    <div className="bg-blanc rounded-xl shadow-card p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-bold text-noir">Speakers ({speakers.length})</h2>
+        {!showForm && (
+          <button
+            onClick={openCreate}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+          >
+            + Ajouter un speaker
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <div className="border border-gris/20 rounded-lg p-4 mb-6 space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Nom *</span>
+              <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Entreprise</span>
+              <input value={form.company} onChange={(e) => setForm({ ...form, company: e.target.value })} className={inputClass} />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Ville</span>
+              <input value={form.city} onChange={(e) => setForm({ ...form, city: e.target.value })} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Sponsor associé</span>
+              <select
+                value={form.sponsorId}
+                onChange={(e) => setForm({ ...form, sponsorId: e.target.value })}
+                className={inputClass}
+              >
+                <option value="">— Aucun —</option>
+                {sponsors.map((sp) => (
+                  <option key={sp.id} value={sp.id}>{sp.name}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div>
+            <span className="block text-sm font-medium text-noir mb-1">Photo</span>
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={() => setIsImagePickerOpen(true)}
+                className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+              >
+                {form.photoUrl ? "Changer la photo" : "Choisir une photo"}
+              </button>
+              {form.photoUrl && (
+                <>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={form.photoUrl} alt="Photo" className="h-12 w-12 rounded-full object-cover" />
+                  <button
+                    type="button"
+                    onClick={() => setForm({ ...form, photoUrl: "" })}
+                    className="text-sm text-terre-cuite hover:underline"
+                  >
+                    Retirer
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Bio (FR)</span>
+              <textarea value={form.bioFr} onChange={(e) => setForm({ ...form, bioFr: e.target.value })} rows={3} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Bio (EN)</span>
+              <textarea value={form.bioEn} onChange={(e) => setForm({ ...form, bioEn: e.target.value })} rows={3} className={inputClass} />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">LinkedIn</span>
+              <input type="url" value={form.linkedin} onChange={(e) => setForm({ ...form, linkedin: e.target.value })} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">GitHub</span>
+              <input type="url" value={form.github} onChange={(e) => setForm({ ...form, github: e.target.value })} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">X / Twitter</span>
+              <input type="url" value={form.twitter} onChange={(e) => setForm({ ...form, twitter: e.target.value })} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Site web</span>
+              <input type="url" value={form.website} onChange={(e) => setForm({ ...form, website: e.target.value })} className={inputClass} />
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-6">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={form.isFeatured}
+                onChange={(e) => setForm({ ...form, isFeatured: e.target.checked })}
+                className="rounded border-gris/30 text-malachite focus:ring-malachite"
+              />
+              <span className="text-sm text-noir">En vedette (page d&apos;accueil)</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={form.publicationStatus === "PUBLISHED"}
+                onChange={(e) => setForm({ ...form, publicationStatus: e.target.checked ? "PUBLISHED" : "DRAFT" })}
+                className="rounded border-gris/30 text-malachite focus:ring-malachite"
+              />
+              <span className="text-sm text-noir">Publié (visible sur le site)</span>
+            </label>
+          </div>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              onClick={handleSave}
+              disabled={isSaving || !form.name.trim()}
+              className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+            >
+              {isSaving ? "Enregistrement…" : "Enregistrer"}
+            </button>
+            <button
+              onClick={() => setShowForm(false)}
+              className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+            >
+              Annuler
+            </button>
+          </div>
+        </div>
+      )}
+
+      {speakers.length === 0 ? (
+        <p className="py-8 text-center text-gris text-sm">Aucun speaker pour cette édition.</p>
+      ) : (
+        <ul className="divide-y divide-gris/10">
+          {speakers.map((s) => (
+            <li key={s.id} className="flex items-center gap-4 py-3">
+              {s.photoUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={s.photoUrl} alt={s.name} className="h-10 w-10 rounded-full object-cover" />
+              ) : (
+                <span className="flex h-10 w-10 items-center justify-center rounded-full bg-blanc-casse text-sm font-bold text-gris">
+                  {s.name.charAt(0)}
+                </span>
+              )}
+              <span className="flex-1 text-noir">
+                {s.name}
+                {s.company && <span className="text-gris"> · {s.company}</span>}
+              </span>
+              {s.isFeatured && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-terre-cuite/10 text-terre-cuite">Vedette</span>
+              )}
+              <span
+                className={`text-xs px-2 py-0.5 rounded-full ${
+                  s.publicationStatus === "PUBLISHED" ? "bg-malachite/10 text-malachite" : "bg-gris/10 text-gris"
+                }`}
+              >
+                {s.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+              </span>
+              <button onClick={() => openEdit(s)} className="text-sm text-bleu hover:underline">Éditer</button>
+              <button onClick={() => setDeleteTarget(s)} className="text-sm text-terre-cuite hover:underline">Supprimer</button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ImagePickerDialog
+        open={isImagePickerOpen}
+        onClose={() => setIsImagePickerOpen(false)}
+        onSelect={(url) => setForm((f) => ({ ...f, photoUrl: url }))}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        title="Supprimer ce speaker ?"
+        message={`« ${deleteTarget?.name} » sera définitivement supprimé.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -164,6 +164,23 @@ export interface SponsorDetail {
   speakers: SponsorSpeakerRef[];
 }
 
+// Admin speaker entity (CRUD).
+export interface Speaker {
+  id: number;
+  slug: string;
+  name: string;
+  photoUrl: string | null;
+  company: string | null;
+  city: string | null;
+  bioFr: string | null;
+  bioEn: string | null;
+  socialLinks: Record<string, string>;
+  isFeatured: boolean;
+  sponsorId: number | null;
+  publicationStatus: "DRAFT" | "PUBLISHED";
+  editionId: number;
+}
+
 export interface EditionDetail {
   id: number;
   year: number;


### PR DESCRIPTION
Closes #73. Gestion admin des speakers d'une édition (US-240, US-243). Dépend de #69.

## Backend
- `admin/speakers.ts` : `GET/POST/PUT/DELETE /api/admin/speakers`, edition-scoped, scope ADMIN+EDITOR. Slug auto dédupliqué par édition, socialLinks JSON, `sponsorId` optionnel (lien manuel speaker↔sponsor RG-204), flag `isFeatured` (RG-202).
- `revalidateSpeakers()` ajouté ; `revalidateSponsors()` couvre désormais aussi `/sponsors`.

## Frontend
- Type `Speaker`.
- `SpeakersTab` : liste + formulaire create/edit (nom, entreprise, ville, photo via image picker, bio bilingue, réseaux, toggles vedette + publié, select sponsor) + confirmation suppression.
- Branché dans la fiche édition (remplace le placeholder Speakers).

## Test plan
- `tsc` back+front : OK. ESLint : OK (0 warning).
- Route montée et protégée : `GET /api/admin/speakers` → **403** sans auth.
- Logique CRUD testée via Prisma : slug dédupliqué (`marie-dupont` → `marie-dupont-2`), create avec sponsorId + isFeatured, lien sponsor résolu (→ Google), update, delete.

Suite : #74 (pages publiques speakers), #75 (section vedette home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)