### PR TITLE
feat(lot2): featured speakers section on the home page (#75)

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -39,6 +39,10 @@
       "cta": "Become a partner",
       "seeAll": "See all partners"
     },
+    "featuredSpeakers": {
+      "title": "Featured speakers",
+      "seeAll": "See all speakers"
+    },
     "about": {
       "behindTitle": "Behind #DevFestToulouse",
       "gdgDescription": "DevFest Toulouse is organized by GDG Toulouse, a passionate developer community. Since 2016, we bring together the Toulouse tech community every year around talks, workshops, and networking.",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -39,6 +39,10 @@
       "cta": "Devenir Partenaire",
       "seeAll": "Voir tous les partenaires"
     },
+    "featuredSpeakers": {
+      "title": "Speakers en vedette",
+      "seeAll": "Voir tous les speakers"
+    },
     "about": {
       "behindTitle": "Derrière le #DevFestToulouse",
       "gdgDescription": "Le DevFest Toulouse est organisé par le GDG Toulouse, une communauté de développeurs passionnés. Depuis 2016, nous rassemblons chaque année les acteurs de la tech toulousaine autour de conférences, de workshops et de moments de partage.",

--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -17,6 +17,7 @@ import LatestNewsSection from "@/components/home/LatestNewsSection";
 import AboutSection from "@/components/home/AboutSection";
 import EcosystemSection from "@/components/home/EcosystemSection";
 import SponsorsSection from "@/components/home/SponsorsSection";
+import FeaturedSpeakersSection from "@/components/home/FeaturedSpeakersSection";
 
 function buildEventJsonLd(
   edition: {
@@ -153,6 +154,8 @@ export default async function HomePage() {
       )}
 
       {isAnnouncement && <SponsorsSection />}
+
+      {isAnnouncement && <FeaturedSpeakersSection />}
 
       {isAnnouncement && articles.length > 0 && (
         <LatestNewsSection articles={articles} locale={locale} />

--- a/src/frontend/src/components/home/FeaturedSpeakersSection.tsx
+++ b/src/frontend/src/components/home/FeaturedSpeakersSection.tsx
@@ -1,0 +1,35 @@
+import { getTranslations } from "next-intl/server";
+
+import { getFeaturedSpeakers } from "@/lib/api";
+import { Link } from "@/i18n/navigation";
+import SpeakerCard from "@/components/speakers/SpeakerCard";
+
+export default async function FeaturedSpeakersSection() {
+  const [t, speakers] = await Promise.all([
+    getTranslations("home.featuredSpeakers"),
+    getFeaturedSpeakers(),
+  ]);
+
+  // Hidden when no speaker is featured (US-202).
+  if (speakers.length === 0) return null;
+
+  return (
+    <section className="px-6 py-10 lg:py-14">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="mb-8 text-2xl font-bold text-noir lg:text-4xl">{t("title")}</h2>
+
+        <div className="grid grid-cols-2 gap-8 sm:grid-cols-3 lg:grid-cols-4">
+          {speakers.map((s) => (
+            <SpeakerCard key={s.id} speaker={s} />
+          ))}
+        </div>
+
+        <div className="mt-8 text-center">
+          <Link href="/speakers" className="font-bold text-bleu hover:underline">
+            {t("seeAll")}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #75. Section « Speakers en vedette » sur la page d'accueil (US-202), mode ANNOUNCEMENT.

## Livré
- `FeaturedSpeakersSection` : titre, grille jusqu'à 8 speakers vedette (réutilise `SpeakerCard` + la route `/api/speakers/featured` créée en #74), lien « Voir tous les speakers ». Masquée si aucun speaker vedette.
- Branchée dans la home entre les sections sponsors et actualités.
- Clés i18n `home.featuredSpeakers` (fr/en).

Clôt le domaine **Speakers** public : #73 (CRUD) + #74 (pages) + #75 (home).

## Test plan
- `tsc` + ESLint : OK.
- Rendu vérifié sur `/fr` (rebuild `.next` propre) : titre « Speakers en vedette », Jean Martin + Marie Dupont, lien « Voir tous les speakers ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)