### PR TITLE
feat(lot2): public session detail page + OG (#78)

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -18,6 +18,7 @@ import brochureRoutes from "./routes/brochure.js";
 import sponsorRoutes from "./routes/sponsors.js";
 import speakerRoutes from "./routes/speakers.js";
 import categoryRoutes from "./routes/categories.js";
+import talkRoutes from "./routes/talks.js";
 import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
@@ -199,6 +200,7 @@ await app.register(brochureRoutes, { prefix: "/api" });
 await app.register(sponsorRoutes, { prefix: "/api" });
 await app.register(speakerRoutes, { prefix: "/api" });
 await app.register(categoryRoutes, { prefix: "/api" });
+await app.register(talkRoutes, { prefix: "/api" });
 
 // Per-user routes (any authenticated back-office user — own resources only)
 await app.register(myApiKeysRoutes, { prefix: "/api/me" });

--- a/src/backend/src/routes/talks.ts
+++ b/src/backend/src/routes/talks.ts
@@ -1,0 +1,44 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { getFeaturedEdition } from "./editions.js";
+
+export default async function talkRoutes(app: FastifyInstance) {
+  // GET /api/talks/:slug — detail of a published talk + its published speakers
+  // and category. The full programme grid (rooms, time slots) is Lot 3.
+  app.get<{ Params: { slug: string } }>("/talks/:slug", {
+    schema: {
+      params: { type: "object", required: ["slug"], properties: { slug: { type: "string" } } },
+    },
+  }, async (request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+
+    const talk = await prisma.talk.findFirst({
+      where: { editionId: edition.id, slug: request.params.slug, publicationStatus: "PUBLISHED" },
+      include: {
+        speakers: {
+          where: { publicationStatus: "PUBLISHED" },
+          select: { slug: true, name: true, photoUrl: true, company: true },
+          orderBy: { name: "asc" },
+        },
+        category: { select: { nameFr: true, nameEn: true, color: true } },
+      },
+    });
+
+    if (!talk) return reply.status(404).send({ error: "Talk not found" });
+
+    return {
+      id: talk.id,
+      slug: talk.slug,
+      titleFr: talk.titleFr,
+      titleEn: talk.titleEn,
+      descriptionFr: talk.descriptionFr,
+      descriptionEn: talk.descriptionEn,
+      format: talk.format,
+      level: talk.level,
+      language: talk.language,
+      category: talk.category,
+      speakers: talk.speakers,
+    };
+  });
+}

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -247,7 +247,18 @@
     "heading": "DevFest Toulouse {year} schedule",
     "comingSoonTitle": "Schedule coming soon",
     "comingSoonBody": "The conference, quickie and keynote schedule for DevFest Toulouse {year} will be published here once finalized. Meanwhile, check out the aftermovie and key figures from last year's edition.",
-    "home": "Home"
+    "home": "Home",
+    "speakersLabel": "Speakers",
+    "format": {
+      "CONFERENCE": "Conference",
+      "QUICKIE": "Quickie",
+      "KEYNOTE": "Keynote"
+    },
+    "level": {
+      "DEBUTANT": "Beginner",
+      "INTERMEDIAIRE": "Intermediate",
+      "CONFIRME": "Advanced"
+    }
   },
   "speakers": {
     "title": "Speakers",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -247,7 +247,18 @@
     "heading": "Programme du DevFest Toulouse {year}",
     "comingSoonTitle": "Le programme arrive bientôt",
     "comingSoonBody": "Le programme des conférences, quickies et keynotes du DevFest Toulouse {year} sera publié ici dès qu'il sera finalisé. En attendant, consultez l'aftermovie et les chiffres clés de l'édition précédente.",
-    "home": "Accueil"
+    "home": "Accueil",
+    "speakersLabel": "Speakers",
+    "format": {
+      "CONFERENCE": "Conférence",
+      "QUICKIE": "Quickie",
+      "KEYNOTE": "Keynote"
+    },
+    "level": {
+      "DEBUTANT": "Débutant",
+      "INTERMEDIAIRE": "Intermédiaire",
+      "CONFIRME": "Confirmé"
+    }
   },
   "speakers": {
     "title": "Conférenciers",

--- a/src/frontend/src/app/[locale]/conferences/[slug]/opengraph-image.tsx
+++ b/src/frontend/src/app/[locale]/conferences/[slug]/opengraph-image.tsx
@@ -1,0 +1,60 @@
+import { ImageResponse } from "next/og";
+
+import { getTalkBySlug } from "@/lib/api";
+
+export const alt = "DevFest Toulouse — Session";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Dynamic OG image for a session (RG-215): title + speakers + category + branding.
+export default async function TalkOgImage({
+  params,
+}: {
+  params: Promise<{ slug: string; locale: string }>;
+}) {
+  const { slug, locale } = await params;
+  const talk = await getTalkBySlug(slug);
+
+  const title = talk
+    ? locale === "en"
+      ? talk.titleEn
+      : talk.titleFr
+    : "DevFest Toulouse";
+  const speakers = talk?.speakers.map((s) => s.name).join(", ") ?? "";
+  const category = talk?.category ? (locale === "en" ? talk.category.nameEn : talk.category.nameFr) : "";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          background: "linear-gradient(135deg, #0B7350 0%, #109E6E 60%, #41B38E 100%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {category ? (
+          <div style={{ display: "flex", fontSize: 28, fontWeight: 700, color: "rgba(255,255,255,0.9)", marginBottom: 24, textTransform: "uppercase", letterSpacing: 2 }}>
+            {category}
+          </div>
+        ) : null}
+        <div style={{ display: "flex", fontSize: 64, fontWeight: 900, color: "#FFFFFF", lineHeight: 1.1, maxWidth: 1040 }}>
+          {title}
+        </div>
+        {speakers ? (
+          <div style={{ display: "flex", fontSize: 36, color: "rgba(255,255,255,0.92)", marginTop: 32 }}>
+            {speakers}
+          </div>
+        ) : null}
+        <div style={{ display: "flex", fontSize: 28, color: "rgba(255,255,255,0.8)", marginTop: 48 }}>
+          DevFest Toulouse · devfesttoulouse.fr
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/frontend/src/app/[locale]/conferences/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/conferences/[slug]/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { getTalkBySlug } from "@/lib/api";
+import { localizedField } from "@/lib/i18n-helpers";
+import Breadcrumb from "@/components/Breadcrumb";
+import { Link } from "@/i18n/navigation";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const talk = await getTalkBySlug(slug);
+
+  if (!talk) return { title: "Session not found" };
+
+  const title = localizedField(talk, "title", locale);
+  const description = localizedField(talk, "description", locale) || title;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/${locale}/conferences/${slug}`,
+      languages: {
+        fr: `/fr/conferences/${slug}`,
+        en: `/en/conferences/${slug}`,
+        "x-default": `/fr/conferences/${slug}`,
+      },
+    },
+    // OG image generated dynamically by ./opengraph-image (RG-215).
+    openGraph: { title, description },
+  };
+}
+
+export default async function TalkDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const t = await getTranslations("conferences");
+  const talk = await getTalkBySlug(slug);
+
+  if (!talk) notFound();
+
+  const title = localizedField(talk, "title", locale);
+  const description = localizedField(talk, "description", locale);
+  const categoryName = talk.category ? localizedField(talk.category, "name", locale) : null;
+
+  const breadcrumbItems = [
+    { label: t("home"), href: `/${locale}` },
+    { label: t("title"), href: `/${locale}/conferences` },
+    { label: title, href: `/${locale}/conferences/${slug}` },
+  ];
+
+  return (
+    <div className="px-6 py-8 lg:py-12">
+      <div className="mx-auto max-w-4xl">
+        <Breadcrumb items={breadcrumbItems} />
+
+        {/* Meta badges */}
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <span className="rounded-full bg-bleu/10 px-3 py-1 text-sm font-bold text-bleu">
+            {t(`format.${talk.format}`)}
+          </span>
+          {talk.level && (
+            <span className="rounded-full bg-gris/10 px-3 py-1 text-sm text-noir">
+              {t(`level.${talk.level}`)}
+            </span>
+          )}
+          {categoryName && (
+            <span
+              className="rounded-full px-3 py-1 text-sm font-bold"
+              style={{ backgroundColor: `${talk.category!.color}20`, color: talk.category!.color }}
+            >
+              {categoryName}
+            </span>
+          )}
+          <span className="text-sm uppercase text-gris">{talk.language}</span>
+        </div>
+
+        <h1 className="mt-4 text-3xl lg:text-5xl font-bold text-noir">{title}</h1>
+
+        {description && (
+          <p className="mt-6 whitespace-pre-line text-lg leading-relaxed text-noir">{description}</p>
+        )}
+
+        {talk.speakers.length > 0 && (
+          <section className="mt-12">
+            <h2 className="mb-6 text-2xl font-bold text-noir">{t("speakersLabel")}</h2>
+            <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4">
+              {talk.speakers.map((sp) => (
+                <Link
+                  key={sp.slug}
+                  href={`/speakers/${sp.slug}`}
+                  className="group flex flex-col items-center gap-3 text-center"
+                >
+                  <div className="relative h-24 w-24 overflow-hidden rounded-full bg-blanc-casse">
+                    {sp.photoUrl ? (
+                      <Image src={sp.photoUrl} alt={sp.name} fill className="object-cover" sizes="96px" />
+                    ) : (
+                      <span className="flex h-full w-full items-center justify-center text-2xl font-bold text-gris">
+                        {sp.name.charAt(0)}
+                      </span>
+                    )}
+                  </div>
+                  <span className="font-bold text-noir group-hover:text-bleu">{sp.name}</span>
+                  {sp.company && <span className="text-sm text-gris">{sp.company}</span>}
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   SponsorDetail,
   SpeakerPublic,
   SpeakerDetail,
+  TalkDetail,
   EcosystemPartner,
 } from "./types";
 
@@ -149,4 +150,8 @@ export async function getFeaturedSpeakers(): Promise<SpeakerPublic[]> {
 
 export async function getSpeakerBySlug(slug: string): Promise<SpeakerDetail | null> {
   return fetchAPI<SpeakerDetail>(`/api/speakers/${slug}`);
+}
+
+export async function getTalkBySlug(slug: string): Promise<TalkDetail | null> {
+  return fetchAPI<TalkDetail>(`/api/talks/${slug}`);
 }

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -198,6 +198,21 @@ export interface SpeakerDetail {
 export type TalkFormat = "CONFERENCE" | "QUICKIE" | "KEYNOTE";
 export type TalkLevel = "DEBUTANT" | "INTERMEDIAIRE" | "CONFIRME";
 
+// Public talk detail.
+export interface TalkDetail {
+  id: number;
+  slug: string;
+  titleFr: string;
+  titleEn: string;
+  descriptionFr: string;
+  descriptionEn: string;
+  format: TalkFormat;
+  level: TalkLevel | null;
+  language: string;
+  category: { nameFr: string; nameEn: string; color: string } | null;
+  speakers: { slug: string; name: string; photoUrl: string | null; company: string | null }[];
+}
+
 // Admin talk/session entity (CRUD).
 export interface Talk {
   id: number;


### PR DESCRIPTION
Closes #78. Vue détail session publique (US-201 note, RG-215, RG-216). Dépend de #77/#74.

## Backend
- `routes/talks.ts` (public) : `GET /api/talks/:slug` (talk publié + speakers publiés + catégorie). Salle/créneaux exclus (Lot 3).

## Frontend
- `getTalkBySlug` + type `TalkDetail`.
- **`/conferences/[slug]`** : badges format/niveau/catégorie/langue, titre + description bilingues, speakers liés cliquables vers `/speakers/[slug]` (boucle le lien bidirectionnel speaker↔session), breadcrumb.
- **OG image dynamique** : titre + speakers + catégorie + branding (RG-215).
- Clés i18n (speakersLabel, labels format/niveau).

> La page liste `/conferences` reste minimale en Lot 2 ; la grille programme + filtrage = Lot 3.

## Test plan
- `tsc` back+front + ESLint : OK.
- Vérifié bout-en-bout : API renvoie le talk (catégorie + speaker) ; `/fr/conferences/kubernetes-en-production` rend titre, « Conférence », Marie Dupont ; OG image 200.

Suite : #79 (liens de modification), #80 (bonus Sessionize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)