### PR TITLE
feat(lot2): session categories (tracks) CRUD admin (#76)

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -17,6 +17,7 @@ import contactRoutes from "./routes/contact.js";
 import brochureRoutes from "./routes/brochure.js";
 import sponsorRoutes from "./routes/sponsors.js";
 import speakerRoutes from "./routes/speakers.js";
+import categoryRoutes from "./routes/categories.js";
 import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
@@ -197,6 +198,7 @@ await app.register(contactRoutes, { prefix: "/api" });
 await app.register(brochureRoutes, { prefix: "/api" });
 await app.register(sponsorRoutes, { prefix: "/api" });
 await app.register(speakerRoutes, { prefix: "/api" });
+await app.register(categoryRoutes, { prefix: "/api" });
 
 // Per-user routes (any authenticated back-office user — own resources only)
 await app.register(myApiKeysRoutes, { prefix: "/api/me" });

--- a/src/backend/src/lib/revalidate.ts
+++ b/src/backend/src/lib/revalidate.ts
@@ -75,6 +75,13 @@ export function revalidateSpeakers(): Promise<void> {
   ]);
 }
 
+export function revalidateConferences(): Promise<void> {
+  return revalidatePaths([
+    ...bilingualPaths(""),
+    ...bilingualPaths("/conferences"),
+  ]);
+}
+
 export function revalidateCfp(): Promise<void> {
   return revalidatePaths([
     ...bilingualPaths(""),

--- a/src/backend/src/routes/admin/categories.ts
+++ b/src/backend/src/routes/admin/categories.ts
@@ -1,0 +1,88 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../lib/prisma.js";
+import { revalidateConferences } from "../../lib/revalidate.js";
+
+interface CategoryCreateBody {
+  editionId: number;
+  nameFr: string;
+  nameEn: string;
+  color?: string;
+  sortOrder?: number;
+}
+
+type CategoryUpdateBody = Partial<Omit<CategoryCreateBody, "editionId">>;
+
+interface CategoryIdParams {
+  id: string;
+}
+
+interface CategoryListQuery {
+  editionId?: string;
+}
+
+export default async function adminCategoryRoutes(app: FastifyInstance) {
+  // GET /api/admin/categories?editionId=X
+  app.get<{ Querystring: CategoryListQuery }>("/categories", {
+    schema: { querystring: { type: "object", properties: { editionId: { type: "string" } } } },
+  }, async (request, reply) => {
+    const { editionId } = request.query;
+    if (!editionId) return reply.code(400).send({ error: "editionId required" });
+
+    return prisma.category.findMany({
+      where: { editionId: Number(editionId) },
+      orderBy: { sortOrder: "asc" },
+    });
+  });
+
+  // POST /api/admin/categories
+  app.post<{ Body: CategoryCreateBody }>("/categories", async (request, reply) => {
+    const body = request.body;
+    if (!body.editionId || !body.nameFr?.trim() || !body.nameEn?.trim()) {
+      return reply.code(400).send({ error: "editionId, nameFr and nameEn are required" });
+    }
+
+    const category = await prisma.category.create({
+      data: {
+        editionId: body.editionId,
+        nameFr: body.nameFr.trim(),
+        nameEn: body.nameEn.trim(),
+        color: body.color || "#109E6E",
+        sortOrder: body.sortOrder ?? 0,
+      },
+    });
+
+    revalidateConferences();
+    return reply.code(201).send(category);
+  });
+
+  // PUT /api/admin/categories/:id
+  app.put<{ Params: CategoryIdParams; Body: CategoryUpdateBody }>("/categories/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request) => {
+    const { id } = request.params;
+    const body = request.body;
+
+    const category = await prisma.category.update({
+      where: { id: Number(id) },
+      data: {
+        ...(body.nameFr !== undefined && { nameFr: body.nameFr.trim() }),
+        ...(body.nameEn !== undefined && { nameEn: body.nameEn.trim() }),
+        ...(body.color !== undefined && { color: body.color }),
+        ...(body.sortOrder !== undefined && { sortOrder: body.sortOrder }),
+      },
+    });
+
+    revalidateConferences();
+    return category;
+  });
+
+  // DELETE /api/admin/categories/:id
+  app.delete<{ Params: CategoryIdParams }>("/categories/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const { id } = request.params;
+    await prisma.category.delete({ where: { id: Number(id) } });
+    revalidateConferences();
+    return reply.code(204).send();
+  });
+}

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -13,6 +13,7 @@ import adminUserRoutes from "./users.js";
 import adminSponsorPlanRoutes from "./sponsor-plans.js";
 import adminSponsorRoutes from "./sponsors.js";
 import adminSpeakerRoutes from "./speakers.js";
+import adminCategoryRoutes from "./categories.js";
 import adminApiKeyRoutes from "./api-keys.js";
 import adminTranslateRoutes from "./translate.js";
 
@@ -30,6 +31,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminTranslateRoutes);
     await editorApp.register(adminSponsorRoutes);
     await editorApp.register(adminSpeakerRoutes);
+    await editorApp.register(adminCategoryRoutes);
   });
 
   // Routes restricted to ADMIN only

--- a/src/backend/src/routes/categories.ts
+++ b/src/backend/src/routes/categories.ts
@@ -1,0 +1,17 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { getFeaturedEdition } from "./editions.js";
+
+export default async function categoryRoutes(app: FastifyInstance) {
+  // GET /api/categories — tracks of the featured edition (used by session filters).
+  app.get("/categories", async (_request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+
+    return prisma.category.findMany({
+      where: { editionId: edition.id },
+      orderBy: { sortOrder: "asc" },
+      select: { id: true, nameFr: true, nameEn: true, color: true },
+    });
+  });
+}

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -12,6 +12,7 @@ import KeyFiguresTab from "@/components/admin/edition-detail/KeyFiguresTab";
 import SponsoringTab from "@/components/admin/edition-detail/SponsoringTab";
 import SponsorsTab from "@/components/admin/edition-detail/SponsorsTab";
 import SpeakersTab from "@/components/admin/edition-detail/SpeakersTab";
+import CategoriesTab from "@/components/admin/edition-detail/CategoriesTab";
 
 interface EditionData {
   id: number;
@@ -41,6 +42,7 @@ const TABS = [
   { key: "ticketing", label: "Billetterie" },
   { key: "speakers", label: "Speakers" },
   { key: "conferences", label: "Conférences (0)" },
+  { key: "categories", label: "Catégories" },
   { key: "sponsors", label: "Sponsors" },
   { key: "sponsoring", label: "Sponsoring" },
   { key: "cfp", label: "CFP" },
@@ -105,6 +107,9 @@ export default function EditionDetailPage() {
             <p className="text-lg font-medium">Conférences</p>
             <p className="mt-2 text-sm">Fonctionnalité à venir — gestion des conférences de l&apos;édition.</p>
           </div>
+        )}
+        {activeTab === "categories" && (
+          <CategoriesTab editionId={edition.id} />
         )}
         {activeTab === "sponsors" && (
           <SponsorsTab editionId={edition.id} />

--- a/src/frontend/src/components/admin/edition-detail/CategoriesTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/CategoriesTab.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Category } from "@/lib/types";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+
+const COLOR_PRESETS = ["#109E6E", "#EC6839", "#509EE3", "#F8AB06", "#EE7CAD", "#9A6CB8"];
+
+const emptyForm = { nameFr: "", nameEn: "", color: "#109E6E", sortOrder: "0" };
+
+interface CategoriesTabProps {
+  editionId: number;
+}
+
+export default function CategoriesTab({ editionId }: CategoriesTabProps) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState(emptyForm);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Category | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    const { data } = await adminFetch<Category[]>(`/categories?editionId=${editionId}`);
+    if (data) setCategories(data);
+    setIsLoading(false);
+  }, [editionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function openCreate() {
+    setEditingId(null);
+    setForm({ ...emptyForm, sortOrder: String(categories.length) });
+    setShowForm(true);
+  }
+
+  function openEdit(c: Category) {
+    setEditingId(c.id);
+    setForm({ nameFr: c.nameFr, nameEn: c.nameEn, color: c.color, sortOrder: String(c.sortOrder) });
+    setShowForm(true);
+  }
+
+  async function handleSave() {
+    if (!form.nameFr.trim() || !form.nameEn.trim()) return;
+    setIsSaving(true);
+    const payload = {
+      editionId,
+      nameFr: form.nameFr.trim(),
+      nameEn: form.nameEn.trim(),
+      color: form.color,
+      sortOrder: Number(form.sortOrder) || 0,
+    };
+    if (editingId) {
+      await adminFetch(`/categories/${editingId}`, { method: "PUT", body: JSON.stringify(payload) });
+    } else {
+      await adminFetch("/categories", { method: "POST", body: JSON.stringify(payload) });
+    }
+    setIsSaving(false);
+    setShowForm(false);
+    void load();
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await adminFetch(`/categories/${deleteTarget.id}`, { method: "DELETE" });
+    setDeleteTarget(null);
+    void load();
+  }
+
+  if (isLoading) return <p className="py-12 text-center text-gris">Chargement…</p>;
+
+  const inputClass =
+    "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+  return (
+    <div className="bg-blanc rounded-xl shadow-card p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-bold text-noir">Catégories ({categories.length})</h2>
+        {!showForm && (
+          <button
+            onClick={openCreate}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+          >
+            + Ajouter une catégorie
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <div className="border border-gris/20 rounded-lg p-4 mb-6 space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Nom (FR) *</span>
+              <input value={form.nameFr} onChange={(e) => setForm({ ...form, nameFr: e.target.value })} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Nom (EN) *</span>
+              <input value={form.nameEn} onChange={(e) => setForm({ ...form, nameEn: e.target.value })} className={inputClass} />
+            </label>
+          </div>
+
+          <div>
+            <span className="block text-sm font-medium text-noir mb-1">Couleur</span>
+            <div className="flex items-center gap-3">
+              {COLOR_PRESETS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setForm({ ...form, color: c })}
+                  className={`h-8 w-8 rounded-full border-2 ${form.color === c ? "border-noir" : "border-transparent"}`}
+                  style={{ backgroundColor: c }}
+                  aria-label={c}
+                />
+              ))}
+              <input
+                type="color"
+                value={form.color}
+                onChange={(e) => setForm({ ...form, color: e.target.value })}
+                className="h-8 w-12 rounded border border-gris/30"
+              />
+            </div>
+          </div>
+
+          <label className="block max-w-[160px]">
+            <span className="block text-sm font-medium text-noir mb-1">Ordre</span>
+            <input
+              type="number"
+              value={form.sortOrder}
+              onChange={(e) => setForm({ ...form, sortOrder: e.target.value })}
+              className={inputClass}
+            />
+          </label>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              onClick={handleSave}
+              disabled={isSaving || !form.nameFr.trim() || !form.nameEn.trim()}
+              className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+            >
+              {isSaving ? "Enregistrement…" : "Enregistrer"}
+            </button>
+            <button
+              onClick={() => setShowForm(false)}
+              className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+            >
+              Annuler
+            </button>
+          </div>
+        </div>
+      )}
+
+      {categories.length === 0 ? (
+        <p className="py-8 text-center text-gris text-sm">Aucune catégorie pour cette édition.</p>
+      ) : (
+        <ul className="divide-y divide-gris/10">
+          {categories.map((c) => (
+            <li key={c.id} className="flex items-center gap-4 py-3">
+              <span className="h-5 w-5 rounded-full" style={{ backgroundColor: c.color }} />
+              <span className="flex-1 text-noir">
+                {c.nameFr} <span className="text-gris">/ {c.nameEn}</span>
+              </span>
+              <button onClick={() => openEdit(c)} className="text-sm text-bleu hover:underline">Éditer</button>
+              <button onClick={() => setDeleteTarget(c)} className="text-sm text-terre-cuite hover:underline">Supprimer</button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        title="Supprimer cette catégorie ?"
+        message={`« ${deleteTarget?.nameFr} » sera supprimée. Les sessions associées perdront leur catégorie.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -195,6 +195,16 @@ export interface SpeakerDetail {
   talks: SpeakerTalkRef[];
 }
 
+// Session category / track.
+export interface Category {
+  id: number;
+  nameFr: string;
+  nameEn: string;
+  color: string;
+  sortOrder: number;
+  editionId: number;
+}
+
 // Admin speaker entity (CRUD).
 export interface Speaker {
   id: number;


### PR DESCRIPTION
Closes #76. Gestion des catégories (tracks) de sessions par édition (US-246). Dépend de #69.

## Backend
- `admin/categories.ts` : `GET/POST/PUT/DELETE /api/admin/categories`, edition-scoped, ADMIN+EDITOR (nameFr/En + couleur + ordre).
- `categories.ts` (public) : `GET /api/categories` (tracks de l'édition featured, pour les futurs filtres sessions).
- `revalidateConferences()` ajouté.

## Frontend
- Type `Category`.
- `CategoriesTab` : liste + formulaire (nom bilingue, presets couleur + picker, ordre) + confirmation suppression.
- Nouvel onglet « Catégories » dans la fiche édition.

## Test plan
- `tsc` back+front + ESLint : OK.
- Routes vérifiées : admin **403** sans auth ; public renvoie les 2 catégories seedées (Cloud & DevOps, Web & Mobile).

Débloque #77 (les sessions référencent une catégorie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)