### PR TITLE
feat(lot2): modification links for speakers & sponsors (#79)

### DIFF
--- a/src/backend/prisma/migrations/20260609120517_lot2_entity_contact_email/migration.sql
+++ b/src/backend/prisma/migrations/20260609120517_lot2_entity_contact_email/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Speaker" ADD COLUMN     "contactEmail" TEXT;
+
+-- AlterTable
+ALTER TABLE "Sponsor" ADD COLUMN     "contactEmail" TEXT;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -441,6 +441,8 @@ model Speaker {
   bioEn            String?
   // JSON object of social links, e.g. {"twitter":"...","github":"...","linkedin":"...","bluesky":"...","website":"..."}
   socialLinks      String?
+  // Contact email used to send the modification link (RG-243). Optional.
+  contactEmail     String?
   // Shown in the homepage "featured speakers" section (RG-202).
   isFeatured       Boolean           @default(false)
   publicationStatus PublicationStatus @default(DRAFT)
@@ -523,6 +525,8 @@ model Sponsor {
   descriptionEn    String?
   // JSON object of social links (same shape as Speaker.socialLinks).
   socialLinks      String?
+  // Contact email used to send the modification link (RG-243). Optional.
+  contactEmail     String?
   publicationStatus PublicationStatus @default(DRAFT)
 
   // Modification-link token infrastructure (issue #79, RG-242 to RG-251).

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -19,6 +19,7 @@ import sponsorRoutes from "./routes/sponsors.js";
 import speakerRoutes from "./routes/speakers.js";
 import categoryRoutes from "./routes/categories.js";
 import talkRoutes from "./routes/talks.js";
+import editRoutes from "./routes/edit.js";
 import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
@@ -201,6 +202,7 @@ await app.register(sponsorRoutes, { prefix: "/api" });
 await app.register(speakerRoutes, { prefix: "/api" });
 await app.register(categoryRoutes, { prefix: "/api" });
 await app.register(talkRoutes, { prefix: "/api" });
+await app.register(editRoutes, { prefix: "/api" });
 
 // Per-user routes (any authenticated back-office user — own resources only)
 await app.register(myApiKeysRoutes, { prefix: "/api/me" });

--- a/src/backend/src/lib/edit-link-email.ts
+++ b/src/backend/src/lib/edit-link-email.ts
@@ -1,0 +1,29 @@
+import { sendEmail } from "./email.js";
+
+const baseUrl = (process.env.BASE_URL || "http://localhost:3000").replace(/\/$/, "");
+
+// Sends the modification-link email (RG-243, RG-250). Throws on SMTP failure so
+// the caller can surface an error and let the admin retry (RG-251).
+export async function sendEditLinkEmail(opts: {
+  to: string;
+  name: string;
+  token: string;
+  kind: "speaker" | "sponsor";
+}) {
+  const url = `${baseUrl}/edit/${opts.token}`;
+  const what = opts.kind === "speaker" ? "votre fiche speaker" : "votre fiche sponsor";
+
+  await sendEmail({
+    to: [opts.to],
+    subject: "DevFest Toulouse — Lien de modification de votre fiche",
+    text: `Bonjour ${opts.name},\n\nVoici votre lien personnel pour modifier ${what} sur le site du DevFest Toulouse :\n${url}\n\nCe lien est personnel, ne le partagez pas. Vous pouvez l'utiliser jusqu'à 48h avant l'événement.\n\nL'équipe DevFest Toulouse`,
+    html: `
+      <h3>Lien de modification de votre fiche</h3>
+      <p>Bonjour ${opts.name},</p>
+      <p>Voici votre lien personnel pour modifier ${what} sur le site du DevFest Toulouse :</p>
+      <p><a href="${url}">Modifier ma fiche</a></p>
+      <p>Ce lien est personnel, ne le partagez pas. Vous pouvez l'utiliser jusqu'à 48h avant l'événement.</p>
+      <p><em>L'équipe DevFest Toulouse</em></p>
+    `,
+  });
+}

--- a/src/backend/src/lib/edit-token.ts
+++ b/src/backend/src/lib/edit-token.ts
@@ -1,0 +1,18 @@
+import { randomBytes } from "node:crypto";
+
+// Crypto-random modification-link token: 32 bytes -> 64 hex chars, far above
+// the 32-char minimum (RG-248). Stored on the entity (editToken) so it can be
+// revoked simply by clearing/replacing it (RG-244).
+export function generateEditToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+// Modification links are frozen 48h before the event starts (RG-246). Returns
+// true when editing should be blocked because we are within that window (or
+// past the start). A null start date means we cannot freeze yet -> not frozen.
+const FREEZE_WINDOW_MS = 48 * 60 * 60 * 1000;
+
+export function isEditingFrozen(editionStartDate: Date | null, now: Date = new Date()): boolean {
+  if (!editionStartDate) return false;
+  return now.getTime() >= editionStartDate.getTime() - FREEZE_WINDOW_MS;
+}

--- a/src/backend/src/routes/admin/speakers.ts
+++ b/src/backend/src/routes/admin/speakers.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateSpeakers } from "../../lib/revalidate.js";
 import { slugify, uniqueSlug } from "../../lib/slug.js";
+import { generateEditToken } from "../../lib/edit-token.js";
+import { sendEditLinkEmail } from "../../lib/edit-link-email.js";
 
 interface SpeakerCreateBody {
   editionId: number;
@@ -12,6 +14,7 @@ interface SpeakerCreateBody {
   bioFr?: string;
   bioEn?: string;
   socialLinks?: Record<string, string>;
+  contactEmail?: string;
   isFeatured?: boolean;
   sponsorId?: number | null;
   publicationStatus?: "DRAFT" | "PUBLISHED";
@@ -70,6 +73,7 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
         bioFr: body.bioFr || null,
         bioEn: body.bioEn || null,
         socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+        contactEmail: body.contactEmail || null,
         isFeatured: body.isFeatured ?? false,
         sponsorId: body.sponsorId ?? null,
         publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
@@ -99,6 +103,7 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
         ...(body.socialLinks !== undefined && {
           socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
         }),
+        ...(body.contactEmail !== undefined && { contactEmail: body.contactEmail || null }),
         ...(body.isFeatured !== undefined && { isFeatured: body.isFeatured }),
         ...(body.sponsorId !== undefined && { sponsorId: body.sponsorId ?? null }),
         ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
@@ -117,5 +122,53 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
     await prisma.speaker.delete({ where: { id: Number(id) } });
     revalidateSpeakers();
     return reply.code(204).send();
+  });
+
+  // POST /api/admin/speakers/:id/edit-link — (re)generate the token, unlock it,
+  // and email the link to the given address (US-221, RG-244, RG-251).
+  app.post<{ Params: SpeakerIdParams; Body: { email?: string } }>("/speakers/:id/edit-link", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const id = Number(request.params.id);
+    const speaker = await prisma.speaker.findUnique({ where: { id } });
+    if (!speaker) return reply.code(404).send({ error: "Speaker not found" });
+
+    const email = request.body.email?.trim() || speaker.contactEmail;
+    if (!email) return reply.code(400).send({ error: "No contact email provided" });
+
+    const token = generateEditToken();
+    await prisma.speaker.update({
+      where: { id },
+      data: { editToken: token, editLinkLocked: false, editTokenSentAt: new Date(), contactEmail: email },
+    });
+
+    try {
+      await sendEditLinkEmail({ to: email, name: speaker.name, token, kind: "speaker" });
+    } catch (err) {
+      request.log.error({ err }, "Failed to send speaker edit link email");
+      return reply.code(502).send({ error: "Email sending failed", detail: "retry" });
+    }
+    return { sent: true, email };
+  });
+
+  // DELETE /api/admin/speakers/:id/edit-link — revoke (invalidate) the link.
+  app.delete<{ Params: SpeakerIdParams }>("/speakers/:id/edit-link", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request) => {
+    const id = Number(request.params.id);
+    await prisma.speaker.update({ where: { id }, data: { editToken: null } });
+    return { revoked: true };
+  });
+
+  // PUT /api/admin/speakers/:id/edit-link/lock — lock/unlock without deleting (RG-245).
+  app.put<{ Params: SpeakerIdParams; Body: { locked: boolean } }>("/speakers/:id/edit-link/lock", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request) => {
+    const id = Number(request.params.id);
+    const s = await prisma.speaker.update({
+      where: { id },
+      data: { editLinkLocked: !!request.body.locked },
+    });
+    return { locked: s.editLinkLocked };
   });
 }

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateSponsors } from "../../lib/revalidate.js";
 import { slugify, uniqueSlug } from "../../lib/slug.js";
+import { generateEditToken } from "../../lib/edit-token.js";
+import { sendEditLinkEmail } from "../../lib/edit-link-email.js";
 
 const SPONSOR_LEVELS = ["PLATINUM", "GOLD", "SILVER", "SOUTIEN", "COMMUNAUTE"] as const;
 type SponsorLevel = (typeof SPONSOR_LEVELS)[number];
@@ -15,6 +17,7 @@ interface SponsorCreateBody {
   descriptionFr?: string;
   descriptionEn?: string;
   socialLinks?: Record<string, string>;
+  contactEmail?: string;
   publicationStatus?: "DRAFT" | "PUBLISHED";
 }
 
@@ -81,6 +84,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         descriptionFr: body.descriptionFr || null,
         descriptionEn: body.descriptionEn || null,
         socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+        contactEmail: body.contactEmail || null,
         publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
       },
     });
@@ -114,6 +118,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         ...(body.socialLinks !== undefined && {
           socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
         }),
+        ...(body.contactEmail !== undefined && { contactEmail: body.contactEmail || null }),
         ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
       },
     });
@@ -132,5 +137,50 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     await prisma.sponsor.delete({ where: { id: Number(id) } });
     revalidateSponsors();
     return reply.code(204).send();
+  });
+
+  // POST /api/admin/sponsors/:id/edit-link — (re)generate token + email it.
+  app.post<{ Params: SponsorIdParams; Body: { email?: string } }>("/sponsors/:id/edit-link", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const id = Number(request.params.id);
+    const sponsor = await prisma.sponsor.findUnique({ where: { id } });
+    if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
+
+    const email = request.body.email?.trim() || sponsor.contactEmail;
+    if (!email) return reply.code(400).send({ error: "No contact email provided" });
+
+    const token = generateEditToken();
+    await prisma.sponsor.update({
+      where: { id },
+      data: { editToken: token, editLinkLocked: false, editTokenSentAt: new Date(), contactEmail: email },
+    });
+
+    try {
+      await sendEditLinkEmail({ to: email, name: sponsor.name, token, kind: "sponsor" });
+    } catch (err) {
+      request.log.error({ err }, "Failed to send sponsor edit link email");
+      return reply.code(502).send({ error: "Email sending failed", detail: "retry" });
+    }
+    return { sent: true, email };
+  });
+
+  // DELETE /api/admin/sponsors/:id/edit-link — revoke the link.
+  app.delete<{ Params: SponsorIdParams }>("/sponsors/:id/edit-link", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request) => {
+    await prisma.sponsor.update({ where: { id: Number(request.params.id) }, data: { editToken: null } });
+    return { revoked: true };
+  });
+
+  // PUT /api/admin/sponsors/:id/edit-link/lock — lock/unlock without deleting.
+  app.put<{ Params: SponsorIdParams; Body: { locked: boolean } }>("/sponsors/:id/edit-link/lock", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request) => {
+    const s = await prisma.sponsor.update({
+      where: { id: Number(request.params.id) },
+      data: { editLinkLocked: !!request.body.locked },
+    });
+    return { locked: s.editLinkLocked };
   });
 }

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -1,0 +1,138 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../lib/prisma.js";
+import { isEditingFrozen } from "../lib/edit-token.js";
+import { revalidateSpeakers, revalidateSponsors } from "../lib/revalidate.js";
+
+// Resolve a modification token to either a speaker or a sponsor. Returns null
+// if no entity carries this token.
+async function resolveToken(token: string) {
+  const speaker = await prisma.speaker.findUnique({
+    where: { editToken: token },
+    include: { edition: { select: { startDate: true } } },
+  });
+  if (speaker) return { kind: "speaker" as const, entity: speaker };
+
+  const sponsor = await prisma.sponsor.findUnique({
+    where: { editToken: token },
+    include: { edition: { select: { startDate: true } } },
+  });
+  if (sponsor) return { kind: "sponsor" as const, entity: sponsor };
+
+  return null;
+}
+
+function parseSocial(raw: string | null): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const p = JSON.parse(raw) as unknown;
+    return p && typeof p === "object" ? (p as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+interface SpeakerEditBody {
+  bioFr?: string;
+  bioEn?: string;
+  company?: string;
+  city?: string;
+  photoUrl?: string;
+  socialLinks?: Record<string, string>;
+}
+interface SponsorEditBody {
+  descriptionFr?: string;
+  descriptionEn?: string;
+  websiteUrl?: string;
+  logoUrl?: string;
+  socialLinks?: Record<string, string>;
+}
+
+export default async function editRoutes(app: FastifyInstance) {
+  // GET /api/edit/:token — load the editable fields of the entity behind the token.
+  app.get<{ Params: { token: string } }>("/edit/:token", {
+    schema: { params: { type: "object", required: ["token"], properties: { token: { type: "string" } } } },
+  }, async (request, reply) => {
+    const resolved = await resolveToken(request.params.token);
+    // Invalid/unknown token -> 404 (RG-249 cas limite).
+    if (!resolved) return reply.code(404).send({ error: "invalid_token" });
+
+    const { kind, entity } = resolved;
+    // Locked (RG-245) or frozen 48h before the event (RG-246) -> 403 with reason.
+    if (entity.editLinkLocked) return reply.code(403).send({ error: "locked" });
+    if (isEditingFrozen(entity.edition.startDate)) return reply.code(403).send({ error: "frozen" });
+
+    if (kind === "speaker") {
+      return {
+        kind,
+        name: entity.name,
+        fields: {
+          bioFr: entity.bioFr,
+          bioEn: entity.bioEn,
+          company: entity.company,
+          city: entity.city,
+          photoUrl: entity.photoUrl,
+          socialLinks: parseSocial(entity.socialLinks),
+        },
+      };
+    }
+    return {
+      kind,
+      name: entity.name,
+      fields: {
+        descriptionFr: entity.descriptionFr,
+        descriptionEn: entity.descriptionEn,
+        websiteUrl: entity.websiteUrl,
+        logoUrl: entity.logoUrl,
+        socialLinks: parseSocial(entity.socialLinks),
+      },
+    };
+  });
+
+  // PUT /api/edit/:token — save the editable fields. Name, sessions, level and
+  // publication status are NOT editable here (RG-247).
+  app.put<{ Params: { token: string }; Body: SpeakerEditBody | SponsorEditBody }>("/edit/:token", {
+    schema: { params: { type: "object", required: ["token"], properties: { token: { type: "string" } } } },
+  }, async (request, reply) => {
+    const resolved = await resolveToken(request.params.token);
+    if (!resolved) return reply.code(404).send({ error: "invalid_token" });
+
+    const { kind, entity } = resolved;
+    if (entity.editLinkLocked) return reply.code(403).send({ error: "locked" });
+    if (isEditingFrozen(entity.edition.startDate)) return reply.code(403).send({ error: "frozen" });
+
+    if (kind === "speaker") {
+      const body = request.body as SpeakerEditBody;
+      await prisma.speaker.update({
+        where: { id: entity.id },
+        data: {
+          ...(body.bioFr !== undefined && { bioFr: body.bioFr || null }),
+          ...(body.bioEn !== undefined && { bioEn: body.bioEn || null }),
+          ...(body.company !== undefined && { company: body.company || null }),
+          ...(body.city !== undefined && { city: body.city || null }),
+          ...(body.photoUrl !== undefined && { photoUrl: body.photoUrl || null }),
+          ...(body.socialLinks !== undefined && {
+            socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+          }),
+        },
+      });
+      revalidateSpeakers();
+    } else {
+      const body = request.body as SponsorEditBody;
+      await prisma.sponsor.update({
+        where: { id: entity.id },
+        data: {
+          ...(body.descriptionFr !== undefined && { descriptionFr: body.descriptionFr || null }),
+          ...(body.descriptionEn !== undefined && { descriptionEn: body.descriptionEn || null }),
+          ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
+          ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
+          ...(body.socialLinks !== undefined && {
+            socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+          }),
+        },
+      });
+      revalidateSponsors();
+    }
+
+    return { saved: true };
+  });
+}

--- a/src/frontend/next.config.ts
+++ b/src/frontend/next.config.ts
@@ -45,6 +45,10 @@ const nextConfig: NextConfig = {
         destination: `${backendUrl}/api/brochure/:token`,
       },
       {
+        source: "/api/edit/:token",
+        destination: `${backendUrl}/api/edit/:token`,
+      },
+      {
         source: "/api/editions/:path*",
         destination: `${backendUrl}/api/editions/:path*`,
       },

--- a/src/frontend/src/app/edit/[token]/page.tsx
+++ b/src/frontend/src/app/edit/[token]/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+
+interface EditData {
+  kind: "speaker" | "sponsor";
+  name: string;
+  fields: Record<string, unknown>;
+}
+
+type SocialLinks = Record<string, string>;
+
+export default function EditByTokenPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = use(params);
+
+  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+  const [errorKind, setErrorKind] = useState<string>("");
+  const [data, setData] = useState<EditData | null>(null);
+  const [form, setForm] = useState<Record<string, string>>({});
+  const [social, setSocial] = useState<SocialLinks>({});
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/edit/${token}`, { cache: "no-store" });
+        if (!res.ok) {
+          setErrorKind(res.status === 404 ? "invalid" : "blocked");
+          setState("error");
+          return;
+        }
+        const json: EditData = await res.json();
+        setData(json);
+        const f = json.fields;
+        const strFields: Record<string, string> = {};
+        for (const [k, v] of Object.entries(f)) {
+          if (k === "socialLinks") continue;
+          strFields[k] = (v as string) ?? "";
+        }
+        setForm(strFields);
+        setSocial((f.socialLinks as SocialLinks) ?? {});
+        setState("ready");
+      } catch {
+        setErrorKind("blocked");
+        setState("error");
+      }
+    }
+    void load();
+  }, [token]);
+
+  async function save() {
+    setSaving(true);
+    setSaved(false);
+    const body: Record<string, unknown> = { ...form, socialLinks: social };
+    const res = await fetch(`/api/edit/${token}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    setSaving(false);
+    if (res.ok) setSaved(true);
+    else {
+      setErrorKind(res.status === 404 ? "invalid" : "blocked");
+      setState("error");
+    }
+  }
+
+  if (state === "loading") {
+    return <main className="mx-auto max-w-2xl px-6 py-16 text-center text-gris">Chargement…</main>;
+  }
+
+  if (state === "error") {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <h1 className="text-2xl font-bold text-noir">Lien indisponible</h1>
+        <p className="mt-4 text-gris">
+          {errorKind === "invalid"
+            ? "Ce lien de modification est invalide ou a été révoqué."
+            : "Les modifications sont actuellement clôturées. Contactez l'organisation si nécessaire."}
+        </p>
+        <a href="mailto:contact@devfesttoulouse.fr" className="mt-6 inline-block font-bold text-bleu hover:underline">
+          contact@devfesttoulouse.fr
+        </a>
+      </main>
+    );
+  }
+
+  const isSpeaker = data!.kind === "speaker";
+  const inputClass =
+    "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="text-2xl lg:text-3xl font-bold text-noir">Modifier ma fiche</h1>
+      <p className="mt-1 text-gris">{data!.name}</p>
+
+      <div className="mt-8 space-y-5">
+        {isSpeaker ? (
+          <>
+            <Field label="Biographie (FR)" value={form.bioFr} onChange={(v) => setForm({ ...form, bioFr: v })} textarea className={inputClass} />
+            <Field label="Biographie (EN)" value={form.bioEn} onChange={(v) => setForm({ ...form, bioEn: v })} textarea className={inputClass} />
+            <Field label="Entreprise" value={form.company} onChange={(v) => setForm({ ...form, company: v })} className={inputClass} />
+            <Field label="Ville" value={form.city} onChange={(v) => setForm({ ...form, city: v })} className={inputClass} />
+            <Field label="Photo (URL)" value={form.photoUrl} onChange={(v) => setForm({ ...form, photoUrl: v })} className={inputClass} />
+          </>
+        ) : (
+          <>
+            <Field label="Description (FR)" value={form.descriptionFr} onChange={(v) => setForm({ ...form, descriptionFr: v })} textarea className={inputClass} />
+            <Field label="Description (EN)" value={form.descriptionEn} onChange={(v) => setForm({ ...form, descriptionEn: v })} textarea className={inputClass} />
+            <Field label="Site web" value={form.websiteUrl} onChange={(v) => setForm({ ...form, websiteUrl: v })} className={inputClass} />
+            <Field label="Logo (URL)" value={form.logoUrl} onChange={(v) => setForm({ ...form, logoUrl: v })} className={inputClass} />
+          </>
+        )}
+
+        <div>
+          <p className="block text-sm font-medium text-noir mb-2">Liens sociaux</p>
+          {(["linkedin", "twitter", "github", "website"] as const).map((key) => (
+            <div key={key} className="mb-2">
+              <Field
+                label={key}
+                value={social[key] ?? ""}
+                onChange={(v) => setSocial({ ...social, [key]: v })}
+                className={inputClass}
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-4 pt-2">
+          <button
+            onClick={save}
+            disabled={saving}
+            className="px-6 py-3 rounded-[12px] bg-malachite text-blanc font-bold hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {saving ? "Enregistrement…" : "Enregistrer"}
+          </button>
+          {saved && <span className="text-malachite font-medium">Enregistré ! Les modifications seront visibles sous peu.</span>}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  textarea,
+  className,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  textarea?: boolean;
+  className: string;
+}) {
+  return (
+    <label className="block">
+      <span className="block text-sm font-medium text-noir mb-1 capitalize">{label}</span>
+      {textarea ? (
+        <textarea value={value} onChange={(e) => onChange(e.target.value)} rows={4} className={className} />
+      ) : (
+        <input value={value} onChange={(e) => onChange(e.target.value)} className={className} />
+      )}
+    </label>
+  );
+}

--- a/src/frontend/src/components/admin/EditLinkActions.tsx
+++ b/src/frontend/src/components/admin/EditLinkActions.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+
+import { adminFetch } from "@/lib/admin-api";
+
+interface EditLinkActionsProps {
+  // "speakers" | "sponsors" — the admin route segment.
+  resource: "speakers" | "sponsors";
+  entityId: number;
+  // Current contact email (prefilled) and lock state, from the entity.
+  initialEmail: string;
+  initialLocked: boolean;
+}
+
+// Admin controls for the modification link of a speaker/sponsor (US-221):
+// send (email), revoke, lock/unlock.
+export default function EditLinkActions({
+  resource,
+  entityId,
+  initialEmail,
+  initialLocked,
+}: EditLinkActionsProps) {
+  const [email, setEmail] = useState(initialEmail);
+  const [locked, setLocked] = useState(initialLocked);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function send() {
+    if (!email.trim()) {
+      setMsg({ ok: false, text: "Renseignez une adresse email." });
+      return;
+    }
+    setBusy(true);
+    setMsg(null);
+    const { status } = await adminFetch(`/${resource}/${entityId}/edit-link`, {
+      method: "POST",
+      body: JSON.stringify({ email: email.trim() }),
+    });
+    setBusy(false);
+    setMsg(
+      status === 200
+        ? { ok: true, text: `Lien envoyé à ${email.trim()}.` }
+        : { ok: false, text: "Échec de l'envoi. Réessayez." },
+    );
+  }
+
+  async function revoke() {
+    setBusy(true);
+    setMsg(null);
+    const { status } = await adminFetch(`/${resource}/${entityId}/edit-link`, { method: "DELETE" });
+    setBusy(false);
+    setMsg(status === 200 ? { ok: true, text: "Lien révoqué." } : { ok: false, text: "Échec." });
+  }
+
+  async function toggleLock() {
+    setBusy(true);
+    setMsg(null);
+    const next = !locked;
+    const { status } = await adminFetch(`/${resource}/${entityId}/edit-link/lock`, {
+      method: "PUT",
+      body: JSON.stringify({ locked: next }),
+    });
+    setBusy(false);
+    if (status === 200) {
+      setLocked(next);
+      setMsg({ ok: true, text: next ? "Fiche verrouillée." : "Fiche déverrouillée." });
+    } else {
+      setMsg({ ok: false, text: "Échec." });
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-gris/20 bg-blanc-casse/50 p-4 space-y-3">
+      <p className="text-sm font-medium text-noir">Lien de modification</p>
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="email@exemple.com"
+          className="flex-1 min-w-[200px] rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+        />
+        <button
+          type="button"
+          onClick={send}
+          disabled={busy}
+          className="px-3 py-2 text-sm rounded-lg bg-malachite text-blanc font-medium hover:bg-malachite/90 disabled:opacity-50"
+        >
+          Envoyer le lien
+        </button>
+        <button
+          type="button"
+          onClick={revoke}
+          disabled={busy}
+          className="px-3 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc disabled:opacity-50"
+        >
+          Révoquer
+        </button>
+        <button
+          type="button"
+          onClick={toggleLock}
+          disabled={busy}
+          className="px-3 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc disabled:opacity-50"
+        >
+          {locked ? "Déverrouiller" : "Verrouiller"}
+        </button>
+      </div>
+      {msg && (
+        <p className={`text-sm ${msg.ok ? "text-malachite" : "text-terre-cuite"}`}>{msg.text}</p>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/edition-detail/SpeakersTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SpeakersTab.tsx
@@ -6,6 +6,7 @@ import { adminFetch } from "@/lib/admin-api";
 import type { Speaker, Sponsor } from "@/lib/types";
 import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
 import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import EditLinkActions from "@/components/admin/EditLinkActions";
 
 const emptyForm = {
   name: "",
@@ -247,6 +248,18 @@ export default function SpeakersTab({ editionId }: SpeakersTabProps) {
               <span className="text-sm text-noir">Publié (visible sur le site)</span>
             </label>
           </div>
+
+          {editingId !== null && (() => {
+            const current = speakers.find((s) => s.id === editingId);
+            return current ? (
+              <EditLinkActions
+                resource="speakers"
+                entityId={editingId}
+                initialEmail={current.contactEmail ?? ""}
+                initialLocked={current.editLinkLocked}
+              />
+            ) : null;
+          })()}
 
           <div className="flex items-center gap-3 pt-2">
             <button

--- a/src/frontend/src/components/admin/edition-detail/SponsorsTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SponsorsTab.tsx
@@ -6,6 +6,7 @@ import { adminFetch } from "@/lib/admin-api";
 import type { Sponsor, SponsorLevel } from "@/lib/types";
 import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
 import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import EditLinkActions from "@/components/admin/EditLinkActions";
 
 const LEVELS: { value: SponsorLevel; label: string }[] = [
   { value: "PLATINUM", label: "Platinum" },
@@ -293,6 +294,18 @@ export default function SponsorsTab({ editionId }: SponsorsTabProps) {
               />
               <span className="text-sm text-noir">Publié (visible sur le site)</span>
             </label>
+
+            {editingId !== null && (() => {
+              const current = sponsors.find((s) => s.id === editingId);
+              return current ? (
+                <EditLinkActions
+                  resource="sponsors"
+                  entityId={editingId}
+                  initialEmail={current.contactEmail ?? ""}
+                  initialLocked={current.editLinkLocked}
+                />
+              ) : null;
+            })()}
 
             <div className="flex items-center gap-3 pt-2">
               <button

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -130,6 +130,8 @@ export interface Sponsor {
   descriptionFr: string | null;
   descriptionEn: string | null;
   socialLinks: Record<string, string>;
+  contactEmail: string | null;
+  editLinkLocked: boolean;
   publicationStatus: "DRAFT" | "PUBLISHED";
   editionId: number;
 }
@@ -254,6 +256,8 @@ export interface Speaker {
   bioFr: string | null;
   bioEn: string | null;
   socialLinks: Record<string, string>;
+  contactEmail: string | null;
+  editLinkLocked: boolean;
   isFeatured: boolean;
   sponsorId: number | null;
   publicationStatus: "DRAFT" | "PUBLISHED";

--- a/src/frontend/src/proxy.ts
+++ b/src/frontend/src/proxy.ts
@@ -11,7 +11,9 @@ export default function proxy(request: NextRequest) {
   // through request headers so the root layout can pin <html lang> to the
   // default locale (and ignore any NEXT_LOCALE cookie from a previous
   // visit to a public page).
-  if (pathname.startsWith("/admin")) {
+  // Admin and the token-based edit pages are mono-language: bypass i18n routing
+  // but forward the pathname so the root layout can pin <html lang>.
+  if (pathname.startsWith("/admin") || pathname.startsWith("/edit/")) {
     const requestHeaders = new Headers(request.headers);
     requestHeaders.set("x-pathname", pathname);
     return NextResponse.next({ request: { headers: requestHeaders } });


### PR DESCRIPTION
Closes #79. Édition de fiche sans compte via lien token (US-221, US-230, US-231, RG-242→251). Dépend de #69/#70/#73.

## Données
- Migration : `contactEmail` sur Speaker et Sponsor. (Champs token déjà posés en #69.)

## Backend
- `lib/edit-token.ts` : token crypto-random 64 car + `isEditingFrozen()` (gel 48h avant l'événement, RG-246).
- `lib/edit-link-email.ts` : envoi du lien par SMTP (RG-243/250).
- Admin speakers/sponsors : `POST :id/edit-link` (génère + email, 502 si SMTP échoue → relance RG-251), `DELETE :id/edit-link` (révoque RG-244), `PUT :id/edit-link/lock` (verrouille sans supprimer RG-245).
- Public `routes/edit.ts` : `GET/PUT /api/edit/:token` résout le token (speaker ou sponsor), bloque si verrouillé/gelé (403), 404 si inconnu (RG-249). Champs éditables seulement — nom/sessions/niveau/statut exclus (RG-247).

## Frontend
- `EditLinkActions` (email + envoyer/révoquer/verrouiller) dans les onglets Speakers et Sponsors.
- Page publique `/edit/[token]` : formulaire speaker ou sponsor, messages clairs si lien invalide/verrouillé/gelé. Hors i18n.
- Rewrite Next `/api/edit/:token`.

## Test plan
- `tsc` back+front + ESLint : OK.
- Vérifié : routes admin edit-link **403** sans auth ; token 64 car ; gel (null/loin=false, <48h=true) ; GET charge la fiche ; PUT sauve + persiste ; token invalide → **404** ; fiche verrouillée → **403**.

## Note de périmètre
Photo/logo sont des champs **URL** dans l'espace public (l'upload authentifié par token est hors périmètre de cette PR ; l'upload reste dispo côté admin via le picker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)