### PR TITLE
feat(lot2): #80 — visuels speakers + import Sessionize

### DIFF
--- a/src/backend/src/lib/sessionize-import.test.ts
+++ b/src/backend/src/lib/sessionize-import.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  socialKeyFor,
+  buildSocialLinks,
+  matchEnum,
+  categoryRole,
+  loadSessionizeData,
+  FORMAT_KEYWORDS,
+  LEVEL_KEYWORDS,
+} from "./sessionize-import.js";
+
+describe("socialKeyFor", () => {
+  it("maps by linkType", () => {
+    expect(socialKeyFor({ url: "https://t.co/x", linkType: "Twitter" })).toBe("twitter");
+    expect(socialKeyFor({ url: "https://x", linkType: "LinkedIn" })).toBe("linkedin");
+    expect(socialKeyFor({ url: "https://x", linkType: "GitHub" })).toBe("github");
+  });
+
+  it("falls back to URL host when linkType is absent", () => {
+    expect(socialKeyFor({ url: "https://github.com/jane" })).toBe("github");
+    expect(socialKeyFor({ url: "https://www.linkedin.com/in/jane" })).toBe("linkedin");
+    expect(socialKeyFor({ url: "https://x.com/jane" })).toBe("twitter");
+    expect(socialKeyFor({ url: "https://bsky.app/profile/jane" })).toBe("bluesky");
+  });
+
+  it("returns null for unknown links", () => {
+    expect(socialKeyFor({ url: "https://example.com/blog" })).toBeNull();
+  });
+});
+
+describe("buildSocialLinks", () => {
+  it("collects distinct social links and counts them", () => {
+    const { social, count } = buildSocialLinks([
+      { url: "https://github.com/jane", linkType: "GitHub" },
+      { url: "https://x.com/jane", linkType: "Twitter" },
+    ]);
+    expect(social).toEqual({ github: "https://github.com/jane", twitter: "https://x.com/jane" });
+    expect(count).toBe(2);
+  });
+
+  it("uses the first generic link as website fallback", () => {
+    const { social } = buildSocialLinks([{ url: "https://janedoe.dev" }]);
+    expect(social.website).toBe("https://janedoe.dev");
+  });
+
+  it("does not overwrite an explicit website", () => {
+    const { social } = buildSocialLinks([
+      { url: "https://janedoe.dev", linkType: "Company_Website" },
+      { url: "https://other.dev" },
+    ]);
+    expect(social.website).toBe("https://janedoe.dev");
+  });
+
+  it("handles undefined links", () => {
+    expect(buildSocialLinks(undefined)).toEqual({ social: {}, count: 0 });
+  });
+});
+
+describe("matchEnum (format/level)", () => {
+  it("maps Sessionize format names to our enum", () => {
+    expect(matchEnum("Keynote", FORMAT_KEYWORDS)).toBe("KEYNOTE");
+    expect(matchEnum("Tool in action", FORMAT_KEYWORDS)).toBe("QUICKIE");
+    expect(matchEnum("Conférence", FORMAT_KEYWORDS)).toBe("CONFERENCE");
+    expect(matchEnum("Unknown thing", FORMAT_KEYWORDS)).toBeNull();
+  });
+
+  it("maps level names to our enum", () => {
+    expect(matchEnum("Beginner", LEVEL_KEYWORDS)).toBe("DEBUTANT");
+    expect(matchEnum("Intermédiaire", LEVEL_KEYWORDS)).toBe("INTERMEDIAIRE");
+    expect(matchEnum("Advanced", LEVEL_KEYWORDS)).toBe("CONFIRME");
+  });
+});
+
+describe("categoryRole", () => {
+  it("classifies by type/title", () => {
+    expect(categoryRole({ id: 1, title: "Session format", items: [] })).toBe("format");
+    expect(categoryRole({ id: 2, title: "Niveau", items: [] })).toBe("level");
+    expect(categoryRole({ id: 3, title: "Track", items: [] })).toBe("track");
+  });
+});
+
+describe("loadSessionizeData", () => {
+  it("parses pasted JSON", async () => {
+    const data = await loadSessionizeData({ json: '{"speakers":[],"sessions":[]}' });
+    expect(data.speakers).toEqual([]);
+  });
+
+  it("rejects payloads with no speakers/sessions arrays", async () => {
+    await expect(loadSessionizeData({ json: '{"foo":1}' })).rejects.toThrow();
+  });
+
+  it("rejects when neither json nor url is given", async () => {
+    await expect(loadSessionizeData({})).rejects.toThrow();
+  });
+});

--- a/src/backend/src/lib/sessionize-import.ts
+++ b/src/backend/src/lib/sessionize-import.ts
@@ -1,0 +1,319 @@
+import { prisma } from "./prisma.js";
+import { slugify, uniqueSlug } from "./slug.js";
+
+// --- Sessionize "All data" JSON shapes (only the fields we consume) ---
+
+export interface SzLink {
+  title?: string;
+  url: string;
+  linkType?: string;
+}
+
+interface SzSpeaker {
+  id: string;
+  fullName?: string;
+  firstName?: string;
+  lastName?: string;
+  bio?: string | null;
+  tagLine?: string | null;
+  profilePicture?: string | null;
+  links?: SzLink[];
+  sessions?: Array<number | string>;
+}
+
+interface SzCategoryItem {
+  id: number;
+  name: string;
+}
+
+export interface SzCategory {
+  id: number;
+  title: string;
+  type?: string;
+  items: SzCategoryItem[];
+}
+
+interface SzSession {
+  id: string;
+  title: string;
+  description?: string | null;
+  isServiceSession?: boolean;
+  speakers?: string[];
+  categoryItems?: number[];
+  room?: string | null;
+}
+
+interface SessionizeData {
+  sessions?: SzSession[];
+  speakers?: SzSpeaker[];
+  categories?: SzCategory[];
+}
+
+export interface ImportReport {
+  speakers: { created: number; updated: number };
+  talks: { created: number; updated: number };
+  categories: { created: number; reused: number };
+  links: number;
+  warnings: string[];
+}
+
+// Map a Sessionize link to our socialLinks key. Sessionize sets linkType for
+// well-known networks; we fall back to matching the URL host.
+export function socialKeyFor(link: SzLink): string | null {
+  const type = (link.linkType ?? "").toLowerCase();
+  const url = link.url.toLowerCase();
+  if (type === "twitter" || url.includes("twitter.com") || url.includes("x.com")) return "twitter";
+  if (type === "linkedin" || url.includes("linkedin.com")) return "linkedin";
+  if (type === "github" || url.includes("github.com")) return "github";
+  if (url.includes("bsky.app") || url.includes("bluesky")) return "bluesky";
+  if (type === "blog" || type === "company_website" || type === "website") return "website";
+  return null;
+}
+
+export function buildSocialLinks(links: SzLink[] | undefined): { social: Record<string, string>; count: number } {
+  const social: Record<string, string> = {};
+  let count = 0;
+  for (const link of links ?? []) {
+    const key = socialKeyFor(link);
+    if (key && !social[key]) {
+      social[key] = link.url;
+      count++;
+    }
+  }
+  // Use the first generic link as the website if none matched explicitly.
+  if (!social.website) {
+    const generic = (links ?? []).find((l) => !socialKeyFor(l));
+    if (generic) {
+      social.website = generic.url;
+      count++;
+    }
+  }
+  return { social, count };
+}
+
+export const FORMAT_KEYWORDS: Array<[RegExp, "CONFERENCE" | "QUICKIE" | "KEYNOTE"]> = [
+  [/keynote/i, "KEYNOTE"],
+  [/quick|tool ?in ?action|lightning|éclair|eclair/i, "QUICKIE"],
+  [/conf|talk|session/i, "CONFERENCE"],
+];
+
+export const LEVEL_KEYWORDS: Array<[RegExp, "DEBUTANT" | "INTERMEDIAIRE" | "CONFIRME"]> = [
+  [/beginner|débutant|debutant|introductory|novice/i, "DEBUTANT"],
+  [/intermediate|intermédiaire|intermediaire/i, "INTERMEDIAIRE"],
+  [/advanced|expert|confirmé|confirme/i, "CONFIRME"],
+];
+
+export function matchEnum<T>(name: string, table: Array<[RegExp, T]>): T | null {
+  for (const [re, value] of table) {
+    if (re.test(name)) return value;
+  }
+  return null;
+}
+
+// Resolve a category definition's role from its Sessionize `type`/`title`.
+export function categoryRole(c: SzCategory): "format" | "level" | "track" {
+  const label = `${c.type ?? ""} ${c.title ?? ""}`.toLowerCase();
+  if (/format|type|session ?type/.test(label)) return "format";
+  if (/level|niveau|expérience|experience/.test(label)) return "level";
+  return "track";
+}
+
+// Run the idempotent import. Speakers/talks are matched by their slug derived
+// from name/title within the edition (RG-206/RG-214); re-importing the same
+// data updates existing rows instead of duplicating them (RG-217 idempotence).
+export async function importSessionize(
+  editionId: number,
+  data: SessionizeData,
+): Promise<ImportReport> {
+  const report: ImportReport = {
+    speakers: { created: 0, updated: 0 },
+    talks: { created: 0, updated: 0 },
+    categories: { created: 0, reused: 0 },
+    links: 0,
+    warnings: [],
+  };
+
+  // 1. Index Sessionize category items by id, classified by role.
+  const trackByItemId = new Map<number, string>();
+  const formatByItemId = new Map<number, "CONFERENCE" | "QUICKIE" | "KEYNOTE">();
+  const levelByItemId = new Map<number, "DEBUTANT" | "INTERMEDIAIRE" | "CONFIRME">();
+
+  for (const cat of data.categories ?? []) {
+    const role = categoryRole(cat);
+    for (const item of cat.items ?? []) {
+      if (role === "track") trackByItemId.set(item.id, item.name);
+      else if (role === "format") {
+        const f = matchEnum(item.name, FORMAT_KEYWORDS);
+        if (f) formatByItemId.set(item.id, f);
+      } else {
+        const lvl = matchEnum(item.name, LEVEL_KEYWORDS);
+        if (lvl) levelByItemId.set(item.id, lvl);
+      }
+    }
+  }
+
+  // 2. Upsert track categories, keyed by nameFr within the edition.
+  const existingCategories = await prisma.category.findMany({
+    where: { editionId },
+    select: { id: true, nameFr: true },
+  });
+  const categoryIdByName = new Map(existingCategories.map((c) => [c.nameFr, c.id]));
+  let sortOrder = existingCategories.length;
+  for (const name of new Set(trackByItemId.values())) {
+    if (categoryIdByName.has(name)) {
+      report.categories.reused++;
+      continue;
+    }
+    const created = await prisma.category.create({
+      data: { editionId, nameFr: name, nameEn: name, color: "#109E6E", sortOrder: sortOrder++ },
+    });
+    categoryIdByName.set(name, created.id);
+    report.categories.created++;
+  }
+
+  // 3. Upsert speakers, keyed by slug. Track the resulting db id per Sessionize id.
+  const existingSpeakers = await prisma.speaker.findMany({
+    where: { editionId },
+    select: { id: true, slug: true },
+  });
+  const takenSpeakerSlugs = new Set(existingSpeakers.map((s) => s.slug));
+  const speakerSlugToId = new Map(existingSpeakers.map((s) => [s.slug, s.id]));
+  const dbIdBySzSpeakerId = new Map<string, number>();
+
+  for (const sz of data.speakers ?? []) {
+    const name = sz.fullName?.trim() || `${sz.firstName ?? ""} ${sz.lastName ?? ""}`.trim();
+    if (!name) {
+      report.warnings.push(`Speaker ${sz.id} ignoré : aucun nom.`);
+      continue;
+    }
+    const baseSlug = slugify(name);
+    const { social, count } = buildSocialLinks(sz.links);
+    report.links += count;
+
+    const existingId = speakerSlugToId.get(baseSlug);
+    if (existingId) {
+      const updated = await prisma.speaker.update({
+        where: { id: existingId },
+        data: {
+          name,
+          company: sz.tagLine?.trim() || null,
+          bioFr: sz.bio?.trim() || null,
+          photoUrl: sz.profilePicture || null,
+          socialLinks: count > 0 ? JSON.stringify(social) : null,
+        },
+      });
+      dbIdBySzSpeakerId.set(sz.id, updated.id);
+      report.speakers.updated++;
+    } else {
+      const slug = uniqueSlug(baseSlug, takenSpeakerSlugs);
+      takenSpeakerSlugs.add(slug);
+      const created = await prisma.speaker.create({
+        data: {
+          editionId,
+          slug,
+          name,
+          company: sz.tagLine?.trim() || null,
+          bioFr: sz.bio?.trim() || null,
+          photoUrl: sz.profilePicture || null,
+          socialLinks: count > 0 ? JSON.stringify(social) : null,
+          publicationStatus: "DRAFT",
+        },
+      });
+      speakerSlugToId.set(slug, created.id);
+      dbIdBySzSpeakerId.set(sz.id, created.id);
+      report.speakers.created++;
+    }
+  }
+
+  // 4. Upsert sessions (talks), keyed by slug, linking speakers + category.
+  const existingTalks = await prisma.talk.findMany({
+    where: { editionId },
+    select: { id: true, slug: true },
+  });
+  const takenTalkSlugs = new Set(existingTalks.map((t) => t.slug));
+  const talkSlugToId = new Map(existingTalks.map((t) => [t.slug, t.id]));
+
+  for (const sz of data.sessions ?? []) {
+    if (sz.isServiceSession) continue; // breaks, lunch, etc.
+    const title = sz.title?.trim();
+    if (!title) {
+      report.warnings.push(`Session ${sz.id} ignorée : aucun titre.`);
+      continue;
+    }
+    const baseSlug = slugify(title);
+
+    const items = sz.categoryItems ?? [];
+    const format = items.map((id) => formatByItemId.get(id)).find(Boolean) ?? "CONFERENCE";
+    const level = items.map((id) => levelByItemId.get(id)).find(Boolean) ?? null;
+    const trackName = items.map((id) => trackByItemId.get(id)).find(Boolean);
+    const categoryId = trackName ? categoryIdByName.get(trackName) ?? null : null;
+
+    const speakerDbIds = (sz.speakers ?? [])
+      .map((szId) => dbIdBySzSpeakerId.get(szId))
+      .filter((id): id is number => id !== undefined);
+
+    const description = sz.description?.trim() ?? "";
+
+    const existingId = talkSlugToId.get(baseSlug);
+    if (existingId) {
+      await prisma.talk.update({
+        where: { id: existingId },
+        data: {
+          titleFr: title,
+          titleEn: title,
+          descriptionFr: description,
+          descriptionEn: description,
+          format,
+          level,
+          categoryId,
+          speakers: { set: speakerDbIds.map((id) => ({ id })) },
+        },
+      });
+      report.talks.updated++;
+    } else {
+      const slug = uniqueSlug(baseSlug, takenTalkSlugs);
+      takenTalkSlugs.add(slug);
+      await prisma.talk.create({
+        data: {
+          editionId,
+          slug,
+          titleFr: title,
+          titleEn: title,
+          descriptionFr: description,
+          descriptionEn: description,
+          format,
+          level,
+          language: "fr",
+          categoryId,
+          publicationStatus: "DRAFT",
+          speakers: { connect: speakerDbIds.map((id) => ({ id })) },
+        },
+      });
+      report.talks.created++;
+    }
+  }
+
+  return report;
+}
+
+// Fetch + parse a Sessionize "All data" payload from either a raw JSON string
+// or a Sessionize API URL. Validates the shape minimally before importing.
+export async function loadSessionizeData(opts: { json?: string; url?: string }): Promise<SessionizeData> {
+  let raw: unknown;
+  if (opts.json?.trim()) {
+    raw = JSON.parse(opts.json);
+  } else if (opts.url?.trim()) {
+    const res = await fetch(opts.url, { headers: { accept: "application/json" } });
+    if (!res.ok) throw new Error(`Sessionize fetch failed: HTTP ${res.status}`);
+    raw = await res.json();
+  } else {
+    throw new Error("Provide either `json` or `url`.");
+  }
+
+  if (!raw || typeof raw !== "object") throw new Error("Invalid Sessionize payload.");
+  const data = raw as SessionizeData;
+  if (!Array.isArray(data.sessions) && !Array.isArray(data.speakers)) {
+    throw new Error("Payload has no `sessions` or `speakers` array — is this the 'All data' export?");
+  }
+  return data;
+}

--- a/src/backend/src/routes/admin/import.ts
+++ b/src/backend/src/routes/admin/import.ts
@@ -1,0 +1,40 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../lib/prisma.js";
+import { revalidateSpeakers, revalidateConferences } from "../../lib/revalidate.js";
+import { importSessionize, loadSessionizeData } from "../../lib/sessionize-import.js";
+
+interface SessionizeImportBody {
+  editionId: number;
+  url?: string;
+  json?: string;
+}
+
+export default async function adminImportRoutes(app: FastifyInstance) {
+  // POST /api/admin/import/sessionize — bulk import speakers + sessions from a
+  // Sessionize "All data" export (US-240/US-241, RG-217). Idempotent: matches
+  // by slug, so re-running updates instead of duplicating. Accepts either a
+  // pasted JSON string or a Sessionize API URL fetched server-side.
+  app.post<{ Body: SessionizeImportBody }>("/import/sessionize", async (request, reply) => {
+    const { editionId, url, json } = request.body;
+    if (!editionId) return reply.code(400).send({ error: "editionId required" });
+    if (!url?.trim() && !json?.trim()) {
+      return reply.code(400).send({ error: "Provide either `url` or `json`" });
+    }
+
+    const edition = await prisma.edition.findUnique({ where: { id: editionId }, select: { id: true } });
+    if (!edition) return reply.code(404).send({ error: "Edition not found" });
+
+    let data;
+    try {
+      data = await loadSessionizeData({ url, json });
+    } catch (err) {
+      return reply.code(422).send({ error: "Invalid Sessionize data", detail: (err as Error).message });
+    }
+
+    const report = await importSessionize(editionId, data);
+
+    revalidateSpeakers();
+    revalidateConferences();
+    return report;
+  });
+}

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -15,6 +15,7 @@ import adminSponsorRoutes from "./sponsors.js";
 import adminSpeakerRoutes from "./speakers.js";
 import adminCategoryRoutes from "./categories.js";
 import adminTalkRoutes from "./talks.js";
+import adminImportRoutes from "./import.js";
 import adminApiKeyRoutes from "./api-keys.js";
 import adminTranslateRoutes from "./translate.js";
 
@@ -34,6 +35,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminSpeakerRoutes);
     await editorApp.register(adminCategoryRoutes);
     await editorApp.register(adminTalkRoutes);
+    await editorApp.register(adminImportRoutes);
   });
 
   // Routes restricted to ADMIN only

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -14,6 +14,7 @@ import SponsorsTab from "@/components/admin/edition-detail/SponsorsTab";
 import SpeakersTab from "@/components/admin/edition-detail/SpeakersTab";
 import CategoriesTab from "@/components/admin/edition-detail/CategoriesTab";
 import ConferencesTab from "@/components/admin/edition-detail/ConferencesTab";
+import ImportTab from "@/components/admin/edition-detail/ImportTab";
 
 interface EditionData {
   id: number;
@@ -44,6 +45,7 @@ const TABS = [
   { key: "speakers", label: "Speakers" },
   { key: "conferences", label: "Conférences" },
   { key: "categories", label: "Catégories" },
+  { key: "import", label: "Import" },
   { key: "sponsors", label: "Sponsors" },
   { key: "sponsoring", label: "Sponsoring" },
   { key: "cfp", label: "CFP" },
@@ -108,6 +110,9 @@ export default function EditionDetailPage() {
         )}
         {activeTab === "categories" && (
           <CategoriesTab editionId={edition.id} />
+        )}
+        {activeTab === "import" && (
+          <ImportTab editionId={edition.id} />
         )}
         {activeTab === "sponsors" && (
           <SponsorsTab editionId={edition.id} />

--- a/src/frontend/src/app/speakers/[slug]/social-card/route.tsx
+++ b/src/frontend/src/app/speakers/[slug]/social-card/route.tsx
@@ -1,0 +1,155 @@
+import { ImageResponse } from "next/og";
+
+import { getSpeakerBySlug } from "@/lib/api";
+
+export const contentType = "image/png";
+
+const SIZE = { width: 1200, height: 630 };
+
+// US-250 — Downloadable social-media visual for a speaker.
+// Distinct from the SEO opengraph-image: includes the session title and a
+// "speaker announcement" layout meant to be shared on socials. An optional
+// `?talk=<slug>` query selects which talk title to feature when a speaker has
+// several; otherwise the first talk (if any) is used.
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const speaker = await getSpeakerBySlug(slug);
+
+  if (!speaker) {
+    return new Response("Speaker not found", { status: 404 });
+  }
+
+  const talkSlug = new URL(request.url).searchParams.get("talk");
+  const talk =
+    speaker.talks.find((t) => t.slug === talkSlug) ?? speaker.talks[0] ?? null;
+  const talkTitle = talk?.titleFr ?? "";
+
+  const { name, company, photoUrl } = speaker;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px",
+          background:
+            "linear-gradient(135deg, #0B7350 0%, #109E6E 55%, #41B38E 100%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 30,
+            fontWeight: 700,
+            letterSpacing: 2,
+            color: "rgba(255,255,255,0.9)",
+            textTransform: "uppercase",
+          }}
+        >
+          DevFest Toulouse · Speaker
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: "56px" }}>
+          {photoUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={photoUrl}
+              alt=""
+              width={300}
+              height={300}
+              style={{
+                width: 300,
+                height: 300,
+                borderRadius: 300,
+                objectFit: "cover",
+                border: "8px solid rgba(255,255,255,0.85)",
+              }}
+            />
+          ) : (
+            <div
+              style={{
+                width: 300,
+                height: 300,
+                borderRadius: 300,
+                background: "rgba(255,255,255,0.2)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 140,
+                fontWeight: 900,
+                color: "#FFFFFF",
+              }}
+            >
+              {name.charAt(0)}
+            </div>
+          )}
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              maxWidth: 640,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                fontSize: 64,
+                fontWeight: 900,
+                color: "#FFFFFF",
+                lineHeight: 1.05,
+              }}
+            >
+              {name}
+            </div>
+            {company ? (
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 32,
+                  color: "rgba(255,255,255,0.9)",
+                  marginTop: 12,
+                }}
+              >
+                {company}
+              </div>
+            ) : null}
+            {talkTitle ? (
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 36,
+                  fontWeight: 700,
+                  color: "#F8AB06",
+                  marginTop: 32,
+                  lineHeight: 1.15,
+                }}
+              >
+                « {talkTitle} »
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontSize: 28,
+            color: "rgba(255,255,255,0.85)",
+          }}
+        >
+          devfesttoulouse.fr
+        </div>
+      </div>
+    ),
+    { ...SIZE },
+  );
+}

--- a/src/frontend/src/components/admin/edition-detail/ImportTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/ImportTab.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState } from "react";
+
+interface ImportTabProps {
+  editionId: number;
+}
+
+interface ImportReport {
+  speakers: { created: number; updated: number };
+  talks: { created: number; updated: number };
+  categories: { created: number; reused: number };
+  links: number;
+  warnings: string[];
+}
+
+type Source = "url" | "json";
+
+export default function ImportTab({ editionId }: ImportTabProps) {
+  const [source, setSource] = useState<Source>("url");
+  const [url, setUrl] = useState("");
+  const [json, setJson] = useState("");
+  const [isImporting, setIsImporting] = useState(false);
+  const [report, setReport] = useState<ImportReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleImport() {
+    setIsImporting(true);
+    setReport(null);
+    setError(null);
+
+    const payload =
+      source === "url"
+        ? { editionId, url: url.trim() }
+        : { editionId, json: json.trim() };
+
+    try {
+      const res = await fetch(`/api/admin/import/sessionize`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) {
+        setError(body?.detail || body?.error || `Erreur ${res.status}`);
+      } else {
+        setReport(body as ImportReport);
+      }
+    } catch {
+      setError("Impossible de contacter le serveur.");
+    }
+    setIsImporting(false);
+  }
+
+  const canImport =
+    !isImporting && (source === "url" ? url.trim().length > 0 : json.trim().length > 0);
+
+  const inputClass =
+    "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-bold text-noir">Import Sessionize</h2>
+        <p className="text-sm text-gris mt-1">
+          Importez les speakers et sessions depuis un export Sessionize «&nbsp;All
+          data&nbsp;» (JSON). L&apos;import est idempotent&nbsp;: relancer met à jour
+          les fiches existantes (rapprochées par leur slug) sans créer de doublons.
+          Les fiches importées sont créées en <strong>brouillon</strong>.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setSource("url")}
+          className={`px-3 py-1.5 text-sm rounded-lg border ${
+            source === "url"
+              ? "border-malachite bg-malachite/10 text-malachite font-medium"
+              : "border-gris/30 text-gris hover:bg-blanc-casse"
+          }`}
+        >
+          URL Sessionize
+        </button>
+        <button
+          onClick={() => setSource("json")}
+          className={`px-3 py-1.5 text-sm rounded-lg border ${
+            source === "json"
+              ? "border-malachite bg-malachite/10 text-malachite font-medium"
+              : "border-gris/30 text-gris hover:bg-blanc-casse"
+          }`}
+        >
+          Coller le JSON
+        </button>
+      </div>
+
+      {source === "url" ? (
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">
+            URL de l&apos;API Sessionize
+          </span>
+          <input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://sessionize.com/api/v2/XXXXXXXX/view/All"
+            className={inputClass}
+          />
+          <span className="block text-xs text-gris mt-1">
+            Endpoint «&nbsp;All&nbsp;» de votre événement Sessionize (format JSON).
+          </span>
+        </label>
+      ) : (
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">
+            JSON exporté
+          </span>
+          <textarea
+            value={json}
+            onChange={(e) => setJson(e.target.value)}
+            rows={10}
+            placeholder='{ "sessions": [...], "speakers": [...], "categories": [...] }'
+            className={`${inputClass} font-mono text-xs`}
+          />
+        </label>
+      )}
+
+      <button
+        onClick={handleImport}
+        disabled={!canImport}
+        className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+      >
+        {isImporting ? "Import en cours…" : "Lancer l'import"}
+      </button>
+
+      {error && (
+        <div className="rounded-lg border border-terre-cuite/30 bg-terre-cuite/5 p-4 text-sm text-terre-cuite">
+          {error}
+        </div>
+      )}
+
+      {report && (
+        <div className="rounded-lg border border-malachite/30 bg-malachite/5 p-4 space-y-2">
+          <p className="font-medium text-noir">Import terminé&nbsp;:</p>
+          <ul className="text-sm text-noir space-y-1">
+            <li>
+              Speakers&nbsp;: <strong>{report.speakers.created}</strong> créés,{" "}
+              <strong>{report.speakers.updated}</strong> mis à jour
+            </li>
+            <li>
+              Sessions&nbsp;: <strong>{report.talks.created}</strong> créées,{" "}
+              <strong>{report.talks.updated}</strong> mises à jour
+            </li>
+            <li>
+              Catégories&nbsp;: <strong>{report.categories.created}</strong> créées,{" "}
+              <strong>{report.categories.reused}</strong> réutilisées
+            </li>
+            <li>
+              Liens sociaux importés&nbsp;: <strong>{report.links}</strong>
+            </li>
+          </ul>
+          {report.warnings.length > 0 && (
+            <div className="pt-2">
+              <p className="text-sm font-medium text-terre-cuite">
+                Avertissements ({report.warnings.length})&nbsp;:
+              </p>
+              <ul className="text-xs text-gris list-disc pl-5 mt-1 space-y-0.5">
+                {report.warnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/edition-detail/SpeakersTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SpeakersTab.tsx
@@ -120,7 +120,24 @@ export default function SpeakersTab({ editionId }: SpeakersTabProps) {
     void load();
   }
 
+  function socialCardUrl(s: Speaker) {
+    return `/speakers/${s.slug}/social-card`;
+  }
+
+  function openSocialCard(s: Speaker) {
+    window.open(socialCardUrl(s), "_blank", "noopener");
+  }
+
+  function openAllSocialCards() {
+    const published = speakers.filter((s) => s.publicationStatus === "PUBLISHED");
+    for (const s of published) {
+      window.open(socialCardUrl(s), "_blank", "noopener");
+    }
+  }
+
   if (isLoading) return <p className="py-12 text-center text-gris">Chargement…</p>;
+
+  const publishedCount = speakers.filter((s) => s.publicationStatus === "PUBLISHED").length;
 
   const inputClass =
     "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
@@ -130,12 +147,23 @@ export default function SpeakersTab({ editionId }: SpeakersTabProps) {
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-bold text-noir">Speakers ({speakers.length})</h2>
         {!showForm && (
-          <button
-            onClick={openCreate}
-            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
-          >
-            + Ajouter un speaker
-          </button>
+          <div className="flex items-center gap-3">
+            {publishedCount > 0 && (
+              <button
+                onClick={openAllSocialCards}
+                title="Ouvre le visuel de chaque speaker publié dans un nouvel onglet"
+                className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+              >
+                Générer les visuels ({publishedCount})
+              </button>
+            )}
+            <button
+              onClick={openCreate}
+              className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+            >
+              + Ajouter un speaker
+            </button>
+          </div>
         )}
       </div>
 
@@ -307,6 +335,9 @@ export default function SpeakersTab({ editionId }: SpeakersTabProps) {
               >
                 {s.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
               </span>
+              {s.publicationStatus === "PUBLISHED" && (
+                <button onClick={() => openSocialCard(s)} className="text-sm text-malachite hover:underline">Visuel</button>
+              )}
               <button onClick={() => openEdit(s)} className="text-sm text-bleu hover:underline">Éditer</button>
               <button onClick={() => setDeleteTarget(s)} className="text-sm text-terre-cuite hover:underline">Supprimer</button>
             </li>

--- a/src/frontend/src/proxy.ts
+++ b/src/frontend/src/proxy.ts
@@ -19,6 +19,12 @@ export default function proxy(request: NextRequest) {
     return NextResponse.next({ request: { headers: requestHeaders } });
   }
 
+  // Locale-agnostic image route handlers (e.g. speaker social cards, US-250):
+  // these render a PNG and must not be rewritten through i18n routing.
+  if (pathname.startsWith("/speakers/") && pathname.endsWith("/social-card")) {
+    return NextResponse.next();
+  }
+
   return intlMiddleware(request);
 }
 


### PR DESCRIPTION
## Résumé
Implémente l'intégralité de l'issue #80 (bonus Lot 2) en deux parties.

### 1. Visuels speakers (US-250)
- Route handler PNG `/speakers/[slug]/social-card` (1200×630) : photo/initiale + nom + entreprise + **titre de session** + branding. `?talk=<slug>` optionnel.
- Onglet **Speakers** admin : bouton **« Visuel »** par speaker publié + **« Générer les visuels (N) »** en lot.
- `proxy.ts` : bypass i18n pour `/speakers/*/social-card`.

### 2. Import Sessionize (US-240/US-241)
- `lib/sessionize-import.ts` : parse de l'export JSON « All data », mapping speakers (links → socialLinks, tagLine → company, bio, photo) et sessions (format/level/track via category items), **upsert idempotent par slug**, rapport d'import.
- Endpoint `POST /api/admin/import/sessionize` (URL fetchée côté back **ou** JSON collé).
- Onglet **Import** admin : source URL/JSON + rapport (créés/mis à jour + avertissements). Fiches importées en **brouillon**.
- 13 tests unitaires sur les mappers purs.

## Test plan
- [x] `tsc --noEmit` front + back OK
- [x] `eslint` OK (1 warning préexistant non lié)
- [x] `vitest` : 13 tests sessionize OK (les échecs d'intégration restants nécessitent la DB up — non liés)
- [x] Visuel : `GET /speakers/marie-dupont/social-card` → 200 image/png, rendu vérifié visuellement
- [x] Import idempotent vérifié sur la vraie DB : run 1 crée 2 speakers + 2 talks + 2 catégories ; run 2 (ré-import identique) → 0 créé, 2+2 mis à jour, 2 catégories réutilisées, **compteurs inchangés**
- [x] Mapping vérifié : talk `format=CONFERENCE`, `level=CONFIRME`, `category=Cloud`, speaker lié ; speaker `company`, photo, 3 liens sociaux
- [x] Page `/admin/editions/1` → 200 (onglets Import + Visuel compilent)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)