### PR TITLE
feat(lot2): public speakers pages — list + detail + OG (#74)

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -16,6 +16,7 @@ import pageRoutes from "./routes/pages.js";
 import contactRoutes from "./routes/contact.js";
 import brochureRoutes from "./routes/brochure.js";
 import sponsorRoutes from "./routes/sponsors.js";
+import speakerRoutes from "./routes/speakers.js";
 import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
@@ -195,6 +196,7 @@ await app.register(pageRoutes, { prefix: "/api" });
 await app.register(contactRoutes, { prefix: "/api" });
 await app.register(brochureRoutes, { prefix: "/api" });
 await app.register(sponsorRoutes, { prefix: "/api" });
+await app.register(speakerRoutes, { prefix: "/api" });
 
 // Per-user routes (any authenticated back-office user — own resources only)
 await app.register(myApiKeysRoutes, { prefix: "/api/me" });

--- a/src/backend/src/routes/speakers.ts
+++ b/src/backend/src/routes/speakers.ts
@@ -1,0 +1,80 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { getFeaturedEdition } from "./editions.js";
+
+function parseSocial(raw: string | null): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export default async function speakerRoutes(app: FastifyInstance) {
+  // GET /api/speakers — published speakers of the featured edition, alphabetical.
+  app.get("/speakers", async (_request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+
+    const speakers = await prisma.speaker.findMany({
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+      orderBy: { name: "asc" },
+      select: { id: true, slug: true, name: true, photoUrl: true, company: true, isFeatured: true },
+    });
+    return speakers;
+  });
+
+  // GET /api/speakers/featured — published + featured speakers (home section, US-202).
+  app.get("/speakers/featured", async (_request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+
+    const speakers = await prisma.speaker.findMany({
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED", isFeatured: true },
+      orderBy: { name: "asc" },
+      take: 8,
+      select: { id: true, slug: true, name: true, photoUrl: true, company: true },
+    });
+    return speakers;
+  });
+
+  // GET /api/speakers/:slug — detail of a published speaker + its published talks.
+  app.get<{ Params: { slug: string } }>("/speakers/:slug", {
+    schema: {
+      params: { type: "object", required: ["slug"], properties: { slug: { type: "string" } } },
+    },
+  }, async (request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+
+    const speaker = await prisma.speaker.findFirst({
+      where: { editionId: edition.id, slug: request.params.slug, publicationStatus: "PUBLISHED" },
+      include: {
+        talks: {
+          where: { publicationStatus: "PUBLISHED" },
+          select: { slug: true, titleFr: true, titleEn: true, format: true },
+          orderBy: { titleFr: "asc" },
+        },
+        sponsor: { select: { slug: true, name: true } },
+      },
+    });
+
+    if (!speaker) return reply.status(404).send({ error: "Speaker not found" });
+
+    return {
+      id: speaker.id,
+      slug: speaker.slug,
+      name: speaker.name,
+      photoUrl: speaker.photoUrl,
+      company: speaker.company,
+      city: speaker.city,
+      bioFr: speaker.bioFr,
+      bioEn: speaker.bioEn,
+      socialLinks: parseSocial(speaker.socialLinks),
+      sponsor: speaker.sponsor,
+      talks: speaker.talks,
+    };
+  });
+}

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -251,7 +251,10 @@
     "heading": "DevFest Toulouse {year} speakers",
     "comingSoonTitle": "Speakers will be announced soon",
     "comingSoonBody": "The DevFest Toulouse {year} speaker list will be published here after the talk selection process. Past editions hosted over 300 speakers from France and beyond.",
-    "home": "Home"
+    "home": "Home",
+    "empty": "Speakers will be announced soon.",
+    "sessionsTitle": "Sessions",
+    "backToList": "All speakers"
   },
   "sponsors": {
     "title": "Sponsors",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -251,7 +251,10 @@
     "heading": "Conférenciers du DevFest Toulouse {year}",
     "comingSoonTitle": "Les conférenciers seront annoncés prochainement",
     "comingSoonBody": "La liste des speakers du DevFest Toulouse {year} sera publiée ici après la sélection des talks. Les éditions précédentes ont accueilli plus de 300 conférenciers venus de toute la France et d'ailleurs.",
-    "home": "Accueil"
+    "home": "Accueil",
+    "empty": "Les conférenciers seront annoncés prochainement.",
+    "sessionsTitle": "Sessions",
+    "backToList": "Tous les conférenciers"
   },
   "sponsors": {
     "title": "Sponsors",

--- a/src/frontend/src/app/[locale]/speakers/[slug]/opengraph-image.tsx
+++ b/src/frontend/src/app/[locale]/speakers/[slug]/opengraph-image.tsx
@@ -1,0 +1,80 @@
+import { ImageResponse } from "next/og";
+
+import { getSpeakerBySlug } from "@/lib/api";
+
+export const alt = "DevFest Toulouse — Speaker";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Dynamic OG image for a speaker (RG-208): photo + name + branding.
+export default async function SpeakerOgImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const speaker = await getSpeakerBySlug(slug);
+  const name = speaker?.name ?? "DevFest Toulouse";
+  const company = speaker?.company ?? "";
+  const photoUrl = speaker?.photoUrl ?? null;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: "64px",
+          padding: "80px",
+          background: "linear-gradient(135deg, #0B7350 0%, #109E6E 60%, #41B38E 100%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {photoUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={photoUrl}
+            alt=""
+            width={360}
+            height={360}
+            style={{ width: 360, height: 360, borderRadius: 360, objectFit: "cover", border: "8px solid rgba(255,255,255,0.85)" }}
+          />
+        ) : (
+          <div
+            style={{
+              width: 360,
+              height: 360,
+              borderRadius: 360,
+              background: "rgba(255,255,255,0.2)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 160,
+              fontWeight: 900,
+              color: "#FFFFFF",
+            }}
+          >
+            {name.charAt(0)}
+          </div>
+        )}
+
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ display: "flex", fontSize: 72, fontWeight: 900, color: "#FFFFFF", lineHeight: 1.05 }}>
+            {name}
+          </div>
+          {company ? (
+            <div style={{ display: "flex", fontSize: 36, color: "rgba(255,255,255,0.9)", marginTop: 16 }}>
+              {company}
+            </div>
+          ) : null}
+          <div style={{ display: "flex", fontSize: 28, color: "rgba(255,255,255,0.8)", marginTop: 48 }}>
+            DevFest Toulouse · devfesttoulouse.fr
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/frontend/src/app/[locale]/speakers/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/speakers/[slug]/page.tsx
@@ -1,0 +1,150 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { getSpeakerBySlug } from "@/lib/api";
+import { localizedField } from "@/lib/i18n-helpers";
+import Breadcrumb from "@/components/Breadcrumb";
+import { Link } from "@/i18n/navigation";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const speaker = await getSpeakerBySlug(slug);
+
+  if (!speaker) return { title: "Speaker not found" };
+
+  const description = localizedField(speaker, "bio", locale) || speaker.name;
+
+  return {
+    title: speaker.name,
+    description,
+    alternates: {
+      canonical: `/${locale}/speakers/${slug}`,
+      languages: {
+        fr: `/fr/speakers/${slug}`,
+        en: `/en/speakers/${slug}`,
+        "x-default": `/fr/speakers/${slug}`,
+      },
+    },
+    // OG image is generated dynamically by ./opengraph-image (RG-208).
+    openGraph: { title: speaker.name, description },
+  };
+}
+
+export default async function SpeakerDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const t = await getTranslations("speakers");
+  const speaker = await getSpeakerBySlug(slug);
+
+  if (!speaker) notFound();
+
+  const bio = localizedField(speaker, "bio", locale);
+
+  const breadcrumbItems = [
+    { label: t("home"), href: `/${locale}` },
+    { label: t("title"), href: `/${locale}/speakers` },
+    { label: speaker.name, href: `/${locale}/speakers/${slug}` },
+  ];
+
+  const personJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: speaker.name,
+    ...(speaker.photoUrl ? { image: speaker.photoUrl } : {}),
+    ...(speaker.company ? { worksFor: { "@type": "Organization", name: speaker.company } } : {}),
+    ...(Object.values(speaker.socialLinks).length > 0
+      ? { sameAs: Object.values(speaker.socialLinks) }
+      : {}),
+  };
+
+  return (
+    <div className="px-6 py-8 lg:py-12">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
+      <div className="mx-auto max-w-4xl">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <div className="mt-8 flex flex-col items-center gap-6 sm:flex-row sm:items-start">
+          <div className="relative h-40 w-40 shrink-0 overflow-hidden rounded-full bg-blanc-casse">
+            {speaker.photoUrl ? (
+              <Image src={speaker.photoUrl} alt={speaker.name} fill className="object-cover" sizes="160px" />
+            ) : (
+              <span className="flex h-full w-full items-center justify-center text-5xl font-bold text-gris">
+                {speaker.name.charAt(0)}
+              </span>
+            )}
+          </div>
+
+          <div className="text-center sm:text-left">
+            <h1 className="text-3xl lg:text-5xl font-bold text-noir">{speaker.name}</h1>
+            {(speaker.company || speaker.city) && (
+              <p className="mt-2 text-lg text-gris">
+                {[speaker.company, speaker.city].filter(Boolean).join(" · ")}
+              </p>
+            )}
+            {Object.entries(speaker.socialLinks).length > 0 && (
+              <ul className="mt-4 flex flex-wrap justify-center gap-4 sm:justify-start">
+                {Object.entries(speaker.socialLinks).map(([key, url]) => (
+                  <li key={key}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="capitalize text-bleu hover:underline"
+                    >
+                      {key}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {bio && (
+          <p className="mt-8 whitespace-pre-line text-lg leading-relaxed text-noir">{bio}</p>
+        )}
+
+        {speaker.talks.length > 0 && (
+          <section className="mt-12">
+            <h2 className="mb-4 text-2xl font-bold text-noir">{t("sessionsTitle")}</h2>
+            <ul className="space-y-3">
+              {speaker.talks.map((talk) => (
+                <li key={talk.slug}>
+                  <Link
+                    href={`/conferences/${talk.slug}`}
+                    className="block rounded-xl bg-blanc p-4 shadow-card transition-transform hover:-translate-y-0.5"
+                  >
+                    <span className="font-bold text-noir">
+                      {localizedField(talk, "title", locale)}
+                    </span>
+                    <span className="ml-2 text-sm text-gris">{talk.format}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <div className="mt-10">
+          <Link href="/speakers" className="font-bold text-bleu hover:underline">
+            ← {t("backToList")}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/[locale]/speakers/page.tsx
+++ b/src/frontend/src/app/[locale]/speakers/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
-import { getCurrentEdition } from "@/lib/api";
+import { getCurrentEdition, getSpeakers } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
+import SpeakerCard from "@/components/speakers/SpeakerCard";
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
@@ -20,7 +21,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function SpeakersPage() {
   const locale = await getLocale();
   const t = await getTranslations("speakers");
-  const edition = await getCurrentEdition();
+  const [edition, speakers] = await Promise.all([getCurrentEdition(), getSpeakers()]);
   const year = edition?.year ?? new Date().getFullYear();
 
   const breadcrumbItems = [
@@ -30,21 +31,22 @@ export default async function SpeakersPage() {
 
   return (
     <div className="px-6 py-8 lg:py-12">
-      <div className="mx-auto max-w-4xl">
+      <div className="mx-auto max-w-6xl">
         <Breadcrumb items={breadcrumbItems} />
 
         <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
           {t("heading", { year })}
         </h1>
 
-        <div className="mt-8 p-8 rounded-3xl bg-blanc shadow-card">
-          <h2 className="text-2xl lg:text-3xl font-bold text-noir">
-            {t("comingSoonTitle")}
-          </h2>
-          <p className="mt-4 text-lg text-gris leading-relaxed">
-            {t("comingSoonBody", { year })}
-          </p>
-        </div>
+        {speakers.length === 0 ? (
+          <p className="mt-12 text-lg text-gris">{t("empty")}</p>
+        ) : (
+          <div className="mt-10 grid grid-cols-2 gap-8 sm:grid-cols-3 lg:grid-cols-4">
+            {speakers.map((s) => (
+              <SpeakerCard key={s.id} speaker={s} />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/frontend/src/components/speakers/SpeakerCard.tsx
+++ b/src/frontend/src/components/speakers/SpeakerCard.tsx
@@ -1,0 +1,26 @@
+import Image from "next/image";
+import { Link } from "@/i18n/navigation";
+import type { SpeakerPublic } from "@/lib/types";
+
+export default function SpeakerCard({ speaker }: { speaker: SpeakerPublic }) {
+  return (
+    <Link
+      href={`/speakers/${speaker.slug}`}
+      className="group flex flex-col items-center gap-3 text-center"
+    >
+      <div className="relative h-32 w-32 overflow-hidden rounded-full bg-blanc-casse">
+        {speaker.photoUrl ? (
+          <Image src={speaker.photoUrl} alt={speaker.name} fill className="object-cover" sizes="128px" />
+        ) : (
+          <span className="flex h-full w-full items-center justify-center text-4xl font-bold text-gris">
+            {speaker.name.charAt(0)}
+          </span>
+        )}
+      </div>
+      <div>
+        <p className="font-bold text-noir group-hover:text-bleu">{speaker.name}</p>
+        {speaker.company && <p className="text-sm text-gris">{speaker.company}</p>}
+      </div>
+    </Link>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -15,6 +15,8 @@ import type {
   SponsorPlan,
   SponsorPublic,
   SponsorDetail,
+  SpeakerPublic,
+  SpeakerDetail,
   EcosystemPartner,
 } from "./types";
 
@@ -135,4 +137,16 @@ export async function getSponsors(): Promise<SponsorPublic[]> {
 
 export async function getSponsorBySlug(slug: string): Promise<SponsorDetail | null> {
   return fetchAPI<SponsorDetail>(`/api/sponsors/${slug}`);
+}
+
+export async function getSpeakers(): Promise<SpeakerPublic[]> {
+  return (await fetchAPI<SpeakerPublic[]>("/api/speakers")) || [];
+}
+
+export async function getFeaturedSpeakers(): Promise<SpeakerPublic[]> {
+  return (await fetchAPI<SpeakerPublic[]>("/api/speakers/featured")) || [];
+}
+
+export async function getSpeakerBySlug(slug: string): Promise<SpeakerDetail | null> {
+  return fetchAPI<SpeakerDetail>(`/api/speakers/${slug}`);
 }

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -164,6 +164,37 @@ export interface SponsorDetail {
   speakers: SponsorSpeakerRef[];
 }
 
+// Public speaker list item.
+export interface SpeakerPublic {
+  id: number;
+  slug: string;
+  name: string;
+  photoUrl: string | null;
+  company: string | null;
+  isFeatured?: boolean;
+}
+
+export interface SpeakerTalkRef {
+  slug: string;
+  titleFr: string;
+  titleEn: string;
+  format: string;
+}
+
+export interface SpeakerDetail {
+  id: number;
+  slug: string;
+  name: string;
+  photoUrl: string | null;
+  company: string | null;
+  city: string | null;
+  bioFr: string | null;
+  bioEn: string | null;
+  socialLinks: Record<string, string>;
+  sponsor: { slug: string; name: string } | null;
+  talks: SpeakerTalkRef[];
+}
+
 // Admin speaker entity (CRUD).
 export interface Speaker {
   id: number;


### PR DESCRIPTION
Closes #74. Pages publiques speakers (US-200, US-201). Dépend de #69/#73.

## Backend
- `routes/speakers.ts` (public) : `GET /api/speakers` (publiés, tri alpha), `GET /api/speakers/featured` (publiés + vedette, pour #75), `GET /api/speakers/:slug` (détail + talks publiés + sponsor lié).

## Frontend
- `getSpeakers` / `getFeaturedSpeakers` / `getSpeakerBySlug` + types publics.
- `SpeakerCard` (photo ou placeholder initiale).
- **`/speakers`** : grille alphabétique, breadcrumb, bilingue, état vide.
- **`/speakers/[slug]`** : photo, entreprise/ville, réseaux, bio localisée, liste Sessions (talk↔speaker), Schema.org `Person`.
- **OG image dynamique** : photo + nom + entreprise + branding (1200×630, RG-208).

## Test plan
- `tsc` back+front + ESLint : OK.
- API vérifiée : list/featured/detail (avec sponsor OVHcloud + talk).
- Rendu vérifié (rebuild `.next` propre) : liste (Jean Martin/Marie Dupont), détail (bio + session « Kubernetes en production » + JSON-LD Person), OG image 200.

Suite : #75 (section speakers vedette home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)