### PR TITLE
feat(lot2): sessions (talks) CRUD admin + REST API (#77)

### DIFF
--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -14,6 +14,7 @@ import adminSponsorPlanRoutes from "./sponsor-plans.js";
 import adminSponsorRoutes from "./sponsors.js";
 import adminSpeakerRoutes from "./speakers.js";
 import adminCategoryRoutes from "./categories.js";
+import adminTalkRoutes from "./talks.js";
 import adminApiKeyRoutes from "./api-keys.js";
 import adminTranslateRoutes from "./translate.js";
 
@@ -32,6 +33,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminSponsorRoutes);
     await editorApp.register(adminSpeakerRoutes);
     await editorApp.register(adminCategoryRoutes);
+    await editorApp.register(adminTalkRoutes);
   });
 
   // Routes restricted to ADMIN only

--- a/src/backend/src/routes/admin/talks.ts
+++ b/src/backend/src/routes/admin/talks.ts
@@ -1,0 +1,159 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../lib/prisma.js";
+import { revalidateConferences } from "../../lib/revalidate.js";
+import { slugify, uniqueSlug } from "../../lib/slug.js";
+
+const FORMATS = ["CONFERENCE", "QUICKIE", "KEYNOTE"] as const;
+type TalkFormat = (typeof FORMATS)[number];
+const LEVELS = ["DEBUTANT", "INTERMEDIAIRE", "CONFIRME"] as const;
+type TalkLevel = (typeof LEVELS)[number];
+
+interface TalkCreateBody {
+  editionId: number;
+  titleFr: string;
+  titleEn: string;
+  descriptionFr: string;
+  descriptionEn: string;
+  format: TalkFormat;
+  level?: TalkLevel | null;
+  language: string;
+  categoryId?: number | null;
+  speakerIds?: number[];
+  room?: string;
+  publicationStatus?: "DRAFT" | "PUBLISHED";
+}
+
+type TalkUpdateBody = Partial<Omit<TalkCreateBody, "editionId">>;
+
+interface TalkIdParams {
+  id: string;
+}
+
+interface TalkListQuery {
+  editionId?: string;
+}
+
+function serialize(t: {
+  speakers?: { id: number; name: string }[];
+  [k: string]: unknown;
+}) {
+  return {
+    ...t,
+    speakerIds: t.speakers?.map((s) => s.id) ?? [],
+  };
+}
+
+export default async function adminTalkRoutes(app: FastifyInstance) {
+  // GET /api/admin/talks?editionId=X
+  app.get<{ Querystring: TalkListQuery }>("/talks", {
+    schema: { querystring: { type: "object", properties: { editionId: { type: "string" } } } },
+  }, async (request, reply) => {
+    const { editionId } = request.query;
+    if (!editionId) return reply.code(400).send({ error: "editionId required" });
+
+    const talks = await prisma.talk.findMany({
+      where: { editionId: Number(editionId) },
+      orderBy: { titleFr: "asc" },
+      include: {
+        speakers: { select: { id: true, name: true } },
+        category: { select: { id: true, nameFr: true, color: true } },
+      },
+    });
+    return talks.map(serialize);
+  });
+
+  // POST /api/admin/talks
+  app.post<{ Body: TalkCreateBody }>("/talks", async (request, reply) => {
+    const body = request.body;
+    if (!body.editionId || !body.titleFr?.trim() || !body.titleEn?.trim()) {
+      return reply.code(400).send({ error: "editionId, titleFr and titleEn are required" });
+    }
+    if (!body.format || !FORMATS.includes(body.format)) {
+      return reply.code(422).send({ error: `Invalid format. Allowed: ${FORMATS.join(", ")}` });
+    }
+    if (body.level && !LEVELS.includes(body.level)) {
+      return reply.code(422).send({ error: `Invalid level. Allowed: ${LEVELS.join(", ")}` });
+    }
+    if (!body.language?.trim()) {
+      return reply.code(400).send({ error: "language is required" });
+    }
+
+    const existing = await prisma.talk.findMany({
+      where: { editionId: body.editionId },
+      select: { slug: true },
+    });
+    const slug = uniqueSlug(slugify(body.titleFr), new Set(existing.map((e) => e.slug)));
+
+    const talk = await prisma.talk.create({
+      data: {
+        editionId: body.editionId,
+        slug,
+        titleFr: body.titleFr.trim(),
+        titleEn: body.titleEn.trim(),
+        descriptionFr: body.descriptionFr ?? "",
+        descriptionEn: body.descriptionEn ?? "",
+        format: body.format,
+        level: body.level ?? null,
+        language: body.language.trim(),
+        room: body.room || null,
+        categoryId: body.categoryId ?? null,
+        publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
+        ...(body.speakerIds && body.speakerIds.length > 0
+          ? { speakers: { connect: body.speakerIds.map((id) => ({ id })) } }
+          : {}),
+      },
+      include: { speakers: { select: { id: true, name: true } } },
+    });
+
+    revalidateConferences();
+    return reply.code(201).send(serialize(talk));
+  });
+
+  // PUT /api/admin/talks/:id
+  app.put<{ Params: TalkIdParams; Body: TalkUpdateBody }>("/talks/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const { id } = request.params;
+    const body = request.body;
+
+    if (body.format !== undefined && !FORMATS.includes(body.format)) {
+      return reply.code(422).send({ error: `Invalid format. Allowed: ${FORMATS.join(", ")}` });
+    }
+    if (body.level && !LEVELS.includes(body.level)) {
+      return reply.code(422).send({ error: `Invalid level. Allowed: ${LEVELS.join(", ")}` });
+    }
+
+    const talk = await prisma.talk.update({
+      where: { id: Number(id) },
+      data: {
+        ...(body.titleFr !== undefined && { titleFr: body.titleFr.trim() }),
+        ...(body.titleEn !== undefined && { titleEn: body.titleEn.trim() }),
+        ...(body.descriptionFr !== undefined && { descriptionFr: body.descriptionFr }),
+        ...(body.descriptionEn !== undefined && { descriptionEn: body.descriptionEn }),
+        ...(body.format !== undefined && { format: body.format }),
+        ...(body.level !== undefined && { level: body.level ?? null }),
+        ...(body.language !== undefined && { language: body.language.trim() }),
+        ...(body.room !== undefined && { room: body.room || null }),
+        ...(body.categoryId !== undefined && { categoryId: body.categoryId ?? null }),
+        ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
+        ...(body.speakerIds !== undefined && {
+          speakers: { set: body.speakerIds.map((sid) => ({ id: sid })) },
+        }),
+      },
+      include: { speakers: { select: { id: true, name: true } } },
+    });
+
+    revalidateConferences();
+    return serialize(talk);
+  });
+
+  // DELETE /api/admin/talks/:id
+  app.delete<{ Params: TalkIdParams }>("/talks/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const { id } = request.params;
+    await prisma.talk.delete({ where: { id: Number(id) } });
+    revalidateConferences();
+    return reply.code(204).send();
+  });
+}

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -13,6 +13,7 @@ import SponsoringTab from "@/components/admin/edition-detail/SponsoringTab";
 import SponsorsTab from "@/components/admin/edition-detail/SponsorsTab";
 import SpeakersTab from "@/components/admin/edition-detail/SpeakersTab";
 import CategoriesTab from "@/components/admin/edition-detail/CategoriesTab";
+import ConferencesTab from "@/components/admin/edition-detail/ConferencesTab";
 
 interface EditionData {
   id: number;
@@ -41,7 +42,7 @@ const TABS = [
   { key: "general", label: "Général" },
   { key: "ticketing", label: "Billetterie" },
   { key: "speakers", label: "Speakers" },
-  { key: "conferences", label: "Conférences (0)" },
+  { key: "conferences", label: "Conférences" },
   { key: "categories", label: "Catégories" },
   { key: "sponsors", label: "Sponsors" },
   { key: "sponsoring", label: "Sponsoring" },
@@ -103,10 +104,7 @@ export default function EditionDetailPage() {
           <SpeakersTab editionId={edition.id} />
         )}
         {activeTab === "conferences" && (
-          <div className="py-12 text-center text-gris">
-            <p className="text-lg font-medium">Conférences</p>
-            <p className="mt-2 text-sm">Fonctionnalité à venir — gestion des conférences de l&apos;édition.</p>
-          </div>
+          <ConferencesTab editionId={edition.id} />
         )}
         {activeTab === "categories" && (
           <CategoriesTab editionId={edition.id} />

--- a/src/frontend/src/components/admin/edition-detail/ConferencesTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/ConferencesTab.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Talk, TalkFormat, TalkLevel, Category, Speaker } from "@/lib/types";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+
+const FORMATS: { value: TalkFormat; label: string }[] = [
+  { value: "CONFERENCE", label: "Conférence (40 min)" },
+  { value: "QUICKIE", label: "Quickie (15 min)" },
+  { value: "KEYNOTE", label: "Keynote" },
+];
+const LEVELS: { value: TalkLevel; label: string }[] = [
+  { value: "DEBUTANT", label: "Débutant" },
+  { value: "INTERMEDIAIRE", label: "Intermédiaire" },
+  { value: "CONFIRME", label: "Confirmé" },
+];
+
+const emptyForm = {
+  titleFr: "",
+  titleEn: "",
+  descriptionFr: "",
+  descriptionEn: "",
+  format: "CONFERENCE" as TalkFormat,
+  level: "" as "" | TalkLevel,
+  language: "fr",
+  categoryId: "" as string,
+  speakerIds: [] as number[],
+  publicationStatus: "DRAFT" as "DRAFT" | "PUBLISHED",
+};
+
+interface ConferencesTabProps {
+  editionId: number;
+}
+
+export default function ConferencesTab({ editionId }: ConferencesTabProps) {
+  const [talks, setTalks] = useState<Talk[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState(emptyForm);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Talk | null>(null);
+
+  // Filters
+  const [filterFormat, setFilterFormat] = useState("");
+  const [filterCategory, setFilterCategory] = useState("");
+  const [filterLang, setFilterLang] = useState("");
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    const [{ data: t }, { data: c }, { data: s }] = await Promise.all([
+      adminFetch<Talk[]>(`/talks?editionId=${editionId}`),
+      adminFetch<Category[]>(`/categories?editionId=${editionId}`),
+      adminFetch<Speaker[]>(`/speakers?editionId=${editionId}`),
+    ]);
+    if (t) setTalks(t);
+    if (c) setCategories(c);
+    if (s) setSpeakers(s);
+    setIsLoading(false);
+  }, [editionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const filtered = useMemo(
+    () =>
+      talks.filter(
+        (t) =>
+          (!filterFormat || t.format === filterFormat) &&
+          (!filterCategory || String(t.categoryId) === filterCategory) &&
+          (!filterLang || t.language === filterLang),
+      ),
+    [talks, filterFormat, filterCategory, filterLang],
+  );
+
+  function openCreate() {
+    setEditingId(null);
+    setForm(emptyForm);
+    setShowForm(true);
+  }
+
+  function openEdit(t: Talk) {
+    setEditingId(t.id);
+    setForm({
+      titleFr: t.titleFr,
+      titleEn: t.titleEn,
+      descriptionFr: t.descriptionFr,
+      descriptionEn: t.descriptionEn,
+      format: t.format,
+      level: t.level ?? "",
+      language: t.language,
+      categoryId: t.categoryId ? String(t.categoryId) : "",
+      speakerIds: t.speakerIds,
+      publicationStatus: t.publicationStatus,
+    });
+    setShowForm(true);
+  }
+
+  function toggleSpeaker(id: number) {
+    setForm((f) => ({
+      ...f,
+      speakerIds: f.speakerIds.includes(id)
+        ? f.speakerIds.filter((x) => x !== id)
+        : [...f.speakerIds, id],
+    }));
+  }
+
+  async function handleSave() {
+    if (!form.titleFr.trim() || !form.titleEn.trim()) return;
+    setIsSaving(true);
+    const payload = {
+      editionId,
+      titleFr: form.titleFr.trim(),
+      titleEn: form.titleEn.trim(),
+      descriptionFr: form.descriptionFr,
+      descriptionEn: form.descriptionEn,
+      format: form.format,
+      level: form.level || null,
+      language: form.language,
+      categoryId: form.categoryId ? Number(form.categoryId) : null,
+      speakerIds: form.speakerIds,
+      publicationStatus: form.publicationStatus,
+    };
+    if (editingId) {
+      await adminFetch(`/talks/${editingId}`, { method: "PUT", body: JSON.stringify(payload) });
+    } else {
+      await adminFetch("/talks", { method: "POST", body: JSON.stringify(payload) });
+    }
+    setIsSaving(false);
+    setShowForm(false);
+    void load();
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    await adminFetch(`/talks/${deleteTarget.id}`, { method: "DELETE" });
+    setDeleteTarget(null);
+    void load();
+  }
+
+  if (isLoading) return <p className="py-12 text-center text-gris">Chargement…</p>;
+
+  const inputClass =
+    "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+  return (
+    <div className="bg-blanc rounded-xl shadow-card p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-bold text-noir">Conférences ({talks.length})</h2>
+        {!showForm && (
+          <button
+            onClick={openCreate}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+          >
+            + Ajouter une conférence
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <div className="border border-gris/20 rounded-lg p-4 mb-6 space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Titre (FR) *</span>
+              <input value={form.titleFr} onChange={(e) => setForm({ ...form, titleFr: e.target.value })} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Titre (EN) *</span>
+              <input value={form.titleEn} onChange={(e) => setForm({ ...form, titleEn: e.target.value })} className={inputClass} />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Description (FR)</span>
+              <textarea value={form.descriptionFr} onChange={(e) => setForm({ ...form, descriptionFr: e.target.value })} rows={3} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Description (EN)</span>
+              <textarea value={form.descriptionEn} onChange={(e) => setForm({ ...form, descriptionEn: e.target.value })} rows={3} className={inputClass} />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Format *</span>
+              <select value={form.format} onChange={(e) => setForm({ ...form, format: e.target.value as TalkFormat })} className={inputClass}>
+                {FORMATS.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
+              </select>
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Niveau</span>
+              <select value={form.level} onChange={(e) => setForm({ ...form, level: e.target.value as "" | TalkLevel })} className={inputClass}>
+                <option value="">Tous niveaux</option>
+                {LEVELS.map((l) => <option key={l.value} value={l.value}>{l.label}</option>)}
+              </select>
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Langue</span>
+              <select value={form.language} onChange={(e) => setForm({ ...form, language: e.target.value })} className={inputClass}>
+                <option value="fr">Français</option>
+                <option value="en">English</option>
+              </select>
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Catégorie</span>
+              <select value={form.categoryId} onChange={(e) => setForm({ ...form, categoryId: e.target.value })} className={inputClass}>
+                <option value="">— Aucune —</option>
+                {categories.map((c) => <option key={c.id} value={c.id}>{c.nameFr}</option>)}
+              </select>
+            </label>
+          </div>
+
+          <div>
+            <span className="block text-sm font-medium text-noir mb-1">Speakers</span>
+            {speakers.length === 0 ? (
+              <p className="text-sm text-gris">Aucun speaker disponible — créez-en dans l&apos;onglet Speakers.</p>
+            ) : (
+              <div className="flex flex-wrap gap-3">
+                {speakers.map((sp) => (
+                  <label key={sp.id} className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={form.speakerIds.includes(sp.id)}
+                      onChange={() => toggleSpeaker(sp.id)}
+                      className="rounded border-gris/30 text-malachite focus:ring-malachite"
+                    />
+                    <span className="text-sm text-noir">{sp.name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.publicationStatus === "PUBLISHED"}
+              onChange={(e) => setForm({ ...form, publicationStatus: e.target.checked ? "PUBLISHED" : "DRAFT" })}
+              className="rounded border-gris/30 text-malachite focus:ring-malachite"
+            />
+            <span className="text-sm text-noir">Publié (visible sur le site)</span>
+          </label>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              onClick={handleSave}
+              disabled={isSaving || !form.titleFr.trim() || !form.titleEn.trim()}
+              className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+            >
+              {isSaving ? "Enregistrement…" : "Enregistrer"}
+            </button>
+            <button
+              onClick={() => setShowForm(false)}
+              className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+            >
+              Annuler
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      {talks.length > 0 && (
+        <div className="mb-4 flex flex-wrap gap-3">
+          <select value={filterFormat} onChange={(e) => setFilterFormat(e.target.value)} className="rounded-lg border border-gris/30 px-3 py-1.5 text-sm text-noir bg-blanc">
+            <option value="">Tous formats</option>
+            {FORMATS.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
+          </select>
+          <select value={filterCategory} onChange={(e) => setFilterCategory(e.target.value)} className="rounded-lg border border-gris/30 px-3 py-1.5 text-sm text-noir bg-blanc">
+            <option value="">Toutes catégories</option>
+            {categories.map((c) => <option key={c.id} value={c.id}>{c.nameFr}</option>)}
+          </select>
+          <select value={filterLang} onChange={(e) => setFilterLang(e.target.value)} className="rounded-lg border border-gris/30 px-3 py-1.5 text-sm text-noir bg-blanc">
+            <option value="">Toutes langues</option>
+            <option value="fr">Français</option>
+            <option value="en">English</option>
+          </select>
+        </div>
+      )}
+
+      {filtered.length === 0 ? (
+        <p className="py-8 text-center text-gris text-sm">
+          {talks.length === 0 ? "Aucune conférence pour cette édition." : "Aucune conférence ne correspond aux filtres."}
+        </p>
+      ) : (
+        <ul className="divide-y divide-gris/10">
+          {filtered.map((t) => (
+            <li key={t.id} className="flex items-center gap-4 py-3">
+              <span className="w-28 text-xs font-bold text-gris uppercase">{t.format}</span>
+              <span className="flex-1 text-noir">
+                {t.titleFr}
+                {t.speakers.length > 0 && (
+                  <span className="text-gris"> · {t.speakers.map((s) => s.name).join(", ")}</span>
+                )}
+              </span>
+              {t.category && (
+                <span className="text-xs px-2 py-0.5 rounded-full" style={{ backgroundColor: `${t.category.color}20`, color: t.category.color }}>
+                  {t.category.nameFr}
+                </span>
+              )}
+              <span
+                className={`text-xs px-2 py-0.5 rounded-full ${
+                  t.publicationStatus === "PUBLISHED" ? "bg-malachite/10 text-malachite" : "bg-gris/10 text-gris"
+                }`}
+              >
+                {t.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+              </span>
+              <button onClick={() => openEdit(t)} className="text-sm text-bleu hover:underline">Éditer</button>
+              <button onClick={() => setDeleteTarget(t)} className="text-sm text-terre-cuite hover:underline">Supprimer</button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        title="Supprimer cette conférence ?"
+        message={`« ${deleteTarget?.titleFr} » sera définitivement supprimée.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -195,6 +195,29 @@ export interface SpeakerDetail {
   talks: SpeakerTalkRef[];
 }
 
+export type TalkFormat = "CONFERENCE" | "QUICKIE" | "KEYNOTE";
+export type TalkLevel = "DEBUTANT" | "INTERMEDIAIRE" | "CONFIRME";
+
+// Admin talk/session entity (CRUD).
+export interface Talk {
+  id: number;
+  slug: string;
+  titleFr: string;
+  titleEn: string;
+  descriptionFr: string;
+  descriptionEn: string;
+  format: TalkFormat;
+  level: TalkLevel | null;
+  language: string;
+  room: string | null;
+  categoryId: number | null;
+  category: { id: number; nameFr: string; color: string } | null;
+  speakerIds: number[];
+  speakers: { id: number; name: string }[];
+  publicationStatus: "DRAFT" | "PUBLISHED";
+  editionId: number;
+}
+
 // Session category / track.
 export interface Category {
   id: number;


### PR DESCRIPTION
Closes #77. Gestion admin des sessions d'une édition (US-241, US-243). Dépend de #69/#73/#76.

## Backend
- `admin/talks.ts` : `GET/POST/PUT/DELETE /api/admin/talks`, edition-scoped, ADMIN+EDITOR. Titre/description bilingues, enums format/niveau (validés, 422), langue, slug auto dédupliqué, FK catégorie optionnelle, **speakers N-N** (connect à la création, set à la mise à jour). Champ `room` présent mais inutilisé jusqu'au Lot 3 (RG-216).
- `revalidateConferences()` sur mutations.

## Frontend
- Type `Talk` (+ `TalkFormat`/`TalkLevel`).
- `ConferencesTab` : liste avec **filtres** format/catégorie/langue + formulaire create/edit (titre/desc bilingues, selects format/niveau/langue/catégorie, **multi-select speakers**, toggle publié) + confirmation suppression.
- Branché dans la fiche édition (remplace le placeholder Conférences).

## Test plan
- `tsc` back+front + ESLint : OK.
- Route admin **403** sans auth.
- Logique CRUD vérifiée : slug dédup (`kubernetes-en-production-2`), create avec catégorie + 2 speakers, **relation N-N `set`** (remplacement à 1 speaker), delete.

Suite : #78 (vue détail session publique + liens speaker↔session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)