### PR TITLE
fix(admin): remove nested card in edition tabs

### DIFF
--- a/src/frontend/src/components/admin/edition-detail/CategoriesTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/CategoriesTab.tsx
@@ -79,7 +79,7 @@ export default function CategoriesTab({ editionId }: CategoriesTabProps) {
     "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
 
   return (
-    <div className="bg-blanc rounded-xl shadow-card p-6">
+    <div>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-bold text-noir">Catégories ({categories.length})</h2>
         {!showForm && (

--- a/src/frontend/src/components/admin/edition-detail/ConferencesTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/ConferencesTab.tsx
@@ -149,7 +149,7 @@ export default function ConferencesTab({ editionId }: ConferencesTabProps) {
     "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
 
   return (
-    <div className="bg-blanc rounded-xl shadow-card p-6">
+    <div>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-bold text-noir">Conférences ({talks.length})</h2>
         {!showForm && (

--- a/src/frontend/src/components/admin/edition-detail/SpeakersTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SpeakersTab.tsx
@@ -126,7 +126,7 @@ export default function SpeakersTab({ editionId }: SpeakersTabProps) {
     "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
 
   return (
-    <div className="bg-blanc rounded-xl shadow-card p-6">
+    <div>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-bold text-noir">Speakers ({speakers.length})</h2>
         {!showForm && (

--- a/src/frontend/src/components/admin/edition-detail/SponsorsTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SponsorsTab.tsx
@@ -137,7 +137,7 @@ export default function SponsorsTab({ editionId }: SponsorsTabProps) {
   return (
     <div className="space-y-8">
       {/* US-245 — open sponsoring levels for this edition */}
-      <div className="bg-blanc rounded-xl shadow-card p-6">
+      <div className="rounded-lg border border-gris/20 bg-blanc-casse/50 p-4">
         <h2 className="text-lg font-bold text-noir mb-1">Niveaux de sponsoring ouverts</h2>
         <p className="text-sm text-gris mb-4">
           Seuls les niveaux cochés sont proposés à la création d&apos;un sponsor.
@@ -167,7 +167,7 @@ export default function SponsorsTab({ editionId }: SponsorsTabProps) {
       </div>
 
       {/* Sponsor list + form */}
-      <div className="bg-blanc rounded-xl shadow-card p-6">
+      <div>
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-bold text-noir">Sponsors ({sponsors.length})</h2>
           {!showForm && (


### PR DESCRIPTION
## Problème
Sur la fiche édition admin, le panneau d'onglets est déjà une carte (`bg-blanc rounded-xl shadow-card p-6`). Les onglets **Speakers, Conférences, Catégories, Sponsors** re-créaient une carte identique à l'intérieur → effet « carte dans la carte » (ombre + fond doublés), visible sur l'onglet Speakers.

## Correction
Ces onglets rendent désormais du **contenu nu** (comme Général/CFP qui n'avaient pas le souci) : une seule carte, le panneau. La section « Niveaux de sponsoring ouverts » (Sponsors) devient un encart léger (bordure + blanc-cassé) au lieu d'une 2e carte ombrée, pour rester distincte sans imbrication.

4 fichiers, changement minimal (wrapper `bg-blanc rounded-xl shadow-card p-6` → `div` nu).

## Test plan
- `tsc` + ESLint : OK.
- Frontend recompile sans erreur (page admin 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)