### PR TITLE
feat(history): pages éditions précédentes + import historique (#63)

### DIFF
--- a/src/backend/prisma/devfest-history.json
+++ b/src/backend/prisma/devfest-history.json
@@ -1,0 +1,7861 @@
+{
+  "editions": {
+    "2016": {
+      "date": "2016-11-03",
+      "venue": "IUT Blagnac",
+      "speakers": [
+        {
+          "name": "Gilles Debunne",
+          "company": "Freelance",
+          "city": "",
+          "bio": "Développeur Freelance sur Toulouse depuis 4 ans, je me spécialise dans l'UX, front ou mobile. Éclectique, chercheur au CNRS, en SSII ou dans l'équipe Android chez Google, j'ai toujours travaillé près et pour l'utilisateur.",
+          "photoUrl": "https://pbs.twimg.com/profile_images/3737974281/520e22f642d5820473b38eacc0177ed1.jpeg",
+          "socials": []
+        },
+        {
+          "name": "Elisabel Généreux",
+          "company": "DocDoku",
+          "city": "",
+          "bio": "Développeuse / formatrice Android et iOS à DocDoku J'aime quand les choses sont naturelles et simples !",
+          "photoUrl": "https://pbs.twimg.com/profile_images/524173313816293376/MsIn-Hsu.jpeg",
+          "socials": []
+        },
+        {
+          "name": "Didier Girard",
+          "company": "Sfeir",
+          "city": "",
+          "bio": "Cloud Rider / GDE @Google / VP Engineering @Sfeir / PhD Machine Learning @EnsDeLyon",
+          "photoUrl": "https://pbs.twimg.com/profile_images/768549574554312704/bZJdgS17_400x400.jpg",
+          "socials": []
+        },
+        {
+          "name": "Martin Gorner",
+          "company": "Google",
+          "city": "",
+          "bio": "Martin Gorner, Google Developer Relations. Martin se passionne pour la science, la technologie, l'informatique, les algorithmes et tout ce qui s'en rapproche. Après avoir obtenu son diplôme d'ingénieur à Mines Paris-Tech, Martin a commencé sa carrière dans le groupe \"computer architecture\" chez ST Microelectronics. Il a ensuite passé les 11 années suivantes dans le domaine naissant des livres électroniques, d'abord avec la start-up mobipocket.com, qui est ensuite devenue la partie logicielle du Kindle d'Amazon et ses versions mobiles. I a rejoint Google en 2011 et il s'y consacre aux sujets big data (Cloud Dataflow) et Machine Learning (Tensorflow)",
+          "photoUrl": "https://pbs.twimg.com/profile_images/734738205367472130/GeL6pDWb.jpg",
+          "socials": []
+        },
+        {
+          "name": "Tugdual Grall",
+          "company": "MapR",
+          "city": "",
+          "bio": "Tugdual Grall, est Chief Technical Evangelist EMEA chez MapR. Il travaille avec les clients et les communautés de développeurs européennes, pour faciliter l’adoption de MapR, Hadoop et NoSQL. Avant de travailler chez MapR, “Tug”, était Technical Evangelist chez MongoDB et Couchbase. Tug a travaillé comme CTO chez eXo Platform, et comme Product Manager et Développeur sur la platform Java/JavaEE d’Oracle. Tugdual est également co-fondateur du Nantes JUG (Java Users Group) qui réunit tous les mois depuis 2008 les développeurs et architectes de la région nantaise.",
+          "photoUrl": "https://www.gravatar.com/avatar/6742510452dab26bba43130af24bb202?size=600",
+          "socials": []
+        },
+        {
+          "name": "Alain Regnier",
+          "company": "Alto Labs",
+          "city": "",
+          "bio": "Alain Regnier est Architecte Technique et Entrepreneur passionné d’innovation. Il a passé 10 ans dans la Silicon Valley, où il a travaillé pour des startups et des grosses sociétés et où il a notamment participé à la rédaction de plusieurs standards des Web Services et des Objets Connectés. Au sein d’Alto Labs, un Google Cloud Partner, il travaille en tant que consultant et développeur principalement autour du Cloud, des Applications Web et des Objets Connectés. Il accompagne également des startups dans le développement de prototypes/POCs techniques et en faisant le lien entre les fondateurs et les développeurs. Il est certifié Google Cloud Platform Qualified Systems Operations Professional. Il est aussi le co-fondateur du GDG Paris (Google Developer Group), du GDG Cloud Paris et de StartupVillage (http://www.startupvillage.fr)",
+          "photoUrl": "https://lh6.googleusercontent.com/-DsgSFTFOLC8/AAAAAAAAAAI/AAAAAAAAA7A/3sgpLW1MMng/photo.jpg",
+          "socials": []
+        },
+        {
+          "name": "Sebastian Witalec",
+          "company": "Progress",
+          "city": "",
+          "bio": "Sebastian Witalec is a Technical Evangelist for Telerik with over 8 years of experience in software engineering and architecture. Sebastian has passion for all types of technologies. However in the last few years his focus shifted towards cross platform Mobile development where he gained experience with Apache Cordova and NativeScript. He is always happy to learn about the new stuff and to pass the knowledge as far as his voice (or the wire) can take him. Sebastian is based in London, UK actively working with various Dev communities in the area. When not acting techie he is a massive football fan/player (probably bigger at heart than skills).",
+          "photoUrl": "https://pbs.twimg.com/profile_images/752636760245534720/aWQ8XKJD.jpg",
+          "socials": []
+        },
+        {
+          "name": "Sofiya Huts",
+          "company": "JustAnswer.com",
+          "city": "",
+          "bio": "Sofia is a manager of <a href=\"http://lviv.gdg.org.ua/\">GDG Lviv</a> and also leads local WTM <a href=\"https://www.womentechmakers.com/\">Women Techmakers</a> community in Lviv. Additionally, one of the organisers of <a href=\"https://devfest.gdg.org.ua/\">GDG DevFest Ukraine</a>. Despite that fact that Sofia has been working as the Full-stack.Net developer during last two years, she is passionate about front-end stuff, especially everything related to Progressive Web Apps and developing a fancy web application using Polymer.",
+          "photoUrl": "https://devfest.gdg.org.ua/images/people/sofiya_huts.jpg",
+          "socials": []
+        },
+        {
+          "name": "Olivier Leplus",
+          "company": "Google",
+          "city": "",
+          "bio": "My day to day my mission is to help developers create successful and quality apps. As a passionate web developer, I am always discovering and playing with new web technologies !",
+          "photoUrl": "https://pbs.twimg.com/profile_images/459265225221353473/xilGJIvG.jpeg",
+          "socials": []
+        },
+        {
+          "name": "Romain Mouton",
+          "company": "Webedia",
+          "city": "",
+          "bio": "Père d'une petite fille qui me laisse du temps le soir pour faire de la veille, des apps Android et de l'escalade ! Sinon la journée je suis développeur Android et UX addict chez Webedia (Allociné, Allociné Home, JeuxVideo, 750g, PurePeople, Overblog, ...)",
+          "photoUrl": "https://fr.gravatar.com/userimage/78986938/97aeae8024e855861143722ca85cd7fc.jpg?size=500",
+          "socials": []
+        },
+        {
+          "name": "Arnaud Giuliani",
+          "company": "ekito",
+          "city": "",
+          "bio": "Développeur & Consultant en développement java. J'interviens sur les architectures distribuées, les infrastructures et les solutions cloud (devops, base de données ...). Je suis développeur android depuis quelques années et je m'intéresse aux nouveaux langages comme Kotlin ou Go et aux nouveaux paradigmes comme la programmation fonctionnelle, développement applications réactives ...",
+          "photoUrl": "https://www.ekito.fr/people/wp-content/uploads/userphoto/3.png",
+          "socials": []
+        },
+        {
+          "name": "Didier Plaindoux",
+          "company": "Fungus",
+          "city": "",
+          "bio": "Après avoir dirigé une équipe de R&D chez Fujitsu sur le thème du Grid computing j'ai décidé de devenir Freelance. Mon thème privilégié porte sur les systèmes et architectures distribuées en y intégrant la mobilité et la sécurité. Par ailleurs en tant qu'activiste open source je développe des librairies Java, Javascript, Python et Swift ainsi qu'un langage portant le doux nom de Thicket.",
+          "photoUrl": "https://s.gravatar.com/avatar/9eede8e58faffcb15bcb7c8f8a8dc007?s=80",
+          "socials": []
+        },
+        {
+          "name": "Olivier Guillet",
+          "company": "Emotic",
+          "city": "",
+          "bio": "Olivier Guillet développe depuis plus de 15 ans : jeux vidéos, sites internet ou applications mobiles, le plus souvent sur des technologies web. Egalement passionné de réalité virtuelle, réalité augmentée et innovations en tout genres, aux frontières de l'informatique et du cyberpunk.",
+          "photoUrl": "https://pbs.twimg.com/profile_images/679084020362305536/h-OkGRXd_400x400.png",
+          "socials": []
+        },
+        {
+          "name": "Thierry Chatel",
+          "company": "MethoTIC Conseil",
+          "city": "",
+          "bio": "Consultant indépendant et formateur Angular. Google Developer Expert sur Angular depuis 2014.",
+          "photoUrl": "https://gravatar.com/avatar/b7f1da7c20c20b6aeb1eea0b9dc13f25?s=360",
+          "socials": []
+        },
+        {
+          "name": "Antoine Vernois",
+          "company": "Crafting Labs",
+          "city": "",
+          "bio": "Freelance - Software Anarchist / Common Sense Consultant",
+          "photoUrl": "https://pbs.twimg.com/profile_images/378800000410578599/f46ba12e144dfa139fab3038f2bbf5dc.jpeg",
+          "socials": []
+        },
+        {
+          "name": "Mathieu Passenaud",
+          "company": "",
+          "city": "",
+          "bio": "Diplômé d'informatique embarqué, par le hasard des choses je me suis retrouvé dans l'univers du Cloud.",
+          "photoUrl": "https://scontent-ams3-1.xx.fbcdn.net/t31.0-8/14379846_1055460101189789_6589177864674020639_o.jpg",
+          "socials": []
+        },
+        {
+          "name": "Aurélie Vache",
+          "company": "ATCHIK",
+          "city": "",
+          "bio": "Lead Developer, Développeuse Full-Stack depuis plus de 10 ans. Elle est également Duchess France Leader, marraine de la promo#2 de Simplon.co Tlse et rédactrice pour le magazine Programmez!.",
+          "photoUrl": "https://pbs.twimg.com/profile_images/726148230224949249/g2T2qehD_400x400.jpg",
+          "socials": []
+        },
+        {
+          "name": "Frédéric Cabestre",
+          "company": "",
+          "city": "",
+          "bio": "Développeur, tendance «software craftsman». Depuis longtemps attiré par les langages et leur mise en œuvre. Grand amateur de programmation fonctionnelle, même quand ce n'était pas encore cool. Curieux des systèmes, surtout s'ils sont distribués.",
+          "photoUrl": "https://pbs.twimg.com/profile_images/584007148851564545/2j5Cfo1c.png",
+          "socials": []
+        },
+        {
+          "name": "Igor Laborie",
+          "company": "MonkeyPatch",
+          "city": "",
+          "bio": "Développeur passionné depuis 15 ans. Expert dans les technos Java et Web. Je participe souvent et anime (parfois) des rdv techniques au travers de ma société ou dans des meeting comme le Toulouse JUG, Software Craftsmanship Toulouse.",
+          "photoUrl": "https://pbs.twimg.com/profile_images/3404066863/94e02f3bca9b038c4546f4e42ed05bc6.jpeg",
+          "socials": []
+        },
+        {
+          "name": "François Teychene",
+          "company": "Tabmo",
+          "city": "",
+          "bio": "Devops la journée, JUG Leader le soir sur Montpellier, j'aime parler et discuter de developpements et surtout de Docker. Ancien développeur (Java/Clojure/Python) et gestionnaire de build, j'ai passé le cap vers le Devops et me focus notamment Docker sur lequel j'aime tester de nouvelles choses et mettre en place des services pour les équipes avec lesquelles je travaille.",
+          "photoUrl": "https://lh6.googleusercontent.com/-RvGrfi4p_Uk/AAAAAAAAAAI/AAAAAAAAAeA/laex6frLlLc/photo.jpg?sz=360",
+          "socials": []
+        },
+        {
+          "name": "Alex Danvy",
+          "company": "Microsoft",
+          "city": "",
+          "bio": "Amoureux du code, addicte aux supers pouvoirs qu’il procure et fan de ceux qui tentent de le maitriser. Padawan à la formation inachevée, a plaisir à partager ses passions avec le plus grand nombre. Promoteur de l’Internet of Things, du Cloud, de la transformation numérique et bien-sûr du « code », entre autres.",
+          "photoUrl": "/images/people/AlexDanvy.jpg",
+          "socials": []
+        },
+        {
+          "name": "Cédric Cormont",
+          "company": "Capgemini",
+          "city": "",
+          "bio": "Cédric has been developing and managing software development projects and organizations for 8 years before switching to technical and management consulting for Capgemini BTech (Business & Technology) in 2008. Cedric is specialized in data integration architectures and is is Head of CoE Big Data & Analytics for Digital Transformation",
+          "photoUrl": "https://media.licdn.com/mpr/mpr/shrinknp_400_400/p/6/005/00f/0ce/0af9320.jpg",
+          "socials": []
+        },
+        {
+          "name": "Delphine Nobileau",
+          "company": "Capgemini",
+          "city": "",
+          "bio": "12 ans d'expérience en développement d'algorithmes scientifiques et en traitement d'image appliqué à l'observation de la Terre ainsi que de la gestion de projet et d'équipe.",
+          "photoUrl": "https://media.licdn.com/media/p/8/000/249/054/28ea3f6.jpg",
+          "socials": []
+        }
+      ],
+      "sessions": [
+        {
+          "title": "Keynote d'ouverture : Évolution du métier de développeur ces dernières années.",
+          "description": "Lancement officiel de la conférence. Remerciements des organisateurs, des sponsors et partenaires.<br/>Puis Alex Danvy vous fera parcourir les évolutions du métiers de développeurs ces derniers années, pour comprendre pourquoi vous avez bien fait d'être là ce jour.",
+          "speakers": [
+            "Alex Danvy"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "tags": [],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "De Angular à React (ou pas)",
+          "description": "Tech Lead d'une équipe de 6 dévelopeurs front en `AngularJS` pendant un an, j'ai acquis une bonne expertise de Angular 1.<br>Mais sur mon prochain projet, en solo, j'ai décidé d'utiliser `React`.<br>Parce qu'Angular2 n'a pas grand chose à voir avec le 1, a été mal annoncé et ne semble pas encore mûr. Parce que j'ai eu des échos favorables sur React. Parce que c'est hype et que j'aime bien ce que j'en ai vu. Mais surtout parce que je ne connais pas, et que j'aime apprendre.<br>Le projet est modérément complexe, mais utilisé par 5000 nouvelles personnes chaque jour, il doit être totalement fiable. Le client est à 4 heures de Toulouse, et pour éviter les interventions sur place, je compte blinder les tests.<br>Dans cette présentation, je ferai donc un retour d'expérience et comparerai les deux frameworks. Avantages et inconvénients de  chacun, difficultés et bonnes surprises pour qui souhaite passer de l'un à l'autre.<br>Je commence le  développement à la rentrée et espère terminer fin octobre. On pourra alors savoir si je suis resté en React, et qui sait, tester l'application grandeur nature lors de ma présentation ?",
+          "speakers": [
+            "Gilles Debunne"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé"
+        },
+        {
+          "title": "Android et programmation réactive - RxJava",
+          "description": "Comment et pourquoi utiliser la programmation réactive <a href=\"https://github.com/ReactiveX/RxJava\">RxJava</a> en développant pour Android ?",
+          "speakers": [
+            "Elisabel Généreux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Mobile"
+          ],
+          "complexity": "Confirmé"
+        },
+        {
+          "title": "Cloud Analytics : de 0 à 100000 Evénements par seconde en 50'",
+          "description": "En partant de zéro nous aurons au bout de 50' une chaine complète d'analyse de la donnée qui verra transiter 100000 événements par seconde : de l'injection (qui est semble simple mais n'est pas trivial) jusqu'à l'outil de reporting qui montrera un report temps réel sur les données injectées.<br>En apportant puissance, flexibilité et coût faible, le cloud s'impose de plus en plus comme l'outil indispensable pour construire une chaine d'analyse de la donnée. Nous l'utiliserons durant cette session qui contiendra trucs et astuces, retours d'expérience et live coding.<br>Tags : #BigQuery #Dataflow #PubSub #DataStudio #Datalab #ComputeEngine",
+          "speakers": [
+            "Didier Girard"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé"
+        },
+        {
+          "title": "Tensorflow et l’apprentissage profond, sans les équations différentielles",
+          "description": "Google a récemment publié son framework d’intelligence artificielle appelé Tensorflow. Avec ce nouvel outil, l’apprentissage automatique franchit le pas entre la science de laboratoire et le métier d’ingénieur. Dans cette session, nos vous monterons comment choisir la bonne architecture de réseau de neurones pour votre problème et comment bien gérer son apprentissage. Savoir résoudre des équations différentielles n’est plus nécessaire. Des problèmes difficiles comme la reconnaissance de l’écriture manuscrite peuvent maintenant être résolus avec quelques lignes de Python/Tensorflow et une collection de trucs & astuces d’ingénieur.",
+          "speakers": [
+            "Martin Gorner"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Méthodes et Outils"
+          ],
+          "complexity": "Confirmé"
+        },
+        {
+          "title": "Fast Cars, Big Data - Ou comment le streaming peut aider la Formule 1!",
+          "description": "Les voitures, et tout particulièrement les voitures de courses, génèrent énormément de données. Durant cette présentation, basée sur des démonstrations, vous verrez comment : <ul><li>Capturer et traiter les données en temps réel avec l’API Kafka et Spark</li><li>Analyser ces données avec Apache Spark et Drill</li></ul>Le but de cette présentation, basée sur des démonstrations est de montrer qu’il est possible aujourd’hui, sur une seule plateforme big data: <ul><li>de capturer les données en temps reel sous forme de flux avec Kafka</li><li>les traiter avec Spark Streaming les stocker sous différentes formes en fonction des besoins fichiers (JSON, Parquet), mais aussi base nosql (HBase, MapRDB JSON, ..)</li><li>les analyser en mode batch par exemple pour faire de la maintenance predictive via du machine learning avec Spark ML, ou plus simplement des requetes SQL avec Apache Drill.</li>Le projet est disponible en open source et s’appuie sur: <ul><li>Des Producers/Consumers Apache Kafka</li><li>Une Web Application pour la visualisation en temps reel avec Kafka Consumer+Web Socket</li><li>Un simulateur de course pour la generation des données TORCS (The Open Source Racing Car Simulator)</li>",
+          "speakers": [
+            "Tugdual Grall"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "20 cool things about Google Cloud Platform",
+          "description": "Depuis ses débuts il y’a plusieurs années, GCP aka Google Cloud Platform a considérablement évolué pour devenir une plaforme majeure de l’écosystème Cloud. Composée de nombreux produits et technologies, elle couvre aujourd’hui des choses très différentes comme les Machine Virtuelles, le PaaS, les bases de données relationnelles et NoSQL, le BigData, les Containers, le Machine Learning… Cette présentation donnera une vue d’ensemble de ces technologies et couvrira plus précisément 20 aspects particulièrement intéressants de GCP. Elle sera accompagnée de tips et de retours d’expérience en tant que dévelopeur et utilisateur de GCP depuis plusieurs années.",
+          "speakers": [
+            "Alain Regnier"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Sharing Code Between Web and Native Apps",
+          "description": "NativeScript has opened up a whole new world to Angular developers: the ability to share code directly between your web and native iOS/Android applications. Which is awesome! But, just because you can share code across multiple platforms, doesn’t mean that you necessarily should.<br>In this talk we’ll first take a look at what NativeScript makes possible from a code sharing perspective. We’ll build a few Angular components and use them both in the browser and on mobile devices. Then we’ll take a step back and look at the same code from a pragmatic, maintenance-oriented perspective. Come for practical tips & tricks on sharing code across multiple development environments.",
+          "speakers": [
+            "Sebastian Witalec"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "Mobile"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Wanna more fire? - Let's try polymerfire!",
+          "description": "Have you ever tried to build Web application using Polymer with Firebase integration, additionally adhere to PWA's canons? I have, and know how many surprises can be found during developmet :). Polymerfire is a great Polymer Web Component Firebase and looks very easy to play with. During my talk I want to dive into tips & tricks on how you can integrate your web app on Polymer with Firebase + how to add offline support (since Firebase uses web sockets for data transferring, service worker will not help in that c",
+          "speakers": [
+            "Sofiya Huts"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Don't call me just a website anymore. I am a progressive web app",
+          "description": "A la fin du XXième siècle, le web s’imposait sur nos ordinateurs face aux applications. Plus besoin d’installer de lourdes solutions depuis nos CD-Roms. Aujourd’hui, le mobile domine nos vies et les applications natives ont refait leur apparition.<br><br>Le web n’a pas dit son dernier mot et ne compte pas se laisser faire ! Les progressive web apps relèvent le défis afin d’apporter à vos utilisateurs la même expérience sur votre site qu’une application native.",
+          "speakers": [
+            "Olivier Leplus"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Tips : Productivité et développement Android",
+          "description": "1 slide 1 tip ! Conférence interactive ou nous verrons ensemble des astuces pour améliorer sa productivité. Les sujets abordés seront vastes : Raccourcis, config et plugins Android Studio, méthodes \"utils\" parfois peu connus du SDK Android, tools externes. Vous savez concaténer une liste avec un délimiteur ? Supprimer les données de votre app et la relancer en 1s ? Non ?! Venez n'ayez pas peur ;)",
+          "speakers": [
+            "Romain Mouton"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Mobile"
+          ],
+          "complexity": "Confirmé"
+        },
+        {
+          "title": "Develop a reactive Android app with Kotlin",
+          "description": "Kotlin est un langage développé par Jetbrains. Sa version 1.0 (production ready) est sortie en début d'année et a fait un certain buzz au sein de la communauté android. Cette session propose de découvrir ce langage, qui reprend certains aspects de groovy ou scala, et qui est très proche de swift dans la syntaxe et les concepts. Nous verrons comment Kotlin boost la productivité du développement d’applications Android et comment il permet de bien accompagner le développement réactif.",
+          "speakers": [
+            "Arnaud Giuliani"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Mobile"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "De Java à  Swift en deux temps trois mouvements",
+          "description": "Swift est désormais open source ! \"Google considérerait Swift comme un langage « de première classe » pour Android\" pouvait-on lire en avril sur le réseau. Et enfin un portage Android du langage a été \"merge\" dans la base de code officielle de Swift.<br><br>Bon tout ceci est un bon prétexte pour apprendre ce nouveau langage et les possibilités qu'il peut nous apporter en terme de développement. Une comparaison avec Java sera notamment proposée afin de montrer les similitudes et differences entre ces deux langages .",
+          "speakers": [
+            "Didier Plaindoux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Méthodes et Outils"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "WebVR : de la réalité virtuelle dans nos navigateurs, en route vers le Metaverse !",
+          "description": "WebVR est une future norme du W3C, en phase de draft actuellement.<br>Il s'agit d'une API Javascript expérimentale qui permet d’utiliser le navigateur web de votre ordinateur ou de votre mobile directement dans votre casque de réalité virtuelle, d’un basique Google Cardboard à un très sophistiqué HTC Vive.",
+          "speakers": [
+            "Olivier Guillet"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Modules Angular 2 : des bundles au chargement dynamique",
+          "description": "Dernière modification majeure avant la version finale, les modules introduits dans la RC5 d'Angular 2 changent la donne dans la façon de structurer son application.<br><br>Qu'apportent-il en terme de simplification et d'encapsulation ? Comment s'intègrent-ils avec l'injection de dépendances hiérarchique ? <br><br>Le mythe des composants sur une étagère deviendra-t-il une réalité ?",
+          "speakers": [
+            "Thierry Chatel"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé"
+        },
+        {
+          "title": "Clean Code",
+          "description": "« Une attention continue à l'excellence technique et à une bonne conception renforce l’Agilité » — 9e principe du manifeste agile.<br><br>À quoi ça sert de faire du code propre ? Et puis c'est quoi d'abord ? Et surtout, comment je m'y mets ? Par quoi je commence ?<br>Cette session cherche avant tout à questionner notre relation au code et à notre métier tout en apportant des éléments de réponse.",
+          "speakers": [
+            "Antoine Vernois"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Méthodes et Outils"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "My resumé in an operating system : un buzz et ses conséquences",
+          "description": "Just for fun !<br><br>Pour mon article mensuel sur mon blog, je me suis attelé à écrire un système d'exploitation basique pour expliquer les principes de base. <br><br>S'en est suivi un buzz non voulu :<ul><li>dans le top 5 de hacker news pendant plusieurs heures, top 10 pendant plus d'une journée</li><li>240 000 vues en 2 jours</li><li>quelques milliers de tweets</li><li>des articles sur des sites anglais, russes, allemands, turcs....</li><li>150 stars sur le projet GitHub</li><li>LinkedIn et viadeo qui s'excitent</li><li>quelques recruteurs en direct...</li></ul><br>Comment j'ai essayé de gérer ça dans la panique la plus totale....",
+          "speakers": [
+            "Mathieu Passenaud"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Dans les coulisses de Google BigQuery",
+          "description": "Google BigQuery est la solution \"Analytics As a Service\" de Google.<br>Lorsque l’on pense à des technologies liées à la Big Data, on pense de suite à l’éco-système Hadoop, ou bien à Elasticsearch ou bien ces temps-ci beaucoup à Spark, mais il y a un « petit service » de Google qui ne fait pas beaucoup parler de lui mais qui peut tirer son épingle du jeu dans différents cas de figure.",
+          "speakers": [
+            "Aurélie Vache"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Méthodes et Outils"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Les Acteurs, un modèle pour dompter le parallélisme",
+          "description": "La programmation de machines multi-cœur tiens souvent de l'exercice de style, voire même pour certains de la magie noire. Le modèle de programmation basé sur les Acteurs, apparu dans les années 70, se prête bien à résoudre ce problème. Il a prouvé son efficacité grâce au langage Erlang/OTP et contribue au succès du framework Akka. Je vous propose de faire un tour d'horizon du concept, de ces principes fondamentaux, de ces forces mais aussi de ces faiblesses.",
+          "speakers": [
+            "Frédéric Cabestre"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Méthodes et Outils"
+          ],
+          "complexity": "Confirmé"
+        },
+        {
+          "title": "Client REST en Java: trop facile avec Feign !",
+          "description": "Depuis longtemps on cherche les meilleurs solutions pour écrire des serveurs RESTful en Java, et on se préoccupe moins du coté client REST. Or devant l'émergence des architectures micro-services on est de plus en plus concerné par l'écriture de cette couche client. Nous avons déjà beaucoup de possibilités en Java (Apache http-client et fluent-http), JAX-RS 2 (souvent avec Jersey), Spring RestTemplate, ... Mais aujourd'hui il y a l'excellente API qui vient de Netflix: Feign. Venez découvrir Feign durant une session avec beaucoup live coding qui introduira l'API et montrera la simplicité d'utilisation et l'extensibilité de l'api.",
+          "speakers": [
+            "Igor Laborie"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Méthodes et Outils"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Au secours, ma prod est sous Docker !",
+          "description": "Docker est un outil très puissant qui offre de nombreuses possibilités aux équipes.<br>Après l'avoir essayé en dev puis avoir convaincu les obs de le tester sur des environnements intermédiaires, il est temps de partir en prod, et là, c'est le drame ...<br><br>Le passage d'une production sous Docker engendre des problématiques comme le monitoring des containers, la gestion des logs, le scheduling ou la gestion des datas.<br>Dans cette présentation, je ferai un tour d'horizon des approches existantes pour résoudre ces problématiques ainsi que de solutions existantes.",
+          "speakers": [
+            "François Teychene"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Méthodes et Outils"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Data science in space",
+          "description": "Cloud, big data et machine learning, des buzzwords dont on entend beaucoup parler… mais quelles sont les réelles opportunités d’application ? Le traitement, l’analyse et la valorisation de données spatiales sont des points critiques pour le futur, les activités de notre Pôle Scientifique répondent à ces problématiques. Découvrez comment l’ensemble de ces outils accélèrent le segment spatial à travers notamment un usecase de monitoring de culture de riz sur la base de données Sentinel 1",
+          "speakers": [
+            "Cédric Cormont",
+            "Delphine Nobileau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Méthodes et Outils"
+          ],
+          "complexity": "Débutant"
+        }
+      ]
+    },
+    "2017": {
+      "date": "2017-09-28",
+      "venue": "Centre de Congrès Pierre Baudis",
+      "speakers": [
+        {
+          "name": "Mathias Ortner",
+          "company": "Airbus Defence and space",
+          "city": "",
+          "bio": "I work as a R&D expert, in the field of satellite image processing. I am piloting a small team working on deep learning and cloud aspects within Airbus Defence and Space. Over the past decade, I have been involved in numerous technical problems, all related to the processing of large satellite images. Our main goal is to bring new processing technologies and algorithm into production. It all started with a master in applied mathematics, a PhD and a post doc on image and signal processing.",
+          "photoUrl": "/images/speakers/mathias-ortner.png",
+          "socials": []
+        },
+        {
+          "name": "Emile Vauge",
+          "company": "Containous",
+          "city": "",
+          "bio": "Creator of traefik.io, Emile is developer and founder of containo.us. He has more than 10 years experience developing applications for the web and the industry and is certified Docker trainer. Lately he got interested in the DevOps methods. He is particularly interested in orchestration tools like Swarm, Mesos and Kubernetes.",
+          "photoUrl": "/images/speakers/emile-vauge.png",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/emilevauge/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/emilevauge/"
+            }
+          ]
+        },
+        {
+          "name": "Alain Regnier",
+          "company": "Alto Labs",
+          "city": "",
+          "bio": "Alain Regnier est Architecte Technique et Entrepreneur passionné d’innovation. Il a passé 10 ans dans la Silicon Valley, où il a travaillé pour des startups et des grosses sociétés et où il a notamment participé à la rédaction de plusieurs standards des Web Services et des Objets Connectés. Il travaille en tant que consultant et développeur principalement autour du Cloud, des Applications Web et des Objets Connectés. Il accompagne également des startups dans le développement de prototypes/POCs techniques et en faisant le lien entre les fondateurs et les développeurs. Il est GDE Cloud (Google Developer Expert) et certifié Google Cloud Platform Qualified Systems Operations Professional. Il est aussi le co-fondateur du GDG Paris, du GDG Cloud Paris et de StartupVillage (http://www.startupvillage.fr)",
+          "photoUrl": "/images/speakers/alain-regnier.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/altolabs/"
+            }
+          ]
+        },
+        {
+          "name": "Charlotte Cavalier",
+          "company": "CodinGame",
+          "city": "",
+          "bio": "Développeuse Java passionnée, je suis particulièrement intéressée par les pratiques agiles et le bien-être au travail.",
+          "photoUrl": "/images/speakers/charlotte-cavalier.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/cavalierch/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/CCavalier/"
+            }
+          ]
+        },
+        {
+          "name": "Philippe Charrière",
+          "company": "Clever Cloud",
+          "city": "",
+          "bio": "Tech Evangelist + CSO @Clever_Cloud - Eleveur de bots - Golo tech-evangelist-dev-relation-advocate :p @TypeUnsafe - Geek officiel d'entreprise - @ScalaIO_FR member",
+          "photoUrl": "/images/speakers/philippe-charriere.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/k33g_org/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/k33g/"
+            }
+          ]
+        },
+        {
+          "name": "Didier Plaindoux",
+          "company": "Freelance",
+          "city": "",
+          "bio": "ComputerScientist[Freelance]",
+          "photoUrl": "/images/speakers/didier-plaindoux.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/dplaindoux"
+            }
+          ]
+        },
+        {
+          "name": "Sylvain Wallez",
+          "company": "Elastic",
+          "city": "",
+          "bio": "Architecte et développeur passionné. A travaillé comme architecte, CTO et leader technique dans plusieurs startups. Expert technique multi-compétences : systèmes scalables, NoSQL, moteurs de recherche, mais aussi front-end, devops et Iot. Bref, full-stack. Membre de la fondation Apache.",
+          "photoUrl": "/images/speakers/sylvain-wallez.png",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/bluxte/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/swallez/"
+            }
+          ]
+        },
+        {
+          "name": "Nicolas De Loof",
+          "company": "CloudBees",
+          "city": "",
+          "bio": "Hacker & DockerCaptain",
+          "photoUrl": "/images/speakers/nicolas-de-loof.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/ndeloof/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/ndeloof/"
+            }
+          ]
+        },
+        {
+          "name": "Wassim Chegham",
+          "company": "SFEIR",
+          "city": "",
+          "bio": "Wassim (aka manekinekko on Twitter/Github) is a Developer Advocate that spends most of his time working on production apps, helping developers write better code and provide training on mastering Web technologies (Angular 2+, Polymer, PWA, Web Components...). He enjoys writing technical articles, meeting developers at events, speaking at conferences and contributing to open source projects. Wassim loves the Web Platform and works hard to move it forward",
+          "photoUrl": "/images/speakers/wassim-chegham.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/manekinekko/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/manekinekko/"
+            }
+          ]
+        },
+        {
+          "name": "Emmanuel Demey",
+          "company": "Zenika",
+          "city": "",
+          "bio": "Consultant et Formateur Web chez Zenika Lille depuis avril 2015. Je suis spécialisé dans AngularJS / Angular 2 / TypeScript et l'Accessibilité Web. Speaker à ses heures perdues. Aime également les bières (et oui quand on vient de Lille c'est normal...), le Jazz et la Domotique. Plusieurs expériences en tant que conférencier, notamment depuis septembre 2015 autour du sujet Angular2. - ESLint au Jug Summer Camp et ChtiJS - Angular 2 : ChtiJUG, LyonJS, GDG Paris, GDG Nantes, Meetup AngularJS Grenoble, Devoxx, RivieraDev, Bdx.io, DevFest Nantes, Codeurs en Seine",
+          "photoUrl": "/images/speakers/emmanuel-demey.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/EmmanuelDemey/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/Gillespie59/"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Laforge",
+          "company": "Google",
+          "city": "",
+          "bio": "Le jour, Guillaume Laforge est Developer Advocate chez Google, sur les solutions cloud, et de nuit, il reprends sa casquette de contributeur au projet Apache Groovy. Guillaume est également un des membres du podcast Les Cast Codeurs",
+          "photoUrl": "/images/speakers/guillaume-laforge.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/glaforge/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/glaforge/"
+            }
+          ]
+        },
+        {
+          "name": "Horacio Gonzalez",
+          "company": "Cityzen Data",
+          "city": "",
+          "bio": "Malgré ce que son accent espagnol bien prononcé peut suggérer, Horacio est arrivé en France il y a une quinzaine d'années déjà. Passionné d'informatique, dans laquelle il est tombé depuis tout petit, il a découvert Java en 1997 et depuis il n'a pas arrêté de bosser autour. Après quelques années comme architecte technique au Crédit Mutuel Arkea, Horacio travaille actuellement à Cityzen Data, éditeurs de Warp10, plateforme open source pour les données de capteurs. Il est aussi leader et cofondateur du FinistJUG, le JUG francophone le plus proche de la Silicon Valley. Passionné par le développement web et tout ce qui gravite autour des composants web, Horacio a été nommé Google Developer Expert (GDE) en Web Technologies et Polymer.",
+          "photoUrl": "/images/speakers/horacio-gonzalez.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/LostInBrittany/"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/LostInBrittany/"
+            }
+          ]
+        },
+        {
+          "name": "Thomas Gx",
+          "company": "CommitStrip, KRDS, Oh my Bot!",
+          "city": "",
+          "bio": "Quand des développeurs rencontrent un dessinateur, ça donne un blog de dessins, d’anecdotes et d’actus vu par les codeurs ! Les développeurs, on le sait, aiment beaucoup lire les blogs de dessins :). Ça parle des codeurs, de leur quotidien, des gens qui bossent avec nous, des clients, des technos , des chats et des news aussi",
+          "photoUrl": "/images/speakers/thomas-gx.jpg",
+          "socials": []
+        },
+        {
+          "name": "Etienne Issartial",
+          "company": "CommitStrip",
+          "city": "",
+          "bio": "Etienne Issartial est un dessinateur et auteur spécialisé dans la bande-dessinée au format strip. Issu des Beaux-arts il s'échappe du circuit académique en passant par le dessin de presse et l'enseignement. En 2012, il fonde CommitStrip avec son ami Thomas Guenoux (Co-founder KRDS) et propose chaque jour un strip relatant avec humour le quotidien des developpeurs. Aujourd'hui, CommitStrip est un média majeur dans l'univers du développement et véritablement présent dans l'évolution du secteur (conférences internationales, partenariats...)",
+          "photoUrl": "/images/speakers/etienne-issartial.jpg",
+          "socials": []
+        },
+        {
+          "name": "Cyril Balit",
+          "company": "Sfeir",
+          "city": "",
+          "bio": "Front End CTO @sfeir GDE @google HTML5, JS, Web Components, Angular, Polymer, @bestofwebconf organizer...",
+          "photoUrl": "/images/speakers/cyril-balit.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/cbalit"
+            }
+          ]
+        },
+        {
+          "name": "Samia Drappeau",
+          "company": "Continental",
+          "city": "",
+          "bio": "Machine Learner au sein de l'équipe AI de Continental Digital Services France.",
+          "photoUrl": "/images/speakers/samia-drappeau.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/samiadrappeau"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/samastro/"
+            }
+          ]
+        },
+        {
+          "name": "Florent Pajot",
+          "company": "Continental",
+          "city": "",
+          "bio": "Data Scientist chez Continental Digital Services France.",
+          "photoUrl": "/images/speakers/florent-pajot.jpg",
+          "socials": [
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/florentpajot/?ppe=1"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Leplus",
+          "company": "",
+          "city": "",
+          "bio": "My day to day my mission is to help developers to create successful and quality apps. As a passionate web developer, I am always discovering and playing with new web technologies !",
+          "photoUrl": "/images/speakers/olivier-leplus.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/olivierleplus"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/tagazok/"
+            }
+          ]
+        },
+        {
+          "name": "Paul Dijou",
+          "company": "Nomalab",
+          "city": "",
+          "bio": "Web developper doing... you know... stuff with a keyboard and strange characters on the big internet using coffee as fuel and spending too much time waiting for something to compile.",
+          "photoUrl": "/images/speakers/paul-dijou.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/paul_dijou"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/pauldijou/"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Flebus",
+          "company": "Continental",
+          "city": "",
+          "bio": "Architecte Big Data @ Continental Digital Services France (CDSF). Agiliste convaincu et passionné. 20 ans d'expérience avec une combinaison de développement, de conseil et de business development. En ce moment je m'intéresse particulièrement aux technologies du Big Data, de l'IoT et du Cloud. Avec les équipes de CDSF qui grandissent en permanence nous travaillons à imaginer, développer et opérer de nouveaux services autour de la voiture connectée. Rejoignez-nous!",
+          "photoUrl": "/images/speakers/olivier-flebus.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/olivierflebus"
+            }
+          ]
+        },
+        {
+          "name": "Fanny Martin",
+          "company": "Continental",
+          "city": "",
+          "bio": "Ingénieure développement Big Data chez Continental Digital Services France.",
+          "photoUrl": "/images/speakers/fanny-martin.jpg",
+          "socials": [
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/martinfanny/"
+            }
+          ]
+        },
+        {
+          "name": "Matthieu Bernardin",
+          "company": "Continental",
+          "city": "",
+          "bio": "Continental Digital Services France.",
+          "photoUrl": "/images/speakers/matthieu-bernardin.png",
+          "socials": []
+        },
+        {
+          "name": "Bill Metangmo Tsobze",
+          "company": "BULL SAS",
+          "city": "",
+          "bio": "R&D Data engineer - Passionate about designing complex distributed sytems :).",
+          "photoUrl": "/images/speakers/bill-metangmo-tsobze.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/BillMetangmo"
+            }
+          ]
+        },
+        {
+          "name": "Frederic Cabestre",
+          "company": "EasyMile",
+          "city": "",
+          "bio": "Développeur, tendance «software craftman». Depuis longtemps attiré par les langages et leur mise en œuvre. Grand amateur de programmation fonctionnelle, même quand ce n'était pas encore cool. Curieux des systèmes, surtout s'ils sont distribués.",
+          "photoUrl": "/images/speakers/frederic-cabestre.png",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/fcabestre"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/fcabestre/"
+            }
+          ]
+        },
+        {
+          "name": "Didier Girard",
+          "company": "SFEIR",
+          "city": "",
+          "bio": "Cloud Rider / GDE @Google / VP Engineering @Sfeir / PhD Machine Learning @EnsDeLyon",
+          "photoUrl": "/images/speakers/didier-girard.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/didiergirard"
+            }
+          ]
+        },
+        {
+          "name": "Francois Teychene",
+          "company": "TabMo",
+          "city": "",
+          "bio": "Devops la journée, JUG Leader le soir sur Montpellier, j'aime parler et discuter de developpements et surtout de Docker. Ancien développeur (Java/Clojure/Python) et gestionnaire de build, j'ai passé le cap vers le Devops et me focus notamment Docker sur lequel j'aime tester de nouvelles choses et mettre en place des services pour les équipes avec lesquelles je travaille.",
+          "photoUrl": "/images/speakers/francois-teychene.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/fteychene"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/fteychene/"
+            }
+          ]
+        },
+        {
+          "name": "Estelle Landry",
+          "company": "TabMo",
+          "city": "",
+          "bio": "Product Owner chez TabMo.",
+          "photoUrl": "/images/speakers/estelle-landry.jpg",
+          "socials": [
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/estelle-landry-61866b71/?ppe=1"
+            }
+          ]
+        },
+        {
+          "name": "Florian Chauveau",
+          "company": "Code-Troopers",
+          "city": "",
+          "bio": "Après être passé par une SSII et une startup j'ai créé avec plusieurs collègues et amis Code-Troopers à Tours. Depuis plus de 3 ans nous travaillons en tant que freelance sur les projets et les thèmes qui nous intéressent. Pour ma part c'est le développement Android qui occupe mes journées. La qualité du code et l'efficacité au travail sont les deux choses que j'ai apprises très tôt et que j'essaie d'appliquer au mieux au quotidien. Le partage reste l'un des meilleurs moyens d'apprendre c'est pour cela que je donne des cours à Polytech'Tours et que je cogère le GDG Tours.",
+          "photoUrl": "/images/speakers/florian-chauveau.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/florianchauveau"
+            }
+          ]
+        },
+        {
+          "name": "Cédric Gatay",
+          "company": "Code-Troopers",
+          "city": "",
+          "bio": "Après un passage par une start-up qui n'a malheureusement pas su déployer ses ailes, Cedric a co-fondé Code-Troopers : un studio de développement agile basé à Tours. À côté de cette activité principale, il a aussi participé à plusieurs ouvrages chez Packt Publishing et a co-fondé le Google Developer Group de Tours. Il a aussi lancé l'OpenDeviceLab de Tours.",
+          "photoUrl": "/images/speakers/cedric-gatay.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/Cedric_Gatay"
+            }
+          ]
+        },
+        {
+          "name": "Boris-Wilfried Nyasse",
+          "company": "MIPIH",
+          "city": "",
+          "bio": "Developer and self-entrereneur with a big interest for innovation. He actualy works as Agile Devops for a software publisher company and also worked as IT architect & CTO for few startups at Toulouse. Passionate technical multi-skills",
+          "photoUrl": "/images/speakers/boris-wilfried-nyasse.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/bwnyasse"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/bwnyasse/"
+            }
+          ]
+        },
+        {
+          "name": "Kévin Segaud",
+          "company": "",
+          "city": "",
+          "bio": "Eclectic Developer",
+          "photoUrl": "/images/speakers/kevin-segaud.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/kevin_segaud"
+            }
+          ]
+        },
+        {
+          "name": "Tugdual Grall",
+          "company": "MapR",
+          "city": "",
+          "bio": "Tugdual Grall, est Chief Technical Evangelist EMEA chez MapR. Il travaille avec les clients et les communautés de développeurs européennes, pour faciliter l’adoption de MapR, Hadoop et NoSQL. Avant de travailler chez MapR, “Tug”, était Technical Evangelist chez MongoDB et Couchbase. Tug a travaillé comme CTO chez eXo Platform, et comme Product Manager et Développeur sur la platform Java/JavaEE d’Oracle. Tugdual est également co-fondateur du Nantes JUG (Java Users Group) qui réunit tous les mois depuis 2008 les développeurs et architectes de la région nantaise",
+          "photoUrl": "/images/speakers/tugdual-grall.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "http://twitter.com/tgrall"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/tgrall"
+            }
+          ]
+        },
+        {
+          "name": "Alex Danvy",
+          "company": "Microsoft",
+          "city": "",
+          "bio": "Partage sa passion pour le développement. Amateur de robots et de pommes. Promoteur de l'informatique pour tous. Spécialiste de l'Internet of Things. Evangéliste chez Microsoft.",
+          "photoUrl": "/images/speakers/alex-danvy.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/danvy"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/danvy"
+            }
+          ]
+        },
+        {
+          "name": "Logan Mauzaize",
+          "company": "MonkeyPatch",
+          "city": "",
+          "bio": "Amateur de Java avant le diplôme, j'ai distribué mes conseils lors de mes missions (expert technique, dev leader) et sur les forums. Notamment sur Developpez.com, sur lequel je fais partie de l'équipe Java à la fois en tant que modérateur mais aussi rédacteur.",
+          "photoUrl": "/images/speakers/logan-mauzaize.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/loganmzz"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/loganmzz"
+            }
+          ]
+        },
+        {
+          "name": "Alessio Coltellacci",
+          "company": "",
+          "city": "",
+          "bio": "Software Developer",
+          "photoUrl": "/images/speakers/alessio-coltellacci.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/lightplay8"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Philippot",
+          "company": "Greenspector",
+          "city": "",
+          "bio": "Olivier est CTO chez Greenspector. Il aime les technologies mais surtout les optimiser. En particulier sur Android et l'embarqué. Il est fortement engagé dans les actions de sensibilisation à l'efficience et l'éco-conception logicielle comme le Geen Code Lab Challenge. Speaker a Devoxx, Android Maker, Breizhcamp...",
+          "photoUrl": "/images/speakers/olivier-philippot.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/simplygreenit"
+            }
+          ]
+        },
+        {
+          "name": "Alexis Tual",
+          "company": "JFrog",
+          "city": "",
+          "bio": "Alexis est ingénieur solution chez JFrog, il participe aux activités liées à Artifactory, comme par exemple l'intégration d'Artifactory sur Apache Mesos. Dans l'épisode précédent, Alexis a été Ingénieur Software Craftsman pendant 11 ans dans le domaine de l'éducation sur des projets Java, Grails, Javascript mais a trempé aussi dans les projets DevOps.",
+          "photoUrl": "/images/speakers/alexis-tual.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/alex_tual"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/alextu"
+            }
+          ]
+        },
+        {
+          "name": "Arnaud Giuliani",
+          "company": "ekito",
+          "city": "",
+          "bio": "Développeur Java/JEE pour l'industrie toulousaine depuis une dizaine d'années, plutôt branché trucs coté serveur (systèmes distribués, middleware...). J'ai repris goût pour le \"frontend\" grâce à Android. Depuis que je suis à ekito, je travaille beaucoup sur le dev mobile Android, tout en gardant un pied dans le back. En 2015 je découvre Kotlin, qui me permet d'arrêter d'écrire du Java et de mieux appréhender la programmation réactive. Kotlin est également le sujet central de mes présentations depuis 2016.",
+          "photoUrl": "/images/speakers/arnaud-giuliani.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/arnogiu"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/arnaudgiuliani"
+            }
+          ]
+        },
+        {
+          "name": "Vincent Ogloblinsky",
+          "company": "SII",
+          "city": "",
+          "bio": "Architecte logiciel frontend au sein d'une ESN rennaise, j'évolue entre architecture de projets web, formations, animations techniques, support client et expertise technique. Passionné par le \"grand\" domaine du développement web frontend, j'affectionne particulièrement coder en (Type||Java)script, débugger HTML5, découvrir la capacité grandissante du navigateur à se rapprocher des capteurs (GPS, bluetooth, etc...), et participer à des projets open-source.",
+          "photoUrl": "/images/speakers/vincent-ogloblinsky.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/vogloblinsky"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/vogloblinsky"
+            }
+          ]
+        },
+        {
+          "name": "Alexandre Delattre",
+          "company": "Viseo",
+          "city": "",
+          "bio": "# Ingénieur logiciel Fullstack\n\n31 ans et fort de 7 ans d'expérience dans le développement logiciel, mon parcours, auprès de startups et de grands groupes m'a permis de m'approprier une large gamme de technos fullstack:\n\n- Mobile : Android (Kotlin), iOS (Swift), Ionic \n- Backend : Java, Scala, NodeJS\n- Web : Typescript / Angular 1 & 2\n\nJe suis passioné par la mobilité, la qualité et l'innovation logicielle, l'UX et l'entrepreunariat digital.",
+          "photoUrl": "/images/speakers/alexandre-delattre.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/minegraphite"
+            }
+          ]
+        },
+        {
+          "name": "Damien Cavaillès",
+          "company": "JeChercheUnDev.fr",
+          "city": "",
+          "bio": "Développeur et Entrepreneur, je n'accepte pas que 71% des développeurs français ne soient pas heureux de se lever le matin pour aller bosser. Du coup, j'ai construit une entreprise qui aide les développeurs à trouver leur job de rêve et ça me rend heureux.",
+          "photoUrl": "/images/speakers/damien-cavailles.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/TheDamfr"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/jechercheundev/"
+            }
+          ]
+        },
+        {
+          "name": "Fabien Tregan",
+          "company": "freelance",
+          "city": "",
+          "bio": "After spending 10+ years of my life coding, I started to feel that the problems in software development were not in the code and tryed finding solution elsewhere. Since I started doing that, I started to love coding again :)",
+          "photoUrl": "/images/speakers/fabien-tregan.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/ftregan"
+            }
+          ]
+        },
+        {
+          "name": "Mélanie Bats",
+          "company": "Obeo",
+          "city": "",
+          "bio": "I am Mélanie Bats and I work as a software developer at Obeo. In my daily work, I am mainly focused on the development of modeling tools based on Eclipse with Sirius like UML Designer. I am also committer for 2 Eclipse projects: EEF and Sirius. In my free time I am interested in Arduino stuff and contribute some Eclipse plugins for cross compilation like the Buildroot Eclipse plugin. I am also a free software activist who has organized and participated in free software events in the Toulouse area.",
+          "photoUrl": "/images/speakers/melanie-bats.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/melaniebats"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/mbats"
+            }
+          ]
+        },
+        {
+          "name": "Pauline Iogna",
+          "company": "Casden",
+          "city": "",
+          "bio": "Après 7 dans différentes entreprises, Pauline a rejoint la Casden en tant que développeuse et techlead. Elle aime particulièrement travailler sur les problématiques server side.\nAncienne étudiante de l'université Paris-Est Marne la Vallée, elle y enseigne à présent le java.\nElles est membre actif de Duchess France, association ayant pour but de donner de la visibilité aux femmes qui ont des métiers techniques, elle participe régulièrement à l'organisation d’événements techniques.",
+          "photoUrl": "/images/speakers/pauline-iogna.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/pauline_io"
+            }
+          ]
+        },
+        {
+          "name": "Régis Marie-joseph",
+          "company": "SII BREST",
+          "city": "",
+          "bio": "Dev mobiweb, curieux de tout !",
+          "photoUrl": "/images/speakers/regis-marie-joseph.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/arawak971"
+            }
+          ]
+        },
+        {
+          "name": "Gilles Debunne",
+          "company": "Freelance",
+          "city": "",
+          "bio": "Développeur Freelance sur Toulouse depuis 4 ans, je me spécialise dans l'UX, front ou mobile. Éclectique, chercheur au CNRS, en SSII ou dans l'équipe Android chez Google, j'ai toujours travaillé près et pour l'utilisateur.",
+          "photoUrl": "/images/speakers/gilles-debunne.jpeg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/gdebunne"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/GillesDebunne"
+            }
+          ]
+        },
+        {
+          "name": "Igor Laborie",
+          "company": "MonkeyPatch",
+          "city": "",
+          "bio": "Développeur passionné depuis + de 15 ans. Expert dans les technos Java et Web. Je participe souvent et anime aussi des rdv techniques au travers de ma société ou dans des meetings comme le Toulouse JUG, Software Craftsmanship Toulouse.",
+          "photoUrl": "/images/speakers/igor-laborie.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/ilaborie"
+            },
+            {
+              "name": "GitHub",
+              "link": "https://github.com/ilaborie"
+            }
+          ]
+        },
+        {
+          "name": "Nicolas Decoster",
+          "company": "Magellium",
+          "city": "",
+          "bio": "Informaticien curieux depuis 35 ans, de métier depuis 20 ans (principalement dans le spatial). Non spécialiste touche à tout : du développement logiciel à l'étude scientifique, du développement d'algorithmes de traitement à la mise en œuvre de systèmes, de la programmation en C++ ou Python à l'utilisation des technos Web, de la petite appli en ligne de commande aux IHM ou aux systèmes distribués. Travaille actuellement chez Magellium sur une étude CNES sur l'utilisation de WebAssembly pour la valorisation des données d'observation de la terre.",
+          "photoUrl": "/images/speakers/nicolas-decoster.jpg",
+          "socials": [
+            {
+              "name": "Twitter",
+              "link": "https://twitter.com/nnodot"
+            }
+          ]
+        }
+      ],
+      "sessions": [
+        {
+          "title": "Keynote d'ouverture: Le développeur Full Stack est mort, Vive le développeur universel",
+          "description": "Le développeur Full Stack est mort, Vive le développeur universel",
+          "speakers": [
+            "Emile Vauge"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "tags": [
+            "General"
+          ],
+          "complexity": "",
+          "youtube": "https://www.youtube.com/watch?v=Jcs2Fp8jHEQ"
+        },
+        {
+          "title": "CSS is Awesome !",
+          "description": "Non, le CSS c'est pas du coloriage !\n\nLa puissance du CSS est souvent sous-estimée, cette session de Live-Coding sera l'occasion de montrer quantité de trucs et astuces utiles quotidiennement pour les développeurs web.\n\nAujourd'hui on entre dans l'ère post-IE et on peut utiliser beaucoup plus sereinement la puissance que nous offre le CSS; pourquoi passer à coté !\n\nEn mode 'no-javascript' venez découvrir des solutions pour faire des : collapsibles panels, accordions, popovers, modals, tabs, ...",
+          "speakers": [
+            "2288"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=fPObs60585w"
+        },
+        {
+          "title": "Modules ES6 & HTTP/2 - Va-t-on arrêter de packager notre code JavaScript ?",
+          "description": "Les modules ES6 sont maintenant supportés par la majorité des navigateurs récents.\nEn les utilisant dès maintenant nous découpons notre code pour une meilleure architecture, et un support du tree-shaking par exemple.\nMais ce support natif des navigateurs peut-il nous simplifier la tâche lors de nos développements ?\nA-t-on encore besoin de livrer un seul bundle JavaScript ?\nL'utilisation combinée d'HTTP/2 va-t-elle encore plus simplifier les choses ?\nQu'en est-il pour les applications isomorphiques ?\nDécouvrons toutes les réponses à ces questions lors de ce talk 100% JavaScript !",
+          "speakers": [
+            "810"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=yLUwjl7bN6U"
+        },
+        {
+          "title": "Deep learning for satellite image processing, lessons learned",
+          "description": "We present in this talk the application of deep learning frameworks for satellite images. After a short introduction on deep learning, we start by presenting a couple of applications on which we are successful enough to embed the result in a production world - i.e. satellite ground segments. We then present the tools we are using (tensorflow, google cloud, spark, etc...) and point out three important aspects : the need for a new version control scheme, the need for a data visualisation tool, and the need for continuous integration. \n\nWe illustrate our talk with results on automatic cloud detection within satellite images, automatic target detection, automatic generation of maps, image denoising etc...",
+          "speakers": [
+            "2317"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "IA"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=dLfdmbRz9EE"
+        },
+        {
+          "title": "Quand Internet sera gouvernée par les |chats> de Shrödinger",
+          "description": "Si Internet déborde de vidéos de chatons trop mignons, dans quelques années, nos réseaux véhiculeront des chats de Shrödinger.\n\nSuperposition d'état, indétermination, intrication ... L'informatique quantique est à nos portes. Elle sort doucement de la sphère théorique pour devenir une réalité de laboratoire, voire de premières solutions industrielles. Loin de pures spéculations, elle permettra de casser la sécurité des infras \"legacy\" de 2016 tout en offrant en contrepartie une sécurité inviolable, même par la NSA. Le tout étant de savoir lequel arrivera en premier.",
+          "speakers": [
+            "Alain Regnier"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "WTF"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=4J_KzGvHpcg"
+        },
+        {
+          "title": "Des portes logiques pneumatiques en bois",
+          "description": "Les valves utilisées dans les orgues de barbarie utilisent un système de membrane mobile et de contre-réaction qui permet, en créant un petit débit d'air d'un côté grace aux trous perforés dans le carton, de contrôler un débit d'air plus important vers les flûtes.\nCe principe - contrôler un grand débit à partir d'un petit débit - est précisément celui des lampes utilisées dans les premiers ordinateur (Atanasoff–Berry, Colossus, puis l'ENIAC) et celui des transistors dont nous avons en général quelques millions dans nos poches.\nJe me suis posé la question de savoir s'il était donc possible de réaliser une calculatrice pneumatique avec des outils simples dans son garage.\n\nDans ce talk, je vous propose de montrer rapidement les questions sur lesquels j'ai travaillé, les sources, les prototype, où j'en suis, et ce qu'il reste à faire pour faire une machine qui compte sur les doigts, mais en binaire, quand on soufle dans des pailles.",
+          "speakers": [
+            "2357"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "WTF"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=L3UoWDWoJJE"
+        },
+        {
+          "title": "Plus loin avec Kotlin !",
+          "description": "Kotlin est le langage de JVM développé par Jetbrains. Les communautés Java & Android sont en ébullition depuis la sortie de sa première version “production ready”, début 2016. Google vient de le promouvoir “langage officiel pour Android”, à la Google IO 2017. Kotlin fait désormais parti des grands ! \n\nVous avez déjà commencé à développer en Kotlin ? Envie de voir les capacités du langage ? Cette session propose de faire un tour des API et concepts avancés : Collections & Séquences, Gestion des generics, Programmation fonctionnelle & gestion des lambdas, API Builder & DSL, Coroutines & zoom sur les nouveautés de la version 1.1. \n\nDe quoi booster vos développement d’applications Android et Java ou vous donner envie de développer en Kotlin ;)",
+          "speakers": [
+            "275"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=3zVdKPZyq5Q"
+        },
+        {
+          "title": "Functional Programming Explained to my grandma",
+          "description": "Functional programming reminds you of some old school memories... Monad scares you and you think High Order Function are rude words. However you love lambdas and you feel immutability is a great thing. I will introduce you to core principles of functionnal programming without complexity and you will be able to apply them straight away. No installation required: just internet, a basic knowledge of your favourite language and a web browser.",
+          "speakers": [
+            "Charlotte Cavalier"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "Introduction au marble testing Rx (Web, iOS, Android)",
+          "description": "# Introduction au marble testing Rx (Web, iOS, Android)\n\nCe quicky est une introduction à une technique de test innovante et visuelle d'un flow de données Rx, encore méconnue des utilisateurs de Rx. \n\nCette technique, inspirée des diagrammes marble, facilite énormément l'écriture d'un test unitaire d'un système asynchrone tout en réduisant la verbosité du test.\n\nAppliquée à un MVVM réactif, où les entrées utilisateurs, appels à des services et sorties sont cablés sous forme d'un flow Rx, il devient possible de tester le comportement de l'interface (ViewModel) dans le temps, sans recourir à du test end to end.\n\nCe talk s'appuiera sur l'exemple d'une application météo simple, ou l'utlisateur rentre le nom de sa ville et voit apparaitre la météo dans sa ville.\n\nLe marble testing permettra de tester aisément des cas \"tordus\", mais réalistes, tel qu'un utilisateur qui tape une autre ville alors que la météo de la ville précédente est encore en cours de chargement.\n\nL'exemple live sera donné en RxJs, mais l'application sera déclinée en RxSwift (iOS) et RxJava (Android) sur des repositories fournis ultérieurement.",
+          "speakers": [
+            "2417"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=ei0SOj7oRsg"
+        },
+        {
+          "title": "Ok Google, is there any presentations about ChatBots?",
+          "description": "Ever wanted to build a chatbot? What if you could use a voice assistant to manage your agenda for the conference? Know if there are any presentations on Machine Learning, or Docker, or your favorite programming language? Find out more about a speaker...etc.\n\nIn this session, we will look at how to build our own voice assistant, using Google Cloud's natural speech and voice recognition APIs with API.AI services, and Google Cloud Functions to implement Necessary business logic. \n\nGrab some popcorn and enjoy!",
+          "speakers": [
+            "Wassim Chegham",
+            "Guillaume Laforge"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Débutant"
+        },
+        {
+          "title": "BATTLESTAR GALACTICA: Saison 5 - Les Cylons passent dans le cloud avec Vert.x",
+          "description": "Ne cherchez pas, cette saison n’existe pas. 😭 [BSG S5](https://www.rottentomatoes.com/tv/battlestar_galactica/s05/)\nDepuis la 1ère version de ce talk lors de [l’édition 2015 du JUG SummerCamp](http://www.jugsummercamp.org/edition/6/presentation/1118) les Cylons se sont mis à jour et ont décidé de \"passer au Cloud\"\n\n### Rappel:\n\nLes fonctions internes des \"Basestars\" (vaisseaux mères cylon) sont contrôlées par un système d'ordinateur central mi biologique, mi machine appelé l'Hybride. L'ensemble des 7 humanoïdes Cylons décidèrent lors du Plan (https://www.rottentomatoes.com/m/battlestar_galactica_the_plan/), de basculer l'ensemble des basestars en mode “microservices\" pour donner la possibilité à tous les Hybrides de calculer les positions de milliers de Raiders (chasseurs cylons) afin d'éviter qu'ils n'entrent en collision lors des attaques.\n\n### La mise en oeuvre du Plan consistera en ceci:\n\n- Microservices & Cloud-Native: Qu’est-ce c’est, bonnes pratiques, patterns, ...\n- Du code et de la démo: (Vert.x est polyglotte … donc il y aura plusieurs langages)\n  - Ecrire un microservice en Vert.x\n  - Gérer la partie “Discovery” (sinon personne ne va se parler) 📞\n  - Gérer la partie “Houston we have a problem” (health checks, failures …) 🙀\n  - Il y a toujours quelqu'un pour ne pas faire comme tout le monde 😡: \n    - \"j'avais pas lu les specs, j'ai fait un service en Node.js, je peux jouer quand même?\"\n- Du déploiement: si ça marche en local, ça doit se déployer (et si les 😇 dieux d’internet sont avec nous) \n  - déploiement \"en masse\" des hybrides et de quelques raiders sur une plateforme de cloud 😝\n\nA la fin de ce talk, vous aurez assez de matière pour être opérationnel rapidement sur le sujet",
+          "speakers": [
+            "1772"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=rbuEIIwYly8"
+        },
+        {
+          "title": "Un chatbot en 5 étapes avec api.ai",
+          "description": "Avec api.ai il n'y a pas plus simple pour créer un chatbot. Je vous montrerai comment déployer un chatbot en 5 étapes au cours desquelles nous aborderons les concepts clés d'api.ai. \n\nAu cours de la session, nous verrons comment créer un agent conversationnel, avec des entities pour pouvoir extraire de l'information à partir de texte et des intents pour représenter les différentes réactions du chatbot.\nPuis nous verrons comment entraîner notre chatbot, pour qu'il s'améliore au cours du temps. Il ne restera plus qu'à l'intégrer!",
+          "speakers": [
+            "333"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "IA"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=xh7cTxQCeY0"
+        },
+        {
+          "title": "Quand nous avons emmené notre web app chez les Bisounours",
+          "description": "Les Bisounours sont renommés pour avoir élu domicile dans les nuages. Mais depuis peu ils ne sont plus seul. \nAvec la popularité de plateformes comme Kubernetes, développer et déployer des applications \"cloud native\" devient un pré-requis. Démarrer \"from scratch\" avec des frameworks de type Spring Cloud est relativement aisé, mais adapter une application existante comporte des difficultés à surmonter.\n\nCette présentation technique détaille les changements entrepris pour faciliter le déploiement d'Artifactory 5 sur Kubernetes, Mesos sans toutefois tout re-écrire. \n\n- Pourquoi déployer sur Kubernetes et compagnie ?\n- Architecture Artifactory HA\n- Nouvelles exigences pour les nodes \"cloud native\"\n    * Stateless\n    * Immutable\n    * \"Network agnostic\"\n    * Stockage distribué\n- Comment remplir ces exigences ?\n    * Synchro des configs\n    * Stockage distribué \"maison\" avec redondance\n    * Working queue distribuée\n- Demo lancement d'un cluster Artifactory sur Kubernetes",
+          "speakers": [
+            "224"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=8z00go15PAw"
+        },
+        {
+          "title": "Elastic : comment fonctionne une équipe d'ingénierie totalement distribuée de 250 personnes",
+          "description": "La société Elastic, éditeur des logiciels Elasticsearch et Kibana, est en \"remote first\" : les 250 membres de l'équipe d'ingénierie sont tous en télétravail, ainsi qu'une partie des équipes commerciales et marketing, dans près de 30 pays et 18 fuseaux horaires.\n\nComment fonctionne cette équipe distribuée pour travailler et communiquer efficacement ? Quels outils et processus ont été mis en place au cours du temps ? Comment sont structurées les équipes, et comment est organisé le développement logiciel ? Quelles sont les valeurs communes que partagent les employés pour que ça fonctionne ? Comment créer du lien ? Comment s'opère le recrutement ?\n\nC'est ce que nous verrons à travers l'organisation et le fonctionnement de l'entreprise, et l'illustration du travail au quotidien d'un ingénieur de l'équipe Elastic Cloud. On verra quand utiliser les communications synchrones et asynchrones, la cohésion d'équipe à travers les revues de code, la nécessaire automatisation des processus, les \"all hands\" permettant de se retrouver physiquement, l'intégration des nouveaux arrivants, etc.",
+          "speakers": [
+            "205"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Methods & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=rrlPhedNjbA"
+        },
+        {
+          "title": "Il n'y a pas que Angular, React ou VueJS dans la vie",
+          "description": "Nous connaissons tous les frameworks/librairies à la mode : de Angular à React, en passant par le tout dernier VueJS. Mais devons-nous nous limiter à ces trois solutions ? \nDurant cette conférence, nous allons aborder plutôt les projets les moins connus, mais pas les moins intéressants, et qui pourraient être sources\nd'idées pour les grands du Web. De Inferno à Marko, en passant par Preact, nous allons enfin pouvoir connaitre les avantages et inconvénients de ces solutions\nalternatives.",
+          "speakers": [
+            "227"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=K8U6KDD_6sU"
+        },
+        {
+          "title": "Make load-balancing great again with Traefik!",
+          "description": "How to effectively manage inbound network traffic in your container based infrastructure? This talk will be a deep dive into Traefik, a modern reverse-proxy and load balancer made to deploy microservices with ease. You will learn how Traefik integrates with Docker, Kubernetes, Prometheus and a lot more!",
+          "speakers": [
+            "1142"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=qRatic6jBd4"
+        },
+        {
+          "title": "Comment être un développeur ethique et green ? Dilemne entre la course technologique et mon impact sur la société.",
+          "description": "Le logiciel est partout. Il est clair que le logiciel a un impact réel sur le monde : uberisation, digitalisation... mais stoppons ici la buzzwordisation... Nous, développeurs sommes les architectes du monde virtuel au service du réel. Nos actions ont un effet bien réel. Bénéfique mais aussi néfaste. \nExclusion sociale, impact environnemental, obsolescence sont des effets bien réel de nos logiciels. Mais avons nous le choix face au demandes de nos utilisateurs et clients et aux contraintes associées (planning, sécurité...)\nEt bien oui, c'est le choix qui est fait par de nombreuses sociétés et développeurs : bénévolat comme code for America, Eco-conception de logiciel publique... Etre développeur ethique et green est possibles, nous verrons concretement comme faire cela au jour le jour.",
+          "speakers": [
+            "1417"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Methods & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=AM-G43Zyqng"
+        },
+        {
+          "title": "Kubernetes et les containers pour votre application Web : step by step",
+          "description": "L'objectif de cette présentation est de montrer un cas concret d'utilisation de Kubernetes et des containers pour le déploiement d'une application Web écrite en Java.\n\nAprès un bref rappel sur les containers et une introduction aux concepts clés de Kubernetes, on suivra étape par étape le développement, la configuration et le déploiement d’une application Web en Java avec Kubernetes sur Google Container Engine. (connection base de donnée, load balanceur, mises à jour, montée en charge…)\n\nLa présentation sera accompagnée de tips et de retours d’expérience.",
+          "speakers": [
+            "236"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=UBkp48NXyW0"
+        },
+        {
+          "title": "Bonnes pratiques React en 15 diapos",
+          "description": "`React` n'est pas un framework, c'est juste une librairie. Elle fait très bien son boulot, mais dans un projet sérieux, il faut lui ajouter d'autres briques. Si certaines se sont imposées comme des standards (redux, react-router), sur d'autres domaines il reste beaucoup d'effervescence, signe que le sujet n'est pas encore mûr (css-in-js, GraphQL...).\n\nComment dans ces conditions mettre en place une pile technique pérenne et de bonnes pratiques sur son projet ? Ces choix importants conditionnent la vitalité du projet, son évolutivité et le plaisir qu'on aura à le créer, donc sa qualité.\n\nJe n'ai bien-sûr pas de réponse définitive à ces questions, mais je me propose de présenter les choix que j'ai faits ou évalués sur les différents projets sur lesquels j'ai travaillé. Ça ne peut être qu'indicatif, mais j'espère susciter la discussion si vous avez un autre point de vue, et pourquoi pas vous faire découvrir de nouvelles choses que vous n'aviez pas envisagées.\n\nPour rendre l'exercice ludique, j'aurais 15 diapos en 15 minutes, un thème par diapo.\n\n[Et pour garantir la qualité du contenu, je compte sonder la communauté React toulousaine et plus, pour recueillir les idées et les avis et partager le résultat.]",
+          "speakers": [
+            "207"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=8t7YdaigW9U"
+        },
+        {
+          "title": "WebAssembly ? Web et assembleur ? WTF !",
+          "description": "Petite présentation pour essayer de cerner ce qu'est cet OVNI dans l'univers des technos Web. Ce nouveau standard débarque dans les navigateurs et soulève pas mal de questions sur ses promesses (rapidité ! cible de compilation universelle !) et son positionnement par rapport aux autres technos, comme JavaScript que certains rêvent de voir disparaître (spoiler alert : non, WebAssembly n'a pas du tout vocation à remplacer JavaScript). Un peu d'histoire et de technique pour s'éclaircir les idées et pour voir comment on travaille avec cette techno émergente.",
+          "speakers": [
+            "2545"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=6nNTQOMb3H8"
+        },
+        {
+          "title": "Mixité dans le monde des Web Components",
+          "description": "Ah, les web components, quelle belle idée ! Un nouveau standard, du développement web basé enfin sur une vraie architecture en composants, de la réutilisation, de la modularisation, de l'encapsulation... Des choses que les développeurs backend ont depuis plus de trente ans enfin disponibles pour les développeurs web… La version 1.0 du standard étant enfin sortie, il est temps de voir si la réalité des Web Components est à la hauteur des promesses.\n \nDans ce talk on va essayer de répondre à une des questions qu'on nous pose le plus souvent quand nous parlons de web components : \"OK, le futur sera beau, mais aujourd'hui, si je fais des componsants avec une bibliothèque X et mon pote en fait avec une bibliothèque Y, je peux les utiliser dans la même application ? Et ils marcheront dans mon framework favori ?\" \n \nPour répondre a cette question, nous allons mettre à profit ces 45 minutes pour intégrer et faire parler des composants web dans un maximum de technologies. Car face à la tendance à se polariser avec des querelles de chapelles type Angular vs React vs Aurelia vs Polymer vs Meteor nous préférons le slogan Let's work hand in hand and move the web forward",
+          "speakers": [
+            "120",
+            "121"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=gAJh58ejuQc"
+        },
+        {
+          "title": "Demain j'arrête le café, je me met au crabe !",
+          "description": "Présentation du langage Rust et de son écosystème.\n\nLe but étant de faciliter le démarrage sur cette technologie pour des personnes utilisant des langages haut niveau comme Java. Dans cette présentation nous découvrirons: \n* Le Langage (3 piliers)\n    * Productivité : API fonctionnelle, pas de gestion manuelle de la mémoire, typage fort, inférence de type\n    * Performance : Compilation native avec LLVM, ∅GC, langage bas niveau\n    * Sûreté : sûreté de la mémoire, pas d’accès concurrent\n    * Features présentées (et animées !) :\n        * struct / trait / generics\n        * ownership / borrowing / lifetime\n        * memory guarantees : Box / Rc / Cell / Arc\n        * macro\n* L'Écosystème :\n    * IDE, tests, debugger, RLS (?)\n    * Build et packages manager (Cargo)\n    * Librairies phares (Iron, Mio, Nom, Piston)\n\nPuis nous terminerons sur une démo multi plateforme avec un backend tournant sur les différentes plateformes: Windows / Linux / ARM, puis un frontend en webassembly avec rust.",
+          "speakers": [
+            "2497",
+            "2498"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=AV-B0caPKMg"
+        },
+        {
+          "title": "Azure pour les développeurs",
+          "description": "Que l'on soit développeur web ou développeur mobile, la question du Cloud se pose. Est-ce fait pour moi ? Qu'est-ce que cela va m'apporter ? Quelques sont les différentes options ? Nous échangerons sur l'impact du Cloud et d'Azure en particulier pour le métier de développeur, les bénéfices et les dangers, histoire que personne ne passe à côté de cette révolution en marche.",
+          "speakers": [
+            "2548"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=RpFCq0KaWlE"
+        },
+        {
+          "title": "Elm, est-ce si bien qu'on le dit",
+          "description": "Elm est un language fonctionnel fortement typé qui compile vers JavaScript. Il offre une approche pure et immutable avec un compiler proposant des messages d'erreur extrêmement compréhensibles. Lorsque l'on lit des articles à son sujet sur internet, on peut voir des phrases fortes comme \"Aucune erreur au runtime\" ou \"Quand ça compile, ça marche\" ou encore \"Le compiler Elm est mon meilleur ami de pair-programming\".Après avoir utilisé ce language pendant plus d'un an en production, nous verrons si tout est si magique que cela et surtout, le cas échéant, quel est le prix à payer pour y parvenir. Nous aborderons également des points comme \"Quelle est la différence avec TypeScript ?\" ou \"Est-ce que cela marche aussi bien côté client que côté serveur ?\".",
+          "speakers": [
+            "119"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=BHTgiBGyY8U"
+        },
+        {
+          "title": "Stream processing avec Apache Flink",
+          "description": "Les données sont au coeur de nos applications, et sont créées de façon continue sous forme de flux (stream). L'architecture orientée flux (Streaming Architecture) permet de réduire la latence entre l'émission d'un évènement et les décisions à prendre en fonction des évènements passés et en cours, tout en gardant une architecture globale simple et efficace. Apache Flink est un framework permettant de créer des application orientées flux, avec:\n\nUne API en Java et Scala qui facilite l'analyse et le traitement des flux\nIntégration avec l'ecosystème Big Data : Kafka, YARN, HDFS, MapR-FS, HBase, MapR-* * Des fonctionnalités avancées: Complex Event Processing, Machne Learning et Gestion des Graphes de données. DB, Cascading, Elasticsearch)\nLe tout déployé de façon distribuée et hautement disponible.\n\nCette présentation est l'occasion de découvrir Flink, son coeur, ses APIs et l'approche \"streaming first\" pour vos applications.\n\nFlink est utilisé en production par de nombreuses entreprises: Bouygues Telecom, Netflix, Alibaba, Ericsson, King, Zalando, et bien d'autres, supporté par la société Data Artisans et une communauté de plus de 140 contributeurs.",
+          "speakers": [
+            "286"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Data"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=wdhKfBs_lvI"
+        },
+        {
+          "title": "A la découverte de Google Flutter et Fuchsia dans l’écosystème Dart",
+          "description": "[Flutter](https://flutter.io/) est un nouveau framework créé par Google dont l’objectif est de nous proposer une **nouvelle approche “cross-platform” de développement mobile**.\nEn utilisant une seule base de code écrite en **Dart**, on construit des **applications natives Android & iOS**.\n\n[Fuchsia](https://github.com/fuchsia-mirror) est le nom de code du nouveau système d’exploitation développé par Google. \nCet OS n’utilise pas le noyau Linux et Flutter est utilisé pour construire son interface graphique. \n\nCe talk vous propose d’aller à la découverte de ces 2 nouvelles technologies. Création de widget, navigation, gestion de plugins et plein d'autres astuces en Flutter vous seront présentées.",
+          "speakers": [
+            "351",
+            "352"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Mobile"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=TzO5dgm-AVE"
+        },
+        {
+          "title": "Déploiement automatique d'app iOS et/ou Android",
+          "description": "Pour tous dev mobile, que ce soit seul ou en équipe, le déploiement d'une app sur le store de Google ou d'Apple est un passage (quasi) obligatoire.\n\nAndroid et iOS sont différents jusque dans les IDE et les outils de build. Mais au delà de XCode, Android Studio, gradle... des libraries tels que fastlane vont tenter de réconcilier (un peu) les deux univers.\n\nNous allons voir comment intégrer la phase de publication dans le processus de build. Et cela via quelques lignes de script ou même directement dans les outils d'intégration continue tel que Jenkins.",
+          "speakers": [
+            "2652",
+            "2653"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Mobile"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=f7UD9nCXrS4"
+        },
+        {
+          "title": "L'UX a sauvé mon DevOps",
+          "description": "Elle s’appelle UX, lui s’appelle Devops.  \nIls sont amoureux mais sont au coeur de disputes entre deux familles rivales tels les Capulet et les Montaigu.  \nElle partage beaucoup de points communs avec lui :\n- Ils ne voient jamais un projet dans son intégralité.\n- Les deux sont des concepts émergeants des années 2010 au sein de l’IT.\n- Ils sont tous les deux au centre des équipes et servent de liant entre les développeurs. Mais malgré tout, tout les sépare !\nCependant, les choses ont changé et les meurs ont évolué.  \n  \nUn jour, alors que notre Devops tentait en vain de convaincre sa hiérarchie, de désespoir, il se tourna vers UX et pria pour son assistance. Ce qu’il vit alors l’enchanta et il compris … Ses faiblesses étaient ses forces et il pouvait lui apporter autant.  \nSon idéation était semblable à son automatisation.  \nQuand il lui parlait de Scale, elle comprenait même si ce n’était pas la même chose (analytics scale) et leurs objectifs étaient beaucoup trop semblables pour que ce soit une coincidence …  \n  \nVenez voir l’histoire d’amour la plus improbable des ces 10 dernières années !",
+          "speakers": [
+            "191",
+            "192"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Methods & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=Fewiev77RR8"
+        },
+        {
+          "title": "Faire du Machine Learning sans Data Scientist",
+          "description": "Le succès du machine learning passera par une démocratisation de son utilisation. Ceci ne pourra pas se faire si les techniques actuelles ne deviennent pas plus accessibles et que ces technologies restent une affaire de spécialistes.\nCette présentation issus de nombreux retour d'expériences expliquera comment il faut s'y prendre pour repenser le métier de son entreprise en s'appuyant sur du machine learning sans pour autant sombrer dans les difficultés théoriques.",
+          "speakers": [
+            "282"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Machine Learning"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=6oYA4tguYUs"
+        },
+        {
+          "title": "Balade au pays de «Let's Encrypt»",
+          "description": "*Let's Encrypt!* Le mot d'ordre est lancé. Ça semble tellement simple. Et pourtant l'arbre cache une forêt. Qu'est-ce qu'une signature numérique, un certificat, une chaîne ou une autorité de certification, une liste de révocation ? C'est à une balade à la découverte de ces concepts que je vous invite, avec pour destination la machinerie de *Let's Encrypt!*",
+          "speakers": [
+            "189"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=o8NYd55Sl2Y"
+        },
+        {
+          "title": "Libérée! Délivrée! ou Comment devenir développeuse open source ?",
+          "description": "On parle de diversité, un peu partout dans les communautés open source maintenant mais pour la plupart cela se résume à avoir un code of conduct. C’est loin d’être suffisant! Et si on regardait ce que l’on peut faire pour s’ouvrir aux gens de tous horizons ? Dans les entreprises ? Au sein des projets open source ? Et si vous veniez comprendre comment j’en suis arrivée à devenir développeuse de logiciels libres ? Ce talk est un retour d’expérience sur quand, pourquoi et comment je suis tombée dans l’open source. Et finalement pourquoi j’ai décidé de continuer dans cette voie.",
+          "speakers": [
+            "2742"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "WTF"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=mx1aX_69Atw"
+        },
+        {
+          "title": "ES2048",
+          "description": "On le sait tous, JavaScript est partout : De l'IoT au serveur en passant par votre téléviseur !\nDans toutes les conférences, on nous présente de nouvelles évolutions exceptées la face cachée de l'iceberg : la publication annuelle pour les révisions de JavaScript.\nCe langage avec lequel on peut tout faire repose sur un ensemble de normes concernant les langages de script et est standardisé.\nQuel organisme s'occupe de ça ?\nComment sont sélectionnées les nouvelles fonctionnalités ?\nQuelles sont celles qui nous attendent pour les versions à venir ?\nVenez découvrir tout cela avec nous dans ce quickie.",
+          "speakers": [
+            "819"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=YAFRxqz8lrU"
+        },
+        {
+          "title": "Les lois de la physique classique s'appliquent aussi au Big Data !",
+          "description": "La révolution de l'électronique initiée à la fin de la seconde guerre mondiale est le principal vecteur de la révolution numérique que nous vivons aujourd'hui. Ceci n'a été rendu possible que grâce à l'étude & la compréhension des phénomènes naturels : la \"physique\". L'objectif de ce talk est donc d'expliciter les interactions possibles/envisageables dans le système  Big Data. Nous en ressortirons alors un ensemble de recommandations pour la définition d'une architecture Big Data suivant les lois fondamentales de la physique.",
+          "speakers": [
+            "2805"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Data"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=0lLf51o4a_o"
+        },
+        {
+          "title": "Et après Développeur, chef de projet ?",
+          "description": "Aujourd'hui, le parcours de carrière d'un développeur manque de modèles et d'idéaux. La réponse la plus courante reste \"Chef de Projet\" et pourtant, ce n'est pas ce qui fait rêver la majorité des développeurs :/\n\nJeChercheUnDev.fr a accompagné plus de 1000 développeurs dans leurs changements de carrière. Voici ce que nous avons appris.",
+          "speakers": [
+            "840"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "WTF"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=JRXUgIwcPlw"
+        },
+        {
+          "title": "Apéro fonctionnel",
+          "description": "Un jour, 4 devs un peu barés 🙋🐼🐥🦁 (attention les rôles peuvent changer au dernier moment 😜) un entrepreneur plein d'humour 🐨 (qui comprend le geek)  se retrouvent à une terrasse de café\n\n- 🙋 : N'empêche que le nom \"Scalafistes\" ça vous va super bien!  `#trollinside`\n- 🐼 : Non. 🙋, tu prends des raccourcis ...\n- 🐥 : Ah moi j'aime bien aussi, je revendique même!  Je suis un Scalafiste de l'extrême, et Play vaincra!!!\n- - 🐼 : depuis quand 🐥 tu fais du Scala? ...\n- 🦁 : Là, mecs,  vous \"vendez\" une vision totalement réductrice du paysage fonctionnel, Il n'y a pas que Scala dans la vie, prend Haskell et la beauté des théories mathématiques associées, l'intelligence du système de types de Rust qui te propose des monades Option en retour de fonction, le ...\n- 🐼 : Vous me faites marrer avec vos types, si tu sais coder, tu peux faire du fonctionnel en JavaScript `#trollinside` `#oupas`\n- 🐥 : MDR 🐼, je suis sûr que avec ton Node tu feras que de la 💩\n- 🐨 : `#defi` est-ce que vous vous croyez capables de m'expliquer ces concepts en termes simples?\n- 🙋 : Oh oui 🐨, dessine nous une monade!\n- 🐥 : Quelqu'un reprend un 🍷?\n- 🙋🐼🐥🐨🦁 👍",
+          "speakers": [
+            "1772",
+            "1773",
+            "1136",
+            "Alain Regnier",
+            "Charlotte Cavalier"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "WTF"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=o4ueMzhro1o"
+        },
+        {
+          "title": "Big Data avec AWS : notre retour d'expérience sur l'utilisation des services managés",
+          "description": "A partir d'une application concrète dans le monde de l'automobile (voitures connectées), cette présentation illustrera l'architecture AWS mise en place pour y répondre. \nNotre approche consiste à collecter et traiter les données des véhicules, en considérant à la fois une approche streaming et une approche batch.\nL'architecture mise en place comprend les services managés suivants:\n- IoT\n- Lambda\n- Kinesis Stream\n- Kinesis Firehose\n- Elastic Map Reduce (EMR)\n- Elastic Search Service (ESS)\n- S3\n- Cloudwatch \n\nPour chacun des services nous présenterons les avantages et les inconvénients rencontrés dans notre cas.",
+          "speakers": [
+            "2691",
+            "2692",
+            "2693"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=4dd-K_fkUx4"
+        },
+        {
+          "title": "Ici votre commandant de bord, on passe en mode avion !",
+          "description": "Vous vous demandez comment améliorer l'expérience de vos utilisateurs web ? Et pourquoi ne pas leur permettre de lancer et d'interagir avec votre application web même lorsqu'il n'y a pas de réseau?\n\nNous verrons comment mettre en place une stratégie offline-first totale en utilisant des nouvelles APIs comme le **service worker**, **background-sync**, la **cache API** et **indexDB**.",
+          "speakers": [
+            "255"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=zzLZSM_pOIE"
+        },
+        {
+          "title": "Interprétabilité des modèles de Machine Learning avec LIME",
+          "description": "**Introduction pratique à LIME** (Local Interpretable Model-Agnostic Explanations), un pas supplémentaire vers l'interprétabilité des modèles de Machine Learning.\n___\nL'utilisation de modèles de Machine Learning (ML) dans la résolution d'une grande variété de problèmes est de plus en plus populaire. Ces modèles mathématiques sont pour certains (comme les régressions linéaires ou bien les arbres de décisions) facilement interprétables. Cependant, les modèles ML à la pointe de la technologie, permettant de répondre à des problèmes complexes, comme les réseaux de neurones profonds, sont de facto des boîtes noires, au fonctionnement interne inaccessible. Cela soulève une question primordiale : puis-je avoir confiance dans les résultats donnés par mon modèle ?\n\nEn prenant l'exemple concret d'un algorithme de classification d'images utilisant un réseau de neurones, nous introduirons LIME une technique novatrice permettant de visualiser les caractéristiques de l'image qui ont permis au modèle de prendre sa décision.",
+          "speakers": [
+            "2823",
+            "2824"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Machine Learning"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=PHMR6j8DvKk"
+        }
+      ]
+    },
+    "2018": {
+      "date": "2018-11-08",
+      "venue": "Centre de Congrès Pierre Baudis",
+      "speakers": [
+        {
+          "name": "Laurent Victorino",
+          "company": "Monkey Moon",
+          "city": "",
+          "bio": "Pas très bon en jeux vidéo Laurent préfère les créer pour se donner une bonne raison de ne pas y jouer. Programmeur moyen mais sympa, Laurent est à la tête de Monkey Moon, un studio de jeux vidéo basé à Lyon qui développe actuellement Night Call, un jeu qui se passe à Paris, parce que Laurent aime les paradoxes. Speaker internationalement reconnu pour sa keynote « 400 vannes sur le Java en moins de 20 minutes », Laurent aime les conférences IT et Web pour les rencontres, les échanges, et la nourriture gratuite. Laurent a vraiment du mal à parler de lui à la troisième personne.",
+          "photoUrl": "/images/speakers/laurent_victorino.jpg",
+          "socials": [
+            {
+              "name": "@on_code",
+              "link": "https://twitter.com/on_code"
+            },
+            {
+              "name": "lvictorino",
+              "link": "https://github.com/lvictorino"
+            }
+          ]
+        },
+        {
+          "name": "Quentin Adam",
+          "company": "Clever Cloud",
+          "city": "",
+          "bio": "Quentin is the CEO of Clever Cloud : a Platform as a Service company allowing you to run java, scala, ruby, node.js, php, python or go applications, with auto scaling and auto healing features. This position allow him to study lots of applications, code, practice, and extract some talks and advises. Regular speaker at various tech conference, he’s focused to help developers to deliver quickly and happily good applications.",
+          "photoUrl": "/images/speakers/quentin_adam.jpg",
+          "socials": [
+            {
+              "name": "@waxzce",
+              "link": "https://twitter.com/waxzce"
+            },
+            {
+              "name": "waxzce",
+              "link": "https://github.com/waxzce"
+            }
+          ]
+        },
+        {
+          "name": "Raúl Jiménez",
+          "company": "Google Developer Expert",
+          "city": "",
+          "bio": "Raul is a software engineer passionate about JS frameworks, web technologies and cross-platform development. Since 2012 he's focused in Angular, HTML5 video and his open source project Videogular. Raul works as CEO of Byte Default, an Angular consultancy company for companies around the world helping them to build high-performance web apps. In his spare time he's usually involved in local meetups, writing blog posts, speaking at conferences and contributing to open source projects. He lives in Barcelona and is happy by default :)",
+          "photoUrl": "/images/speakers/raul_jimenez.png",
+          "socials": [
+            {
+              "name": "@elecash",
+              "link": "https://twitter.com/elecash"
+            },
+            {
+              "name": "elecash",
+              "link": "https://github.com/elecash"
+            }
+          ]
+        },
+        {
+          "name": "Estelle Landry",
+          "company": "Elium",
+          "city": "",
+          "bio": "Product Owner and UX Designer apprentice at @elium_tech , Former Project Manager , Proud to be member of @DuchessFR, @Flupa and @sunnytech_mtp",
+          "photoUrl": "/images/speakers/estelle_landry.jpg",
+          "socials": [
+            {
+              "name": "@estelandry",
+              "link": "https://twitter.com/estelandry"
+            }
+          ]
+        },
+        {
+          "name": "Laurent Wroblewski",
+          "company": "Davidson Consulting",
+          "city": "",
+          "bio": "Laurent Wroblewski, ingénieur développement full stack depuis maintenant près de 9 ans, passionné par les technologies web/mobile. Récent expatrié lillois, qui revient à domicile à la recherche de bières convenables et de bon échanges techniques (l'un n'excluant pas l'autre ;)). J'aime partager autour du JS et de ses principales stars du moment, comme Angular et React, et du riche écosystème qui gravite autour. Mais le mobile n'est pas en reste non plus, que ce soient le natif (Kotlin4ever), les solutions hybrides ou les PWAs.",
+          "photoUrl": "/images/speakers/laurent_wroblewski.jpg",
+          "socials": [
+            {
+              "name": "@LaurentWrob",
+              "link": "https://twitter.com/@LaurentWrob"
+            },
+            {
+              "name": "LWroblewski",
+              "link": "https://github.com/LWroblewski"
+            }
+          ]
+        },
+        {
+          "name": "Hubert Sablonnière",
+          "company": "Clever Cloud",
+          "city": "",
+          "bio": "Hubert est passionné par le Web. Il est toujours à la recherche de nouvelles idées et autres bidouilles pour améliorer l'expérience des utilisateurs et des développeurs.",
+          "photoUrl": "/images/speakers/hubert_sablonniere.jpg",
+          "socials": [
+            {
+              "name": "@hsablonniere",
+              "link": "https://twitter.com/hsablonniere"
+            },
+            {
+              "name": "hsablonniere",
+              "link": "https://github.com/hsablonniere"
+            }
+          ]
+        },
+        {
+          "name": "David Gageot",
+          "company": "Google",
+          "city": "",
+          "bio": "David est Developer Advocate chez Google Cloud. Il travaille sur les Containers Tools. Auparavant, il a participé à l'ouverture du bureau de R&D de Docker, à Paris.",
+          "photoUrl": "/images/speakers/david_gageot.jpg",
+          "socials": [
+            {
+              "name": "@dgageot",
+              "link": "https://twitter.com/dgageot"
+            },
+            {
+              "name": "dgageot",
+              "link": "https://github.com/dgageot"
+            }
+          ]
+        },
+        {
+          "name": "Sylvain Wallez",
+          "company": "Elastic",
+          "city": "",
+          "bio": "Architecte et développeur passionné, tech lead dans l'équipe Cloud chez Elastic. A travaillé comme architecte, CTO et leader technique dans plusieurs startups. Expert technique multi-compétences : systèmes scalables, NoSQL, moteurs de recherche, mais aussi front-end, devops et Iot. Bref, full-stack. Membre de la fondation Apache.",
+          "photoUrl": "/images/speakers/sylvain_wallez.png",
+          "socials": [
+            {
+              "name": "@bluxte",
+              "link": "https://twitter.com/bluxte"
+            },
+            {
+              "name": "swallez",
+              "link": "https://github.com/swallez"
+            }
+          ]
+        },
+        {
+          "name": "Philippe Charrière",
+          "company": "CleverCloud",
+          "city": "",
+          "bio": "currently: 🇪🇺 TAM @GitLab 🦊 + deploying apps as CSO @clever_cloud 💡☁️ + core committer @golo_lang + raising 🤖 @BotsGarden, previously: SE @github",
+          "photoUrl": "/images/speakers/philippe_charriere.jpg",
+          "socials": [
+            {
+              "name": "@k33g_org",
+              "link": "https://twitter.com/k33g_org"
+            },
+            {
+              "name": "k33g",
+              "link": "https://github.com/k33g"
+            }
+          ]
+        },
+        {
+          "name": "Horacio Gonzalez",
+          "company": "OVH",
+          "city": "",
+          "bio": "Malgré ce que son accent espagnol bien prononcé peut suggérer, Horacio est arrivé en France il y a une quinzaine d'années déjà. Passionné d'informatique, dans laquelle il est tombé depuis tout petit, il a découvert Java en 1997 et depuis il n'a pas arrêté de bosser autour. Après quelques années comme tech leader de la partie frontend de @warp10io chez Cityzen Data, Horacio a rejoint OVH en janvier 2018 en tant que Developer Advocate. Il est aussi leader et cofondateur du FinistDevs et du GDG Finistère, le GDG francophone le plus proche de la Silicon Valley. Passionné par le développement web et tout ce qui gravite autour des composants web, Horacio est Google Developer Expert (GDE) en Web Technologies et Polymer.",
+          "photoUrl": "/images/speakers/horacio_gonzalez.jpg",
+          "socials": [
+            {
+              "name": "@LostInBrittany",
+              "link": "https://twitter.com/LostInBrittany"
+            },
+            {
+              "name": "LostInBrittany",
+              "link": "https://github.com/LostInBrittany"
+            }
+          ]
+        },
+        {
+          "name": "Ane Diaz De Tuesta",
+          "company": "Lectra",
+          "city": "",
+          "bio": "Je suis une personne dynamique, curieuse et sociable. Je travaille en tant que développeuse depuis 2012, après avoir obtenu mon diplôme d’ingénieur espagnol et ensuite le français. \nActuellement je travaille chez Lectra comme développeuse FrontEnd et je suis Scrum Master. Je suis passionnée par mon travail qui me rend heureuse.",
+          "photoUrl": "/images/speakers/ane_diaz_de_tuesta.jpg",
+          "socials": [
+            {
+              "name": "@ane_naiz",
+              "link": "https://twitter.com/ane_naiz"
+            },
+            {
+              "name": "anediaz",
+              "link": "https://github.com/anediaz"
+            },
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/ane-diaz-de-tuesta-37785252, http://anediaz.com/"
+            }
+          ]
+        },
+        {
+          "name": "Nicolas Comet",
+          "company": "Lectra",
+          "city": "",
+          "bio": "​\nDéveloppeur passionné, Speaker, grand curieux, j'aime apprendre en permanence. Je ne m'attache pas à une technologie en particulier, même si je gravite plus souvent du côté Java / JavaEE. J'aime les principes fondateurs du TDD. Je porte également un grand intérêt pour la synergie entre DDD et documentation vivante ou \"Living Documentation\". \n\nJe suis actuellement ingénieur d'études R&D chez Lectra, numéro un mondial des solutions dédiées à l'industrie textile (logiciels & machines).",
+          "photoUrl": "/images/speakers/comet_nicolas.jpg",
+          "socials": [
+            {
+              "name": "@NicolasComet",
+              "link": "https://twitter.com/NicolasComet"
+            },
+            {
+              "name": "ncomet",
+              "link": "https://github.com/ncomet"
+            },
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/nicolascomet/"
+            }
+          ]
+        },
+        {
+          "name": "Benoit Prioux",
+          "company": "Lectra",
+          "city": "",
+          "bio": "Je suis Technical Leader au centre R&D de Lectra, éditeur de logiciel dans le monde de la mode, à Bordeaux. Je suis un développeur Java depuis 2005, et membre du bureau du Bordeaux JUG. Impliqué dans le projet open-source Asciidoctor, je suis aussi passionné par tout ce qui finit en DD : TDD, BDD, DDD, ...",
+          "photoUrl": "/images/speakers/benoit_prioux.png",
+          "socials": [
+            {
+              "name": "@binout",
+              "link": "https://twitter.com/binout"
+            },
+            {
+              "name": "binout",
+              "link": "https://github.com/binout"
+            }
+          ]
+        },
+        {
+          "name": "Céline Louvet",
+          "company": "Fairvioo",
+          "city": "",
+          "bio": "CTO & cofondatrice de Fairvioo et développeuse au quotidien",
+          "photoUrl": "/images/speakers/celine_louvet.jpg",
+          "socials": [
+            {
+              "name": "@celine_louvet",
+              "link": "https://twitter.com/celine_louvet"
+            },
+            {
+              "name": "celinelouvet",
+              "link": "https://github.com/celinelouvet"
+            },
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/celinelouvet/"
+            }
+          ]
+        },
+        {
+          "name": "Frédéric Cabestre",
+          "company": "Easy Mile",
+          "city": "",
+          "bio": "Développeur, tendance «software craftman». Depuis longtemps attiré par les langages et leur mise en œuvre. Grand amateur de programmation fonctionnelle, même quand ce n'était pas encore cool. Curieux des systèmes, surtout s'ils sont distribués.",
+          "photoUrl": "/images/speakers/frederic_cabestre.png",
+          "socials": [
+            {
+              "name": "@fcabestre",
+              "link": "https://twitter.com/fcabestre"
+            },
+            {
+              "name": "fcabestre",
+              "link": "https://github.com/fcabestre"
+            }
+          ]
+        },
+        {
+          "name": "Arnaud Bos",
+          "company": "MonkeyPatch",
+          "city": "",
+          "bio": "Amateur de hamacs et de '(parenthèses). Du développement mobile au back-end, je suis revenu à mes premiers amours, les systèmes distribués, au fil des projets. Avec ma casquette de data engineer sur la tête, je me concentre sur le développement de (micro?)services et me passionne pour langages de programmation et les architectures distribuées.",
+          "photoUrl": "/images/speakers/arnaud_bos.jpg",
+          "socials": [
+            {
+              "name": "@arnaud_bos",
+              "link": "https://twitter.com/arnaud_bos"
+            },
+            {
+              "name": "arnaudbos",
+              "link": "https://github.com/arnaudbos"
+            }
+          ]
+        },
+        {
+          "name": "Julien Topçu",
+          "company": "Société Générale & OWASP fundation",
+          "city": "",
+          "bio": "Senior Lead Developer à la Société Générale, je suis un fervent défenseur du Software Craftsmanship.\n\nJ'évangélise activement autour de DDD/Hexagonal Architecture, l'XP et le Kanban #NoEstimates au sein de cours et de [meetups](https://www.youtube.com/watch?v=P0_M00X4Xlw/)  ainsi qu'à travers d'articles de [blog](https://beyondxscratch.wordpress.com/).\n\nMembre de la fondation OWASP, je m'efforce de transmettre à la communauté une philosophie DevSecOps que je pense être l'avenir du métier de développeur. J'ai participé à la mise en place de pipeline de Continuous Security à l'échelles d'entreprises.",
+          "photoUrl": "/images/speakers/julien_topcu.jpeg",
+          "socials": [
+            {
+              "name": "@JulienTopcu",
+              "link": "https://twitter.com/JulienTopcu"
+            },
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/julien-top%C3%A7u/, https://beyondxscratch.wordpress.com/"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Membré",
+          "company": "Zenika",
+          "city": "",
+          "bio": "Geek à toute heure, je travaille principalement autour des technologies Java/JavaEE mais aussi sur des problématiques de déploiement continu, de qualimétrie. Désormais, je partage son expérience pour faciliter la mise en place de démarche devops chez différents acteurs. J'adore bidouiller des RaspberryPi ou Arduino pour créer des choses inutiles donc indispensables.\nLorsque le temps le permet, je décris mes aventures sur mon [site web](https://www.geekeries.fun).",
+          "photoUrl": "/images/speakers/guillaume_membre.jpg",
+          "socials": [
+            {
+              "name": "@GuillaumeMembre",
+              "link": "https://twitter.com/GuillaumeMembre"
+            },
+            {
+              "name": "gmembre-zenika",
+              "link": "https://github.com/gmembre-zenika"
+            }
+          ]
+        },
+        {
+          "name": "Robert Firek",
+          "company": "Codurance",
+          "city": "",
+          "bio": "Robert Firek is a software craftsman who has tasted many different flavours of programming. His broad range of experiences has helped to deliver quality software in many companies and organisations. He strives to create software according to the rule \"Simplicity is the final achievement\". He is trying to unite worlds of the software development and the infrastructure delivery by promoting the DevOps culture.",
+          "photoUrl": "/images/speakers/robert_firek.jpg",
+          "socials": [
+            {
+              "name": "@RobertFirek",
+              "link": "https://twitter.com/RobertFirek"
+            },
+            {
+              "name": "robertfirek",
+              "link": "https://github.com/robertfirek"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Laforge",
+          "company": "Google",
+          "city": "",
+          "bio": "Le jour, Guillaume Laforge est Developer Advocate chez Google, sur les solutions cloud, et de nuit, il reprends sa casquette de contributeur au projet Apache Groovy. Guillaume est également un des membres du podcast Les Cast Codeurs",
+          "photoUrl": "/images/speakers/guillaume_laforge.jpeg",
+          "socials": [
+            {
+              "name": "@glaforge",
+              "link": "https://twitter.com/glaforge"
+            },
+            {
+              "name": "glaforge",
+              "link": "https://github.com/glaforge"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Leplus",
+          "company": "Botfuel",
+          "city": "",
+          "bio": "My day to day my mission is to help developers create successful and quality apps.\nAs a passionate web developer, I am always discovering and playing with new web technologies !",
+          "photoUrl": "/images/speakers/olivier_leplus.jpg",
+          "socials": [
+            {
+              "name": "@olivierleplus",
+              "link": "https://twitter.com/olivierleplus"
+            },
+            {
+              "name": "tagazok",
+              "link": "https://github.com/tagazok"
+            },
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/olivierleplus/, https://tagazok.github.io/"
+            }
+          ]
+        },
+        {
+          "name": "Tiffany Souterre",
+          "company": "JEMS Datafactory",
+          "city": "",
+          "bio": "I love science and I love data! After finishing a Ph.D. in genetic engineering, I continued my quest for discovering new patterns through data science and machine learning. I currently work as a Big Data engineer and I play with machine learning algorithms on my free time. Someday, I wish to leverage data exploration to improve people's life.",
+          "photoUrl": "/images/speakers/tiffany_souterre.jpg",
+          "socials": [
+            {
+              "name": "@tiffanysouterre",
+              "link": "https://twitter.com/tiffanysouterre"
+            },
+            {
+              "name": "Amagash",
+              "link": "https://github.com/Amagash"
+            }
+          ]
+        },
+        {
+          "name": "Benoit El Amrani",
+          "company": "Informatique Banque Populaire",
+          "city": "",
+          "bio": "Passionné par le monde du web, je suis en veille constante pour trouver des nouvelles idées permettant d'améliorer à la fois le quotidien des développeurs et les applications sur lesquelles je travaille.",
+          "photoUrl": "/images/speakers/benoit_el_amrani.jpg",
+          "socials": [
+            {
+              "name": "@bentah31",
+              "link": "https://twitter.com/bentah31"
+            },
+            {
+              "name": "belamrani",
+              "link": "https://github.com/belamrani"
+            }
+          ]
+        },
+        {
+          "name": "Tugdual Grall",
+          "company": "MapR",
+          "city": "",
+          "bio": "Tugdual Grall\tBio: Tugdual Grall, est Chief Technical Evangelist EMEA chez MapR. Il travaille avec les clients et les communautés de développeurs européennes, pour faciliter l’adoption de MapR, Hadoop et NoSQL. \n\nAvant de travailler chez MapR, “Tug”, était Technical Evangelist chez MongoDB et Couchbase. Tug a travaillé comme CTO chez eXo Platform, et comme Product Manager et Développeur sur la platform Java/JavaEE d’Oracle.\n\nTugdual est également co-fondateur du Nantes JUG (Java Users Group) qui réunit tous les mois depuis 2008 les développeurs et architectes de la région nantaise.",
+          "photoUrl": "/images/speakers/tugdual_grall.jpg",
+          "socials": [
+            {
+              "name": "@tgrall",
+              "link": "https://twitter.com/tgrall"
+            },
+            {
+              "name": "tgrall",
+              "link": "https://github.com/tgrall"
+            }
+          ]
+        },
+        {
+          "name": "David Pilato",
+          "company": "elastic",
+          "city": "",
+          "bio": "Depuis 2013, David Pilato est développeur et évangéliste chez elastic.co, après avoir passé les deux années précédentes à promouvoir le projet open-source Elasticsearch. Il en anime la communauté française.",
+          "photoUrl": "/images/speakers/david_pilato.jpg",
+          "socials": [
+            {
+              "name": "@dadoonet",
+              "link": "https://twitter.com/dadoonet"
+            },
+            {
+              "name": "dadoonet",
+              "link": "https://github.com/dadoonet"
+            }
+          ]
+        },
+        {
+          "name": "Francois Teychene",
+          "company": "Saagie",
+          "city": "",
+          "bio": "Cloud Developper @ Saagie , meetup addict & organiser @ Montpellier et Organisateur SunnyTech.  \nDéveloppeur couteau suisse pouvant intervenir du Javascript à la table de routage. Mes passions actuelles sont le Rust, le DevOps et le Scala en plus de vouloir mettre des conteneurs partout.",
+          "photoUrl": "/images/speakers/francois_teychene.jpg",
+          "socials": [
+            {
+              "name": "@fteychene",
+              "link": "https://twitter.com/fteychene"
+            },
+            {
+              "name": "fteychene",
+              "link": "https://github.com/fteychene"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Flebus",
+          "company": "Continental Digital Services France",
+          "city": "",
+          "bio": "Enterprise Architect, #Agile enthusiast. Leading #BigData @Continental Digital Services France. Building a #Cloud platform for #ConnectedCars.",
+          "photoUrl": "/images/speakers/olivier_flebus.jpg",
+          "socials": [
+            {
+              "name": "@olivierflebus",
+              "link": "https://twitter.com/olivierflebus"
+            },
+            {
+              "name": "LinkedIn",
+              "link": "https://www.linkedin.com/in/olivierflebus"
+            }
+          ]
+        },
+        {
+          "name": "Alexandre Delattre",
+          "company": "MonkeyPatch",
+          "city": "",
+          "bio": "Ingénieur logiciel Fullstack à MonkeyPatch\n\n32 ans et fort de 7 ans d'expérience dans le développement logiciel, mon parcours, auprès de startups et de grands groupes m'a permis de m'approprier une large gamme de technos fullstack:\n\n- Mobile : Android (Kotlin), iOS (Swift), Ionic \n- Backend : Java, Scala, NodeJS\n- Web : Typescript / Angular 1 & 2\n\nJe suis passioné par la mobilité, la qualité et l'innovation logicielle, l'UX et l'entrepreunariat digital.",
+          "photoUrl": "/images/speakers/alexandre_delattre.jpg",
+          "socials": [
+            {
+              "name": "@alexandre_del31",
+              "link": "https://twitter.com/alexandre_del31"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Andrieu",
+          "company": "MonkeyPatch",
+          "city": "",
+          "bio": "FP enthusiast",
+          "photoUrl": "/images/speakers/guillaume_andrieu.jpg",
+          "socials": [
+            {
+              "name": "@glmxndr",
+              "link": "https://twitter.com/glmxndr"
+            }
+          ]
+        },
+        {
+          "name": "Sébastien Guilloux",
+          "company": "Elastic",
+          "city": "",
+          "bio": "Cloud Engineer chez Elastic. J'ai un petit faible pour les systèmes distribués, pour le fun et les challenges qu'ils nous apportent ! Auparavant j'ai travaillé chez OVH, en tant que développeur sur plusieurs services (Kafka, Kubernetes, Serverless Functions).\nAh, j'ai une légère tendance à faire des jeux de mots, aussi :)",
+          "photoUrl": "/images/speakers/sebastien_guilloux.jpg",
+          "socials": [
+            {
+              "name": "@_sebgl",
+              "link": "https://twitter.com/_sebgl"
+            },
+            {
+              "name": "sebgl",
+              "link": "https://github.com/sebgl"
+            }
+          ]
+        },
+        {
+          "name": "Nicolas Decoster",
+          "company": "Magellium",
+          "city": "",
+          "bio": "Informaticien curieux depuis 35 ans, de métier depuis 20 ans (principalement dans le spatial). Non spécialiste touche à tout : du développement logiciel à l'étude scientifique, du développement d'algorithmes de traitement à la mise en œuvre de systèmes, de la programmation en C++ ou Python à l'utilisation des technos Web, de la petite appli en ligne de commande aux IHM ou aux systèmes distribués. Ingénieur chez Magellium et co-fondateur et animateur à la Compagnie du Code.",
+          "photoUrl": "/images/speakers/nicolas_decoster.jpg",
+          "socials": [
+            {
+              "name": "@nnodot",
+              "link": "https://twitter.com/nnodot"
+            }
+          ]
+        },
+        {
+          "name": "Juliane Blier",
+          "company": "SchoolMouv",
+          "city": "",
+          "bio": "Développeuse Web, Amoureuse de Vuejs, Node et PHP, Curieuse de nouvelles découvertes",
+          "photoUrl": "/images/speakers/juliane_blier.jpg",
+          "socials": [
+            {
+              "name": "@tactless7",
+              "link": "https://twitter.com/tactless7"
+            },
+            {
+              "name": "Tactless7",
+              "link": "https://github.com/Tactless7"
+            }
+          ]
+        },
+        {
+          "name": "Miro Cupak",
+          "company": "DNAstack",
+          "city": "",
+          "bio": "Miro is a VP of Engineering at DNAstack, where he builds a leading genomics cloud platform. He is a Java enthusiast with expertise in distributed systems and middleware, passionate about genetics and making meaningful software. Miro is the creator of the largest search and discovery engine of human genetic data, and the author of a book on parallelization of genomic queries. In his spare time, he blogs and contributes to several open-source projects.",
+          "photoUrl": "/images/speakers/miro_miro_cupak.jpg",
+          "socials": [
+            {
+              "name": "@mirocupak",
+              "link": "https://twitter.com/mirocupak"
+            },
+            {
+              "name": "mcupak",
+              "link": "https://github.com/mcupak"
+            },
+            {
+              "name": "LinkedIn",
+              "link": "https://mirocupak.com, https://www.linkedin.com/in/mirocupak"
+            }
+          ]
+        },
+        {
+          "name": "Emmanuel Demey",
+          "company": "Zenika",
+          "city": "",
+          "bio": "Directeur technique chez Zenika Lille et Google Developer Expert, je suis spécialisé dans AngularJS / Angular / TypeScript et l'Accessibilité Web. Speaker à ses heures perdues. Aime également les bières (et oui quand on vient de Lille c'est normal...), le Jazz et la Domotique. Plusieurs expériences en tant que conférencier, notamment depuis septembre 2015 autour du sujet Angular2. - ESLint au Jug Summer Camp et ChtiJS - Angular 2 : ChtiJUG, LyonJS, GDG Paris, GDG Nantes, Meetup AngularJS Grenoble, Devoxx, RivieraDev, Bdx.io, DevFest Nantes, Codeurs en Seine",
+          "photoUrl": "/images/speakers/emmanuel_demey.jpg",
+          "socials": [
+            {
+              "name": "@EmmanuelDemey",
+              "link": "https://twitter.com/EmmanuelDemey"
+            },
+            {
+              "name": "Gillespie59",
+              "link": "https://github.com/Gillespie59"
+            }
+          ]
+        },
+        {
+          "name": "Jean-francois Garreau",
+          "company": "Sfeir",
+          "city": "",
+          "bio": "En dehors du travail, je suis co-fondateur du GDG Nantes, organisateur du DevFest Nantes, co-créateur des Nantes Wit et organisateur de Devoxx4Kids",
+          "photoUrl": "/images/speakers/jean-francois_garreau.jpg",
+          "socials": [
+            {
+              "name": "@jefBinomed",
+              "link": "https://twitter.com/jefBinomed"
+            },
+            {
+              "name": "jefBinomed",
+              "link": "https://github.com/jefBinomed"
+            }
+          ]
+        },
+        {
+          "name": "Anastasia Lieva",
+          "company": "Comwatt",
+          "city": "",
+          "bio": "Fuzzy Humanist, Data Science Witch, The Lambda Wisperer",
+          "photoUrl": "/images/speakers/anastasia_lieva.jpg",
+          "socials": [
+            {
+              "name": "@lievAnastazia",
+              "link": "https://twitter.com/lievAnastazia"
+            }
+          ]
+        },
+        {
+          "name": "Victor Kropp",
+          "company": "JetBrains",
+          "city": "",
+          "bio": "Victor Kropp is a Software Engineer at JetBrains, where he has contributed to many projects including ReSharper, dotCover, Hub and Toolbox App. His interests include modern programming languages, practices and tools, and cross-platform development. In his free time, he runs marathons and long distance triathlons or travels with his family.",
+          "photoUrl": "/images/speakers/victor_kropp.jpg",
+          "socials": [
+            {
+              "name": "@kropp",
+              "link": "https://twitter.com/kropp"
+            },
+            {
+              "name": "kropp",
+              "link": "https://github.com/kropp"
+            }
+          ]
+        },
+        {
+          "name": "Giulia Bianchi",
+          "company": "Xebia",
+          "city": "",
+          "bio": "Giulia est Data Scientist de plus de 4 ans d’expérience, elle est consultante à Xebia depuis deux ans et demi. \nElle travaille actuellement sur des volumes de données importants en mettant en place des algorithmes de Machine Learning, avec un objectif concret d’industrialisation. \nEn 2018 elle a organisé la première édition du [DataXDay](https://dataxday.fr/).\nElle suit les nouvelles tendances du monde de la Data en participant aux différents Meetups et en suivant des blogs. Elle contribue activement à cet écosystème en donnant des [talks](https://www.youtube.com/watch?v=N-LXrheCIKM) et en écrivant sur le [blog Xebia](https://blog.xebia.fr/author/gbianchi/).",
+          "photoUrl": "/images/speakers/giulia_bianchi.jpg",
+          "socials": [
+            {
+              "name": "@Giuliabianchl",
+              "link": "https://twitter.com/Giuliabianchl"
+            },
+            {
+              "name": "giulbia",
+              "link": "https://github.com/giulbia"
+            }
+          ]
+        },
+        {
+          "name": "Piotr Przybyl",
+          "company": "Remote Freelance Software Gardener",
+          "city": "",
+          "bio": "Notorious engineer at work and after hours, tracing meanders of the art of software engineering. Software Gardener, mostly working in web-oriented Java gardens. Fan of agility, seen mostly as choosing the right tools and approaches. Lead developer, trainer and conference speaker.",
+          "photoUrl": "/images/speakers/piotr_przybyl.jpg",
+          "socials": [
+            {
+              "name": "@piotrprz",
+              "link": "https://twitter.com/piotrprz"
+            }
+          ]
+        },
+        {
+          "name": "Alessio Coltellacci",
+          "company": "Clever Cloud",
+          "city": "",
+          "bio": "Développeur système chez Clever Cloud, je développe des applications low level en Rust, C, C++. Le reste du temps je m'amuse avec les features low level du kernel: ebpf, XDP socket, Intel SGX ... et Infographiste 3d sur mon free time depuis +7ans.",
+          "photoUrl": "/images/speakers/alessio_coltellacci.jpg",
+          "socials": [
+            {
+              "name": "@lightplay8",
+              "link": "https://twitter.com/lightplay8"
+            },
+            {
+              "name": "NotBad4U",
+              "link": "https://github.com/NotBad4U"
+            }
+          ]
+        },
+        {
+          "name": "Mathieu Passenaud",
+          "company": "please-open.it",
+          "city": "",
+          "bio": "DevOps (Teevity, Berger Levrault, OVH, Connit, Ubleam) depuis 8 ans maintenant sur Toulouse. Issu du milieu de l'embarqué (calculateurs ferroviaires/militaires), je me suis retrouvé parachuté dans l'univers du cloud pendant quelques années jusqu'à revenir au croisement de ces deux mondes : l'IOT. Touche à tout, j'aime beaucoup prototyper et répondre à la question 'est-ce que c'est possible ?'",
+          "photoUrl": "/images/speakers/mathieu_passenaud.png",
+          "socials": [
+            {
+              "name": "@mathieupassenau",
+              "link": "https://twitter.com/mathieupassenau"
+            },
+            {
+              "name": "mathieupassenaud",
+              "link": "https://github.com/mathieupassenaud"
+            }
+          ]
+        },
+        {
+          "name": "Fabien Tregan",
+          "company": "Freelance",
+          "city": "",
+          "bio": "Essaie de faire des logiciels depuis vingt ou trente ans. Au début en se concentrant surtout sur le code, aujourd'hui en essayant de débusquer les problèmes là où ils se trouvent. Heureusement, des fois c'est dans le code.",
+          "photoUrl": "/images/speakers/fabien_tregan.jpg",
+          "socials": [
+            {
+              "name": "@ftregan",
+              "link": "https://twitter.com/ftregan"
+            }
+          ]
+        }
+      ],
+      "sessions": [
+        {
+          "title": "Développeurs de jeux vidéo : rois de la combine ?",
+          "description": "Développeurs de jeux vidéo : rois de la combine ?",
+          "speakers": [
+            "Laurent Victorino"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "tags": [
+            "General"
+          ],
+          "complexity": "",
+          "youtube": "https://www.youtube.com/watch?v=jwaJ7U9SSDM"
+        },
+        {
+          "title": "Hype Driven Development",
+          "description": "Hype Driven Development",
+          "speakers": [
+            "Quentin Adam"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "tags": [
+            "General"
+          ],
+          "complexity": "",
+          "youtube": "https://www.youtube.com/watch?v=nfd3wh-GOQI"
+        },
+        {
+          "title": "Let’s Sketchnote : prise de notes visuelle",
+          "description": "La communication fait aujourd’hui partie intégrante de notre travail; il nous arrive régulièrement de vouloir diffuser une information importante, réaliser une présentation, un compte rendu de réunion… Mais comment être sûrs que le message que l’on souhaite faire passer a bien été compris et retenu par les interlocuteurs ? Le sketchnoting apporte une solution ludique, créative et agréable autant à créer qu’à lire. Venez découvrir comment mettre en valeur votre communication à l’aide de procédés très visuels, simples et accessibles à tous.",
+          "speakers": [
+            "Ane Diaz De Tuesta"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=NInM_wndk2U"
+        },
+        {
+          "title": "Ceinture noire Karate en tests d’API REST",
+          "description": "Vous aviez toujours rêvé d'une syntaxe facile pour tester vos APIs REST ? \n\n`Karate` est fait pour vous ! \nSon format DSL plain text inspiré de la syntaxe Cucumber (ie. Gherkin) permet même aux personnes aux notions basiques en développement de venir couvrir vos APIs ou Web services (micros, nanos ou pas!)\n\nIl n'y a plus ~~Karate~~ qu'à réussir ses tests d'intégration ! \n\nVenez apprendre comment avec `Java` et `maven` comme simples prérequis d'infrastructure, vous pouvez mettre en place et industrialiser ces tests. On l'utilise chez nous, et on ne s'en passe plus.",
+          "speakers": [
+            "Nicolas Comet",
+            "Benoit Prioux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=ZNrCw5T-wls"
+        },
+        {
+          "title": "Premiers pas avec Capacitor... dans le monde réel",
+          "description": "Ah, Capacitor, quelle belle idée, une alternative à Cordova plus facile à utiliser, utilisable dans n'importe quel framework, complètement intégré à la prochaine version d'Ionic... Ben non, au moins au début, l'idée de Capacitor me laissait sceptique. J'ai passé les deux dernières années a développer des PWA, alors la pensée de devoir revenir à faire des applications hybrides ou native me paressait simplement obsolète. Dans ma tête j'avais mis Capacitor dans la case techno cool qui ne m'intéresse pas dans la vraie vie. Mais à ce moment j'ai relu avec attention leur site et j'ai vu une ligne qui m'a séduit: Build web apps that run equally well on iOS, Android, Electron, and as Progressive Web Apps. Hmmm, si je pouvais prendre une PWA et générer à partir d'elle une appli native Android, une autre iOS et une implémentation Electron en bonus, ça pourrait être carrément cool ! J'ai donc décidé de teste Capacitor sur certaines de mes PWA pour voir si je pouvais les transformer en applications natives. Et ce talk est le retour d'expérience de ce processus, mes premiers pas avec Capacitor, ce qui a marché et ce qui n'a pas marché, et surtout ce que j'ai appris dans le processus.",
+          "speakers": [
+            "Horacio Gonzalez"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Native mobile apps"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=a4zCakyQN-o"
+        },
+        {
+          "title": "Votre mission ? Découvrir Haskell et le mettre en prod",
+          "description": "On entend parler de Haskell de plus en plus, mais il parait souvent bien compliqué de se lancer. Haskell fait peur, avec ses Monades, Monoïdes et autres gros mots. \n\nOn verra ensemble que vous n'avez absolument pas besoin de savoir ce que ces termes signifient pour vous lancer. Je vous propose de regarder ce dont vous aurez besoin pour créer une petite API, avec de la sécurité et de la gestion de données, soit de quoi mettre une petite application en prod.",
+          "speakers": [
+            "Céline Louvet"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=5VCIaYvWecM"
+        },
+        {
+          "title": "Développer une application web avec Rust",
+          "description": "Développé par la fondation Mozilla, Rust est un langage fortement typé, sûr, très performant et très économe en ressources (oui oui, tout ça à la fois). Initialement orienté système et bas niveau, l'écosystème Rust s'agrandit rapidement et propose maintenant toutes les librairies nécessaires au développement d'applications web. Pour découvrir le développement web avec Rust, nous parcourerons l'architecture et le code d'un serveur de commentaires open source à la Disqus, développé par le speaker pour les sites statiques faits par exemple avec Jekyll ou Hugo. Nous découvrirons routage http avec extraction typée de paramètres, réponses asynchrones, appel de services tiers, accès aux bases de données, cache, templating HTML, envoi d'emails, logs, métriques, etc. Et nous verrons qu'une application Rust c'est tout petit et très rapide, permettant d'héberger le serveur sur des configurations très modestes.",
+          "speakers": [
+            "Sylvain Wallez"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=rhAqG4gh400"
+        },
+        {
+          "title": "La programmation fonctionnelle sans céder à la mode",
+          "description": "Aujourd'hui, pour être à la mode, il faut parler de programmation fonctionnelle. Et de suite on convoque les mots en vogue: « *Immutabilité* », « *Monade* » ou « *Catamorphisme* ». Au mieux le message est brouillé, mal reçu. Au pire la salle se vide ! \n\nCe que je vous propose c'est de repartir des principes de base, avec des idées bien arrêtées et peut-être parfois provocatrices. Comprendre, comme le disait **John Hugues**, « *Why functionnal programming matters* ». Cerner les quelques idées directrices de la programmation fonctionnelle et ce qu'elles apportent concrètement au quotidien. Voir comment et pourquoi d'autres concepts en découlent nécessairement...\n\nIl sera peut-être finalement question de « *Théorie des catégories* » ! Mais il sera surtout question, en vrac, d'histoire et de mise en œuvre des langages, de typage, de performance, d'artisanat du logiciel, de « *Design patterns* », d'abstraction et, soyons fou, de *réification*. \n\nEn somme, je vais vous parler de programmation fonctionnelle en essayant de ne pas être à la mode !",
+          "speakers": [
+            "Frédéric Cabestre"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=AQ_q-hdtNS4"
+        },
+        {
+          "title": "Architecture Decision Records: Réconciliez vous avec votre documentation",
+          "description": "Les développeurs aiment écrire de la documentation... ou pas !\nPourtant même les plus réfractaires doivent l'admettre, garder une trace des décisions techniques prises au cours d'un projet peut s'avérer indispensable pour la pérennité et maintenabilité de celui-ci.\n\nAlors comment éviter l'obsolescence programmée de la documentation, tout en réduisant la pénibilité de la rédaction ?\n\nDepuis près d'un an, dans \"mon\" équipe, nous utilisons un format simple, les Architecture Decision Records (ADRs), pour écrire des documents d'architecture sous la forme d'un journal immuable.\nCette technique simple gagne en popularité et a donné de bons résultats sur notre projet.\n\nDurant cette présentation vous construirez en direct un ADR.\nEn partant d'un problème constaté sur un projet, vous élaborerez une réponse technique qui servira de base à une implémentation ultérieure.\nVous décrirez les raisons qui vous poussent à faire des compromis, tout en capturant le contexte dans lequel cette décision a été prise pour référence future.\n\nRéconciliez vous avec votre documentation !",
+          "speakers": [
+            "Arnaud Bos"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=EDYplU1PB5s"
+        },
+        {
+          "title": "Détectez et trackez les Zergs qui se cachent dans vos dépendances !",
+          "description": "[44% des applications contiennent des vulnérabilités critiques dans les librairies open-source qu'elles utilisent](https://www.veracode.com/products/software-composition-analysis) et cela bien que des bonnes pratiques comme OWASP Top 10 se soient généralisées. \n\nNe laissez plus ces aliens incuber bien au chaud dans le ventre de votre appli! \nGrâce à ce talk, vous apprendrez comment sont répertoriées ces vilaines bestioles (NVD, CVE) et comment est évaluée leur dangerosité (CVSS).\n\nPuis vous verrez comment créer votre première pipeline de Continuous Security dans Jenkins au moyen de [OWASP DependencyCheck](https://www.owasp.org/index.php/OWASP_Dependency_Check)  qui détecte les vulnérabilités et trackez les grâce à [OWASP DependencyTrack](https://www.owasp.org/index.php/OWASP_Dependency_Track_Project) (logiciels open-source) \n \nFaites le premier pas vers le DevSecOps !!!",
+          "speakers": [
+            "Julien Topçu"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=aZeR6PypJ8k"
+        },
+        {
+          "title": "La tête dans les nuages avec un Raspberry Pi",
+          "description": "En hackant une clé USB de réception TNT, La Radio Logicielle (ou SDR) est à la portée de tous. Il est alors possible d'écouter les balises de positionnement des avions de lignes sur un rayon de plusieurs dizaines de km avec une simple antenne. Voulez vous connaitre le fonctionnement du projet comme [flightradar24](https://www.flightradar24.com) ? Nous verrons comment mettre en oeuvre un tel projet avec du matériel grand public et accessible comme un Raspberry Pi.",
+          "speakers": [
+            "Guillaume Membré"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "IOT"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=UcADSVfOg3k"
+        },
+        {
+          "title": "Agile, Craftsmanship, DevOps and other monsters - how to fight with them.",
+          "description": "Our industry has an amazing ability to build extremely good theoretical models, methodologies and approaches that actually drive us crazy. Theoretically, we can show how easy it is to introduce Waterfall, XP, Agile or DevOps (delete as appropriate) but the reality is more complicated. Sometimes, something does not work in our unique context and we end with so well known sentence \"It doesn't work for us\". \n\nMany hours of discussions with colleagues about the state of our industry indicate that we have to come up with something new and glowing. Something that allowed us to avoid the mistakes we made so far.\n\nIn this presentation, we will look at all errors we made in the past and we will take a closer look at elements which could have been done better and which ideas can change to better our industry. By retrospecting our achievements, we will try to define what awaits us and why this time we will succeed;)",
+          "speakers": [
+            "Robert Firek"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=tWPlvgtJgF4"
+        },
+        {
+          "title": "Google Container Tools : développer efficacement dans un monde de conteneurs",
+          "description": "Kubernetes est devenu l'orchestrateur de choix pour déployer des applications. Mais qu'en est-il du quotidien des développeurs qui créent ces applications ? Plus on s'appuie sur la plateforme, plus il est compliqué de développer en dehors de la plateforme. Et développer à l'intérieur de conteneurs n'est pas réputé facile ni agréable. Google est à l'origine de plusieurs projets Open-Source qui se focalisent sur l'expérience des développeurs dans un monde de conteneurs. Kaniko permet de construire une image Docker à partir d'un Dockerfile, dans un cluster Kubernetes, de manière sécurisée. Skaffold facilite le déploiement continu d'applications pour Kubernetes. Les images Distroless offrent des images de base légères, sécurisées et de qualité. Bazel permet meme de construire des images Docker sans Docker. Venez découvrir comment ces outils se combinent pour offrir un environment de développement agréable et performant dans le monde des conteneurs.",
+          "speakers": [
+            "David Gageot"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=-t1cTnhoGTg"
+        },
+        {
+          "title": "S'aider du Data-Oriented Design pour écrire des applications performantes",
+          "description": "La performance est redevenue un sujet critique aujourd’hui avec le Cloud et les traitements de la données avec le Big data.\n\nAu delà des choix d'algorithmes et de structures de données, un moyen d'écrire du code performant, c'est de s'assurer que le processeur soit utilisé le plus efficacement possible et d'éviter qu’il perde du temps à charger/déplacer des données en mémoire.\n\nLe Data Oriented Design se place justement dans cette optique et fournit des méthodes pour écrire du code performant en prenant en compte les limitations du hardware.\n\nContenu de la présentation:\n\n * Explication du concept du Dod.\n\n * Comment fonctionnent les processeurs et montrer les grosses différences d’ordres de grandeurs des accès à la mémoire.\n\n* Comment le DoD permet de régler ces problèmes, avec des exemples de structures de données adaptées.\n\n* Comment le Dod a été mis en place sur le reverse proxy http de Clever Cloud: Sozu.\n\n* Comment mettre en place une approche DoD sur un cas concret par la création d’un entity manager qu'on trouve dans un moteur de jeu.\n\n* Réduire le temps d'exécution d'un programme JavaScript par 6 en s'aidant du Data-Oriented Design.",
+          "speakers": [
+            "Alessio Coltellacci"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=3lzpK45cyBo"
+        },
+        {
+          "title": "#RetourAuxSources : 🍪 Les cookies HTTP",
+          "description": "Les cookies HTTP sont partout ! Pas une journée sans qu’un site nous demande “d’accepter les cookies”. Rares sont les projets Web qui ne les utilisent pas et pourtant leur fonctionnement nous échappe trop souvent. On confond les règles auxquelles ils sont soumis au sein des navigateurs. On fait des amalgames avec les sessions côté serveur. Ces petits trous dans le gigantesque éventail de connaissances du développeur moderne ont parfois des impacts non négligeables sur la sécurité de nos applications et sur la préservation de notre vie privée en tant qu’utilisateur du Web. Au menu de cette session, je vous propose de (re)découvrir les cookies HTTP par l’exemple et la pratique. Nous reviendrons sur leurs origines et nous verrons en détails leur fonctionnement. Enfin, nous aborderons les aspects les plus récents dans le domaine (SameSite, cookie prefix...). Ce talk sera plus généralement l’occasion de parler de sécurité, de tracking et de vie privée.",
+          "speakers": [
+            "Hubert Sablonnière"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=CcTbecZ67_o"
+        },
+        {
+          "title": "Des APIs de Machine Learning sur étagère, à l'entrainement distribué dans le cloud",
+          "description": "Vous pouvez booster vos applications grâce aux APIs de Machine Learning, afin d'analyser ce que contiennent les images uploadées par vos utilisateurs, de comprendre la structure du texte, ou de reconnaître la voix. Pour le développeur, un simple appel REST suffit, pour interroger les APIs Google Cloud Vision, Speech, Translate ou Natural Language.\n\nA l'opposé, le framework open source Tensorflow permets au data scientist de créer ses propres modèles de Machine Learning, de les entrainer localement ou dans le Cloud, et de lancer ses prédictions en ligne ou même embarquées dans des applis mobiles.\n\nEntre les deux, il est aussi possible de personnaliser les modèles sur étagère, pour reconnaître vos propres images, classifier vos textes, grâce à Google Cloud AutoML.",
+          "speakers": [
+            "Guillaume Laforge"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Big Data / ML / AI"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=gSewdZrom10"
+        },
+        {
+          "title": "Tests BDD: faites rédiger vos tests End-to-End par les fonctionnels",
+          "description": "Tout le monde (dans un monde idéal) fait des tests unitaires. Rares par contre sont ceux qui s'aventurent à mettre en place des tests end-to-end. Longs à développer, laborieux à maintenir, ils sont souvent les premiers à passer à la trappe. Et si ces tests devenaient faciles à développer et à lancer? Mieux encore, si ce n'était plus aux développeurs (déjà chargés comme des mules, c'est bien connu) de les rédiger, mais aux fonctionnels? Des tests à base de phrases compréhensibles par tous, faciles à lancer et à maintenir? Ce sera le but de ce talk: à partir d'une application web Angular, nous verrons comment configurer et lancer vos tests BDD avec TestCafe, Serenity et Cucumber.",
+          "speakers": [
+            "Laurent Wroblewski"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=7u3luu6BmDg"
+        },
+        {
+          "title": "Lighthouse : mesurer et améliorer votre performance web",
+          "description": "L'idée de ce talk est de présenter une série de bonnes pratiques / tips and tricks pour améliorer la performance d'un site web grâce à l'outil open source lighthouse sur plusieurs niveaux:\n- performance\n- progressive web app\n - accessibilité\n- autres bonnes pratiques.\n\nLa présentation démarre par la génération d'un blog statique , le lancement d'un audit et un score de performance médiocre. Puis une série d'améliorations en live coding. Le talk se termine par un résumé des techniques utilisées et bien sûr un excellent score dans lighthouse.",
+          "speakers": [
+            "sara_harkousse"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Intermédiaire"
+        },
+        {
+          "title": "Et si on parlait accessibilité du web ?",
+          "description": "**Aria**, **a11Y**, que veulent dire ces termes exotiques ? Nous verrons à travers des exemples les bonnes pratiques pour que votre site soit accessible. Puis, nous passerons en revue les sites internet des géants du web afin de voir si ce sont de bons élèves... ou pas.",
+          "speakers": [
+            "Olivier Leplus"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=1oKEcDdYANY"
+        },
+        {
+          "title": "Tensorflow, is there really no spoon ?",
+          "description": "With the advance of Deep learning, Image recognition is everywhere! But like all technologies, it has its flaws. It is indeed possible to fool neural network models used for critical applications such as self-driving cars, drones, security cameras... Together, we will see how to generate adversarial images and fool a neural network into seeing something in an image that is not there.\n\nNo Tensorflow, there is no spoon!",
+          "speakers": [
+            "Tiffany Souterre"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "Big Data / ML / AI"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=4QIjIoHP0x4"
+        },
+        {
+          "title": "Comment perdre sa surchage featurale ?",
+          "description": "Le cycle de vie d'une application est un chemin nébuleux et plein de dangers. La complexité ne fait que croitre durant les mois et les années d'utilisation. L'un des plus gros challenges d'un développeur est de pouvoir la contrôler tout en ajoutant de nouvelles fonctionnalités (features). Des solutions existent : le ré-écriture de code ou encore la maitrise de la dette technique. En effet, ces deux actions permettent de lever \"la complexité accidentelle\". Mais que faisons nous de la \"complexité essentielle\" ? La complexité qui n'est pas liée au code. La seule solution : Supprimer des fonctionnalités ! Ce talk vous expliquera comment perdre la surcharge featurale de vos applications en comprenant la différence entre la complexité essentielle et la complexité accidentelle, mais aussi en vous donnant des clés pour mener à bien ce changement de vie dans vos équipes projet. ",
+          "speakers": [
+            "Estelle Landry"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=YM3pnJDhATE"
+        },
+        {
+          "title": "Angular Elements",
+          "description": "In this session we will see how to create our first Web Component with Angular Elements and use it in a plain JS app.",
+          "speakers": [
+            "Raúl Jiménez"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=ozVffQPTQXk"
+        },
+        {
+          "title": "Comment t'organiser quand tu es b****lique de naissance (et depuis des décennies), que tu as plusieurs jobs (ou projets), sans exploser en vol ... Et bosser à plusieurs ... Et y arriver",
+          "description": "À (presque) 50 ans, je crois que j'y arrive enfin. ... à m'organiser.\nJ'ai fait pas mal de choses (le plus souvent en SSII ... *lire ESN*) et notamment chef de projet, directeur de projets, responsable de centre de services, ... Le tout accompagné:\n- d'oublis (oh p... 🙀 j'ai oublié de répondre au client, c'était urgent ... il y a une semaine), \n- d'angoisses (et crises d'angoisse) (rahhhh 😥 je vais jamais arriver à tout faire), \n- d'anéantissements (vous me faites tous ... J'arrête, bande de gros c...)\n- de (grands) moments de solitude (ah? On t'a pas dit, la réunion est en 🇬🇧, c'est toi qui mène ... 😡 euh, mais l'🇬🇧 je l'écris ... et encore ...)\n- etc ...\n\nAujourd'hui, j'ai 2 métiers (un commercial et un technique), dont un à 95% en 🇬🇧, et j'arrive à faire les 2 (et plutôt correctement il me semble), sans crise d'angoisse, en ayant encore du temps pour mes sides projects, dormir, m'occuper de ma famille (pas assez, mes geekeries peuvent prendre le dessus), aller à la pêche, regarder des séries, ...\n\nJ'ai donc tenté de me trouver des \"méthodes\" de travail à la fois pour mes tâches en solo mais aussi pour les moments où je travaille en équipe, pour cela j'ai utilisé les outils que j'avais sous la main (mais d'une certaine manière), dans mon cas: VSCode, DropBox, le markdown (asciidoc c'est bien aussi), Slack, GitLab (avec GitBucket, GitHub ou BitBucket ça fonctionne aussi), une façon limitée et particulière d'utiliser GMail, 1 écran externe, ...\nRien de magique, mais ça fonctionne pour moi",
+          "speakers": [
+            "Philippe Charrière"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=2_hdqZ3TuQo"
+        },
+        {
+          "title": "Découvrir par l’exemple: Microservices et Event Sourcing avec Kafka et Kubernetes",
+          "description": "Lorsque vous développez des applications vous avez besoin de vous adapter rapidements aux changements (métiers, comme technologiques). Pour cela les développeurs et les “ops” doivent travailler de concert, pour déployer toujours plus rapidement de nouveaux services tout en garantissant la haute disponibilité et la montée en charge des applications.\n\nLes microservices et l’event-sourcing offrent une grande flexibilité aux développeurs; et la containerization par la biais de Kubernetes permet de déployer ces services en toute tranquillité.\n\nCette présentation, en s’appuyant sur des cas d’usage et des démonstration, vous permettra de découvrir:\n\n* Les micro-services l'’event sourcing avec Apache Kafka\n* Les containers avec Docker\n* Le déploiement et management des services avec Kubernetes\n\nSi vous n’utilisez pas encore ces technologies, cette présentation vous donnera une bonne idées des avantages qu’elles apportent aux développeurs, administrateurs systèmes, et donc aux utilisateurs; et je suis certain que vous les adopterez rapidement pour vos prochains développements!",
+          "speakers": [
+            "Tugdual Grall"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Big Data / ML / AI"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=RXaGjS5C-lE"
+        },
+        {
+          "title": "Testcontainers pour de vrais tests d'intégration d'Elasticsearch",
+          "description": "Les tests d'intégration peuvent devenir un cauchemar lorsqu'ils sont lancés depuis la même JVM que votre code:\n\n* Conflit de JARs (JAR Hell)\n* Security Manager\n* Effets de bord\n\nDe plus, tester avec un produit qui est lancé de façon différente de la façon dont il est lancé en production, ne garantira jamais que les tests d'intégration sont sincères.\n\nAussi, après avoir découvert le projet [TestContainers](https://www.testcontainers.org/) qui lance des conteneurs Docker depuis, j'ai décidé d'écrire une implémentation pour Elasticsearch: [testcontainers-java-module-elasticsearch](https://github.com/dadoonet/testcontainers-java-module-elasticsearch).\nJe vous propose de découvrir tout cela pendant ce quickie.",
+          "speakers": [
+            "David Pilato"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=KgcV15lCDk4"
+        },
+        {
+          "title": "Systemd, de /dev/null à root",
+          "description": "La démocratisation de la culture Devops et du cloud public amènent de plus en plus les dévelopeurs à travailler sur la mise en production de leurs applications.    \nSi vous n'êtes pas équipé d'un orchestrateur de conteneurs, il y a fort à parier que vous soyez amené à intéragir avec systemd voir d'écrire des services pour vos applications. N'ayez pas peur ! non seulement c'est accessible mais cela vous offre de nombreuses possibilités .  \n\nDécouvrons ensemble systemd et sa galaxie, ce qu'il peut vous apporter pour l'installation et le run de vos application mais également comment il peut vous aider tout les jours dans votre vie de développeur.",
+          "speakers": [
+            "Francois Teychene"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=4AqbpZrBaOE"
+        },
+        {
+          "title": "Template de déploiements Kubernetes avec Kontemplate",
+          "description": "Kontemplate est un projet qui vise à faire des templates de déploiement pour Kubernetes. Petit retour d'expérience de l'utilisation de kontemplate dans le cadre de la vie d'une plateforme depuis l'environnement de développement jusqu'à la production.",
+          "speakers": [
+            "Mathieu Passenaud"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=KF3gvGnpjIg"
+        },
+        {
+          "title": "Burger Quiz s'invite au DevFest avec un Sel ou Poivre \"Code, Data ou les deux\"",
+          "description": "Etes-vous incollable plutôt sur le \"Code\" (Software Engineer) ou sur la \"Data\" (Data Engineer, Data Scientist) ? \n\nRetrouvons-nous pour un moment fun autour de questions et situations de notre quotidien pour lesquelles il faudra choisir \"Code, Data ou les deux\". Avec des images, du rythme,  un soupçon d'injustice, des surprises et une Jeep Renegade à la fin. \n\nLa salle est également ouverte aux personnes sérieuses qui y trouveront j'espère une stimulation pour réfléchir sur le sujet de fond d'évolution du métier de développeur avec la montée des approches centrées sur les données.",
+          "speakers": [
+            "Olivier Flebus"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "WTF"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=9kUmvV947X8"
+        },
+        {
+          "title": "Introduction à Arrow - Typeclass is the new interface",
+          "description": "Introduction à Arrow - `Typeclass` is the new `interface`\n===\n\nLa programmation fonctionnelle, c'est à la mode ! Et pour de bonnes raisons: l'industrie impose des architectures de plus en plus distribuées. Code facilement composable, immutabilité, contrôle des effets de bord: l'application de ces concepts rend le code plus sûr et efficace.\n\n*\"Mais qu'est-ce que ça m'apporte vraiment ?\"*, demande le programmeur pragmatique. En plus d'offrir des structures de données et opérateurs vraiment utiles, la notion de `typeclass` nous permet de rajouter des comportements/interfaces sur n'importe quel type de données.\n\nPour illustrer cette notion, nous nous appuierons sur la librairie `Arrow` en `Kotlin`. `Kotlin` est un langage de plus en plus populaire qui mixe plusieurs paradigmes. À défaut d'être un langage fonctionnel \"pur\", il dispose de nombreuses caractéristiques \"fonctionnelles\", et permet d'émuler des `typeclasses`.\n\nCette présentation, accessible sans connaissance de programmation fonctionnelle, permettra de se familiariser avec `Arrow` et les `typeclasses`.\n\n*(😸 Aucune monade ne sera maltraitée durant ce talk. 😸)*",
+          "speakers": [
+            "Alexandre Delattre",
+            "Guillaume Andrieu"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=uiLimq64zJI"
+        },
+        {
+          "title": "Comprendre le théorème de CAP avec Apache Kafka",
+          "description": "Durant cette présentation, nous nous pencherons sur le théorème de CAP (choix entre consistence, disponibilité et partition pour tout système distribué). Quand s'applique-t'il? Quels sont les choix qu'il propose?\n\nNous prendrons pour exemple Apache Kafka, afin de comprendre comment ce théorème s'applique en pratique. Nous étudierons les scénarios catastrophe potentiels en cas de crash d'un ou plusieurs noeuds. Quel est le niveau de garantie de délivrance d'un message? Que se passe-t'il quand le leader du cluster tombe? Comment est assurée la réplication des données? Quand et comment est-il possible d'ajuster le curseur entre consistence et disponibilité?\n\nIl n'est pas nécessaire de connaitre Kafka pour pouvoir suivre cette présentation.",
+          "speakers": [
+            "Sébastien Guilloux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=yLp0crdThzQ"
+        },
+        {
+          "title": "Remake de jeux rétro avec Vue.js",
+          "description": "Quoi de mieux que de recoder son jeu préféré pour apprendre une nouvelle techno ? Nous allons nous replonger dans notre enfance pour découvrir les concepts de Vue.js appliqués à Pong, Pac-Man, Tetris ou autre Pokemon.\n\nUn jeu n’est rien d’autre qu’un joueur interagissant avec un univers représenté à l’écran. Et Vue est un framework pensé pour isoler interactions, informations (qui décrivent l’univers du jeu) et la représentation visuelle basée sur ces informations.\n\nNous verrons ensemble pourquoi Vue est un outil adapté au développement de jeu et qu’inversement, le développement d’un jeu offre un bon angle pour découvrir les concepts clés de Vue.",
+          "speakers": [
+            "Nicolas Decoster",
+            "Juliane Blier"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=TDgln192b-Y"
+        },
+        {
+          "title": "Exploring reactive programming in Java",
+          "description": "When Java 8 was first introduced, it revolutionized the way Java applications were written by providing the core constructs for asynchronous programming and handling data streams. With Java 9, 10, and 11, these capabilities were extended to the level that allows us to write truly modern, reactive applications with the JDK.\n\nIn this live-coding session, we explore JDK 9-11 features enabling all the aspects of reactive programming - updates to the Stream and CompletableFuture APIs, Reactive Streams publish-subscribe framework, HTTP/2 client, and more.",
+          "speakers": [
+            "Miro Cupak"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=LxBn42ROcwg"
+        },
+        {
+          "title": "The Big Web Quizz",
+          "description": "Nous aimons tous le web. Nous avons tous notre framework de prédilection avec lequel nous concevons des applications qui vont révolutionner le monde. Mais connaissons nous les bases du Web ? Connaissons nous toutes les subtilités de la specification des modules ? Maitrisons nous à la perfection les différents mécanismes de cache de vos navigateurs ?\n\nNous n'en sommes pas sûrs. C’est pour cela qu’aujourd’hui nous vous proposons de participer au plus grand quizz du monde. Présenté par nos experts Jean-François et Emmanuel, venez tous tester vos compétences de la plateforme Web.\n\nLes questions ne seront pas si simples, vous allez apprendre énormément de choses… et en plus ce sera drôle.",
+          "speakers": [
+            "Emmanuel Demey",
+            "Jean-francois Garreau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=PL9aQDMgv4w"
+        },
+        {
+          "title": "Pourquoi et comment crafter la Data-Science sur mesure.",
+          "description": "Il n'est pas évident d'intégrer de la Data Science dans les sociétés qui développent un business qui de base ne prévoyait pas de l’intelligence artificielle (IA), et pour lequel l’IA n'est pas au cœur du métier. Malgré la motivation d'utiliser l’IA, de nombreux projets Data Science dans ces sociétés échouent.\n\nC'est autant frustrant pour les responsables d'entreprises que démotivant pour les data-scientists, dont les projets finissent au placard.\nOn va analyser ensemble cette situation, pour déterminer les raisons de ces échecs. On va également étudier comment éviter les erreurs les plus courantes, et comment mener ce changement sans encombre afin d'enrichir vos produits avec l’IA.\n\nL’objectif du talk est que peu importe le profil que vous avez - dev front, dev back, data-scientist, CTO, CEO, Product Manager - vous retournerez lundi dans votre société en sachant à la fois identifier et mener à bien les opportunités de Data Science.",
+          "speakers": [
+            "Anastasia Lieva"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "Big Data / ML / AI"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=rFxSrzR-EXE"
+        },
+        {
+          "title": "Multiplatform projects with Kotlin",
+          "description": "Kotlin is an alternative programming language for JVM. But it is not limited to a single platform. Instead, the team is working hard to bring it everywhere. It is already possible to run Kotlin on Android and compile it to JavaScript to write homogeneous web applications. And there is Kotlin/Native project actively in development, which will bring Kotlin to desktop and iOS.\n\nIn this session, we'll see how Kotlin can help us share code between platforms and what are the best practices in doing this.",
+          "speakers": [
+            "Victor Kropp"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "Languages"
+          ],
+          "complexity": "Intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=9ukHegwJivg"
+        },
+        {
+          "title": "Angular Schematics pour une meilleure productivité et plus de partage",
+          "description": "La CLI d'Angular, célèbre framework web de Google, est basée sur les Schematics. Cette technologie permet de définir des transformations de code au sein de vos applications Angular comme la création de nouveaux composants, directives, providers... et plus récemment la configuration ou mise à jour de vos librairies automatiquement. Grâce à la nouvelle librairie @angular-devkit/schematics proposée par la team Angular, vous n’êtes désormais plus obligé d’attendre une évolution de la part de l’équipe Angular pour créer une nouvelle commande répondant à vos besoins. Ainsi il est plus facile de partager entre développeurs du tooling ou alors de la génération de code automatique pour gagner en productivité.\nNous verrons donc pendant ces 15 minutes comment créer des schematics et ce qu'apporte cette technologie avec différents cas concrets qui je l'espère vous donnerons envie de créer plein de schematics <3 .",
+          "speakers": [
+            "Benoit El Amrani"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Web"
+          ],
+          "complexity": "Confirmé",
+          "youtube": "https://www.youtube.com/watch?v=VLQYPA5gZEA"
+        },
+        {
+          "title": "GCP pour les Data Scientists",
+          "description": "Depuis son arrivée, GCP a démocratisé la conception et la mise en place de services basés sur l'IA sans avoir besoin en pré-requis de connaissances spécifiques en IA. Typiquement avec Dialogflow pour la création d'un chatbot personnalisé ce qui compte est le savoir-faire du développeur qui va mettre en place et intégrer le pipeline complet pour l'exposition du service. Comment un Data Scientist peut-il s'orienter dans ce monde qui n'est pas le sien pour apporter de la valeur aux projets utilisant tout le potentiel de GCP ?",
+          "speakers": [
+            "Giulia Bianchi"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "Cloud"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=yjOkeruVBIE"
+        },
+        {
+          "title": "CONTEXTVS, STVLTE! (Context, stupid!)",
+          "description": "\"The best sorting algorithm is quick sort.\"\n\"Indexes make DB faster.\"\n\"Data should be sorted using ORDER BY.\"\n\"Composition - good; inheritance - not good.\"\n\"Windows is an operating system.\"\n\"You must have transactions in your DB.\"\n\"Java is slow.\"\n\"Don't eat yellow snow.\"\n\"You shall not self-sign your certificates.\"\n\"Interrupt in Java is broken.\"\n\nThe IT world is full of mantras/revealed truth, passed (often in oral tradition) among developer tribes. Mindlessly repeated from generation to generation, they cause a reckless usage. At best this results in more harm than good, in the worst case: a total disaster worth whole train of money.\nThe context is indispensable part of each mantra. Right context can help to distinguish proper usage from incoming disaster.\n\nDo you believe in a mantra by any chance?\nHow to find out the context?\nCan one eat yellow snow?\nCome and see.",
+          "speakers": [
+            "Piotr Przybyl"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "Method & Tools"
+          ],
+          "complexity": "Débutant",
+          "youtube": "https://www.youtube.com/watch?v=eLN3smdZZYg"
+        },
+        {
+          "title": "The Old Man Glitch - Escalade de bug sur la première génération de Pokemon sur Gameboy",
+          "description": "Je vous propose de prendre avec vous le temps de regarder un bug dans du code 8-bit de 1996 et de parler de techniques obsolètes d'escalade de failles. Juste pour le plaisir. Off-by-one error, underflow, buffer overflow, injection de code... avec des Pokemon alors même les adultes vont comprendre.",
+          "speakers": [
+            "Fabien Tregan"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "WTF"
+          ],
+          "complexity": "Beginner",
+          "youtube": "https://www.youtube.com/watch?v=hBo28RVftNc"
+        }
+      ]
+    },
+    "2019": {
+      "date": "2019-10-03",
+      "venue": "Centre de Congrès Pierre Baudis",
+      "speakers": [
+        {
+          "name": "Adrien Anceau",
+          "company": "Airbus",
+          "city": "Toulouse, France",
+          "bio": "",
+          "photoUrl": "/images/speakers/adrien_anceau.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/aaadrieeen"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/aanc"
+            }
+          ]
+        },
+        {
+          "name": "Aleksey Kladov",
+          "company": "Ferrous Systems",
+          "city": "St Petersburg, Russia",
+          "bio": "@matklad is a Rust developer, who specializes in dev tools and IDEs. He spearheaded [IntelliJ Rust](https://intellij-rust.github.io/) and currently leads the development of [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer).",
+          "photoUrl": "/images/speakers/aleksey_kladov.jpg",
+          "socials": [
+            {
+              "name": "github",
+              "link": "https://github.com/matklad"
+            }
+          ]
+        },
+        {
+          "name": "Alessio Coltellacci",
+          "company": "Clever Cloud",
+          "city": "Toulouse, France",
+          "bio": "Développeur à Clever Cloud.",
+          "photoUrl": "/images/speakers/alessio_coltellacci.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/lightplay8"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/NotBad4U"
+            }
+          ]
+        },
+        {
+          "name": "Andrew Radev",
+          "company": "",
+          "city": "Sofia, Bulgaria",
+          "bio": "Professional Rails developer with an excessive amount of Vimscript in his Github profile. Teaches a Rust course in Sofia University.",
+          "photoUrl": "/images/speakers/andrew_radev.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/AndrewRadev"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/AndrewRadev"
+            }
+          ]
+        },
+        {
+          "name": "Cédric Moulard",
+          "company": "",
+          "city": "",
+          "bio": "Diplômé de Arts & Métiers ParisTech et pas vraiment destiné à faire de l'informatique. \nDéveloppeur autodidacte. \n\n20 ans d'expérience, dont :\n- Architecte Java\n- Développeur Angular\n- Chef de projet\n- ScrumMaster\n- Evaluateur CMMi\n- Responsable Méthodes & Outils",
+          "photoUrl": "/images/speakers/cedric_moulard.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/cedric_moulard"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/cedricmoulard"
+            }
+          ]
+        },
+        {
+          "name": "Christian Fauré",
+          "company": "",
+          "city": "Paris, France",
+          "bio": "IT & Philosophy - [http://www.christian-faure.net/](http://www.christian-faure.net/)",
+          "photoUrl": "/images/speakers/christian_faure.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/ChristianFaure"
+            }
+          ]
+        },
+        {
+          "name": "Christophe Jollivet",
+          "company": "Apside",
+          "city": "Tours, France",
+          "bio": "Agitateur technique chez Apside, Christophe prêche les bonnes pratiques sur divers projets informatiques et universités en région tourangelle. Reconverti à l’informatique il y a 15 ans suite à un doctorat de neurobiologie, il contribue activement dans les communautés Java en ayant été co-responsable de la rubrique Java du site developpez.com mais aussi en participant à des conférences et en ayant fondé le Tours JUG en 2008 et co-fondé TouraineTech en 2017",
+          "photoUrl": "/images/speakers/christophe_jollivet.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/jollivetc"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/jollivetc"
+            }
+          ]
+        },
+        {
+          "name": "Clément Duffau",
+          "company": "Stack Labs",
+          "city": "Toulouse, France",
+          "bio": "Suite à un diplôme d'ingénieur en informatique spécialisé en Architecture Logicielle, j'ai effectué un doctorat en Génie Logiciel appliqué aux domaines critiques afin d'aborder les problèmes liant les méthodologies de développement logiciel, la sûreté de fonctionnement et la certification. \n\nJ'utilise actuellement ma double compétence de chercheur en Génie Logiciel et lead DevOps pour l'entreprise Stack Labs. \nMon poste consiste à intervenir chez des clients dans les domaines critiques (aérospatial notamment) afin de les aider à mettre en place et structurer leur approche DevOps mais également à être pro-actif sur les sujets R&D portés en interne par Stack Labs.",
+          "photoUrl": "/images/speakers/clement_duffau.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/clement0210"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/clement0210"
+            }
+          ]
+        },
+        {
+          "name": "Corentin Wallez",
+          "company": "Google",
+          "city": "Paris, France",
+          "bio": "Graphics plumber @google\n\nCorentin is an engineer working on Chrome's GPU team in Google Paris. \nHe leads development of the WebGPU API and chairs the \"GPU for the Web\" W3C group.",
+          "photoUrl": "/images/speakers/corentin_wallez.png",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/DaKangz"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/Kangz"
+            }
+          ]
+        },
+        {
+          "name": "Cyril Delmas",
+          "company": "Blue Valet",
+          "city": "Mérignac, France",
+          "bio": "Développeur depuis une douzaine d'années, je m'intéresse à plein de choses, notamment : la programmation fonctionnelle, le cloud, et tout ce qui n'est pas frontend en fait (bon surtout le CSS)... J'aime partager mes expérimentations et découvertes, échanger autour d'une bière, ...",
+          "photoUrl": "/images/speakers/cyril_delmas.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/cyril_delmas"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/cdelmas"
+            }
+          ]
+        },
+        {
+          "name": "Erik Rasmussen",
+          "company": "",
+          "city": "Cantabria, Spain",
+          "bio": "American expat living in Spain, making awesome Javascript open source.",
+          "photoUrl": "/images/speakers/erik_rasmussen.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/erikras"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/erikras"
+            }
+          ]
+        },
+        {
+          "name": "Fabien Trégan",
+          "company": "",
+          "city": "Toulouse, France",
+          "bio": "After spending 10+ years of my life coding, I started to feel that the problems in software development were not in the code and tryed finding solutions elsewhere. Since I started doing that, I started to love coding again :)",
+          "photoUrl": "/images/speakers/fabien_tregan.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/ftregan"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/fabientregan"
+            }
+          ]
+        },
+        {
+          "name": "Francois-Guillaume Ribreau",
+          "company": "Ouest-France/Image-Charts",
+          "city": "Rennes, France",
+          "bio": "Architect & Head of Digital Development @OuestFrance 🌟#FullStack CTO @imagecharts @Redsmin @killbugapp @motiondynamic_ @mailpopin founder",
+          "photoUrl": "/images/speakers/francois_guillaume_ribreau.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/fgribreau"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/fgribreau"
+            }
+          ]
+        },
+        {
+          "name": "François Teychene",
+          "company": "Elastic",
+          "city": "Montpellier, France",
+          "bio": "Cloud Developer @ Saagie , meetup addict & organizer @ Montpellier,  SunnyTech team.  \nDéveloppeur couteau suisse pouvant intervenir du Javascript à la table de routage. Mes passions actuelles sont le Rust, le DevOps et le Scala en plus de vouloir mettre des conteneurs partout.",
+          "photoUrl": "/images/speakers/francois_teychene.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/fteychene"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/fteychene"
+            }
+          ]
+        },
+        {
+          "name": "fs0c131y",
+          "company": "",
+          "city": "Toulouse, France",
+          "bio": "- French security researcher.\n- Worst nightmare of Oneplus, Wiko, UIDAI, Kimbho, Donald Daters and others.\n- Not completely schizophrenic.\n- Not related to USANetwork.\n\n<https://fs0c131y.com/>",
+          "photoUrl": "/images/speakers/fs0c131y.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/fs0c131y"
+            }
+          ]
+        },
+        {
+          "name": "Gautier Mechling",
+          "company": "Nilhcem",
+          "city": "Paris, France",
+          "bio": "Android Crafter && Google Developer Expert IoT",
+          "photoUrl": "/images/speakers/gautier_mechling.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/Nilhcem"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/Nilhcem"
+            }
+          ]
+        },
+        {
+          "name": "Gilles Debunne",
+          "company": "Freelance",
+          "city": "Toulouse, France",
+          "bio": "Développeur Freelance sur Toulouse depuis 4 ans, je me spécialise dans l'UX, front ou mobile. Éclectique, chercheur au CNRS, en SSII ou dans l'équipe Android chez Google, j'ai toujours travaillé près et pour l'utilisateur.",
+          "photoUrl": "/images/speakers/gilles_debunne.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/gdebunne"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/GillesDebunne"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Andrieu",
+          "company": "MonkeyPatch",
+          "city": "Toulouse, France",
+          "bio": "Matheux converti de force à l'informatique.\nDéveloppeur back end depuis plus de 10 ans.\nProgrammation fonctionnelle, théorie des types, systèmes distribués.\nAu delà: changement climatique, droits humains, philosophie.",
+          "photoUrl": "/images/speakers/guillaume_andrieu.png",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/glmxndr"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/glmxndr"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Smet",
+          "company": "Red Hat",
+          "city": "Lyon, France",
+          "bio": "Après 13 années dans une SSLL, d'abord comme chef de projet puis directeur technique et responsable du pôle développement spécifique Java (avec beaucoup de contributions Open Source notamment à PostgreSQL), Guillaume est, depuis 3 ans, Senior Software Engineer chez Red Hat. Il est le project lead d'Hibernate Validator et travaille sur toutes les bibliothèques Hibernate (ORM, Search et Validator).\n\nEmbarqué dans l'aventure Quarkus pour y intégrer les technologies Hibernate, il est désormais l'un des principaux contributeurs au projet.",
+          "photoUrl": "/images/speakers/guillaume_smet.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/gsmet_"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/gsmet"
+            }
+          ]
+        },
+        {
+          "name": "Horacio Gonzalez (LostInBrittany)",
+          "company": "OVH",
+          "city": "Brest, France",
+          "bio": "Malgré ce que son accent espagnol bien prononcé peut suggérer, Horacio est arrivé en France il y a plus d'une quinzaine d'années. Passionné d'informatique, dans laquelle il est tombé depuis tout petit, il a découvert le développement web en 1997 et depuis il n'a pas arrêté de bosser autour.\n\nAprès quelques années comme tech leader de la partie frontend de [@warp10io](https://twitter.com/warp10io/) chez [Cityzen Data](https://twitter.com/cityendata/), Horacio a rejoint [OVH](](https://twitter.com/ovh/) en janvier 2018 en tant que Developer Advocate. Il est cofondateur du [FinistDevs](https://twitter.com/finistdevs/), le JUG/GDG français le plus proche de la Silicon Valley.\n\nPassionné par le développement web et tout ce qui gravite autour des composants web, Horacio est [Google Developer Expert (GDE)](https://developers.google.com/experts/people/horacio-gonzalez) en Web Technologies et Flutter.\n\nVous pouvez voir mes derniers talks sur [mon profil Notist](https://noti.st/lostinbrittany)",
+          "photoUrl": "/images/speakers/horacio_gonzalez__lostinbrittany_.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/LostInBrittany"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/LostInBrittany"
+            }
+          ]
+        },
+        {
+          "name": "Jérémy Voisin",
+          "company": "Apside",
+          "city": "Le Mans, France",
+          "bio": "Tech lead chez Apside, Jérémy est un explorateur des technologies modernes et passées qui apporte ses découvertes dans le cadre de formations ou d'interventions d'expertises.\nIssu d'un parcours universitaire en intelligence artificielle, il mène des travaux en IA sémantique et ses domaines d'expertises, outre l'IA, sont le développement mobile et les trois réalités (AR, VR, MR).",
+          "photoUrl": "/images/speakers/jeremy_voisin.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/_JeremyVoisin_"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/JeremyVoisin"
+            }
+          ]
+        },
+        {
+          "name": "Juliane Blier",
+          "company": "SchoolMouv",
+          "city": "Toulouse, France",
+          "bio": "Développeuse Web depuis presque 3 ans, je pratique Vue.js et Koa.js au quotidien chez SchoolMouv à Toulouse. \nCela fait maintenant trois conférences que je coprésente aux DevFest de Toulouse, de Brest puis à MiXiT 2019. Et je m'épanouis totalement dans cette nouvelle activité !",
+          "photoUrl": "/images/speakers/juliane_blier.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/tactless7"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/Tactless7"
+            }
+          ]
+        },
+        {
+          "name": "Liliia Abdulina",
+          "company": "JetBrains",
+          "city": "Munich, Germany",
+          "bio": "Kotlin QA since 2017. Writing Kotlin code on a daily basis to be one of the first persons who try the things around Kotlin, mostly tooling; multiplatform is the biggest and a favorite part — made 200+ posts answering the users when we've announced Kotlin Multiplatform 1.3 for the first time. I have a rich mobile apps QA background, used to be a Java developer for a little while at the very beginning of the carrier.",
+          "photoUrl": "/images/speakers/liliia_abdulina.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/var_lynx"
+            }
+          ]
+        },
+        {
+          "name": "Loïc Ortola",
+          "company": "Takima",
+          "city": "Paris, France",
+          "bio": "Loïc is the senior advocate of Takima, and CTO of Jawg Maps. \nJVM-based languages, Application performance, DevOps & Automation, Dev Discipline and Tech for Good are his primary targets!\n\nSince last year, Loïc has been orchestrating R&D in the taskforce named Hackers Against Natural Disasters, an organization that creates and deviates technologies to help raise awareness around the risks of Natural Disasters.",
+          "photoUrl": "/images/speakers/loic_ortola.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/LoicOrtola"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/loicortola"
+            }
+          ]
+        },
+        {
+          "name": "Loïs Blanc",
+          "company": "",
+          "city": "Vallauris, France",
+          "bio": "Loïs est en sixième et a eu son jaillissement de l’esprit en découvrant qu’il pouvait coder un Mario Bros avec Scratch.",
+          "photoUrl": "/images/speakers/lois_blanc.jpg",
+          "socials": []
+        },
+        {
+          "name": "Marie Viley",
+          "company": "Zenika",
+          "city": "Nantes, France",
+          "bio": "Recruteuse chez Zenika, je me suis toujours intéressée à la communication non verbale et aux mécanismes d’influence et de prise de décision. \nCe qui me motive, c’est de comprendre au mieux les gens et de pouvoir échanger avec eux. \nFan des conférences TED et  [#TRU] (https://www.linkhumans.fr/tru/) je suis constamment en veille sur le recrutement, le RGPD et les nouveautés tech.\nJ’aime également le métal, la bière et Dikkenek ^^",
+          "photoUrl": "/images/speakers/marie_viley.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/marie_viley"
+            }
+          ]
+        },
+        {
+          "name": "Mathieu Passenaud",
+          "company": "please-open.it",
+          "city": "Toulouse, France",
+          "bio": "DevOps (Teevity, Berger Levrault, OVH, Connit, Ubleam) depuis 8 ans maintenant sur Toulouse. Issu du milieu de l'embarqué (calculateurs ferroviaires/militaires), je me suis retrouvé parachuté dans l'univers du cloud pendant quelques années jusqu'à revenir au croisement de ces deux mondes : l'IOT. Touche à tout, j'aime beaucoup prototyper et répondre à la question 'est-ce que c'est possible ?'",
+          "photoUrl": "/images/speakers/mathieu_passenaud.jpg",
+          "socials": []
+        },
+        {
+          "name": "Mélanie Ducoffe",
+          "company": "Airbus",
+          "city": "Toulouse, France",
+          "bio": "",
+          "photoUrl": "/images/speakers/melanie_ducoffe.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/mducoffe"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/mducoffe"
+            }
+          ]
+        },
+        {
+          "name": "Nicolas Decoster",
+          "company": "Magellium",
+          "city": "Toulouse, France",
+          "bio": "Informaticien curieux depuis 35 ans, de métier depuis 20 ans (principalement dans le spatial). Non spécialiste touche à tout : du développement logiciel à l'étude scientifique, du développement d'algorithmes de traitement à la mise en œuvre de systèmes, de la programmation en C++ ou Python à l'utilisation des technos Web, de la petite appli en ligne de commande aux IHM ou aux systèmes distribués. Ingénieur chez Magellium et co-fondateur et animateur à la Compagnie du Code.",
+          "photoUrl": "/images/speakers/nicolas_decoster.png",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/ogadaki"
+            }
+          ]
+        },
+        {
+          "name": "Noël Macé",
+          "company": "",
+          "city": "Toulouse, France",
+          "bio": "Noël est un passionné de DevRel, d’enseignement, et de transmission de compétences en général. Tour à tour developer advocate, ingénieur pédagogique, formateur, architecte et développeur web depuis plus de 10 ans, il consacre aujourd’hui l’essentiel de son temps à accompagner la communauté vers une meilleure maîtrise et adoption des capacités modernes du Web..",
+          "photoUrl": "/images/speakers/noel_mace.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/noel_mace"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/noelmace"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Leplus",
+          "company": "Microsoft",
+          "city": "Paris, France",
+          "bio": "Developer Relation Manager at Microsoft and Google Developer Expert in Web Technologies. I love to share knowledge (and love) among developers and people in general.",
+          "photoUrl": "/images/speakers/olivier_leplus.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/olivierleplus"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/tagazok"
+            }
+          ]
+        },
+        {
+          "name": "Piotr Przybyl",
+          "company": "@piotrprz",
+          "city": "Wroclaw, Poland",
+          "bio": "Notorious engineer at work and after hours, tracing meanders of the art of software engineering. Software Gardener, mostly working in web-oriented Java gardens. Fan of agility, seen mostly as choosing the right tools and approaches. Lead developer, trainer and conference speaker.",
+          "photoUrl": "/images/speakers/piotr_przybyl.png",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/piotrprz"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/pioorg"
+            }
+          ]
+        },
+        {
+          "name": "Yves Boyez",
+          "company": "Continental Digital Service France",
+          "city": "Toulouse, France",
+          "bio": "Yves BOYEZ   \nIngénieur de 47 ans, marié, 4 enfants (eeeeeeeet ouais !)  \n\nActuellement administrateur des Outils ATLASSIAN chez CONTINENTAL DIGITAL SERVICES FRANCE au sein de l'équipe Devops  \nAnciennement Gestionnaire et Développeur du Systèmes d’Information RH chez CONTINENTAL AUTOMOTIVE  \nPlus anciennement encore Chef de Projet Groupware chez SIEMENS VDO AUTOMOTIVE  \nEt vraiment il y a fort fort longtemps : Ingénieur Système Informatique & CAO chez PROMECA mais comme on était encore en Francs je sais pas si ça compte ...  \n\nJ'aime les jeux vidéos, chanter avec mon groupe de Blues-Rock, nager et les pâtisseries (même si elles ne font que détruire mon organisme sans me demander mon avis).\n\nEt participer au Devfest ce serait cool ! (Du moins pour un vieux  :-D)",
+          "photoUrl": "/images/speakers/qj7nbl6wiyug1rhqtxf818a46po1.jpg",
+          "socials": [
+            {
+              "name": "github",
+              "link": "https://github.com/Zorkbomb"
+            }
+          ]
+        },
+        {
+          "name": "Richard Fagot",
+          "company": "",
+          "city": "Toulouse, France",
+          "bio": "Tombé dans l'informatique vers l'âge de 8 ans, j'en ai fait mon métier et si, après plusieurs années à faire du développement, je suis aujourd'hui chef de projet je reste un curieux inlassable, autant intéressé par les technologies, l'artisanat que l'humain.",
+          "photoUrl": "/images/speakers/richard_fagot.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/richardfagot"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/richard-fagot"
+            }
+          ]
+        },
+        {
+          "name": "Saskia Blanc",
+          "company": "",
+          "city": "Vallauris, France",
+          "bio": "Saskia est en troisième et est passionnée par la programmation. \nElle a déjà 3 keynotes à son actif ainsi qu’un talk à DevoxxFR.",
+          "photoUrl": "/images/speakers/saskia_blanc.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/SaskiaLois"
+            }
+          ]
+        },
+        {
+          "name": "Sébastien Blanc",
+          "company": "Red Hat",
+          "city": "Vallauris, France",
+          "bio": "Sébastien travaille actuellement pour Red Hat, il fait partie de l’équipe KeyCloak qui délivre un serveur Open Source d'authentification et de gestion d'identité. Il aime également partager sa passion du code et notamment sur la façon de transmettre cette passion aux générations futures.",
+          "photoUrl": "/images/speakers/sebastien_blanc.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/sebi2706"
+            }
+          ]
+        },
+        {
+          "name": "Sébastien Brault",
+          "company": "Orange",
+          "city": "Trégastel, France",
+          "bio": "Développeur mobile sur iOS depuis 2010, je suis le principal développeur du composant d'authentification de l'ensemble des applications Orange France iOS. Depuis plusieurs mois maintenant je me suis penché sur les impacts environnementaux du numérique, les identifier, en mesurer les ordres de grandeur, identifier les leviers d'actions efficaces.",
+          "photoUrl": "/images/speakers/sebastien_brault.png",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/sebastienbrault"
+            }
+          ]
+        },
+        {
+          "name": "Steve Klabnik",
+          "company": "Cloudflare",
+          "city": "Austin, TX, USA",
+          "bio": "Steve is on the core team of Rust, leads the documentation team, and is an author of The Rust Programming Language. Klabnik is a frequent speaker at conferences and is a prolific open source contributor, previously working on projects such as Ruby and Ruby on Rails.",
+          "photoUrl": "/images/speakers/steve_klabnik.jpg",
+          "socials": []
+        },
+        {
+          "name": "Sylvain Wallez",
+          "company": "Elastic",
+          "city": "Toulouse, France",
+          "bio": "Architecte et développeur passionné, tech lead dans l'équipe Cloud chez Elastic. A travaillé comme architecte, CTO et leader technique dans plusieurs startups. Expert technique multi-compétences : systèmes scalables, NoSQL, moteurs de recherche, mais aussi front-end, devops et Iot. Bref, full-stack. Membre de la fondation Apache.",
+          "photoUrl": "/images/speakers/sylvain_wallez.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/bluxte"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/swallez"
+            }
+          ]
+        },
+        {
+          "name": "Theophile Wallez",
+          "company": "ENS Ulm",
+          "city": "Paris, France",
+          "bio": "Théophile Wallez est étudiant en informatique à l’ENS Paris. Passionné - entre autres - par la programmation, du Brainfuck aux preuves formelles, et aussi de régie son & lumière et DJ’ing. Il est aussi contributeur sur le compilateur vérifié [CakeML].\n\n[CakeML]: https://cakeml.org",
+          "photoUrl": "/images/speakers/theophile_wallez.png",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/twallez"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/TWal"
+            }
+          ]
+        },
+        {
+          "name": "Tiffany Souterre",
+          "company": "JEMS Datafactory",
+          "city": "Paris, France",
+          "bio": "I love science and I love data! After finishing a PhD in genetic engineering, I continued my quest for discovering new patterns through data science and machine learning. I currently work as a Data Scientist and I play with machine learning algorithms on my free time. Someday, I wish to leverage artificial intelligence and genetics to improve people's life.",
+          "photoUrl": "/images/speakers/tiffany_souterre.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/tiffanysouterre"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/amagash"
+            }
+          ]
+        },
+        {
+          "name": "Valeriane Venance",
+          "company": "Clever Cloud",
+          "city": "Paris, France",
+          "bio": "Valériane had nothing to do with coding or anything related in her previous life, and she basically fell into computer science, internet, communities, philosophies and ethics at école 42.\nShe has learned web basics with Le wagon and started as freelancer in Paris right after.\nPassionate about the startup ecosystem she has been a backend developer, consultant and deputy CTO for many and started talking in local meetups by the time.\nNowadays she writes about the techs she loves as a developer advocate for Clever Cloud and organizes the DevRelSalon meetup in Paris.",
+          "photoUrl": "/images/speakers/valeriane_venance.png",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/valeriane_IT"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/vvenance"
+            }
+          ]
+        },
+        {
+          "name": "Vincent Ogloblinsky",
+          "company": "SII Ouest",
+          "city": "Rennes, France",
+          "bio": "Brestois du bout du monde émigré à Rennes, je suis architecte logiciel dans une ESN française et passionné par les technologies du web, et la plupart du temps je les utilise en codant en (Type||Java)script. . Je suis également Google Developer Expert sur les technologies web.\nLe partage de la connaissance est pour moi une chose importante : au sein de ma société au travers de déjeuners techniques ou de sessions de mobprogramming; durant des formations HTML5, Angular 1 & 2 ou autres; en présentant des sujets lors de conférences; et enfin en contribuant et en maintenant des projets open-source.\n\"Let's browsers rock\"",
+          "photoUrl": "/images/speakers/vincent_ogloblinsky.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/vogloblinsky"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/vogloblinsky"
+            }
+          ]
+        },
+        {
+          "name": "Wassim Chegham",
+          "company": "Microsoft",
+          "city": "Paris, France",
+          "bio": "Wassim is a member of the Angular team and a Senior Developer Advocate at Microsoft. He is the author of many open source projects such as xlayers.dev and ngx.tools. He is also a GDE for the Angular team, the Google Assistant and the GCP teams at Google. He is a member of the Node.js Foundation. A former member of the Angular Universal core team and part of the current Angular Console core team. He is currently learning about music composition. You can reach out to him on Twitter @manekinekko",
+          "photoUrl": "/images/speakers/wassim_chegham.jpg",
+          "socials": [
+            {
+              "name": "twitter",
+              "link": "https://twitter.com/manekinekko"
+            },
+            {
+              "name": "github",
+              "link": "https://github.com/manekinekko"
+            }
+          ]
+        }
+      ],
+      "sessions": [
+        {
+          "title": "10 est une puissance de 2",
+          "description": "Le code barre est une invention qui a radicalement modifié nos sociétés. Sans elle, pas d'inventaire efficace, de supermarchés ou de vente en ligne.\n\nMais comment coder les chiffres de façon fiable avec des petites barres noires et blanches ? Quand les contraintes matérielles empêchent d'utiliser le binaire, l'ingéniosité et un peu de chance ont permis de créer ce produit, maintenant présent partout.\n\n\nNous découvrirons les détails de ce codage, et comment il pourrait même contenir davantage d'informations.",
+          "speakers": [
+            "Gilles Debunne"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=3XIAC098fAI"
+        },
+        {
+          "title": "3 techniques faciles de manipulation",
+          "description": "Qui ne s’est jamais fait manipuler ? Évidemment, on est tous allé à une soirée alors qu’on en avait pas envie, on a tous acheté un truc sans en avoir besoin et on a tous été influencé par nos proches. \n\nL’idée de cette présentation est de vous ouvrir les yeux sur les relations et les influences entre les gens. Je vous exposerai les mécanismes de prise de décision au travers de 3 techniques simples de manipulation.\n\nA la sortie de ce talk, vous devriez être moins influençable et maître de vos décisions (voire même manipuler les autres).",
+          "speakers": [
+            "Marie Viley"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=OgOAMs6b5R0"
+        },
+        {
+          "title": "Allo Paris, ici San Francisco. Et si on codait ensemble avec VS Code?",
+          "description": "Vous aimez VS Code car il est simple, intuitif et qu'il fait ce que vous lui demandez.   \nMais saviez-vous que vous pouviez coder à plusieurs dans VS Code? et même permettre à une personne tierce de jouer avec votre débugger depuis l'autre bout du monde? Saviez-vous que vous pouviez avoir un client slack dans VS Code, et même un chat audio?  \nEt avez-vous exploré toutes les possibilités que VS Code offre quand vous utilisez GitHub?\nNous verrons dans ce talk tout ce qui fait de VS Code l'éditeur de code parfait pour faire du code collaboratif.",
+          "speakers": [
+            "Olivier Leplus",
+            "Tiffany Souterre"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_method___tools"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=6KR0rNN4coU"
+        },
+        {
+          "title": "Applications de Brainfuck, langage minimaliste mais Turing-complet",
+          "description": "Brainfuck est probablement le plus connu des langages de programmation ésotériques. Ses 8 instructions en font un langage Turing-complet avec lequel il est théoriquement possible d’écrire n’importe quel programme.\n\nEt en pratique ? Après une explication du langage (avec 8 instructions c’est rapide !) on verra comment j’ai utilisé Brainfuck pour les qualifications au concours d’informatique Prologin, sur un problème de parcours de graphes !",
+          "speakers": [
+            "Theophile Wallez"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=deswvXZ0Sjc"
+        },
+        {
+          "title": "Authentication/Authorization Starters Battle",
+          "description": "When you start a brand new app or service, you need to think about how you will manage authentication and permissions. But if you are like everyone else, you genuinely do not want to actually think about this. If someone else could do that for you, life would be great. And this has actually happened, you have the choice between several boilerplate projects or authentication/authorization libraries. In fact, you have a lot of options. Which one to choose? Let's have a closer look to them!\n\nAt the end of this talk, you will have a good overview of the common existing solutions and their benefits.",
+          "speakers": [
+            "Valeriane Venance"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_method___tools"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=yU_Uvm3m3VY"
+        },
+        {
+          "title": "A Kotlin multiplatform evolution",
+          "description": "Have you heard of the code-sharing feature in Kotlin, accompanied with \"Write once, run everywhere\" slogan? Among its users not only libraries and frameworks authors; there are some projects which have already adopted multiplatform for production. Their applications, written in Kotlin for *both* iOS and Android, are published in stores. \nWith this talk, you'll get a brief overview of the evolution of multiplatform technology in Kotlin, concerning the tasks it's evolved to solve. How it was and how it is expected to be; what has changed and which tasks can be already solved with it. What are the facilities right now and which real projects already use multiplatform?",
+          "speakers": [
+            "Liliia Abdulina"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "_languages"
+          ],
+          "complexity": "advanced",
+          "youtube": "https://www.youtube.com/watch?v=NedshJ6n7UI"
+        },
+        {
+          "title": "A la découverte de la réalité augmentée avec ARCore",
+          "description": "Avec les annonces de l'arrivée de la réalité augmentée (ou RA)  dans Google Maps et Google Search sur Android lors de Google IO 2019, nous constatons que la RA va prendre une place de plus en plus importante dans notre quotidien. La sortie d'ARCore en mars 2018 sur Android a simplifié le développement d’application en RA sur Android.\n\nAu cours de cette session, nous vous proposons de découvrir ARCore, via l’utilisation dans un navigateur, des applications natives ou des moteurs 3D comme Unity ainsi que les CloudAnchors qui permettent la persistance et le partage de positions d’objets dans les scènes de réalité augmentée, y compris avec des utilisateurs d’iOS.\n\nAprès une initiation aux concepts liés à la RA (meshes, 6 DoF,...), nous présenterons les différentes fonctionnalités d’ARCore. Nous discuterons aussi des différentes approches d’utilisation, de leurs limitations et avantages au travers d'une application de cartographie 3D en réalité augmentée.",
+          "speakers": [
+            "Christophe Jollivet",
+            "Jérémy Voisin"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_native_mobile_apps"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=MPnesJY8f0s"
+        },
+        {
+          "title": "Brace yourself, \\U0001F366Vanilla is coming … back \\U0001F576!",
+          "description": "Dans un monde de saveurs complexes et sophistiquées, la guerre du toping fait rage chez les crèmes glacées du Web ! Face au champs de bétail, les pronostiques vont bon train pour savoir qui l’emportera entre le crunchy Angulaire, le fondant Reactif et le décoratif Vue.\n\nDurant ce temps, loin de ces vicissitudes, la petite saveur basique vanille fait son bonhomme de chemin. S’agirait-il du héros de la légende, susceptible de renverser le destin de ce monde sans heurt ?\n\nSache, voyageur, qu’elle est déjà passée par nos contrées. Laisse moi te raconter comment elle nous a permis de renverser notre vieux roi, et tu sauras enfin ce qui se prépare pour ton royaume.\n\n---\n\n<blockquote class=\"twitter-tweet\">\n    <p lang=\"en\" dir=\"ltr\">Enjoyed or missed my talk at <a href=\"https://twitter.com/DevFestToulouse?ref_src=twsrc%5Etfw\">@DevFestToulouse</a> yesterday? Wanna learn more? Here is what you need:<br>👨‍🏫 Slides: <a href=\"https://t.co/XaNFvipCDh\">https://t.co/XaNFvipCDh</a><br>✍️ Blog posts (soon): <a href=\"https://t.co/kAtbQKJLC5\">https://t.co/kAtbQKJLC5</a><br>📖 Notes (for impatients): <a href=\"https://t.co/Bm9xa95OCw\">https://t.co/Bm9xa95OCw</a><br>🔥 <a href=\"https://t.co/xmmfCQcWAJ\">https://t.co/xmmfCQcWAJ</a><a href=\"https://twitter.com/hashtag/DevFestToulouse?src=hash&amp;ref_src=twsrc%5Etfw\">#DevFestToulouse</a></p>&mdash; Noël Macé (@noel_mace) <a href=\"https://twitter.com/noel_mace/status/1180091372164042753?ref_src=twsrc%5Etfw\">October 4, 2019</a>\n</blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>",
+          "speakers": [
+            "Noël Macé"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_web"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=-d_Ka7OE4Xk"
+        },
+        {
+          "title": "Comprendre le rôle du noyau d'un système d'exploitation",
+          "description": "Programmer le noyau d'un système d'exploitation est un très bon moyen pour en comprendre le fonctionnement et le scope de son travail (IO, gestion de la mémoire, etc).\nCette présentation a pour but de présenter et de développer les composants élémentaires d'un micro noyau UNIX.\n\nDans ce talk je présenterai:\n- L'émulateur QEMU\n- La réalisation d'un secteur de boot avec une micro console\n- Comment gérer les interruptions hardware (clavier) et software\n- La gestion des appels systèmes\n- Un système multi-process simple qui va permettre de découvrir le surcoût des changements de contexte liés à la programmation concurrentielle",
+          "speakers": [
+            "Alessio Coltellacci"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_cloud___infra"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=y928d3uVEys"
+        },
+        {
+          "title": "Développeurs en reconversion, développeurs quand même !",
+          "description": "Ces dernières années, les \"fabriques de dev\" et autres formations courtes explosent. C'est un fait, tout dev a été ou sera amené à travailler avec l'un de ces jeunes développeurs.euses. Mais qui sont-ils ? Pourquoi une reconversion dans ce genre d'organisation ? Qu'ont-ils appris lors de leur formation express ? C'est fiable ce genre de dev ? Comment puis-je les intégrer au mieux dans ma structure ?\n\nAutant de questions que vous vous êtes sans doute déjà posées. Pendant ces 15 minutes, je vous présenterai mon retour d'expérience en tant que développeuse provenant de l'une de ces écoles de dev et maintenant développeuse Javascript depuis 2 ans au sein d'une startup Toulousaine.",
+          "speakers": [
+            "Juliane Blier"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=jyTISfF8MTo"
+        },
+        {
+          "title": "DevOps at scale",
+          "description": "DevOps is everywhere, and every new or existing project is at least considering to follow its principles. While implementing DevOps for single projects become more and more straightforward, it's still a challenge to have a coherent DevOps approach at Enterprise level.\n\nLet's dig in what it takes to achieve DevOps in large companies, with Airbus as an example.",
+          "speakers": [
+            "Adrien Anceau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_method___tools"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=ww-Kg0bH6E4"
+        },
+        {
+          "title": "De Java à un exécutable natif : GraalVM et Quarkus changent la donne",
+          "description": "Les microservices, la scalabilité instantanée et les plates-formes à haute densité comme Kubernetes nécessitent des applications à faible empreinte mémoire et démarrage rapide. Java n'était pas bien positionné car il favorise les temps de traitement aux dépens du CPU et de la RAM.\n\nPlus maintenant.\n\nEntre en scène Quarkus, une stack Java orientée microservices qui supporte vos composants favoris (Hibernate, Vert.x, Camel, RESTEasy ...) sur GraalVM et HotSpot avec une faible empreinte mémoire et un démarrage rapide. Tout ce qu'il faut pour tirer pleinement parti des containers.\n\nLa gestion de la donnée est souvent l'aspect le plus complexe : découvrons comment Quarkus gère la persistance avec Hibernate ORM. Venez explorer le live reload, notre vision de la persistance avec Hibernate Panache, l'indexation full text avec Hibernate Search, l'environnement de test, la compilation native GraalVM et bien plus. Quarkus se vit plus qu'il ne se verbalise, attendez-vous à une démo détaillée.",
+          "speakers": [
+            "Guillaume Smet"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_method___tools"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=cLyw7vPr3mo"
+        },
+        {
+          "title": "Four Diseases",
+          "description": "How a developer can tell if the system is sick just by taking a look at the input and the output? If you'd like to know that (plus you like standup comedy), come an see! The treatment is safe ;-)\n\nOne approach to get familiar with a system is a long and intense reading the manual (and to run an eye over the source code sometimes). Another approach is to take a deep dive into the data model (often in the DB) and to surf the user interface. Both are natural ends of the system, the legendary Input and Output. By examining these ends one can check if there's good digestion or if guts are rotten. Careful examination can confirm \"common DDDosis\", \"malignant stringosis\", \"regex diarrhoea\" or \"not-made-here syndrome\".\nUnfortunately, sometimes developers get infected in their prenatal life (meaning: at their university). Let me invite you to treatment. A laxative one. (That is: a sequel of \"Passwords. Do you keep them safe?\")",
+          "speakers": [
+            "Piotr Przybyl"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=E9EKWrRcyYk"
+        },
+        {
+          "title": "Introduction à la programmation par contraintes",
+          "description": "Quel est le point commun entre un jeu de sudoku, la planification d'une conférence et les déplacements d'un commercial ?\n\nQuand on souhaite les traiter automatiquement, tous ces problèmes peuvent être résolus par un solveur de contraintes. Dans ce talk, je vais essayer de vous faire une introduction pratique à la programmation par contraintes, en présentant les concepts de base, puis en les mettant en application avec plusieurs exemples de problèmes connus de tout le monde (ou presque), pour finir par un cas plus complexe sur lequel je travaille actuellement.\n\n---\n\n<blockquote class=\"twitter-tweet\">\n    <p lang=\"fr\" dir=\"ltr\">Les slides de ma présentation au <a href=\"https://twitter.com/hashtag/DevFestToulouse?src=hash&amp;ref_src=twsrc%5Etfw\">#DevFestToulouse</a> sur la programmation par contraintes sont ici : <a href=\"https://t.co/2lk9XoGnzN\">https://t.co/2lk9XoGnzN</a><br>Pour le code, ça se passe sur github : <a href=\"https://t.co/f6Ndt8zdB4\">https://t.co/f6Ndt8zdB4</a></p>&mdash; Cyril Delmas 🐧🍺 (@cyril_delmas) <a href=\"https://twitter.com/cyril_delmas/status/1180104468295278593?ref_src=twsrc%5Etfw\">October 4, 2019</a>\n</blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>",
+          "speakers": [
+            "Cyril Delmas"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_big_data___ml___ai"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=l44o4gt62GM"
+        },
+        {
+          "title": "Une analyse critique des \"Tech Trends\"",
+          "description": "Notre secteur d'activité est régulièrement abreuvé de prévisions et de tendances : quel sera le prochain langage, le prochain framework, la nouvelle architecture, les nouveaux \"use cases\", les prochaines technologies disruptives ? Etc.\n\nDe nombreuses sociétés publient des \"tech trends\" et certaines ont même fait de cette publication un coeur de métier (notamment les grands cabinets d'analystes). En marge du discours très \"marketing oriented\" des entreprises, il y a également l'omni-présence de nombreux gourous, futurologues ou prospectivistes qui jouent aux oracles. Mais il y a aussi de nombreuses personnalités indépendantes qui ont un discours sur l'innovation technologique plus libre, comme par exemple Kevin Kelly ou Simon Wardley.\n\nJe vous propose non pas une vision du futur de plus, mais de vous faire part des résultats d'une étude, que j'ai mené avec d'autres, qui analyse et compare les différentes méthodes et approches utilisées pour prédire l'avenir des technologies informatiques.",
+          "speakers": [
+            "Christian Fauré"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "tags": [
+            "keynote"
+          ],
+          "complexity": "",
+          "youtube": "https://www.youtube.com/watch?v=aYA_a0-bplY"
+        },
+        {
+          "title": "Une histoire de l'informatique, du métier à tisser à la machine de Babbage...",
+          "description": "...où l'on parle aussi de la Pascaline, de table de logarithmes et d'éviter les erreurs. Et d'en faire.\n\n---\n\n[Histoires de Mathématiques](https://hist-math.fr/)\n\n<blockquote class=\"twitter-tweet\">\n    <p lang=\"fr\" dir=\"ltr\">Petit thread complément indispensable à mon talk d&#39;hier au <a href=\"https://twitter.com/DevFestToulouse?ref_src=twsrc%5Etfw\">@DevFestToulouse</a> , deux choses que je n&#39;ai pas réussi à dire dans le temps : D&#39;abord si je vous ai donné un tout petit peu envie d&#39;en savoir plus sur l&#39;histoire des maths et de l&#39;informatique, le site de Bernard Ycart <a href=\"https://t.co/ejtAam5Kjy\">pic.twitter.com/ejtAam5Kjy</a></p>&mdash; Fabien Trégan (@FTregan) <a href=\"https://twitter.com/FTregan/status/1180059776371306496?ref_src=twsrc%5Etfw\">October 4, 2019</a>\n</blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>",
+          "speakers": [
+            "Fabien Trégan"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "tags": [
+            "keynote"
+          ],
+          "complexity": "",
+          "youtube": "https://www.youtube.com/watch?v=LHzVkjHjSso"
+        },
+        {
+          "title": "Le burn-out agile",
+          "description": "En 2019, le monde de l’informatique n’a que l’agilité à la bouche. Ca groome à tous les coins de rue, ça s’excite en daily, ça colle des post-it et ça empile les serious game en rétro. Bien sûr, ça gère la transformation numérique (désolé, même au second degré, je ne peux pas employer “digitale”) et au final plus personne ne comprend rien. \n\nDes chefs de projet subitement propulsés ScrumMaster qui ne savent pas ce qu’ils doivent faire. Des PO qui découvrent la priorisation. Des développeurs qui doivent composer avec des specs floues et changeantes sans vision globale du projet. Pour compléter le tableau, la subite apparition de coachs agile à peine sortis de l’école qui n’ont jamais vu un projet de leur vie et qui viennent expliquer des concepts qu’ils ne maîtrisent qu’à moitié.\n\nEn 2019 le monde de l’informatique rêve secrètement de cycles en V, de stabilité, de spécifications générales et de dossier d’architecture.\n\nEn 2019 le monde de l’informatique est au bord du burn-out agile.\n\n## Plan du talk  \n\n- Petit historique : l’évolution des pratiques sur les 20 dernières années \n- Pourquoi ce bordel agile ? \n- Finalement l’agilité c’est quoi ? \n- Est-ce qu’il faut revenir au cycle en V ?",
+          "speakers": [
+            "Cédric Moulard"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_method___tools"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=ciAORrJYHc8"
+        },
+        {
+          "title": "Le design de l'erreur",
+          "description": "Nos systèmes sont designés de manière optimiste, de la gestion technique des erreurs à la modélisation de nos interfaces.  \nQue ce soient les codes d'erreurs, les exceptions ou les modélisations plus avancées, elles servent pour arrêter un traitement et _potentiellement_ afficher un message d'information à un utilisateur.\n\nMais avec les architectures microservices, la distribution des traitements ou une simple volonté de résilience, la gestion des erreurs est devenue un enjeu important de tous les systèmes afin qu’ils restent accessibles de tous, tout le temps tout en maintenant le système dans un état cohérent.\n\nQue fait-on lorsqu’une erreur intervient ? Peut-on compenser voire gérer l’erreur depuis le système pour l’utilisateur ?\n\nLa réponse à ces questions se trouve autant dans la définition du produit que dans le choix technique.\nUn outil bien conçu est un outil intelligent qui peut faire les bons choix au bon moment pour l'utilisateur. Et si on apprenait ensemble à concevoir nos erreurs ?",
+          "speakers": [
+            "François Teychene"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_method___tools"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=9P8FZIqUuTM"
+        },
+        {
+          "title": "Le jaillissement de l'esprit",
+          "description": "Les enfants sont eux-mêmes les bâtisseurs actifs de leurs propres structures intellectuelles et l'informatique y joue un rôle déterminant, disait Piaget, un célèbre biologiste, psychologue et logicien. Son collaborateur, Seymour Papert, inventera le langage Logo, langage qui fait qu'aujourd’hui je suis un développeur épanoui.\nQu'en est-il aujourd'hui ? Comment donner le goût du code à nos enfants et surtout pourquoi est-ce important ?\nAvec Saskia, Loïs et leur père nous voyagerons à travers le temps, en partant de la tortue sur ce bon vieux M05 en passant par Scratch, le Logo hipster de nos jours, jusqu’à Groovy et Python.\n\n---\n\n<blockquote class=\"twitter-tweet\">\n    <p lang=\"fr\" dir=\"ltr\">Pas mal de personnes m&#39;ont demandé le lien vers les cartes d&#39;activités <a href=\"https://twitter.com/scratch?ref_src=twsrc%5Etfw\">@scratch</a> : <a href=\"https://t.co/QwgHepwZ7Z\">https://t.co/QwgHepwZ7Z</a> et voici le lien vers les cartes d&#39;activités <a href=\"https://twitter.com/makeymakey?ref_src=twsrc%5Etfw\">@makeymakey</a> faites par <a href=\"https://twitter.com/Saskia_Blanc?ref_src=twsrc%5Etfw\">@Saskia_Blanc</a> : <a href=\"https://t.co/MMFimwixbY\">https://t.co/MMFimwixbY</a> <a href=\"https://twitter.com/hashtag/DevFestToulouse?src=hash&amp;ref_src=twsrc%5Etfw\">#DevFestToulouse</a></p>&mdash; Sébastien Blanc 🇪🇺 🥑 (@sebi2706) <a href=\"https://twitter.com/sebi2706/status/1180413658612092929?ref_src=twsrc%5Etfw\">October 5, 2019</a>\n</blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>",
+          "speakers": [
+            "Loïs Blanc",
+            "Saskia Blanc",
+            "Sébastien Blanc"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_method___tools"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=3r12HslMosQ"
+        },
+        {
+          "title": "Le troll dans ta machine",
+          "description": "Jean-Yves Girard, le génial inventeur des indispensables [montres à moutarde](http://girard.perso.math.cnrs.fr/moutarde.pdf) (1990), est certes un joyeux trublion.\n\nMais avant d'en arriver à ce sommet indépassable, il a tout de même publié deux-trois petites choses en chemin:\n\n- Rust, vous connaissez? L'idée première du système de typage de Rust est la logique dite \"[linéaire](http://girard.perso.math.cnrs.fr/linear.pdf)\", due à Jean-Yves Girard (1987).\n- Haskell, ça vous dit quelque chose? Les systèmes de typage de Haskell mais aussi Scala (et d'une certaine manière Java) sont basés sur le \"[système F](https://en.wikipedia.org/wiki/System_F)\" (ou lambda-calcul de second ordre), dû à... Jean-Yves Girard (1972).\n- Idris, vous avez entendu parler? Le système de typage d'Idris est basé sur la théorie des types de Per Martin-Löf, dont la première version a été prouvée incorrecte par... Jean-Yves Girard, qui depuis possède un [paradoxe](https://en.wikipedia.org/wiki/System_U#Girard's_paradox) à son nom. (Girard et Martin-Löf sont par ailleurs de très bons potes et ont ferraillé sec contre les logiciens classiques dans leur prime jeunesse.)\n\nTrès méconnu mais probalement l'un des penseurs les plus influents pour l'informatique de ce début de XXIe siècle, Girard est tout aussi sérieux que fantasque. Son style toujours acéré et polémique s'appuie sur une vision très claire de ce que devrait être la logique: vivante, joyeuse, fertile.\n\nDans cette courte présentation, on s'attachera à comprendre pourquoi Girard est aussi virulent dans son discours, quels sont les objectifs de sa pensée, et pourquoi elle a déjà porté tant de fruits dans le monde de l'informatique.",
+          "speakers": [
+            "Guillaume Andrieu"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=w_KFjqAxEu8"
+        },
+        {
+          "title": "Live coding musical : vous savez coder ?",
+          "description": "Sans nécessiter de formation musicale pointue, tout développeur peut créer des morceaux qui sonnent bien et faire du \"live coding\" pour improviser en direct.\n\nAprès un rapide tour d'horizon des environnements de codage musical comme Sonic-Pi en Ruby ou FoxDot en Python, on codera/composera en live un morceau de musique électro avec comme seul outil un navigateur web, les API WebAudio et WebMIDI et la librairie Tone.js.\n\nQuelques samples bien choisis, une pincée de séquences harmonieuses, une bonne dose d'aléatoire encadré, et hop, tout le monde se mettra à danser ! Et puisque la musique c'est aussi des maths, on parlera de musique générative avec des chaînes de Markov et des L-Systems.\n\nDavid Guetta n'a qu'à bien se tenir !\n\n---\n<blockquote class=\"twitter-tweet\">\n    <p lang=\"en\" dir=\"ltr\">The code for my music live coding talk at <a href=\"https://twitter.com/DevFestToulouse?ref_src=twsrc%5Etfw\">@DevFestToulouse</a> and the code used on stage are available at <a href=\"https://t.co/DCT1k4UQss\">https://t.co/DCT1k4UQss</a><br><br>And here&#39;s a quick recording of the &quot;grand finale&quot;<br>🎶 <a href=\"https://t.co/TXPrfnHRXG\">https://t.co/TXPrfnHRXG</a></p>&mdash; Sylvain Wallez (@bluxte) <a href=\"https://twitter.com/bluxte/status/1180535831477530624?ref_src=twsrc%5Etfw\">October 5, 2019</a>\n</blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>",
+          "speakers": [
+            "Sylvain Wallez"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_web"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=LShM4QzMOxY"
+        },
+        {
+          "title": "L'histoire de la découverte d'une backdoor signée OnePlus",
+          "description": "## Résumé\nEn Novembre 2017, j'ai découvert \"une backdoor\" dans tous les téléphones de la marque OnePlus. À l'aide d'une simple ligne de commande, un attaquant ayant un accès physique au téléphone, pouvait devenir root et ainsi obtenir un contrôle total du téléphone de la victime.\n\n## Détails\nDans ce talk, j'expliquerai le processus qui m'a permis de faire cette découverte :\n1. Extraction du build\n2. Récupération des applications dites \"système\"\n3. Détection de la vulnérabilité dans l'application Android \"EngineeringMode\"\n4. Exploitation de la vulnérabilité\n\n## Sujet abordés\nLors de la détection et l'analyse de cette faille, nous aborderons la philosophie du **hacking**, comment faire du **reverse engineering** sur des applications **Android** et une **librairie native**. Nous analyserons du **Java** ainsi que du **C**.\n\n## Categorie\nNative mobile apps\n\n## Format\nUne conférence de 40 min\n\n---\n\n<blockquote class=\"twitter-tweet\">\n    <p lang=\"en\" dir=\"ltr\">It was a pleasure for me to speak at <a href=\"https://twitter.com/hashtag/DevFestToulouse?src=hash&amp;ref_src=twsrc%5Etfw\">#DevFestToulouse</a>! Thank you all for your very nice feedbacks 🥰<br><br>The video will be available soon and I will publish the slides tomorrow <a href=\"https://t.co/CCJXQL03Bp\">pic.twitter.com/CCJXQL03Bp</a></p>&mdash; Elliot Alderson (@fs0c131y) <a href=\"https://twitter.com/fs0c131y/status/1179807694041108480?ref_src=twsrc%5Etfw\">October 3, 2019</a>\n</blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>",
+          "speakers": [
+            "fs0c131y"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_native_mobile_apps"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=XyczLWRnD8M"
+        },
+        {
+          "title": "Machine learning avec des allumettes et des cotillons",
+          "description": "Dans ce talk je vous montrerai comment expliquer simplement le fonctionnement de l'apprentissage par renforcement. Pour cela pas besoin d'ordinateur : quelques allumettes, des sacs de cotillons et un peu de pédagogie sont suffisants pour mettre en évidence les mécanismes intrinsèques de cette technique et pour aborder les enjeux et les limites des algorithmes d'\"intelligence artificielle\" basés sur l'apprentissage.",
+          "speakers": [
+            "Nicolas Decoster"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "_big_data___ml___ai"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=KrKEAaNQVTQ"
+        },
+        {
+          "title": "Modern Forms in React",
+          "description": "If the new React Context API and Suspense killed Redux (they didn't), surely Hooks kill the need for a form library, right? Well, not exactly. Managing form state is more than just holding your current values in state; it's about sync and async validition errors, and much more! But that doesn't mean that Hooks are irrelevant to the situation. Hooks make building forms in React easier than ever before.",
+          "speakers": [
+            "Erik Rasmussen"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "_web"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=DDLqhCMaMLU"
+        },
+        {
+          "title": "Monitoring OVH: 300k serveurs, 27 DCs une plateforme de métriques ",
+          "description": "Comment faire quand on doit faire le suivi de toute l'infrastructure du plus grand fournisseur de cloud Européen ?  Comment choisir un outil quand les plus populaires ne tient pas la marée à cette échelle ?  Comment construire une plateforme Metrics pour unifier, concilier et remplacer des années de legacy fragmenté et des solutions partielles ?\n\nDans ce talk nous racontons notre expérience sur la construction et la maintenance d'OVH Metrics, la plateforme utilisée pour monitorer toute l'infrastructure OVH. Nous avions besoin d'aller à des endroits où la plupart des solutions de monitoring ne sont jamais allées, opérer à l'échelle du plus grand fournisseur Européen de cloud et hosting : 27 data centers, plus de 300k serveurs (physiques !) et des centaines de produits pour accomplir notre mission avec nos 1,3 millions de clients.\n\nVenez pour entendre cette histoire de séries temporelles, de solutions open-sources poussées à l'extrême, de clusters HBase opérés en limite de capacité, et de comment une petite équipe  s'est appuyée sur une poignée de solutions open-source et une bonne dose de code maison pour construire une des solutions de monitoring parmi les plus performantes au monde.",
+          "speakers": [
+            "Horacio Gonzalez (LostInBrittany)"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_big_data___ml___ai"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=lnW1_X9WxkM"
+        },
+        {
+          "title": "Mon p*** de voyant moteur est encore allumé !",
+          "description": "Depuis les années 70 tous les constructeurs autos intégrent des calculateurs électroniques.\nLes moteurs des voitures modernes sont des systèmes informatiques complexes qui s'appuient sur des dizaines de capteurs... et du code. \nComment ça fonctionne ? A quoi ressemble ce code et que fait-il ?\nQu'est-ce qu'il se passe lorsqu'on fait une \"reprog\" ? \nQue signifie le voyant moteur allumé ? Comment débugger tout ça ?\nSoulevons le capot (électronique), analysons le matériel mis en oeuvre mais surtout le logiciel grâce aux sources des calculateurs \"Megasquirt\" et allons explorer la face cachée numérique de nos voitures.\n\n---\n\nLe code utilisé pendant ma conf pour les intéressés : <https://github.com/mathieupassenaud/devfesttoulouse-python-obd>\n\n\n<blockquote class=\"twitter-tweet\">\n    <p lang=\"fr\" dir=\"ltr\">Cette année au <a href=\"https://twitter.com/DevFestToulouse?ref_src=twsrc%5Etfw\">@DevFestToulouse</a> j&#39;ai fait tourner un mock de moteur. Du coup, puisque vous me l&#39;avez demandé voici comment j&#39;ai pu en arriver là <a href=\"https://t.co/iq5juHH3MT\">pic.twitter.com/iq5juHH3MT</a></p>&mdash; Mathieu Passenaud (@mathieupassenau) <a href=\"https://twitter.com/mathieupassenau/status/1180873060272021505?ref_src=twsrc%5Etfw\">October 6, 2019</a>\n</blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>",
+          "speakers": [
+            "Mathieu Passenaud"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=1o5v8Ew9FjE"
+        },
+        {
+          "title": "Premiers pas avec un microcontrôleur et Google Cloud IoT Core",
+          "description": "De nombreux services en ligne existent pour gérer en toute sécurité des appareils IoT à grande échelle : \"Azure IoT\" de Microsoft et \"AWS IoT\" d'Amazon sont parmi les plus connus.\n\nGoogle propose également sa solution : \"Cloud IoT\" basée sur la plate-forme Google Cloud (GCP).\nDans ce talk, nous partirons d'un microcontrôleur neuf ultra connu et abordable, et notre but sera tout d'abord de découvrir comment écrire du code pour ce composant nous permettant de récupérer des informations sur notre environnement.\nEnsuite, nous ferons en sorte que ce composant envoie ses données vers un service Cloud, pour enfin découvrir ce que permettent ces solutions en ligne dédiées à l'IoT.\n\nPour l'exemple, et parce qu'il faut bien choisir une solution, nous utiliserons Google Cloud IoT Core, les concepts restant similaires sur les autres plates-formes.",
+          "speakers": [
+            "Gautier Mechling"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_iot"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=kQYepd4mFLo"
+        },
+        {
+          "title": "Quand les ratés des IAs nous renvoient à nos propres biais sociétaux",
+          "description": "Un chatbot créé par Microsoft qui dérive avec des propos antisémites, Amazon qui scanne des CVs et finit par ne recruter que des hommes blancs, des algorithmes de reconnaissance faciale qui ont du mal avec les personnes de couleur noire, ... Que d'exemples où l'IA a intégré nos propres biais sociétaux. Il est urgent que nous, développeurs, prenions nos responsabilités et mesurions les enjeux éthiques de l'IA pour éviter que les stéréotypes, les inégalités et les préjugés se retrouvent au cœur de nos futurs systèmes.\n\nCette présentation propose des root cause analysis sur des exemples concrets de ces biais et présente des alternatives qui auraient permis d'éviter ces biais en \"production\" autant d'un point de vue humain que technique.\n\nNous verrons notamment que l’éthique peut directement être abordée au niveau des données et de leur préparation à l’apprentissage. Nous nous concentrerons principalement sur l’impact des statistiques des données d’entraînement et les transformations à appliquer en pré-processing (métriques de fairness, améliorer la fairness sur des données annotées), et nous montrerons comment des benchmarks permettent d'appréhender l’impact des méthodes de fairness sur la précision des modèles entraînés.\n\nLa confiance et l’équité passe avant tout par une compréhension de la prise de décision par l’utilisateur. Par conséquent, nous présenterons diverses méthodes pour expliquer la prise de décision d’un modèle boîte noire (principalement des algorithmes de deep learning) et mettons en garde contre une mauvaise interprétation de ces explications.",
+          "speakers": [
+            "Clément Duffau",
+            "Mélanie Ducoffe"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_big_data___ml___ai"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=gB5qsODoGhU"
+        },
+        {
+          "title": "Rockin’ in the Angular World",
+          "description": "_« Make it work, make it right, make it fast »_ - Kent Beck\n\nNous connaissons tous cette citation. Pourtant nous sommes trop souvent restés bloqué à l’étape 1 par manque de temps ou de priorisation.\n\nL’accueil d’un nouveau développeur·euse dans une équipe est un des meilleurs moments pour vérifier qu’une base de code est « saine et scalable ».\n\nNous vous proposons dans ce talk un retour d’expérience sur quelques années de consulting sur des projets Angular au travers de cas concrets :\n- quelles sont les mauvaises pratiques à éviter ?\n- quels sont les choix orientés et assumés d’Angular pour vous éviter tout ça ?\n- quelle que soit la taille de votre équipe ou l’expérience de vos collègues, quels sont les principes d’architecture à adopter pour améliorer tout ça ?",
+          "speakers": [
+            "Vincent Ogloblinsky",
+            "Wassim Chegham"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_web"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=OA4-sHevu9s"
+        },
+        {
+          "title": "Rust as a High-Level Langage",
+          "description": "The singe most important feature of Rust is memory safety. Writing code with performance of C++, at a typical development cost, and with guaranteed absence of certain classes of memory safety related vulnerabilities is something that was not possible before. \n\nHowever, all popular managed languages with garbage collection take memory safety for granted, so this aspect of Rust doesn't bring anything new to the table, if you already use Java or Go. Nevertheless, Rust can be an interesting choice as a high-level language, and this talks explains way.  \n\nThe focus of the talk is fearless concurrency. Data races are a pervasive and unsolved problem in languages like Java and Rust's guaranteed thread safety is a liberating experience for application development. We also touch on some other benefits of the language for high-level tasks:\n\n* predictable performance due to absence of garbage  collection\n*  control over the memory layout of objects, which gives you extra performance if you need it\n*  module (crate) system that, at the language level, prevents dependency hell\n* additional correctness guarantees, like the absence of iterator validation or strict control of error conditions",
+          "speakers": [
+            "Aleksey Kladov"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "_languages"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=AAr6uALbYY0"
+        },
+        {
+          "title": "Rust, WebAssembly, and the future of Serverless",
+          "description": "A lot of things have been said about WebAssembly inside of the\nbrowser; after all, that's why it was originally created. But a new\ncase is emerging as well, and that's WebAssembly on the server. More\nspecifically, we're seeing a rise of support for WebAssembly in\nserverless application platforms, combining two brand-new technologies\ntogether. We're also seeing a lot of growth of the Rust programming\nlanguage, and its close alignment with WebAssembly. In this talk,\nSteve will talk about Rust, WebAssembly, serverless technologies, and\nhow it all fits together.",
+          "speakers": [
+            "Steve Klabnik"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "_cloud___infra"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=qZGimWMYc2E"
+        },
+        {
+          "title": "The Freedom of Static Typing",
+          "description": "It's a common idea: Dynamic typing gives you freedom to do whatever you want, but then you suffer mistakes and runtime errors. Static typing limits your freedom, but it leads to fewer bugs, even if it's harder to actually write code.\n\nThis isn't entirely false. Yes, it can be quite hard to write a Rust or Haskell program that compiles, enough that it's a running gag in their communities. \"But once you get it to compile, it's probably correct!\", the joke goes. On the other hand, when writing Ruby or Javascript, you're free to call functions with all sorts of things, and then runtime errors can easily slip into production. That said, it's not as simple as a sliding scale between \"freedom\" and \"safety\". Neither of these terms is one-dimensional -- a language feature that restricts your freedom in one way can actually free you in different ways.\n\nI'd like to demonstrate some interesting language features in Rust that make it easier to write code and to express concepts compared to dynamic languages. Features that don't just protect you from shooting your foot, but give you power that's only available within the rules and \"limitations\" of a statically typed language. Even if you're not familiar with Rust, I hope to focus the examples on the features themselves rather than on the specifics of the language, so come by and let's talk about being (type-safely) free.",
+          "speakers": [
+            "Andrew Radev"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "_languages"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=qfyhzwYWVn8"
+        },
+        {
+          "title": "The rise of the web",
+          "description": "Il y a 20 ans, personne de **sobre** n’aurait utilisé Javascript pour autre chose que des étoiles filantes qui sortent de ta souris. Non, à l'époque, on préférait les serveurs d'application en Java!  \nAujourd’hui, non seulement on a des frameworks front, mais il y a même des hipsters qui font du backend avec... Et depuis, on fait des APIs.  \n**Comment en est-on arrivé là?**  \nC’est ça inspecteur. C’est ça la bonne question.\n\nSi tu ne les as pas vécus, viens découvrir l'arrivée du Web, l'histoire de Netscape, la browser-war, la naissance du serveur d'application, les débuts du web dynamique et la prise d'assaut du JS.\n\nSit back, relax, and Enjoy!",
+          "speakers": [
+            "Loïc Ortola"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_web"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=wPRwD4rLOVo"
+        },
+        {
+          "title": "Un distributeur automatique d'argent de poche pour les enfants",
+          "description": "Avec mon épouse nous avons commencé à donner de l'argent de poche à nos enfants.\n\n![Calvin et l'argent de poche](https://i.pinimg.com/originals/ad/47/94/ad47940ca35ce4bd5122a916abf9f589.png)\n\nPour qu'ils puissent faire comme les grands (et parce que c'est fun aussi :D) j'ai conçu un DAAP (**D**istributeur **A**utomatique d'**A**rgent de **P**oche) qui leur permet, le jour de la distribution de l'argent de poche, d'insérer  leur \"carte bleue\", saisir leur code et de voir la machine s'ébranler pour distribuer les pièces.\n\nDans ce talk on parlera d'Arduino, d'impression 3D, de cartes à puce, d'électronique et des problèmes que j'ai rencontrés et comment j'ai pu les résoudre.\n\n---\n\n<blockquote class=\"twitter-tweet\" data-lang=\"en\"><p lang=\"fr\" dir=\"ltr\">Un petit <a href=\"https://twitter.com/hashtag/THREAD?src=hash&amp;ref_src=twsrc%5Etfw\">#THREAD</a> pour détailler un peu plus mon talk au <a href=\"https://twitter.com/hashtag/DevfestToulouse?src=hash&amp;ref_src=twsrc%5Etfw\">#DevfestToulouse</a> (cc: <a href=\"https://twitter.com/Heliox_Lab?ref_src=twsrc%5Etfw\">@Heliox_Lab</a>)<br>⬇️⬇️⬇️</p>&mdash; Richard Fagot (@richardfagot) <a href=\"https://twitter.com/richardfagot/status/1181189540800876544?ref_src=twsrc%5Etfw\">October 7, 2019</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>",
+          "speakers": [
+            "Richard Fagot"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=z72VgzUirL4"
+        },
+        {
+          "title": "WebGPU: Next-generation 3D Graphics on the Web",
+          "description": "This talk will give an overview of the WebGPU API that will provide modern features such as “GPU compute” on the Web as well as lower overhead access to GPU hardware and better, more predictable performance. This will allow for much more graphically intensive games on the Web and boost performance of frameworks like Tensorflow.js up to 10x.",
+          "speakers": [
+            "Corentin Wallez"
+          ],
+          "language": "en",
+          "format": "conference",
+          "tags": [
+            "_web"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=_UFkuYZrXV0"
+        },
+        {
+          "title": "« 47 ans : ils n’ont toujours pas remarqué … »",
+          "description": "L’âgisme dans les fonctions IT, et en particulier dans le Développement Soft, est incontournable.\n\nLes « vieux » n’ont décidément pas la cote, le marché de l'emploi des softeux cinquantenaires en est la preuve !\nPourtant, codage et sénioritude semblent loin d'être incompatibles.\n\n- Alors quels préjugés peuvent en être la cause ?\n- L’avance rapide de la technologie numérique est-elle incompatible avec le ralentissement biologique ?\n- Les cheveux gris sont-ils un Handicap pour la Sécurité de l’Info ?\n- Le Cloud doit-il être « Arthrose-free » ?\n\nEt surtout, comment se fait-il qu’à 47 ans je vienne d’intégrer l’équipe Devops & Tools de Continental Digital Services et que personne ne m’ait encore rien dit ?",
+          "speakers": [
+            "Yves Boyez"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=JADZMaRL4cE"
+        },
+        {
+          "title": "Numérique et environnement",
+          "description": "Le numérique fait-il partie du problème ou de la solution quand on parle de réchauffement climatique ?\n\n5 milliards de smartphones en circulation en 2020, ça représente quoi en consommation énergétique, en gaz à effet de serre, en pollution chimique ?\n\nLe streaming illimité à 10 euros par mois c'est le pied mais aujourd'hui Netflix a à peu près l'empreinte carbone du plus gros cimentier mondial, qui va payer la facture environnementale ?\n\nTous les mails de votre vie (que vous ne lirez plus jamais) disponibles sur Gmail, très utile, mais après 2020 on ne saura peut-être plus produire industriellement les équipements nécessaires à leur stockage.\n\nOn arrive dans \"l'âge des limites\", pour le numérique comme pour le reste. Quels sont les leviers pour basculer vers un numérique durable ?\n\nEt si malgré tout on décidait de s'en foutre ? 2 degrés en plus, c'est juste un pull en moins non ? Non. Par contre c'est 30% en moins sur les rendements agricoles pour ... 30 % de population en plus en 2050. En 1970, Dennis Meadows modélisait sur les ordinateurs du MIT un crash du système planétaire pour les décennies 2020-2030. Pour l'instant, c'est cette trajectoire que notre monde suit.",
+          "speakers": [
+            "Sébastien Brault"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_wtf"
+          ],
+          "complexity": "beginner",
+          "youtube": "https://www.youtube.com/watch?v=jA8aHSMZ_DI"
+        },
+        {
+          "title": "⛳️ Votre API web passe-t-elle le contrôle technique ? ",
+          "description": "Nous savons tous développer une API mais avons-nous tous bien intégré les problématiques d'environnements et de cycles logiciels multiples ? L'opérabilité, la gouvernance, le versioning, la traçabilité, la sécurité — et bien plus encore — de ces API web une fois en production ?\n\nDurant ce talk, c'est plusieurs dizaines de points d'attention rarement évoqués que je vous propose d'aborder, à la lumière de retours d'expériences provenant de chez Uber, Stripe, Facebook, ...",
+          "speakers": [
+            "Francois-Guillaume Ribreau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "tags": [
+            "_method___tools"
+          ],
+          "complexity": "intermediate",
+          "youtube": "https://www.youtube.com/watch?v=k7IIz7Z1MxM"
+        }
+      ]
+    },
+    "2023": {
+      "date": "2023-11-16",
+      "venue": "Centre de Congrès Diagora, Labège",
+      "speakers": [
+        {
+          "name": "Loïc Ortola",
+          "company": "Takima",
+          "city": "Paris",
+          "bio": "Loïc is the current CTO of Takima. His main field of expertise lies in distributed architectures and platform engineering. He likes sharing his vision about technology and put his hands-on expertise to good use in techy workshops",
+          "socials": []
+        },
+        {
+          "name": "Aurélien Moreau",
+          "company": "Takima",
+          "city": "Paris (France)",
+          "bio": "<p>Aurélien n’est pas juste un adepte de la marinière. Ops érudit, ayant fait ses armes dans les équipes infra chez EDF, il a vu passer 10 ans d’innovations et a vécu les changements de paradigmes engendrés par l’avènement des outils DevOps. Docker, Kubernetes, il est devenu Cloud Ops Architect et saura vous donner une lecture de ce que le DevOps a changé dans sa manière de fonctionner au quotidien. Spoiler alert : maintenant, il code !</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/AurelOps"
+            },
+            {
+              "type": "github",
+              "url": "aurelien-moreau"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Roche",
+          "company": "Genymobile",
+          "city": "()",
+          "bio": "<p>I'm an Android system engineer and tech lead at Genymobile (recently acquired by shadow.tech), and I have been working on the Genymotion Android emulator for almost a decade. It means that I don't make Android apps, but I (sort of) know how Android will run them.\n\nOn a more personal side, I love to see how technology can be hijacked from its original purpose and can be used to do unintended stuff.\n\nYou won't find me on social platforms, not because I'm particularly anti-social, I just prefer actual, real life discussions.\n</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            }
+          ]
+        },
+        {
+          "name": "Valentin Deleplace",
+          "company": "Google",
+          "city": "()",
+          "bio": "<p>Valentin is a developer of cloud backends. He's into performance, algorithms, DB, UX, DX, and Go.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/val_deleplace"
+            },
+            {
+              "type": "github",
+              "url": "Deleplace"
+            }
+          ]
+        },
+        {
+          "name": "Edouard CATTEZ",
+          "company": "Hoppr",
+          "city": "Lille (France)",
+          "bio": "<p>RESTafarian, je suis un développeur fasciné par le web et son impact sur notre manière de vivre. Je suis également Head of Craft chez Hoppr: je prône la qualité logicielle comme résultat d'une communication efficace entre équipe produit et métier.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/ecattez"
+            },
+            {
+              "type": "github",
+              "url": "ecattez"
+            }
+          ]
+        },
+        {
+          "name": "Vivien Maleze",
+          "company": "Ippon Technologies",
+          "city": "Bordeaux (France)",
+          "bio": "<p>Vivien est architecte solution chez Ippon Technologies.\nPassioné de nouvelles technologies, il est toujours avide de découvrir de nouveaux sujets, mais aussi de les partager.\n\nVivien a eu l'occasion de travailler sur de multiples architectures distribuées avec chacune leur facette bien spécifique. Il a eu la chance de travailler aussi bien sur le développement de microservices, que sur leur déploiement et leur maintient sur les plateformes clouds</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/vmaleze"
+            },
+            {
+              "type": "github",
+              "url": "vmaleze"
+            }
+          ]
+        },
+        {
+          "name": "Carmen Piciorus",
+          "company": "BSCC - La Poste",
+          "city": "Montpllier",
+          "bio": "Après plusieurs années de développement, et quelques années dédiés à la protection de la messagerie laposte.net, j’intègre à présent une équipe  au service des projets du SI de la branche Services Courrier - Colis de La Poste. Passionnée par la cybersécurité, je me suis dédiée à faciliter la communication entre les développeurs et la sécurité pour aider aux développement des applications sécurisées et cyber-résilientes dans le cloud.",
+          "socials": []
+        },
+        {
+          "name": "Amine AIT AAZIZI",
+          "company": "IPPON Technologies",
+          "city": "Toulouse (France)",
+          "bio": "<p>Amine est un architecte Cloud / SRE  chez IPPON Technologies. \nIl accompagne ses clients à développer leurs expertise Cloud et s'intéresse particulièrement aux sujets liés aux architectures Cloud, SRE et Platform Engineering.\n\n</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/aaitaazizi"
+            }
+          ]
+        },
+        {
+          "name": "Christophe Farges",
+          "company": "onepoint.",
+          "city": "Bordeaux (France)",
+          "bio": "<p>Historique de développeur backend, actuellement tech lead/architecte technique, je m'intéresse surtout au sujets cloud/conteneurisation, à l'optimisation des ressources utilisées par les applications, ainsi qu'au confort du développeur au quotidien.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/chfarges"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/delvin1933"
+            }
+          ]
+        },
+        {
+          "name": "Alexandre Delattre",
+          "company": "MonkeyPatch",
+          "city": "Toulouse (France)",
+          "bio": "<p>Sofware engineer at MonkeyPath\n\nI have 8 year experience in backend,  web and mobile technologies.\n\nI love JVM languages, especially Kotlin, and love to apply functional programming and architectural concepts in my projects.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/alexandre_del31"
+            },
+            {
+              "type": "github",
+              "url": "alexd6631"
+            }
+          ]
+        },
+        {
+          "name": "Maha ALSAYASNEH",
+          "company": "Elastic",
+          "city": "Grenoble (France)",
+          "bio": "<p>I am a computer scientist with more than 10 years of experience in various fields ranging from web development to big data, including cloud\ncomputing and artificial intelligence. My experience combines technical and analytical aptitudes with problem-solving strengths to\ndrive projects to on-time and high-quality completion. \n\nI also have a Ph.D. in optimizing the performance of multi-tier distributed systems.\n\nCurrently, I am an Engineering Manager at Elastic. We are the leading platform for search-powered solutions.\n\nI love communicating and sharing knowledge  with people ;) ( I also love sports and mountains ;) )\n\nMy motto in life is LIVE + LOVE + LAUGH :)\n\n\n</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/MahaALSayasneh"
+            }
+          ]
+        },
+        {
+          "name": "Virginie J",
+          "company": "Ankorstore",
+          "city": "Toulouse (France)",
+          "bio": "<p>Je suis Ingénieure en informatique, diplômée de l'ENSEEIHT en informatique et mathématiques appliquées en 2008. J'ai évolué du développement, en passant par l'architecture, le coaching puis le management au fil des années. Ma grande motivation est de rendre les équipes et organisation tech efficace. J'ai un sentiment d'accomplissement quand je vois les membres de mon équipe s'épanouir dans leur métier de Dev.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/JugieV"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/Einigriv"
+            }
+          ]
+        },
+        {
+          "name": "Jérôme Tama",
+          "company": "Onepoint",
+          "city": "Bordeaux",
+          "bio": "Je viens du monde java et j'aime ça.\r\n\r\nMon travail de tous les jours s'éparpille entre :\r\n\r\n- Le dev\r\n- Le monde des conteneurs\r\n- Le coaching technique\r\n- Faire aimer la qualité",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/jtama_"
+            },
+            {
+              "type": "github",
+              "url": "jtama"
+            }
+          ]
+        },
+        {
+          "name": "Emmanuelle ABOAF",
+          "company": "Dcube",
+          "city": "Paris (France)",
+          "bio": "<p>Sourde de naissance, bionique (deux implants cochléaires) et surtout développeuse Fullstack Angular .NET chez DCube, je lutte chaque jour pour l’accessibilité. Dans mon monde idéal, tout doit être accessible aussi bien dans la vraie vie que dans le Web. Je suis également fière d’être certifiée d’Access42 sur l’accessibilité numérique et certifiée Opquast pour la qualité du web.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/eaboaf_"
+            },
+            {
+              "type": "github",
+              "url": "emma11y"
+            }
+          ]
+        },
+        {
+          "name": "Damien Lucas",
+          "company": "",
+          "city": "",
+          "bio": "Après avoir passé une quinzaine d'années dans le développement logiciel en société de services, j'ai maintenant rejoint Mirakl et par la même occasion, l'édition de logiciel. J'adore lire la doc avant de me lancer dans le code. Et par dessus tout, j'aime échanger et transmettre sur ce que j'ai pu apprendre de mes expériences, des discussions avec mes pairs, des conférences vues ...",
+          "socials": []
+        },
+        {
+          "name": "Sylvain Dedieu",
+          "company": "Criteo",
+          "city": "Claix (France)",
+          "bio": "Bonjour à vous,\r\n\r\nPassionné de développement et technologies front-end/mobile, je me suis spécialisé dans ce domaine.\r\n\r\nAu sein de l'équipe ui-foundation chez [Criteo](https://www.criteo.com/fr/), j'ai la chance d'approfondir chaque jour cette expertise.\r\n\r\nFormateur, je monte et dispense des formations sur Angular, AngularJS (deprecated), VueJS et Flutter.\r\n\r\nDepuis 2019, j'ai également la chance d'intervenir à l'Université [UGA (Grenoble)](https://www.univ-grenoble-alpes.fr/) pour dispenser une UE sur le développement mobile cross-plateforme aux Master 2 Génie Informatique.\r\n\r\nLa veille technique et les projets personnels occupent également une grande partie de mon temps.\r\n\r\nLe reste est principalement dédié au sport et à la nourriture ;).",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/DedieuS"
+            },
+            {
+              "type": "github",
+              "url": "sdedieu"
+            }
+          ]
+        },
+        {
+          "name": "Lucian Precup",
+          "company": "Adelean",
+          "city": "()",
+          "bio": "<p>Lucian Precup est CTO de [all.site](https://all.site/) - le moteur de recherche collaboratif développé à [Station F](http://stationf.co). Avec ses collègues d’[Adelean](http://adelean.com), Lucian développe des solutions pour l’indexation, la recherche et l’analyse de données.  Lucian participe régulièrement en tant qu'orateur à des conférences internationales spécialisées sur les moteurs de recherche et organise le [Meetup Search & Data](https://www.meetup.com/fr-FR/search-and-data/) à Paris.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/lucianprecup"
+            },
+            {
+              "type": "github",
+              "url": "adelean"
+            }
+          ]
+        },
+        {
+          "name": "Anne-Laure Gaillard",
+          "company": "ManoMano",
+          "city": "Bordeaux (France)",
+          "bio": "<p>Anne-Laure Gaillard est actuellement Staff Quality Advisor à ManoMano. Elle a été testeuse, développeuse et a enseigné aux étudiant⸱e⸱s en informatique. Elle est membre du comité d’organisation de l’Agile Tour Bordeaux depuis 2020 et de la ParisTestConf depuis 2022.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/alauregaillard"
+            }
+          ]
+        },
+        {
+          "name": "Alexia Souvane",
+          "company": "",
+          "city": "Vevey (Suisse)",
+          "bio": "<p></p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/Xhya"
+            }
+          ]
+        },
+        {
+          "name": "Noémie M. Rivière",
+          "company": "Onepoint",
+          "city": "Bordeaux (France)",
+          "bio": "<p></p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            }
+          ]
+        },
+        {
+          "name": "Sylvain Gougouzian",
+          "company": "Dev'in",
+          "city": "Feurs",
+          "bio": "Dev / Formateur GreenIT\r\nSpeaker,\r\nChef d'orchestre,\r\n(Retro)Gamer,\r\nPapa geek,\r\nEleveur de GNUs",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://www.twitter.com/GouZ"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Laforge",
+          "company": "Google",
+          "city": "",
+          "bio": "Guillaume Laforge is Developer Advocate for Google Cloud Platform, at day, focusing on generative AI, LLMs, serverless technologies and event-driven architecture, and at night, he is a Java Champion and wears his Apache Groovy hat.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/glaforge"
+            },
+            {
+              "type": "website",
+              "url": "https://glaforge.dev/"
+            }
+          ]
+        },
+        {
+          "name": "fs0c131y",
+          "company": "",
+          "city": "()",
+          "bio": "<p></p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Poncet",
+          "company": "",
+          "city": "",
+          "bio": "Geek, ex-nerd repenti, je code, je teste, je bricole, je soude et parfois fait sauter les plombs. CTO et spécialiste du magiciel, je suis aussi libriste dans l'âme et très impliqué dans le mouvement des logiciels libres.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/ponceto91"
+            },
+            {
+              "type": "website",
+              "url": "https://www.emaxilde.net/"
+            }
+          ]
+        },
+        {
+          "name": "Romain BERTHON",
+          "company": "",
+          "city": "",
+          "bio": "Développeur freelance, je place au centre de ma démarche professionnelle la qualité. Pour cela, je m'intéresse à de nombreux sujets tels que les tests, le Domain Driven Design, la programmation fonctionnelle, les méthodologies telles que l'Agilité, la sociologie, etc. Je participe également à la vie des communautés tech Lyonnaises, notamment au sein de l'organisation des événements des Software Crafters Lyon.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/RomainTrm"
+            },
+            {
+              "type": "github",
+              "url": "RomainTrm"
+            }
+          ]
+        },
+        {
+          "name": "Corentin Wallez",
+          "company": "Google",
+          "city": "Paris (France)",
+          "bio": "Graphics plumber and WebGPU tech lead at Google, WebGPU chair at the W3C.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/DaKangz"
+            },
+            {
+              "type": "github",
+              "url": "@Kangz"
+            }
+          ]
+        },
+        {
+          "name": "Anthony Le Goas",
+          "company": "Zenika",
+          "city": "Brest (France)",
+          "bio": "<p>Dév. web & directeur @Zenika Brest / Co-organisateur Svelte Society France + BrestJS + UX Design Brest.\n\nPassionné par le web et son optimisation. \nContributeur SvelteJS.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/anthony_legoas"
+            },
+            {
+              "type": "github",
+              "url": "@anthonylegoas"
+            }
+          ]
+        },
+        {
+          "name": "Maxime Beugnet",
+          "company": "MongoDB",
+          "city": "Paris (France)",
+          "bio": "<p>Maxime est un Developer Advocate chevronné avec plus de 12 ans d'expérience dans l'industrie informatique. Depuis 5 ans, il travaille chez MongoDB, où il joue un rôle en tant que blogueur, expert du forum communautaire et conférencier. En tant que blogueur, Maxime contribue au MongoDB Developer Center, partageant ses connaissances et son expérience avec la communauté au sens large. Il est également un expert de confiance sur le forum de la communauté MongoDB, où il aide les utilisateurs à dépanner et à optimiser leurs déploiements de bases de données.\n\nEn plus de son travail axé sur la communauté, Maxime est un formateur MongoDB et Java avec des certifications DEV et DBA MongoDB, démontrant sa profonde compréhension de la technologie des bases de données. Avant de rejoindre MongoDB, il a travaillé comme formateur chez Zenika, dispensant des formations sur Java, MongoDB et Couchbase.\n\nMaxime est un vrai passionné de technologie, toujours désireux de participer dans des concours d'algorithmie et d'explorer de nouvelles technologies. En dehors du travail, il aime la plongée sous-marine et a un faible pour les vikings.\n</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/MBeugnet"
+            },
+            {
+              "type": "github",
+              "url": "MaBeuLux88"
+            }
+          ]
+        },
+        {
+          "name": "Laurent Guérin",
+          "company": "Capgemini",
+          "city": "Nantes (France)",
+          "bio": "<p>Software architect, \nOpen Source & Agile supporter, \nTelosys project leader, \nSenior Architect at Capgemini \nPart time professor (Univ. Nantes), \nLecturer</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/ltguerin"
+            },
+            {
+              "type": "github",
+              "url": "l-gu"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Leplus",
+          "company": "AWS",
+          "city": "Paris",
+          "bio": "Developer Advocate at AWS and Google Developer Expert in Web Technologies. I love to share knowledge among developers and people in general.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/olivierleplus"
+            },
+            {
+              "type": "github",
+              "url": "tagazok"
+            }
+          ]
+        },
+        {
+          "name": "Renaud Mathieu",
+          "company": "Advisely",
+          "city": "Paris",
+          "bio": "Organizer GDG Paris Android.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/renaud_mathieu"
+            },
+            {
+              "type": "github",
+              "url": "renaudmathieu"
+            }
+          ]
+        },
+        {
+          "name": "Theophile Wallez",
+          "company": "ENS Ulm",
+          "city": "Paris (France)",
+          "bio": "Théophile Wallez en thèse à l'Inria Paris. Son travail de recherche porte sur la vérification formelle de la sécurité du protocole de messagerie de groupe sécurisé MLS.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/twallez"
+            },
+            {
+              "type": "github",
+              "url": "TWal"
+            }
+          ]
+        },
+        {
+          "name": "Julien BAJON",
+          "company": "Pictarine",
+          "city": "()",
+          "bio": "Senior Android Developer at Pictarine, over 5 years experience in mobile development. Passionate about the Android and Kotlin environment. I'm always on the lookout to explore new features and share my findings.",
+          "socials": []
+        },
+        {
+          "name": "Nicolas Boutin",
+          "company": "Sopra Steria",
+          "city": "()",
+          "bio": "Always passionate about new (and old) technologies, I have been Mobile Tech Leader at Sopra Steria Factory for over 5 years. I have a particular interest in Android platform and, of course, it’s amazing language Kotlin.",
+          "socials": []
+        },
+        {
+          "name": "Guillaume Andrieu",
+          "company": "MonkeyPatch",
+          "city": "Toulouse (France)",
+          "bio": "<p>Matheux converti de force à l'informatique.\nDéveloppeur back end depuis plus de 10 ans.\nProgrammation fonctionnelle, théorie des types, systèmes distribués.\nAu delà: changement climatique, droits humains, philosophie.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/glmxndr"
+            },
+            {
+              "type": "github",
+              "url": "glmxndr"
+            }
+          ]
+        },
+        {
+          "name": "Maria-Eliza Paez",
+          "company": "",
+          "city": "",
+          "bio": "::::::::::::::::::::::::::::::::::::\r\n🐣 Product Manager\r\n::::::::::::::::::::::::::::::::::::\r\n\r\nBercée par le Lean Startup et le Design Thinking, j'accompagne les individus, les équipes et les entreprises à devenir plus agile et adopter une culture Produit :)",
+          "socials": []
+        },
+        {
+          "name": "Mélanie Bats",
+          "company": "Obeo",
+          "city": "Toulouse (France)",
+          "bio": "<p>I am Mélanie Bats and I am CTO at Obeo. In my daily work, I am mainly focused on the development of modeling tools with Sirius. I am also committer for  the Sirius project. I am also involved in the Eclipse community as being part of the Eclipse Planning Council. I am also a free software activist who has organized and participated in free software events in the Toulouse area.</p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/melaniebats"
+            },
+            {
+              "type": "github",
+              "url": "mbats"
+            }
+          ]
+        },
+        {
+          "name": "Thomas Salvetat",
+          "company": "MonkeyPatch",
+          "city": "Toulouse (France)",
+          "bio": "<p></p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            }
+          ]
+        },
+        {
+          "name": "Moustapha Agack",
+          "company": "Zenika",
+          "city": "Lyon",
+          "bio": "Smash my keyboard for a living—results vary, but sometimes cool stuff happens",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/mousstoh"
+            }
+          ]
+        },
+        {
+          "name": "Pietro Mele",
+          "company": "",
+          "city": "()",
+          "bio": "<p></p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            }
+          ]
+        },
+        {
+          "name": "Loïc PINÇON",
+          "company": "",
+          "city": "()",
+          "bio": "<p></p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            }
+          ]
+        },
+        {
+          "name": "Leclerc Gwendal",
+          "company": "OVHcloud",
+          "city": "Chasné-sur-Illet (France)",
+          "bio": "<p></p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/skillo1989"
+            },
+            {
+              "type": "github",
+              "url": "gwleclerc"
+            }
+          ]
+        },
+        {
+          "name": "Quentin Gasparotto",
+          "company": "Thales",
+          "city": "Mérignac (France)",
+          "bio": "<p></p>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/"
+            },
+            {
+              "type": "github",
+              "url": "GasparQ"
+            }
+          ]
+        },
+        {
+          "name": "Ilona-Marie Lemaire Lefebvre",
+          "company": "",
+          "city": "()",
+          "bio": "",
+          "socials": []
+        },
+        {
+          "name": "Arnaud Bos",
+          "company": "MonkeyPatch",
+          "city": "Toulouse (France)",
+          "bio": "Functional programming, parens and distributed systems enthusiast. Lifelong hammock aficionado. Toulouse JUG organizer.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/arnaud_bos"
+            }
+          ]
+        },
+        {
+          "name": "Camille Roux",
+          "company": "Human Coders",
+          "city": "Montpellier, France",
+          "bio": "Démarrant ma carrière en tant que développeur web, je me suis rapidement spécialisé dans l’univers Ruby on Rails. Entrepreneur dans l’âme, il y a dizaine d’années, j’ai créé Human Coders (https://www.humancoders.com/), un centre de formation pour développeuses et développeurs. \r\nEnfin, récemment, j’ai exploré ma facette artistique en m’immergeant dans l’art génératif, mêlant technologie et esthétique. J’adore partager et échanger autour de mes expériences et découvertes.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/CamilleRoux"
+            },
+            {
+              "type": "website",
+              "url": "https://www.camilleroux.com/"
+            }
+          ]
+        },
+        {
+          "name": "Sebastien Vandenberghe",
+          "company": "Microsoft",
+          "city": "Toulon (France)",
+          "bio": "",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/sebavanjs"
+            }
+          ]
+        },
+        {
+          "name": "Alex Palma",
+          "company": "Zenika",
+          "city": "Brest (France)",
+          "bio": "Consultante front end @ Zenika Brest, passionnée par l'accessibilité et l'UI/UX design.",
+          "socials": []
+        },
+        {
+          "name": "Guillaume Escande",
+          "company": "Obeo",
+          "city": "Toulouse (France)",
+          "bio": "Guillaume travaille actuellement chez Obeo à Colomiers (France) en tant qu'architecte Cloud et Ingénieur DevOps.\r\n\r\nIl est un fan de toujours d'informatique, de toute l'informatique, en partant du hardware jusqu'au web, en passant par le cloud, le réseau, le code, etc...\r\n\r\nDurant sa carrière il a pu intervenir sur bien des domaines: du développement (C, C++) sur des librairies algorithmiques dans le domaine du spatial, de l'intégration, de la platforme de développement, de l'infrastructure, de l'IT, du cloud, du DevOps et enfin de l'architecture. L'ensemble de ces activités lui ont permis d'avoir une vision globale d'un système informatique, d'en comprendre le fonctionnement profond et les bonnes pratiques associées. De là en a découlé naturellement la découverte de l'approche Craftmanship et de ses bonnes pratiques.\r\n\r\nAujourd'hui, il a décidé de se recentrer sur l'essentiel : l'intégration, le DevOps, le cloud. Il s'occupe désormais de l'exploitation et de l'amélioration de tous les outils et de toute la stack technologique de la partie SaaS d'Obeo. Son objectif est de simplifier, automatiser et améliorer à tel point qu'il ne lui reste plus qu'à regarder des tableaux de bord, assis dans son canapé ! (sarcasme).",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/EscandeGuillau1"
+            }
+          ]
+        }
+      ],
+      "sessions": [
+        {
+          "title": "Art génératif: de la découverte à la publication d’un projet dans un studio prestigieux",
+          "description": "Il y a 2 ans, il me prend l'envie d'apprendre à dessiner. Très vite, l'ordinateur remplace le papier, et le code, le crayon. Je me passionne alors pour le code créatif et l'art génératif (principalement avec p5.js ou avec des fragment shaders en GLSL). Je partage avec vous cette aventure inattendue qui me conduira à découvrir un univers fascinant, discuter avec des artistes du monde entier, faire une expo dans plusieurs villes du monde dont New York ou encore publier un projet avec un studio renommé.",
+          "speakers": [
+            "Camille Roux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=g0aNeMUAODU"
+        },
+        {
+          "title": "Bienvenue à TLA-La-Land (ou introduction à la vérification logicielle)",
+          "description": "Il est bien connu qu'il existe 2 problèmes difficiles des systèmes distribués :\r\n<ul>\r\n \t<li>2/ La garantie de livraison \"exactly-once\"</li>\r\n \t<li>1/ L'ordonnancement des messages</li>\r\n \t<li>2/ La garantie de livraison \"exactly-once\"</li>\r\n</ul>\r\nAvec l'avénement des micro-services, la programmation de systèmes distribués, autrefois réservées aux experts, prend une part de plus en plus importante dans le quotidien du développeur d'application.\r\n\r\nIl est aussi bien connu qu'écrire du code concurrent correct est difficile. Quiconque affirmant le contraire est soit naif, soit un menteur (ou bien un génie).\r\n\r\nAvoir un modèle pour raisonner sur notre système distribué, son état et ses échanges devient primordial pour s'assurer que notre système est conçu correctement. Et c'est quelque chose que nous faisons plus ou moins consciemment lors du développement. Cependant un modèle mental a ses limites et il est très facile de passer à coté de quelque chose lors du design.\r\n\r\nC'est précisément là ou TLA+ va nous aider, en nous permettant d'exprimer le design de notre système, et le comportement souhaité sous forme d'invariants, (tout en ommettant les détails bas niveau), ce dernier va pouvoir nous aider à détecter des erreurs dans notre design.\r\n\r\nA travers ce talk, nous allons présenter cet outil de modélisation dans un cas pratique, et espérons vous donner les clefs pour aller plus loin dans le domaine de la vérification logicielle.",
+          "speakers": [
+            "Arnaud Bos"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=vUWA773y3MM"
+        },
+        {
+          "title": "Envolez-vous vers le low code!",
+          "description": "En tant que développeur, écrire du code n'est pas une fatalité! Aujourd'hui d'autres horizons s'ouvrent à nous! Vous avez déjà l’habitude de vous reposer sur de nombreux frameworks pour vos devs alors pourquoi pas sur un **outil low code**?\r\nCette session démontre concrètement comment développer, en un battement d’aile, grâce au low code, **un outil de création de jeux d’obstacles** à la **“Flappy Bird”**.\r\n\r\n**Découvrez la plateforme low code open source : [Sirius web](https://www.eclipse.org/sirius/sirius-web.html) !**\r\n* Facilité d’utilisation: une appli web prête à l’utilisation,\r\n* Productivité accrue: le temps d’une session, on crée une plateforme de création de jeux,\r\n* Flexibilité: c’est vrai pour n’importe quel domaine!\r\n* Extensibilité: dans low code, il y a code vous pouvez étendre la plateforme basée sur des technos classiques : Spring, Java, React!\r\n\r\nVenez faire voler en éclats vos préjugés sur le low code! Le low code n’est pas l’oiseau de mauvaise augure que vous imaginez, mais il peut vous amener vers d’autres cieux.\r\n\r\n*“Envole-moi, envole-moi, envole-moi\r\nLoin de cette fatalité qui colle à ma peau\r\nEnvole-moi, envole-moi\r\nRemplis ma tête d’autres horizons, d’autres mots” JJ Goldman*",
+          "speakers": [
+            "Guillaume Escande",
+            "Mélanie Bats",
+            "Guillaume Escande"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=ocE3JGpMqFE"
+        },
+        {
+          "title": "Architecturer en oignon sans avoir les yeux qui pleurent",
+          "description": "<p>Pour délivrer de la valeur chez nos clients, nous sommes amenés à développer des applications numériques. Le code source de celles-ci traduit les fonctionnalités qui vont permettre à nos clients de se différencier des autres, de faciliter les usages de ses utilisateurs, de faire plus de bénéfices, [...].\r\n\r\nPour se comprendre, entre équipe produit et métier, nous portons des méthodologies de travail comme le BDD (Behavior-Driven Development). Les besoins deviennent des fonctionnalités, les fonctionnalités deviennent des cas d'usage. Nous pouvons alors entamer les développements. C'est là que nous arrivons à un détail qui à son importance: l'architecture logicielle. La manière de l'aborder peut avoir un impact significatif sur le produit final: sa maintenance, sa résilience, sa qualité.\r\n\r\nL'architecture oignon est particulièrement adaptée pour répondre à des besoins métier à forte valeur ajoutée. Mais qu'est-ce que c'est ? Comment ça se traduit dans le code ? Quelle différence avec l'architecture hexagonale et l'architecture n-tiers ?\r\n\r\nRevêtons notre plus beau tablier, partons d'un besoin, et découpons notre archi.</p>",
+          "speakers": [
+            "Edouard CATTEZ"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=gZdOXB4-0Yw"
+        },
+        {
+          "title": "Programme et preuves - Le typage dépendant comme un moyen de structurer sa pensée",
+          "description": "<p>Dans le vieux débat typage statique/typage dynamique, le typage statique semble gagner du terrain. Le typage statique s'est introduit dans le monde JS avec Typescript, et même dans Python avec ses \"type hints\" puis mypy.\n\nMais les langages à typage statique eux-mêmes lorgnent vers plus de flexibilité, et tous jalousent en secret les capacités d'expression des langages à types dépendants. Même Haskell se voit doter de plusieurs initiatives pour y intégrer des types \"liquides\" ou carrément des types dépendants.\n\nLe typage dépendant est d'une simplicité conceptuelle radicale: là où de nombreux langages font une séparation nette entre valeurs et types (que des ~apprenti-sorciers~ développeurs astucieux s'évertuent souvent à contourner), les langages à types dépendants permettent aux types d'être des valeurs \"comme les autres\": des fonctions peuvent renvoyer des types, ou en prendre en arguments, et les types peuvent être paramétrés (ou \"indexés\", dans le jargon) par des valeurs.\n\nAlors certes, peu de langages ont ces particularités. Pourtant, apprendre à considérer les programmes comme des preuves a des bénéfices mêmes quand on ne dispose pas de ce type de typage dans son activité quotidienne.\n\nLors de cette présentation, on découvrira les types dépendants à travers deux exemples simples, dans le langage Idris2. Le but est de réfléchir ensemble sur la notion de preuve en explorant les possibilités qu'offrent ce typage, notamment la possibilité d'écrire des preuves formelles. On appliquera notamment cette technique à l'optimisation d'une fonction, en prouvant formellement que notre optimisation n'a pas d'impact sur le comportement de la fonction. Nous en profiterons pour aborder la manière dont on peut s'inspirer de ces techniques dans d'autres langages.\n</p>",
+          "speakers": [
+            "Guillaume Andrieu"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=fZ3kgerrLPQ"
+        },
+        {
+          "title": "Comment automatiser ses tests d'accessibilité ?",
+          "description": "<p>Les tests d'accessibilités web : on en voit trop peu dans nos chaînes de CI/CD et pourtant, il est possible de faire pas mal de choses ! Les outils et techniques pour automatiser des tests d'accessibilité sont multiples mais relativement méconnus des développeurs web. Que pouvons-nous tester, et comment ? Etudions tout cela ensemble, regardons comment intégrer ces tests dans nos pipelines (Gitlab CI, GitHub Actions, ...).</p>",
+          "speakers": [
+            "Anthony Le Goas"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=YaVGU_SuxVY"
+        },
+        {
+          "title": "Les enjeux de l'IA Green pour l'embarqué",
+          "description": "<p>Le Edge Computing est une technique permettant de réduire la charge de traitement du Cloud computing en distribuant les traitements en bordure du réseau. Ces sujets impliquent dans certains cas de déployer les traitements en sortie des capteurs sur des systèmes embarqués, fortement contraints en termes de ressources. Nous présenterons les travaux que nous menons depuis 3 ans sur l’IA embarquée : Compression et Segmentation d’objets sur images satellites, reconnaissance vocale embarquée et suivi de santé des téléphériques urbains.\n\nMots clés :  Edge Computing, IA, Embarqué, IoT, Green Computing  \n\n## 1.    Introduction\n\nLe Edge Computing est une technique permettant de réduire la quantité de données qui transitent, ainsi que la charge de calcul du Cloud computing en distribuant les traitements en bordure du réseau.\n\nOn peut faire du Edge Computing soit sur data center local (Cloud Edge), soit sur cluster embarqué (Far Edge) soit directement en sortie de capteur (Device Edge) et dans chacun des cas, on fait face à des contraintes croissantes de :\n-    Consommation énergétique limitant fortement les ressources disponibles\n-    Réactivité des traitements devant aller au moins aussi vite que l’acquisition pour respecter le temps réel\n-    Précision convenable des résultats pour ne pas donner de fausses informations aux opérateurs\n\nPour déployer de l’IA sur du Edge computing, il est donc nécessaire de maîtriser la chaîne d’intégration de l’IA sur systèmes embarqués et de repenser complètement la conception des modèles ainsi que leur optimisation sur cible finale dans un objectif de frugalité calculatoire important.\n\nNous vous proposons de présenter les enjeux opérationnels du Edge Computing pour un certain nombre d’applications concrètes de nos clients :\n-    Compression d’image et segmentation d’objet à bord des satellites\n-    Reconnaissance de la parole en temps réel sur systèmes embarqués\n-    Suivi de santé du freinage des téléphériques urbains avec un parc IoT\n\nNous verrons dans chacun des cas le processus de réflexion et d’expérimentation qui nous a amené à définir notre propre framework de portage IA embarquée pour permettre aux data-scientistes et aux développeurs embarqués de dialoguer et converger vers la meilleure implémentation.\n\n## 2.    Méthodologie\n\nVoici les méthodes spécifiques utilisées pour chacun de nos cas d’usage.\n\nCompression d’image à bord des satellites : entrainement, optimisation et déploiement d’un auto-encodeur convolutif de compression d’image sur une cible FPGA Xilinx à l’aide du framework open-source N2D2 développé par le CEA.\n\nSuivi de freinage des téléphériques urbains sur parc IoT : étude, modélisation et déploiement d’un réseau de neurones sur un parc IoT de téléphériques urbains pour la détection de l’usure lente du système de freinage des remontées mécaniques.\n\nCommande vocale sur systèmes embarqués : entrainement, adaptation et déploiement du réseau de neurones et d’algorithmes de traitement du signal sonore en temps réel sur Raspberry Pi 4 et Arducam Pico 4ML (PicoPi).\n\nDétection de routes à bord des satellites : entrainement, miniaturisation et benchmark de réseaux de neurones pour de la segmentation d’image à l’aide de la distillation de connaissances sur cible Nvidia Jeston Nano.\n\n## 3.    Originalité / perspective\n\nLes compilateurs de deep learning disponibles en Open Source se focalisent sur le déploiement de modèles IA existants sur des systèmes embarqués contraints.\n\nIls proposent souvent des techniques de quantification ou d’élagage pour réduire l’empreinte mémoire des poids des modèles mais ces techniques peuvent ne pas suffire pour porter des modèles volumineux.\n\nDe plus, ils occultent totalement l’adaptation des modèles aux capteurs présents sur les systèmes (ex : échantillonnage des micros).\n\nNotre objectif est de traiter l’intégralité de la chaîne d’intégration de l’IA embarquée, de la conception des modèles incluant la \nminiaturisation des architectures de réseaux de neurones, à leur optimisation fine pour un matériel d’exécution donné jusqu’aux campagnes de benchmarks sur les cibles d’exécution finales.\n\nL’objectif étant de fluidifier les échanges entre deux expertises très différentes :\n-    Data Science : développer des modèles dans un environnement virtuellement illimité\n-    Développement embarqué : intégrer des traitements frugaux sur des systèmes très limités en ressources de calcul et peu consommateurs en énergie\n\nEgalement nos cas d’usage couvrent un large spectre d’activités nous permettant d’éprouver notre framework sur des problématiques métiers pourtant très spécifiques.\n\nDe plus, de par la diversité de nos cas d’usage ainsi que des clients de Thales Services Numériques, nous avons une position privilégiée dans le groupe pour faciliter le transfert technologique dans toutes nos activités internes militaires comme civiles.\n\nNous comptons par la suite étudier la réduction de la consommation énergétique de l’IA dans le cloud en utilisant des technologies venant du monde de l’embarqué. Etant donné que nous avons développé notre framework avec de fortes contraintes de consommation énergétique, nous comptons l’utiliser pour proposer des actions de mitigations et fournir des services de Green Computing autour de la Green AI.</p>",
+          "speakers": [
+            "Quentin Gasparotto",
+            "Ilona-Marie Lemaire Lefebvre"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=SLM9AIIcKIc"
+        },
+        {
+          "title": "CSS renaît de ses cendres: (re)devenez copains avec votre feuille de style",
+          "description": "<p>On ne va pas se mentir: quand on a commencé notre aventure dans le développement web il y a 15 ans, le CSS et nous, ce n'était pas vraiment le grand amour. Malgré l'arrivée des variables et des nouveaux systèmes de layouts, on n'était toujours pas convaincus, et on ne l'utilisait que par obligation. En 2023, on a décidé de lui donner une nouvelle chance: comme pour le JavaScript, les nouveautés de CSS ont considérablement changé le langage ces dernières années, et on a été agréablement surpris.\n\nDans ce talk interactif et riche en démos, on abordera les standards existants et ceux à venir qui nous on fait redécouvrir le CSS. Préparez-vous à explorer des fonctionnalités cools telles que :is(), :has(), le nesting, les custom media queries, les custom properties (bien plus puissantes qu'on ne le pense) et bien d'autres innovations encore !\n\nRejoignez-nous pour donnez une nouvelle chance au CSS, qui pourrait bien devenir votre nouveau copain incontournable dans le développement front-end !</p>",
+          "speakers": [
+            "Alex Palma",
+            "Olivier Leplus",
+            "Alex Palma"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=_Dg1Wb7rMRs"
+        },
+        {
+          "title": "Generative AI par la pratique : cas concrets d’utilisation d’un LLM en Java, avec l’API PaLM",
+          "description": "<p>Les Large Language Models (LLM) sont une nouvelle technologie puissante qui peut être utilisée pour une variété de tâches, notamment la génération de texte, la traduction de texte et la rédaction de différents types de contenu créatif. Cependant, les LLMs peuvent être difficiles à utiliser, en particulier pour les développeurs qui ne sont pas expérimentés en Python, la “lingua franca” de l'IA. Alors, qu'en est-il des développeurs Java ? Comment pouvons-nous tirer parti de l'IA générative ?\n\nCette présentation vous montrera comment utiliser les LLMs en Java sans avoir besoin de Python. Nous utiliserons l'API PaLM, fournie par les services Google Cloud Vertex AI, pour effectuer une variété de tâches, telles que la recherche dans de la documentation, la génération d'histoires pour enfants, la synthèse du contenu, l'extraction de mots-clés ou d'entités, et plus encore.</p>",
+          "speakers": [
+            "Guillaume Laforge"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=ar0lbL5ZPKI"
+        },
+        {
+          "title": "Une autre manière de tester vos microservices",
+          "description": "<p>Dans une architecture microservices, l’interdépendance entre les microservices et le couplage avec des services externes (base de données, cache, message queue, ...) peuvent rendre les tests très compliqués. Les tests unitaires vont souvent nécessiter de mocker beaucoup de choses de manière invasive, pour au final tester peu de code métier, sans pouvoir tout couvrir.\n\nPour répondre à cette problématique, dans l’équipe domaine d’OVHcloud, nous avons mis en place une manière de tester nos différents services en “boîte grise”. Dans ce talk nous explorerons les concepts derrière cette stratégie de test, ainsi que ses avantages et inconvénients.\n\nNous verrons comment la mettre en œuvre via quelques outils :\n\n* Un peu de Shell et de Docker\n* [Venom](https://github.com/ovh/venom) : un test runner déclaratif qui permet de faire des appels HTTP, manipuler des bases de données, et plein d’autres choses\n* [Smocker](https://smocker.dev/guide/) : un server de mocks HTTP déclaratif pilotable via API\n\n\nVous découvrirez ainsi comment tester un microservice de manière complètement isolée, puis comment tester un ensemble de microservices interconnectés.\n</p>",
+          "speakers": [
+            "Leclerc Gwendal"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=Y1CnSDbOWLA"
+        },
+        {
+          "title": "Mesurer et réduire concrètement l'impact de vos applications en prod avec OpenTelemetry",
+          "description": "<p>Pour toutes les personnes qui travaillent dans un système distribué, il est aujourd’hui vital de monitorer son architecture. L’optimisation d’une architecture passe avant tout par une connaissance accrue de son fonctionnement. C’est à partir de cette problématique qu’est né OpenTelemetry.\n\nOpenTelemetry, c’est quoi ? Quel est le rapport avec l’impact de vos applications ? \nOn passera un peu de temps à vous présenter ce projet, puis on rentrera dans le vif du sujet. Une fois passée l’étape du tutoriel, on se retrouve souvent face à la dure réalité de mettre ça en place sur sa stack en production. Comment faire pour monitorer plus de 400 microservices en prod ? Quelles techniques peut-on utiliser pour concrètement optimiser les ressources dont on a besoin ?\n\nOn ressort souvent des conférences avec de belles démo et s’ensuit ce qu’on aime appeler le Hype Driven Development. Mais lorsqu’il faut mettre en place ce monitoring sur une stack existante, comment ça marche ?\n\nA travers un retour d’expérience et des exemples concrets d’utilisation, on vous présentera les enjeux et les bonnes pratiques pour monitorer votre production.</p>",
+          "speakers": [
+            "Vivien Maleze",
+            "Loïc PINÇON"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=7zFgp55luLw"
+        },
+        {
+          "title": "Cloner ChatGPT avec Hugging Face et Elasticsearch",
+          "description": "<p>Elasticsearch est un moteur de recherche, une base de données NoSQL et un moteur d'analyse de données qui vous permet d'indexer et de visualiser vos données de manière efficace. Hugging Face est la plateforme collaborative pour développer, tester et déployer les meilleurs modèles de Machine Learning Open Source. L'intégration des deux plateformes permet la création d’applications très puissantes augmentant les données et les performances de leur rendu. Dans cette conférence nous montrons quelques exemples et prototypes construits à l’aide de deux technologies. Une occasion pour approfondir Hugging Face, revisiter Elasticsearch et … refaire ChatGPT.</p>",
+          "speakers": [
+            "Pietro Mele",
+            "Lucian Precup"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=e0wdmT_DK98"
+        },
+        {
+          "title": "Jay-Z, Maths and Signals ! How to clone Shazam 🎧",
+          "description": "<p>J’ai toujours rêver de comprendre comment fonctionnait Shazam.\n\nCette application qui permet de retrouver l’artiste et le titre d’une chanson juste avec un enregistrement de quelques secondes.\nDu coup j’ai décider de la re-coder ! Je vous montre tout cela pendant ce talk,  et ce sera l’occasion de parler notes musicales, harmoniques, fréquences, signaux, et de transformée de fourrier (et de Jay-Z) pour recréer l’algorithme qui fait tourner le moteur Shazam  ⚡️\n</p>",
+          "speakers": [
+            "Moustapha Agack"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=2i4nstFJRXU"
+        },
+        {
+          "title": "Mais non, c'est pas une erreur de CORS",
+          "description": "<p>Lorsqu'une application Web fait une requête vers un backend, il arrive que l'on rencontre le terrifiant message \"Cross-Origin Request Blocked\"\n\nOn a bien mis \"Access-Control-Allow-Origin: *\" et on a encore une erreur de CORS ? qu'est ce que c'est que cette histoire ?\n\nMais qu'est ce qui se cache derrière ce message ?\n\nEst-ce réellement l'erreur que l'on rencontre ?\n\nNous allons dans cette présentation faire un rappel sur ce mécanisme de sécurité, pourquoi il existe et aussi pourquoi, des fois, ce n'est pas ça l'erreur.</p>",
+          "speakers": [
+            "Christophe Farges"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=g6mlRVdttlc"
+        },
+        {
+          "title": "Machine to machine : jouons un peu avec MQTT, Mosquitto et Paho",
+          "description": "<p>MQTT est un protocole léger basé sur le pattern « Publish/Subscribe » qui s’est imposé pour les échanges M2M et donc l’IoT. \nSimple et facile à appréhender il peut être utilisé pour des cas d’usage très variés aussi bien avec un Raspberry Pi qu’un serveur Linux ou dans le cloud.\n\nCette présentation vous permettra de découvrir les principes de base du protocole MQTT, avec des démos utilisant le brocker « Mosquitto » et bien sûr un peu de code avec la librairie « Paho » et différents langages (Java, Python, Go, etc)\n\nDes exemples illustreront différents cas d’usage (smartphone, dashboard, websocket, etc)</p>",
+          "speakers": [
+            "Laurent Guérin"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=YL_rmzrzA1Y"
+        },
+        {
+          "title": "Kotlin Multiplatform : The (very) Good, The Bad & The Ugly",
+          "description": "<p>Kotlin Multiplatform, KMP pour les intimes, est une technologie mobile basée sur\nl'excellent langage Kotlin, qui permet de mutualiser son code technique et\nmétier entre son application Android et iOS (ainsi que les autres plateformes\nsupportées Linux, Windows, macOS, watchOS et bien d'autres)\n\nDans ce talk, nous allons vous présenter notre retour d'expérience de\ndéveloppement de deux applications KMP de production.\n\nNous présenterons brièvement KMP, son historique, ses objectifs et son\npositionnement dans un écosystème. \n\nNous verrons alors comment KMP nous a fait gagner du temps sur nos projets,\npartager les bonnes pratiques issues de nos expérience sur ces deux\napplications. \n\nNous verrons également là où le bât blesse, voir les situations ou nous ne\nconseillons pas KMP.\n\nPour finir, nous nous intéresserons à l'avenir de cette techno, notamment\nCompose multiplatform et le support Webassembly.</p>",
+          "speakers": [
+            "Thomas Salvetat",
+            "Alexandre Delattre"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=vaqoMUznFhE"
+        },
+        {
+          "title": "Product Management, le futur de l’Agilité ?",
+          "description": "<p>Au début de ma carrière de PO je me suis dit “l'Agilité🤍 C'est super!” et pourtant... sur le terrain, elle était très loin de ce que j’avais imaginé.\n\nComment délivrer des produits à fort impact et fédérateurs ? \nÉviter de refaire la même fonctionnalité ? Mettre la qualité au centre ?\n\nDans ce REX, je vous propose de vous partager mon histoire et de découvrir en quoi le Product Management a transformé mes pratiques et m’a permis de faire face à des organisations qui appliquent l’agilité comme “recette magique”.</p>",
+          "speakers": [
+            "Maria-Eliza Paez"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=tKybpH4TKRM"
+        },
+        {
+          "title": "Développeurs sans frontière : Jetpack Compose pour Android et iOS",
+          "description": "<p>Développer une application Android /iOS avec une seule base de code, de la logique métier à l’UI, c'est la promesse faite par Jetbrains, les papas de Kotlin!\n\nVoilà maintenant 5 ans qu'ils peaufinent Kotlin Multiplatform pour en faire un outil de développement convaincant, notamment en permettant aux applications Android et iOS natives de partager un même cœur de logique métier écrit en Kotlin.\n\nCette logique de mutualisation a été poussée encore plus loin avec Compose Multiplatform, initialement disponible pour Android, Desktop et Web uniquement.  Mais, lors de la dernière Kotlin Conf, Jetbrains a jeté un grand pavé dans la marre en annonçant la sortie de Compose for iOS, intégrant la pomme à l’écosystème.\n\nLa promesse est-elle tenue? \nPouvez-vous enfin vous débarrasser de vos développeurs iOS?\nVenez le découvrir avec nous (présentation garantie sans troll).</p>",
+          "speakers": [
+            "Julien BAJON",
+            "Nicolas Boutin"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=LTYpabeRmzQ"
+        },
+        {
+          "title": "\"Don't roll your own crypto\": les méthodes formelles au service de la sécurité",
+          "description": "On entend souvent \"don't roll your own crypto\". Mais pourquoi ?\r\nParce que concevoir et implémenter un protocole cryptographique, c'est très complexe !\r\nLes failles de sécurité peuvent se loger aussi bien dans les primitives cryptographiques (comme le chiffrement ou les signatures) que dans le protocole qui repose sur ces primitives.\r\nCes failles peuvent se trouver non seulement dans le code, mais aussi dans la spécification du protocole ou de la primitive.\r\n\r\nLes méthodes formelles fournissent des outils qui permettent de prouver l'absence de telles failles.\r\nCes méthodes, si elles sont utilisées principalement par des chercheurs ont des applications bien réelles pour valider et sécuriser les protocoles que vous utilisez quotidiennement.\r\n\r\nNous verrons comment des failles comme Heartbleed [1], le buffer overflow dans SHA-3 [2], ou encore les multiples failles de Matrix [3] auraient pu être évitées grâce aux méthodes formelles, et je partagerai mon expérience avec l'application de ces méthodes sur le futur protocole de messagerie sécurisé MLS [4].\r\n\r\n- [1] https://heartbleed.com/\r\n- [2] https://mouha.be/sha-3-buffer-overflow/\r\n- [3] https://nebuchadnezzar-megolm.github.io/\r\n- [4] https://eprint.iacr.org/2022/1732",
+          "speakers": [
+            "Theophile Wallez"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=_om52-oOIO4"
+        },
+        {
+          "title": "Ce n’est qu’une histoire de Date",
+          "description": "<p>Une tâche courante dans le développement consiste à manipuler des dates. \n\nPourtant, c’est tout sauf simple…\n\nIl existe différentes contraintes liées à la gestion des dates, telles que différents calendriers, différents fuseaux horaires ou simplement parce que la rotation de la Terre n’est pas uniforme. \n\nNous profiterons de cette conférence pour examiner l’histoire de la gestion des dates en Java et Kotlin et comment tout cela a évolué au fil du temps pour répondre aux besoins des développeurs. Bien sur, nous discuterons aussi des meilleures pratiques ainsi que la gestion des fuseaux horaires pour améliorer notre quotidien !</p>",
+          "speakers": [
+            "Renaud Mathieu"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=cSAi_q_xbw0"
+        },
+        {
+          "title": "40 Minutes pour Construire des APIs REST et GraphQL Serverless",
+          "description": "Au début de la pandémie de COVID-19, l'Université Johns Hopkins a travaillé sur la collecte et le raffinage des données provenant de plusieurs sources et a fourni au monde un dépôt Github et un tas de fichiers CSV. Le problème? Il est presque impossible de construire quoi que ce soit à partir de données brutes comme celle-ci.\r\n\r\nDans cette session de codage en direct, Maxime Beugnet, Developer Advocate chez MongoDB, vous montrera comment créer une API REST sans serveur et une API GraphQL basée sur cet ensemble de données en utilisant Python et la plateforme de données MongoDB. Nous allons enfin mettre à profit le serverless et l’offre gratuite d’Atlas App Services.",
+          "speakers": [
+            "Maxime Beugnet"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=Sip3Q1G8498"
+        },
+        {
+          "title": "J'aime le Big-O mais il me trompe",
+          "description": "<p>Nous apprenons que trier N éléments prend un temps proportionnel à (N log N). Concentrons-nous sur la complexité algorithmique, le reste ce sont des détails d'implémentation! Cette approche universitaire permet en effet d'être rapidement productif en faisant abstraction de l'architecture physique des ordinateurs, du jeu d'instruction du microprocesseur, de la latence du SSD.\n\nAttention, c'est parfois un gros mensonge! Quand vous avez besoin d'améliorer les performances, c'est rarement \"Big-O\" qui vous y aidera. Je vais montrer plusieurs exemples où l'analyse de la complexité algorithmique ne sert à rien, et quelques cas où elle vous envoie carrément dans le mur.\nMieux vaut être terre-à-terre, ne pas ignorer les coefficients multiplicateurs \"cachés\", apprendre la \"compassion mécanique\", et surtout mesurer les véritables latences, encore et encore.</p>",
+          "speakers": [
+            "Valentin Deleplace"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=u4H94kkjp5o"
+        },
+        {
+          "title": "WebGPU and Babylon.js: a fruitful collaboration",
+          "description": "WebGPU is a new Javascript API that allows Web pages to access advanced GPU functionality for fancier graphics and faster scientific computation (like ML) in the browser. The first version of WebGPU was released in Chrome in May 2023 and was extremely well received. Babylon.js is very popular state of the art Web 3D engine developed primarily by Microsoft. Since the Babylon.js 5.0 release it has full support for WebGPU.\r\n\r\nIn this talk Sebastian Vandenberghe, lead developer of Babylon.js at Microsoft, and Corentin Wallez, WebGPU chair and lead at Google (and Pechabou kid :D) will show practical benefits of aspects of WebGPU through their use in Babylon.js, and will show how the early adoption of Babylon.js shaped part of WebGPU.\r\n\r\nOver the many years of WebGPU's development they both collaborated directly. Sebastian's extensive feedback contributed to shape WebGPU and in return Corentin helped him get Babylon.js get the gains promised by WebGPU. After some general context we will detail several aspects of Babylon.js' use of WebGPU to exemplify the benefits of this API, as well as examples where feedback changed the API. If time permits we'll also give a quick peek at what's planned in the future.",
+          "speakers": [
+            "Sebastien Vandenberghe",
+            "Corentin Wallez",
+            "Sebastien Vandenberghe"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=6KsaVW9EyUk"
+        },
+        {
+          "title": "L'AGC : retour sur l'ordinateur qui a amené l'humanité sur la Lune",
+          "description": "Lundi 21 juillet 1969, l’humanité posait pour la première fois le pied sur la Lune. Cet exploit est le fruit de nombreuses avancées techniques et technologiques, notamment en électronique et dans le domaine de l’informatique alors naissant. Pour mener à bien leurs missions, les astronautes s’appuyaient sur l’AGC, l’ordinateur de bord du programme Apollo qui permettra de réaliser ces exploits.\r\n\r\nEmbarquez avec nous et découvrons ensemble sa conception et les rôles qu’il devait assurer au cours d’une mission jusqu’à la Lune. Nous nous replacerons dans le contexte historique, aborderons les moyens qui étaient alors à disposition des ingénieurs de l’époque, les avancées technologiques qui ont été nécessaires pour relever ce défi ainsi que les héritages que ce programme nous aura laissé, notamment dans le domaine de l'ingénierie logicielle.",
+          "speakers": [
+            "Olivier Poncet",
+            "Romain BERTHON"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=Wmqpnxb_GPE"
+        },
+        {
+          "title": "En 2 min, un hacker vous refait le portrait (numérique)",
+          "description": "<p>Connaissez vous votre empreinte numérique ? \n\nTout les jours vous laissez des traces sur Internet à votre insu. Durant cette présentation, Baptiste Robert vous montrera comment une personne malveillante peut, à partir de très peu d'information (nom prénom, pseudonyme, ...) connaître toute votre vie ou presque.</p>",
+          "speakers": [
+            "fs0c131y"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=nrGS0Omsxmg"
+        },
+        {
+          "title": "Sous le capot du \"docker build\"",
+          "description": "<p>Comprendre comment le docker build fonctionne sous le capot va vous aider à gérer les erreurs lors du build, à utiliser de manière optimisée le cache et à diminuer la taille des layers. Ce quickie vous permettra de comprendre rapidement comment builder et télécharger une image de manière sécurisée et optimisée, ainsi que les commandes docker clés pour détecter des éventuelles fuites de données. </p>",
+          "speakers": [
+            "Carmen Piciorus"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=Yd5ap7rj5u0"
+        },
+        {
+          "title": "De JavaScript à l'impression 3D, promenons nous dans les jardins de Babylon",
+          "description": "<p>De nos jours, l'impression 3D est de plus en plus accessible, on en voit de plus en plus dans les foyers. Il est facile de télécharger un modèle sur Thingiverse, ou encore Cults3D. Mais, lorsque l'on veut créer nos propres modèles cela devient plus compliqué.\n\nEn effet, il faut apprendre à manipuler un logiciel de CAD (Conception Assistée par Ordinateur). Même pour créer des modèles simples, il n'y a pas grand chose sur le marché. Il existe bien OpenSCAD, mais il faut également apprendre un nouveau langage.\n\nD'un autre côté, beaucoup de développeuses et développeurs connaissent le JavaScript et Il existe des bibliothèques comme ThreeJS, BabylonJS, ... pour faire de la 3D.\n\nAlors comment faire le lien ?\n\nA travers un projet à destination éducative que j'ai créé pour les enfants, \"Kody\", j'explique le fonctionnement d'une imprimante 3D, du format STL et de comment, depuis BabylonJS et une librairie codée pour Kody, je peux imprimer des cartes perforées en quelques lignes de codes.</p>",
+          "speakers": [
+            "Sylvain Gougouzian"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=jj0OiKda0J0"
+        },
+        {
+          "title": "Comment inclure l’inclusivité dès les premières étapes de conception d’un service ou d’un produit digital ?",
+          "description": "<p>L’inclusivité gagne du terrain dans le débat public, les marques s’y mettent timidement… comment les services et produits digitaux peuvent-ils se faire les porte-parole des minorités dans le fond comme dans la forme ?\n\nPour savoir comment l’inclure dans un projet, il faut déjà savoir ce qu’est l’inclusivité et ce qu’elle n’est pas. Et puis forcément on se pose la question des bénéfices qu’elle apporte dans un produit et qui en aura la responsabilité. On rentrera dans le concret pour terminer, parce que pour l’instant ça reste flou : on verra comment a travers des questionnements, des formulaires, des données, des visuels, des mots on peut être inclusif dans un produit. Et comment on peut pérenniser tout ça, parce que oui l’objectif c’est qu’un projet devienne, soit et reste inclusif !</p>",
+          "speakers": [
+            "Noémie M. Rivière"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=BVWm0FcswQc"
+        },
+        {
+          "title": "Une architecture pour tester son front-end",
+          "description": "<p>Dans le monde du développement, tout le monde parle de test: \"Si tu n’écris pas de test, ton code ne peut pas être de qualité\". \n\nCela fait 4 ans que je développe et tout autant de temps que je me pose la question de comment tester unitairement mon frontend. Tester son backend semble approprié car il contient une grande part de logique: le cœur métier. \n\nMais est-ce aussi simple côté frontend? - où l'on doit gérer un état global, le garder synchronisé avec des données provenant de diverses sources et afficher le tout à l'utilisateur. Il y a bien quelques logiques d’affichage et transformations de données, mais les tester unitairement ne semble pas couvrir la globalité d’un comportement, de l'interaction utilisateur jusqu’à l’affichage à l’écran.\n\nAprès plusieurs années à travailler sur des projets sans tests et d'autres projets où l'on testait individuellement chaque fonction, aujourd'hui je présente une architecture permettant de tester unitairement son front de manière efficace en couvrant les comportements plus que l’implémentation.</p>",
+          "speakers": [
+            "Alexia Souvane"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=Bs9Roq-fl7Y"
+        },
+        {
+          "title": "Explorons nos APIs",
+          "description": "<p>Lorsqu'on parle de tester des APIs, nous pensons généralement automatisation. Par exemple, vérifier les codes d'état, les éléments du corps de la réponse, ou encore tester les temps de réponse.\n\nEt si vous exploriez un peu plus les opportunités de tests des APIs ? Les tests exploratoires incontournables en agile s’appliquent également très bien aux APIs. Peu importe le niveau technique de la personne testant, les résultats sont au rendez-vous !\n\nJe vous partage dans cette présentation le processus que nous avons créé et que nous utilisons au sein de mon équipe. Vous aurez ainsi toutes les clés pour explorer vous aussi les APIs.\n</p>",
+          "speakers": [
+            "Anne-Laure Gaillard"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=FPrMPOlqZN4"
+        },
+        {
+          "title": "Plongeons au coeur des frameworks frontend modernes pour comprendre leur réactivité🔬⚛️",
+          "description": "<p>Le mot \"réactivité\" est omniprésent dès lors que l'on lise un article ou que l'on écoute un podcast sur un framework frontend.\n\nMais qu'est-ce que ce terme signifie ? Plus concrètement encore, comment cette réactivité est traduite en code au sein de nos frameworks préférés ?\n\nJe vous propose de pratiquer une opération à coeur ouvert de Vue, React, Svelte et Angular afin de comprendre leurs mécanismes internes de \"rafraîchissement\" du DOM. \n\nNous nous attarderons d'avantage sur ce dernier qui est en train de complètement changer sa logique réactive. \nLe but de ce focus est de vous présenter les challenges auxquels la core team fait actuellement face et surtout le futur proche d'Angular.\n\nAlors si vous voulez être réactif, suivez le guide ! ;-) </p>",
+          "speakers": [
+            "Sylvain Dedieu"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=JEGiinYVttg"
+        },
+        {
+          "title": "Les super pouvoirs du package java.util.function",
+          "description": "<p>Le package `java.util.function` fêtera ses 10 ans en 2024 et force est de constater que malgré son omniprésence dans nos développements, son utilisation reste probablement sous-estimé et mal comprise.  \n \nAvez-vous déjà utilisé ces classes comme paramètre de vos méthodes ? Avez-vous déjà utilisé leur capacité de composition ?  Ne vous êtes vous jamais dit que cet héritage douteux entre deux classes, ne vous plait pas, mais que faute de mieux, il reste là ?\n \nSans pour autant abuser des concepts de programmation fonctionnelle, nous aimerions vous présenter pendant ce talk à travers de cas concrets, une utilisation plus avancée du package java.util.function. \n\nFonctions anonymes, d'ordre supérieur ou encore la composition de fonctions, toutes ces notions n'auront désormais plus de secret pour vous et trouveront une place de choix dans votre boîte à outils de refactoring.\n\nVous repartirez avec un dépôt git avant/après en prime !\n</p>",
+          "speakers": [
+            "Jérôme Tama",
+            "Damien Lucas"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=ZSXqUFvDqUg"
+        },
+        {
+          "title": "Comment débuter dans l'accessibilité numérique ?",
+          "description": "<p>Vous êtes développeuse ou développeur et vous êtes intéressés par l'accessibilité numérique mais vous ne savez pas par où commencer ? Venez découvrir les bases du développement de l'accessibilité numérique en HTML.</p>",
+          "speakers": [
+            "Emmanuelle ABOAF"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=escvx8cKZB0"
+        },
+        {
+          "title": "Une équipe Tech 100% à distance : ça marche !  / A 100% remote working Tech team : it rocks !",
+          "description": "<p>Je suis passée du côté obscur et je travaille à 100% à distance depuis 1 an dans une équipe de développement au sein d'une startup.\nL'effet covid a encouragé les entreprises à adopter ce mode de travail d'une manière brutale. Certaines ont été conquise d'autre non. Pour ma part l'expérience est super positive.\nDans cette conférence j'aimerais partagé mes retours à la fois personnel en tant qu'employé sur ce que m'a apporté le remote et également en tant que manager de cette équipe, l'une des plus brillante équipe que j'ai rencontré en 15 ans d'expérience.\nQu'apporte le remote par rapport à des équipes en présenciel ? Quels mécanisme se mettent en place et sont gage de réussite dans ce contexte? \nJe n'aurais pas une réponse absolue à ces questions mais je pourrais partager avec vous les éléments qui m'ont paru être la clé de cette réussite.\n\n-----------\n\nI've gone over to the dark side and have been working 100% remotely for 1 year in a development team at a startup.\nThe covid effect has encouraged companies to adopt this way of working brutally. Some have been won over, others not. For me, the experience has been super positive.\nIn this conference, I'd like to share my personal experience of what remote working has brought me, both as an employee and as the manager of this team, one of the most successful I've met in my 15 years of experience.\nWhat does remote control bring to the table compared with face-to-face teams? What mechanisms are put in place to ensure success in this context? \nI won't have an absolute answer to these questions, but I will be able to share with you the elements that seemed to me to be the key to this success.</p>",
+          "speakers": [
+            "Virginie J"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=WK0rFpfXvmw"
+        },
+        {
+          "title": "How To Review Someone's Code While Not Being A Jerk!",
+          "description": "<p>Most of us do code reviews very often if not daily. However, how can we tell whether we are good reviewers or not? Do we review a code as robots? Do we keep in mind that we are reviewing the code of someone who invested time and knowledge to write this code, and thus deserves to get respectful feedback?\n\nIn this talk, we present the code review best practices and we answer the following questions: What to look for in a code review? How can we write useful reviews?\n\nFurthermore, we explain the key tips for writing respectful and constructive code review feedback. To discover more about all these points and more, come and see our talk.\n\n</p>",
+          "speakers": [
+            "Maha ALSAYASNEH"
+          ],
+          "language": "en",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=ULdGoaAB25o"
+        },
+        {
+          "title": "Simplifiez la gestion de vos applications sur Kubernetes avec CDK8S",
+          "description": "<p>\nCDK8S (CDK for kubernetes) est un framework de développement open source qui permet de définir des ressources kubernetes en utilisant des langages de programmation familiers: Typescript, JavaScript, Python, Java, et Go\n\nAujourd'hui, la gestion de ressources K8S est faite la plupart du temps via des fichiers YAML. Plus ces applications évoluent, plus ces fichiers deviennent plus compliqués à gérer et à maintenir. Par conséquent, la réutilisation ou l’utilisation des abstractions devient assez compliquée.\n\nDans cette session, nous allons découvrir comment utiliser cdk8s et créer des composants réutilisables pour vos équipes afin d'accélérer le développement de vos applications sur K8S.\n\nA la fin de ce talk, vous serez à même de déployer une application sur Kubernetes K8S ou de créer un composant réutilisable avec votre langage préféré.\n</p>",
+          "speakers": [
+            "Amine AIT AAZIZI"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=2MDWnidWawU"
+        },
+        {
+          "title": "Comment fabriquer un émulateur NES",
+          "description": "Émulation, simulation, virtualisation... Ces différents concepts permettent d'exécuter des programmes hors du cadre materiel et logiciel pour lequel ils ont été conçu. Si le cas d'usage le plus populaire aujourd'hui est le *rétro-gaming*, Il en existe une multitude. Il est d'ailleurs probable que vous utilisiez au quotidien ces technologies.\r\n\r\nPassionné par ces aspects, je me suis plus lancé le défi d'implémenter un émulateur d'une console NES. Pourquoi la NES ? C'est une machine relativement simple, extrêmement bien documentée, et de nombreux émulateurs open-source existants peuvent nous aider.\r\n\r\nJe vous propose de découvrir avec moi une architecture possible d'un émulateur, et comment en implémenter un en nous focalisant sur le CPU, la mémoire, et les fameuses *ROMs*. Nous évoquerons également comment rendre notre émulateur le plus fidèle possible. Enfin, nous verrons quelle stratégie de tests peuvent s’appliquer sur des projets d'émulateurs.",
+          "speakers": [
+            "Guillaume Roche"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=O9VrAw85UWU"
+        },
+        {
+          "title": "Une Architecture GitOps e2e : Terraform, Ansible, Kubernetes et AWS",
+          "description": "<p>On a compris : Kubernetes permet de gérer les ressources applicatives.\n\nMais du coup, comment provisionner mon socle technique ? Où est-ce que je déclare mes rôles ? Combien de clusters / de namespaces ? Comment gérer mes Secrets ? Quid de la zone grise (DNS, Storage, DBs, Storage…) qui touche à la fois à de l’infra et à de l’applicatif ? Où mettre mon socle d’observabilité ?\n\nDans ce talk, on va vraiment aborder les aspects importants du day-2. \nOn présentera une approche d’architecture dans un SI pas trop compliqué (pas de multi-régions, pas de multi-tenancy, pas de cluster on-premises) pour que tu puisses repartir avec une grille d’analyse complète (CI / Infra-as-code / Templating / Managed services) que tu pourras rapidement adapter et mettre en place dans ton projet !</p>",
+          "speakers": [
+            "Loïc Ortola",
+            "Aurélien Moreau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=yJwbEibS-vs"
+        }
+      ]
+    },
+    "2024": {
+      "date": "2024-11-07",
+      "venue": "Centre de Congrès Diagora, Labège",
+      "speakers": [
+        {
+          "name": "Carmen Piciorus",
+          "company": "BSCC - La Poste",
+          "city": "Montpllier",
+          "bio": "Après plusieurs années de développement, et quelques années dédiés à la protection de la messagerie laposte.net, j’intègre à présent une équipe  au service des projets du SI de la branche Services Courrier - Colis de La Poste. Passionnée par la cybersécurité, je me suis dédiée à faciliter la communication entre les développeurs et la sécurité pour aider aux développement des applications sécurisées et cyber-résilientes dans le cloud.",
+          "socials": []
+        },
+        {
+          "name": "Jérôme Tama",
+          "company": "Onepoint",
+          "city": "Bordeaux",
+          "bio": "Je viens du monde java et j'aime ça.\r\n\r\nMon travail de tous les jours s'éparpille entre :\r\n\r\n- Le dev\r\n- Le monde des conteneurs\r\n- Le coaching technique\r\n- Faire aimer la qualité",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/jtama_"
+            },
+            {
+              "type": "github",
+              "url": "jtama"
+            }
+          ]
+        },
+        {
+          "name": "Damien Lucas",
+          "company": "",
+          "city": "",
+          "bio": "Après avoir passé une quinzaine d'années dans le développement logiciel en société de services, j'ai maintenant rejoint Mirakl et par la même occasion, l'édition de logiciel. J'adore lire la doc avant de me lancer dans le code. Et par dessus tout, j'aime échanger et transmettre sur ce que j'ai pu apprendre de mes expériences, des discussions avec mes pairs, des conférences vues ...",
+          "socials": []
+        },
+        {
+          "name": "Guillaume Laforge",
+          "company": "Google",
+          "city": "",
+          "bio": "Guillaume Laforge is Developer Advocate for Google Cloud Platform, at day, focusing on generative AI, LLMs, serverless technologies and event-driven architecture, and at night, he is a Java Champion and wears his Apache Groovy hat.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/glaforge"
+            },
+            {
+              "type": "website",
+              "url": "https://glaforge.dev/"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Poncet",
+          "company": "",
+          "city": "",
+          "bio": "Geek, ex-nerd repenti, je code, je teste, je bricole, je soude et parfois fait sauter les plombs. CTO et spécialiste du magiciel, je suis aussi libriste dans l'âme et très impliqué dans le mouvement des logiciels libres.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/ponceto91"
+            },
+            {
+              "type": "website",
+              "url": "https://www.emaxilde.net/"
+            }
+          ]
+        },
+        {
+          "name": "Romain BERTHON",
+          "company": "",
+          "city": "",
+          "bio": "Développeur freelance, je place au centre de ma démarche professionnelle la qualité. Pour cela, je m'intéresse à de nombreux sujets tels que les tests, le Domain Driven Design, la programmation fonctionnelle, les méthodologies telles que l'Agilité, la sociologie, etc. Je participe également à la vie des communautés tech Lyonnaises, notamment au sein de l'organisation des événements des Software Crafters Lyon.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/RomainTrm"
+            },
+            {
+              "type": "github",
+              "url": "RomainTrm"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Leplus",
+          "company": "AWS",
+          "city": "Paris",
+          "bio": "Developer Advocate at AWS and Google Developer Expert in Web Technologies. I love to share knowledge among developers and people in general.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/olivierleplus"
+            },
+            {
+              "type": "github",
+              "url": "tagazok"
+            }
+          ]
+        },
+        {
+          "name": "Renaud Mathieu",
+          "company": "Advisely",
+          "city": "Paris",
+          "bio": "Organizer GDG Paris Android.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/renaud_mathieu"
+            },
+            {
+              "type": "github",
+              "url": "renaudmathieu"
+            }
+          ]
+        },
+        {
+          "name": "Julien BAJON",
+          "company": "Pictarine",
+          "city": "()",
+          "bio": "Senior Android Developer at Pictarine, over 5 years experience in mobile development. Passionate about the Android and Kotlin environment. I'm always on the lookout to explore new features and share my findings.",
+          "socials": []
+        },
+        {
+          "name": "Aurélie Vache",
+          "company": "OVHcloud",
+          "city": "Toulouse",
+          "bio": "Aurélie Vache is a Developer Advocate at OVHcloud in Toulouse, France. She is Docker Captain, CNCF ambassador, Google Cloud Developer Expert, Women techmarkers Ambassador &amp; GitPod Hero. She has been working as a Developer and Ops for over 18 years. Cloud enthusiast and advocates DevOps/Cloud/Golang best practices.\r\n\r\nConferences and meetups organizer since 2016. Technical writer (dev.to/aurelievache), a book author &amp; reviewer, a sketchnoter and a speaker at international conferences.\r\n\r\nMentor and promote diversity and accessibility in technology.\r\n\r\nShe created a new visual way for people to learn and understand Cloud technologies: \"Understanding Kubernetes/Istio/Docker in a visual way\" in sketchnotes, books and videos.\r\n\r\nBlog: https://dev.to/aurelievache/\r\nYouTube: https://www.youtube.com/c/AurelieVache",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/aurelievache"
+            },
+            {
+              "type": "website",
+              "url": "https://noti.st/aurelievache"
+            }
+          ]
+        },
+        {
+          "name": "Frédéric Cabestre",
+          "company": "SIGUSR",
+          "city": "Toulouse",
+          "bio": "Développeur indépendant, tendance «software crafter». Depuis longtemps attiré par les langages et leur mise en œuvre. Grand amateur de programmation fonctionnelle, même quand ce n'était pas encore cool. Curieux des systèmes, surtout s'ils sont distribués.",
+          "socials": []
+        },
+        {
+          "name": "Nicolas De Loof",
+          "company": "",
+          "city": "",
+          "bio": "Fellow Apache Maven committee\nWorked on Jenkins for 8 years (Jenkinsfile is partly my fault)\nDocker captain\nDeveloper experience engineer by Doctolib",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/ndeloof"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/ndeloof/"
+            }
+          ]
+        },
+        {
+          "name": "Logan Mauzaize",
+          "company": "Advae",
+          "city": "Toulouse",
+          "bio": "Amateur de Java avant le diplôme, j'ai distribué mes conseils lors de mes missions (expert technique, dev leader) et sur les forums. Notamment sur Developpez.com, sur lequel j'ai fait partie de l'équipe Java à la fois en tant que modérateur mais aussi rédacteur.\r\nCes dernières années je me suis spécialisé dans l'accompagnement des équipes projets (au sens large) autour de l'industrialisation et de l'automatisation (pipeline, déploiement, self-service, etc.)\r\n\r\nA temps perdu je développe en Rust et j'explore les technologies Cloud et DevOps.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/LoganMzz"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/loganmzz"
+            }
+          ]
+        },
+        {
+          "name": "Arnaud Giuliani",
+          "company": "Kotzilla",
+          "city": "Toulouse",
+          "bio": "Arnaud is a seasoned software developer with over 15 years of experience. He specializes as a Senior Android developer while maintaining proficiency in backend development, catering to both large corporations and startups. Since 2016, he has been an active speaker on various topics such as Kotlin, Android Architecture, and Koin. Arnaud was recognized as a Google Developer Expert for Kotlin in 2020.\n\nIn 2017, Arnaud initiated the development of Koin (https://insert-koin.io), a lightweight dependency injection framework for Kotlin. By the end of 2022, he co-founded Kotzilla, a company aimed at spearheading Saas and open-source software development for software architecture.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/arnogiu"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/arnaudgiuliani"
+            }
+          ]
+        },
+        {
+          "name": "Philippe Charrière",
+          "company": "Docker",
+          "city": "",
+          "bio": "- Principal Solution Architect chez Docker\r\n- WebAssembly lover\r\n- GenAI on Raspberry Pi addict\r\n- Container oriented",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/k33g_org"
+            },
+            {
+              "type": "website",
+              "url": "https://k33g.hashnode.dev/"
+            }
+          ]
+        },
+        {
+          "name": "David Pilato",
+          "company": "Elastic",
+          "city": "Cergy",
+          "bio": "David Pilato discovered Elasticsearch project in 2011. After contributed to the project and created open source plugins for it, David joined elastic the company in 2013 where he is Developer and Evangelist. He also created and still actively managing the French spoken language User Group. At elastic, he mainly worked on Elasticsearch source code, specifically on open-source plugins. In his free time, he likes talking about elasticsearch in conferences or in companies (Brown Bag Lunches AKA BBLs - https://www.elastic.co/blog/free-lunch-for-open-source-engineers). He is also author of FSCrawler (https://github.com/dadoonet/fscrawler) project which helps to index your pdf, open office, whatever documents in elasticsearch using Apache Tika behind the scene.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/dadoonet"
+            },
+            {
+              "type": "website",
+              "url": "https://david.pilato.fr/"
+            }
+          ]
+        },
+        {
+          "name": "Sébastien Blanc",
+          "company": "Port",
+          "city": "",
+          "bio": "Sébastien Blanc is a Passion-Driven-Developer with one primary goal : share his passion by giving talks that are pragmatic, fun and focused on live coding.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/sebi2706"
+            }
+          ]
+        },
+        {
+          "name": "Mathieu Passenaud",
+          "company": "please-open.it",
+          "city": "Péchabou",
+          "bio": "Après 8 ans en tant que DevOps dans les univers du Cloud et de l'IOT, j'ai découvert la nécessité absolue de bien fait l'authentification sur les applications.\r\nDepuis bientôt 4 ans, j'ai décidé de ne faire que ça avec please-open.it",
+          "socials": []
+        },
+        {
+          "name": "Dararath BEAUVOIR",
+          "company": "Palooma",
+          "city": "Toulouse",
+          "bio": "Consultante et développeuse d'applications Google Workspace chez Palooma, a accompagné +3000 salariés d'Airbus à devenir autonomes dans les automatisations de leurs tâches avec Google Apps Script et AppSheet",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/feudaratifice"
+            }
+          ]
+        },
+        {
+          "name": "Kevin DAVIN",
+          "company": "Gradle Inc",
+          "city": "Plaisance du Touch",
+          "bio": "Google Developer Expert on Google Cloud & Kotlin, Gitlab Hero, I am above all passionate about tech, languages, infrastructure, and automation. \nKotlin, Java, TypeScript are my day-to-day languages. I deploy all of those on the Google Kubernetes Engine with the GitLab's Continuous Integration 🚀. \n\nAddict of agility and DevOps, some of my missions were to help teams to follow those philosophies. \nFrom code quality analysis to unit or end-to-end tests setup all the way to continuous deployment and operation, I try to follow a project from birth to production. \n\nI'm currently Principal Software Engineer at Gradle and I'm working on Gradle Enterprise, the product which can improve the developer productivity by reducing its build and test time.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/davinkevin"
+            }
+          ]
+        },
+        {
+          "name": "Jules CLÉRO",
+          "company": "Smappen",
+          "city": "Toulouse",
+          "bio": "Jules: la barbue de l'équipe! De l'embarqué au web, le chemin n'est finalement pas si différent! Fan de git et de vim j'utilise toujours les mêmes outils pour mes développements.\nAujourd'hui développeur Full Stack chez Smappen, je travaille avec 5 autres développeurs pour permettre à nos utilisateurs de faire du géomarketing facilement et en autonomie.",
+          "socials": []
+        },
+        {
+          "name": "Damien MATHIEU",
+          "company": "Elastic",
+          "city": "Toulouse",
+          "bio": "Damien est ingénieur logiciel sur le produit d'observabilité de Elastic, et passe la majorité de son temps à contributer à OpenTelemetry, ou il est approver pour le SDK Go.",
+          "socials": []
+        },
+        {
+          "name": "Samuel MOREL",
+          "company": "Sorpa Steria Group",
+          "city": "Aubière",
+          "bio": "Architecte Logiciel @ Sopra Steria depuis 2016, je suis un touche à tout !  \nFormateur, recruteur, manager, j'aime varier les plaisirs. \n\nL'*industrialisation* 🚀 a toujours été pour moi une approche séduisante, et dans mes différentes expériences, il y a toujours eu une partie d'automatisation 🤖  \nJ'ai essentiellement travaillé dans des environnements *Java*, mais également plus récemment sur de l'*Angular* et bien sûr un peu de *Devops* 🛠 , surtout dans le *cloud* ☁   \nAdepte de la *sécurité applicative*,  je suis attentif à toute l'actualité sécu 🔐 (riche en ce moment ... 😱)\n\nEn dehors du boulot, je fais pas mal de ski 🎿, du tennis 🎾, et beaucoup de VTT surtout en descente et en skatepark 🚵‍♀️\n\nAu plaisir de vous rencontrer 👋",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/samuelmorel"
+            }
+          ]
+        },
+        {
+          "name": "Nicolas MENGIN",
+          "company": "TraefikLabs",
+          "city": "Toulouse",
+          "bio": "Traefik Maintainer\nHead of Support at Traefik Labs\nMarathon Runner\nGitOps follower\n",
+          "socials": []
+        },
+        {
+          "name": "Manon RETOURNAT",
+          "company": "Sopra Steria",
+          "city": "Toulouse",
+          "bio": "Actuellement alternante à la Mobile Factory de Sopra Steria, spécialisée dans le développement d'applications mobiles, j'ai précédemment poursuivi un master dans les métiers de l'art. Passionnée par l'interaction entre l'art et les sciences, j'explore comment la technologie, les algorithmes, et l'intelligence artificielle peuvent enrichir et transformer les pratiques artistiques contemporaines.",
+          "socials": []
+        },
+        {
+          "name": "Théo GIANELLA",
+          "company": "Zenika",
+          "city": "Lyon",
+          "bio": "Anciennement enseignant-chercheur en littérature, je me suis reconverti dans le développement web en 2023. Je travaille désormais à Zenika Lyon et je suis en mission chez Bedrock Streaming où je participe à maintenir et améliorer les applications web de certaines des plus grandes plateformes de streaming européenes !\n\nLa principale chose que j'ai gardé de ma première carrière est une réelle passion pour la transmission de ce que j'aime ou qui me rend curieux. J'ai déjà eu la chance de pouvoir parler au Devoxx France en 2024 et bientôt au Breizhcamp !",
+          "socials": []
+        },
+        {
+          "name": "Ludivine DOBIGNY",
+          "company": "Yumans design",
+          "city": "TOULOUSE",
+          "bio": "I'm a designer, passionate about my work.",
+          "socials": []
+        },
+        {
+          "name": "Laurie GHIONE",
+          "company": "Air France",
+          "city": "Toulouse",
+          "bio": "Développeuse depuis plus de 10 ans, attirée particulièrement par le code front-end, je me dirige vers une expertise Angular depuis 3 ans. Depuis 3 ans sur des projets Air France j'évolue sur une stack Java Springboot / Angular. Lead depuis 3 ans, je suis support auprés de l'équipe, garante du code front et de la qualité du code sur mes projets. \nJe suis également formatrice dans l'IT à l'école my digital school et freelance dans la réalisation de site web simples.\n",
+          "socials": []
+        },
+        {
+          "name": "Julien Briault",
+          "company": "Deezer & Les Restos du Coeur",
+          "city": "Paris",
+          "bio": "Network Engineer SRE chez Deezer et IT Manager à mes heures perdues au Restos du Cœur et développeur Rust/Go sur le temps qu'il me reste, je suis un passionné d'informatique, de réseau informatique et de logiciels libres. ",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/ju_hnny5"
+            },
+            {
+              "type": "website",
+              "url": "https://blog.jbriault.fr/"
+            }
+          ]
+        },
+        {
+          "name": "Matthieu VINCENT",
+          "company": "Sopra Steria",
+          "city": "Cusset",
+          "bio": "🎤 Speaker in 2022, 2023 @ Devoxx FR, @SnowCamp\n🛠 University in 2023 @ Snowcamp, Devoxx FR, Breizhcamp\n🌋 Co-founder of Volcamp @Clermont-Fd : https://volcamp.io\n🦊 Gitlab hero | 🤖 R2Devops ambassador\n✍️ Blog @ https://yodamad.hashnode.dev/",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/yodamad03"
+            }
+          ]
+        },
+        {
+          "name": "Laurent Grangeau",
+          "company": "Google",
+          "city": "France",
+          "bio": "Laurent Grangeau is a Solutions Architect at Google. He is also the organiser of the Serverless Paris meetup, as well as co-organiser of the Kubernetes and Docker Paris meetups. He has developed in several languages, mainly object-oriented like Java or C#. For several years, he has been helping companies to adopt the Cloud, as well as DevOps principles. He has experienced with building microservices and distributed systems. He loves to automate things and run distributed applications at scale.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/laurentgrangeau"
+            }
+          ]
+        },
+        {
+          "name": "Axel SIMON",
+          "company": "",
+          "city": "",
+          "bio": "Je suis un développeur spécialisé dans les applications mobiles et  dans les expériences XR (Extended Reality) chez Sopra Steria depuis plus de quatre ans. J'ai pu utiliser des logiciels tel que l'Unreal Engine, Unity3D et Omniverse, qui ouvrent la voie à la programmation en XR grâce à la 3D. En dehors de mes heures de travail, je suis attentif aux avancées de ces technologies et les explore activement dans mon temps libre.C'est pourquoi j'aimerais vous parler de ces technologies.",
+          "socials": []
+        },
+        {
+          "name": "Dan FAUDEMER",
+          "company": "Smappen",
+          "city": "Toulouse",
+          "bio": "Je suis le fondateur de Smappen, initialement un side project conçu pour se retrouver en covoiturage avec ma compagne. Passionné de développement et d'électronique depuis toujours, j'adore transformer des idées en solutions :)",
+          "socials": []
+        },
+        {
+          "name": "François-Xavier LAIR",
+          "company": "Onepoint",
+          "city": "NANTES (44000)",
+          "bio": "Après plus d'une dizaine d'année de Devfront j'interviens à présent sur les projets en tant qu'expert accessibilité et qualité. Expert BBQ (Bike, Beer and QualityWeb), quand je ne bosse pas sur la qualité Web j'adore bricoler des vélos ou brasser de la bière.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/lair_net"
+            }
+          ]
+        },
+        {
+          "name": "Fabien VAUCHELLES",
+          "company": "",
+          "city": "Paris",
+          "bio": "Fabien Vauchelles is an Anti-Ban Expert. With over a decade of experience in Web Scraping, Fabien's passion for code and technology helps him to bypass bans. He is the creator of Scrapoxy, a mature free and open-source proxy aggregator tailored for the Web Scraping industry.\n\nHe had the opportunity to speak at Devoxx, PyCon, etc.\n",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/fabienv"
+            }
+          ]
+        },
+        {
+          "name": "Rémi VERCHÈRE",
+          "company": "Accenture",
+          "city": "Aubagne",
+          "bio": "D'abord chez les devs sur des solutions embarquées, j'ai au fur et à mesure de mes postes basculé chez les ops sur des solutions d'infrastructure diverses et variées. Pendant plus de 10 ans j'ai donc bossé avec les devs et les ops, affichant une volonté de proposer des choix autour des solutions Open Source. Je suis maintenant consultant depuis plus de 3 ans, et apporte aux entreprises mon savoir-faire sur des sujets d'automatisation et observabilité, en tant qu'ops au service des devs.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/rverchere"
+            }
+          ]
+        },
+        {
+          "name": "Damien GUERIN",
+          "company": "Lyra Network",
+          "city": "Labège",
+          "bio": "Architecte Lyra, et marathonien à ses heures perdues, Damien est un ingénieur touche à tout. Passionné d'opensource, c'est notre monsieur OpenAPI...! Retrouvez le sur https://github.com/gigaga",
+          "socials": []
+        },
+        {
+          "name": "Julien SULPIS",
+          "company": "Zenika",
+          "city": "Lyon",
+          "bio": "Développeur front-end passionné, j'aime explorer les outils du web moderne pour créer des applications sans compromis entre performance, accessibilité, et design qui sort du lot. CSS, WebGL et librairies JS minimalistes sont mes outils de prédilection.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/jsulpis"
+            }
+          ]
+        },
+        {
+          "name": "Olivier HUBER",
+          "company": "Aiven",
+          "city": "Paris",
+          "bio": "Olivier HUBER est un passionné de création. Pour lui, notre métier d'informaticien est l'un des rares à nous donner la capacité de matérialiser une idée rapidement et à faible coût. Initié à l'agilité  par l'eXtrême Programming dès ses débuts, il intervient pendant 24 ans en dev/conseil/formation pour des clients, écoles, assoc. Toujours à la recherche de nouvelles façons de faire pédagogique et de partager son savoir, vous pouvez le croiser de temps en temps aux conférences suivantes, Devoxx, DevFest, Mix-IT, BreizhCamp, ... sur divers sujets techniques ou non. Il quitte ses postes de Responsable Pédagogique et Directeur Technique à Zenika pour rejoindre Aiven en novembre 2022 ou il y occupe le poste de Senior Partner Solution Architect.  ",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/olivierhuber"
+            }
+          ]
+        },
+        {
+          "name": "Jonathan GAFFIOT",
+          "company": "Kaizen Solutions",
+          "city": "Grenoble",
+          "bio": "J'ai commencé par une thèse en physique des particules, avec beaucoup de C++ orienté performance pour la simulation et l'analyse de gros volumes de données. Sur la fin, je me suis un peu mis à Python pour comparer et synthétiser les résultats. Après 2 post-docs dans le même domaine, j'ai enchainé pendant 3 ans en pur Python à concevoir, développer, opérer et maintenir un logiciel de commande autonome de centrales solaires avec stockage, chargé de gérer en temps quasi réel les transferts d'électricité entre le champs solaire, le parc de batterie et le réseau électrique. Revenu à Grenoble, après plusieurs missions autour de la connectivité et de l'IoT en C++ et Python, je suis maintenant dans un groupe d'analyse de données et d'IA en support des services d’ingénieries chez EDF.",
+          "socials": []
+        },
+        {
+          "name": "Gwendal LECLERC",
+          "company": "OVHcloud",
+          "city": "Rennes",
+          "bio": "Fullstack developer depuis une décennie.\nJe fais du Go, du React, du Python, ... \nJ'aime bien toucher à tout et j'adore les tests :)",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/Skillo1989"
+            }
+          ]
+        },
+        {
+          "name": "Alexandre Daubois",
+          "company": "Les-Tilleuls.coop",
+          "city": "Lyon",
+          "bio": "Alexandre is part of the Symfony Core Team and Symfony/PHP Expert Developer based in Lyon, France.\r\n\r\nAs well as giving talks at official Symfony events, Pimcore, PHPers and Malt Academy, Alexandre's involvement in the PHP world was strengthened by contributing to PHP and Symfony's source code and documentation. He then continued this dynamic by joining Sensiolabs (the company that created Symfony), as well as writing his first book, \"Clean Code in PHP\" in October 2022.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/alexdaubois"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/alexandre-daubois"
+            },
+            {
+              "type": "website",
+              "url": "https://alex-daubois.medium.com/"
+            }
+          ]
+        },
+        {
+          "name": "Alexandre MOUREAUX",
+          "company": "BAM",
+          "city": "Paris",
+          "bio": "Salut, je suis dev mobile depuis 8 ans, en passant par React Native, Flutter ou Compose. J'aicréé Flashlight, un ligthhouse pour app mobile (parce qu'une lampe torche, c'est un peu un phare mobile). Je crois que développer des apps performantes fait partie des façons qu'on a en tant que dev de lutter contre le réchauffement climatique !",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/almouro"
+            }
+          ]
+        },
+        {
+          "name": "Sylvain MÉTAYER",
+          "company": "Onepoint",
+          "city": "Bordeaux",
+          "bio": "Tech Lead à onepoint, je viens du monde PHP, j'aime la CI/CD et la conteneurisation, tout comme me simplifier la vie en automatisant mes tâches du quotidien.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/sylvain_metayer"
+            }
+          ]
+        },
+        {
+          "name": "Julien Lenormand",
+          "company": "Kaizen Solutions",
+          "city": "Grenoble",
+          "bio": "Développeur Python convaincu par l'Agile, le Craft, Accelerate et la philosophie grecque antique.\r\nConsultant dans de grands groupes industriels (SNCF, EDF, Thales, Schneider).\r\nMeetupeur grenoblois investi : Human Talks, Python, Craft et Web.\r\nOrganisateur d'évènements, speaker et accompagnant technique à Kaizen Solutions.",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://lenormand-julien.fr/"
+            }
+          ]
+        },
+        {
+          "name": "Jérôme JAMES",
+          "company": "SOPRA STERIA",
+          "city": "TOULOUSE",
+          "bio": "Passionné par la création d'expériences numériques captivantes, je suis un développeur Android expérimenté, ainsi qu'un expert en Unity 3D et Unreal Engine. Mon parcours professionnel est le reflet de ma passion pour l'innovation technologique et l'aspect créatif du développement logiciel.",
+          "socials": []
+        },
+        {
+          "name": "Thierry CHANTIER",
+          "company": "OVHcloud",
+          "city": "Lyon",
+          "bio": "Développeur de métier, du jeu vidéo au monde du master data management, j'ai aussi touché aux univers de la QA et de la CI/CD.\nJe suis maintenant ce que l'on appelle un DevRel, chez OVHcloud, jonglant entre technique, communauté et transmission de savoirs.\n\nComme une passion mérite toujours qu'on la transmette, j'ai fondé Mixteen pour essayer d'aider les enfants à appréhender le monde numérique puis cofondé le GDG Lyon.\nDe manière parallèle, j'essaie de partager également par le biais d'articles sur mon blog et de vidéos sur ma chaîne YouTube.\n\nhttps://www.twitch.tv/titimoby\nhttps://mixteen.org/ \nhttps://www.youtube.com/thierrychantier\n",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/titimoby/"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume SAINT-ETIENNE",
+          "company": "ITER organization",
+          "city": "Toulouse",
+          "bio": "I'm a software coder since my first ZX81 at 11 yo (guess my age) and agile practitioner since 2006.\nKotlin and C# fanboy. Monads saved my life. Currently working for ITER organization.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/guillaume_agile"
+            }
+          ]
+        },
+        {
+          "name": "Benoît MASSON",
+          "company": "OVHcloud",
+          "city": "Rennes",
+          "bio": "Tombé dans la potion quand j'étais petit, je m'intéresse depuis toujours à l'informatique : d'abord joueur, bidouilleur et développeur sur calculatrice, puis professionnellement en tant que chercheur et formateur, et finalement de retour au développement web full-stack depuis quelques années.\n\nPassionné par les langages modernes, de bas niveau (Go, Rust) ou fonctionnels (Caml, Elm) permettant par leur conception de limiter les risques d'erreur humaine, je m'implique dans les communautés locales pour partager mes expériences et améliorer mes pratiques.\n\nActuellement Team Leader dans l'équipe Noms de Domaines chez OVHcloud.",
+          "socials": []
+        },
+        {
+          "name": "Guillaume Lours",
+          "company": "Docker",
+          "city": "Rouen",
+          "bio": "Staff Software Engineer @docker, Compose Specification maintainer, working on Docker Compose and Dev Environments",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/glours"
+            },
+            {
+              "type": "website",
+              "url": "https://blog.docker.com"
+            }
+          ]
+        },
+        {
+          "name": "Florian Bernard",
+          "company": "OpenAirlines",
+          "city": "Toulouse",
+          "bio": "Après un début de carrière en 2009 en tant que développeur, j'ai peu à peu évolué sur des rôles de tech lead / architecte (dans plusieurs sociétés) et actuellement j'occupe le poste de Principal Engineer chez OpenAirlines. Passionné, j'aime apprendre et partager sur tous sujets qui touchent au développement et à l'architecture logicielle (mais pas que :-)).",
+          "socials": []
+        },
+        {
+          "name": "Yann Gloriau",
+          "company": "Sopra Steria",
+          "city": "Paris",
+          "bio": "Débuté le dev sur MO5 (je vous laisse demander à Google) en 1987, passage par le C, l'ADA et autre C++ pour devenir architecte et enfin directeur technique pour Sopra Steria",
+          "socials": []
+        },
+        {
+          "name": "Ivan Béthus",
+          "company": "Onepoint",
+          "city": "Bordeaux",
+          "bio": "Développeur backend depuis 5 ans chez onepoint, formateur et enseignant vacataire à l'IUT de Bordeaux. Au-delà de la résolution de bug et du clean code, une passion : partager !",
+          "socials": []
+        },
+        {
+          "name": "Aurélien Boudoux",
+          "company": "",
+          "city": "Lyon",
+          "bio": "Tout comme l’écrivain qui ne demande qu’à être lu ou le musicien qui désire être écouté, je suis un développeur dont l’objectif est de créer des outils qui apportent une réelle utilité à un maximum de personnes. Après 20 ans dans l’informatique dont 15 ans dans le développement, je découvre chaque jour de nouvelles possibilités offertes par les machines, et mon seul regret consiste à ne pas disposer d’assez de temps pour toutes les explorer.\r\n\r\n« Computers can change your life for better. » - The hacker Ethic, Steven Levy",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/AurelienBoudoux"
+            }
+          ]
+        },
+        {
+          "name": "Bertrand Péchou",
+          "company": "",
+          "city": "Toulouse",
+          "bio": "Bertrand est agriculteur céréalier dans la plaine du Lauragais dans les environs de Toulouse.",
+          "socials": []
+        },
+        {
+          "name": "Nour Mestiri",
+          "company": "AWS",
+          "city": "Paris",
+          "bio": "Joined AWS 4 years ago through the AWS Tech U graduate program. Now Solutions Architect Manager of Early Career Talents.",
+          "socials": []
+        },
+        {
+          "name": "Xi Chen",
+          "company": "Lyra Network",
+          "city": "Toulouse",
+          "bio": "Architecte à Lyra, avec de nombreuses années d'expérience en développement full-stack. Il guide les équipes dans la conception et la mise en place d'architectures micro-services et la modernisation des chaînes de traitement de données, dont le projet de transition de technologies comme IBM DataStage vers DBT et Snowflake. ",
+          "socials": []
+        }
+      ],
+      "sessions": [
+        {
+          "title": "Sortir des ETL : Transition d'une solution \"Code Less\" à une approche \"Code Full\"",
+          "description": "Le traitement des données est depuis longtemps le domaine des outils d'ETL, disposant d'un environnement graphique poussé et ne nécessitant pas ou peu de code.\r\n\r\nDe fait, ces approches fonctionnent mal avec les contraintes modernes de développement (Git flow, livraison incrémentale, ...)\r\n\r\nAu cours de cette conférence, nous reviendrons sur la migration de nos chaines de traitement d'un ETL classique (IBM Data Stage) vers une solution DBT / Snowflake :\r\n<ul>\r\n \t<li>Pourquoi migrer ? Les limitations des outils \"code less\".</li>\r\n \t<li>Comparaison des paradigmes ETL (Extract, Transform, Load) et ELT (Extract, Load, Transform).</li>\r\n \t<li>Avantages d'une approche \"code full\" pour les développeurs et les analystes.</li>\r\n \t<li>Amélioration du suivi et du support pendant le RUN en production : Monitoring, alertes, et résolution des incidents.</li>\r\n \t<li>Transition de \"livrer les données vers les personnes concernées\" à \"rendre les données accessibles par les personnes concernées\".</li>\r\n \t<li>Retour d'expérience et bénéfices observés après la migration.</li>\r\n</ul>",
+          "speakers": [],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=k5txSq17Ddo"
+        },
+        {
+          "title": "Sortir des ETL : Transition d'une solution \"Code Less\" à une approche \"Code Full\"",
+          "description": "Le traitement des données est depuis longtemps le domaine des outils d'ETL, disposant d'un environnement graphique poussé et ne nécessitant pas ou peu de code.\r\n\r\nDe fait, ces approches fonctionnent mal avec les contraintes modernes de développement (Git flow, livraison incrémentale, ...)\r\n\r\nAu cours de cette conférence, nous reviendrons sur la migration de nos chaines de traitement d'un ETL classique (IBM Data Stage) vers une solution DBT / Snowflake :\r\n<ul>\r\n \t<li>Pourquoi migrer ? Les limitations des outils \"code less\".</li>\r\n \t<li>Comparaison des paradigmes ETL (Extract, Transform, Load) et ELT (Extract, Load, Transform).</li>\r\n \t<li>Avantages d'une approche \"code full\" pour les développeurs et les analystes.</li>\r\n \t<li>Amélioration du suivi et du support pendant le RUN en production : Monitoring, alertes, et résolution des incidents.</li>\r\n \t<li>Transition de \"livrer les données vers les personnes concernées\" à \"rendre les données accessibles par les personnes concernées\".</li>\r\n \t<li>Retour d'expérience et bénéfices observés après la migration.</li>\r\n</ul>",
+          "speakers": [
+            "Xi Chen"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant"
+        },
+        {
+          "title": "Il faut sauver le dernier giga de RAM",
+          "description": "A l'approche des fortes volumétries de fin d'année, notre client ne peut plus se permettre d'ajouter à nouveau de la RAM sur son environnement de prod. Avec 96Go déjà en place sur le serveur, ça peut se comprendre !\r\n\r\nLe mot d'ordre : réduire la consommation mémoire de notre application.\r\n\r\n- \"On a des metrics ?\r\n- Non.\r\n- Accès à la prod ?\r\n- Non.\r\n- Un composant identifié ?\r\n- Non, plusieurs dizaines.\r\n- Et on a combien de temps ?\r\n- 3 semaines.\"\r\n\r\nA travers ce talk nous vous présentons les outils que nous avons utilisés pour identifier les composants gourmands en RAM (Java Flight Recorder, MemoryAnalyzer, pg_statements, hypersistence-utils ...). Mais aussi comment nous les avons améliorés afin de réduire leur empreinte mémoire.\r\n\r\nLa stack du projet : Java, Spring, PostgreSQL.",
+          "speakers": [
+            "Ivan Béthus",
+            "Damien Lucas"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=9PpMCwLzljg"
+        },
+        {
+          "title": "La prod est en flammes ? Pas de stress, j'ai strace (et ses copains)",
+          "description": "\"La vie d'un tech est jonchée de productions en flammes et s'appuyant sur la loi de Murphy, plus le problème est compliqué moins la supervision / télémétrie / observabilité est présente.\r\n\r\nLa première réaction cohérente, lorsque l'on arrive dans ce genre de situation, serait la panique tout juste suivie par la proposition d'un voyage à Lourdes ou autres techiques magiques, ou en extrème limite d'un exorcisme réalise par Damien Karras himself (un très bon film au demeurant).\r\n\r\nUne fois ces tentatives épuisées, nous reste la raison et les quelques outils disponibles sur une machine. Fouiller le /proc, comprendre les principaux indicateurs et tracer le fonctionnement de l'application en peine via strace pour poser diagnostic et résolution.\r\n\r\nLe talk se base massivement sur des manipulations réalisées en live. Le support PowerPoint est utilisé avant tout pour lancer le sujet. Par soucis de simplicité, j'utilise WSL qui permet de voir les comportements sans avoir à jongler entre plusieurs machines virtuelles.\r\n\r\nL'idée est de permettre à l'audience qu'un système nous dit beaucoup de choses sans avoir à déployer des montagnes de solutions de supervisions (qui ne font que s'appuyer sur ce que je présente)et que l'on peut rapidement avoir un overview complet sans toutefois être dépendant de la technologie (Java, Python ou autre).\r\n\r\nA la suite du talk, l'audience doit se sentir à l'aise pour partir en exploration d'un problème va un outillage simple, ce qui permet également de mieux alimenter les systèmes de télémétrie et de gagner en pertinence par la suite (proposition de nouvelles sondes ou indicateurs).\r\n\r\nMoralité, nous sortons d'une position subie pour prendre en main le système et tenter d'avoir de meilleurs indicateurs par la suite.\"",
+          "speakers": [
+            "Yann Gloriau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=rc8q9Vv35WU"
+        },
+        {
+          "title": "CQRS / ES : nos heuristiques après plusieurs années de production",
+          "description": "Avez-vous déjà mis en place une architecture CQRS/ES ? Ou peut-être, avez-vous envisagé de le faire ? Vous avez sans doute trouvé beaucoup de ressources sur les bases de cette architecture. Cependant, il y manque trop souvent un côté pratique vous laissant face à de nombreuses interrogations lors de son implémentation.\r\n\r\nMais cela va changer ! Avec de nombreuses années de pratique, nous avons acquis une solide expérience sur ce pattern. Nous vous proposons de faire le tour de nos tips &amp; tricks pour implémenter plus sereinement CQRS/ES sur vos projets. Attention, vous pourriez être surpis.es !",
+          "speakers": [
+            "Aurélien Boudoux",
+            "Romain BERTHON",
+            "Aurélien Boudoux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=aE8cJnJKae8"
+        },
+        {
+          "title": "Créer sa propre Malware Sandbox",
+          "description": "La sécurité est, plus que jamais, au centre de toutes les problématiques en informatique. Peu importe si on parle de web, d’app mobiles ou de logiciels pour ordinateur, la sécurité revient sans cesse au centre de la table.\r\n\r\nMais allons droit au but : qui effectue des vérifications poussées et avancées sur les fichiers reçues dans son application web ? On ne parle pas d’une « simple » vérification de MIME Type bien sûr. Êtes-vous protégés d’un code malicieux, d’injections de commandes ou encore des terrible « tarbombs » qui feront les heures sombres de vos SSD ?\r\n\r\nSans aller jusqu’à créer un véritable antivirus, beaucoup de choses peuvent être faites rapidement et sans trop d’efforts de mise en place pour isoler les potentiels malware, les analyser et traiter les fichiers en toute sécurité en créant sa propre Malware Sandbox. Bienvenue dans la cybersécurité !",
+          "speakers": [
+            "Alexandre Daubois"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=Bxc56OblZTQ"
+        },
+        {
+          "title": "Introduction à la Géodata - Les tuiles vectorielles",
+          "description": "Chez Smappen on sait afficher 1000 fois 1 point! Non.. 1000 points 1 fois.. heu..\r\n\r\nBref chez Smappen on affiche des points sur des cartes, mais passer de 1000 à 1.000.000 n’est pas forcément évident.\r\n\r\nVenez découvrir la puissance des tuiles vectorielles! Une techno que vous utilisez tous les jours avec votre application de cartographie préférée, mais que vous ne connaissez peut-être pas!",
+          "speakers": [
+            "Jules CLÉRO"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=_fdQymt_si4"
+        },
+        {
+          "title": "Fermé pour inventaire : histoire et mécanique des « closures »",
+          "description": "En 1958 naissait LISP, un des tout premiers langages de programmation intégrant la notion de fonction anonyme, communément appelée « lambda ».\r\nEn 1970, une équipe du MIT ayant pour membre Guy L. Steele Jr. créait Scheme, une évolution de LISP munie entre autres de « closures ».\r\nEn 2007, Rich Hickey propose un dialecte de Scheme ciblant la JVM : Clojure.\r\nEn 2014, Java 8 intègre à son tour la notion de « lambda » qui dans les faits sont des « closures ».\r\n\r\nEt dans l’intervalle bien des langages ont intégré des concepts similaires de manière plus ou moins élaborée (qui a dit « pointeur de fonctions » ?). En particulier les langages de programmation fonctionnels qui promeuvent l'usage intensif de fonctions d'ordre supérieur.\r\n\r\nMais au fait, quelle est la différence entre une lambda et une « fermeture » ? Qu'est-ce que cela implique en terme de compilation, de gestion mémoire ? Et quel est le rapport entre Guy L. Steele Jr et Java ?\r\n\r\nAutant de questions auxquelles nous tenterons de répondre au cours de cette session.",
+          "speakers": [
+            "Frédéric Cabestre"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=HYqmX1jaRP0"
+        },
+        {
+          "title": "Après l'ordi 8 bit voici la carte VGA sur breadboard",
+          "description": "\"Ce que je ne peux pas créer, je ne le comprends pas” - Richard Feynman, un des plus grands physiciens, pédagogue remarquable et drôle. Je suis passionné par l’informatique bien sûr, mais surtout par la création en général et l’apprentissage en particulier. Je souhaite vous présenter, mon retour d’expérience de la création d’une carte VGA fonctionnelle à partir de composants électroniques simples et le tout sur breadboard ! Ancré dans un storytelling bien à moi, je ferai une démonstration en live comme j'ai déjà fait avec l’ordinateur 8 bit avant et quels enseignements j’en ai tirés.",
+          "speakers": [
+            "Olivier HUBER"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=VsumNHjalB8"
+        },
+        {
+          "title": "Du CSS aux shaders WebGL : panorama des techniques d'animation",
+          "description": "Parfois subtiles, parfois proéminentes, les animations sont un élément essentiel pour une expérience utilisateur agréable. Mais une fois qu'on a imaginé des animations plus ou moins folles, vient la question fatidique du \"comment fait-on ça ?\", à laquelle j'aimerais vous aider à répondre.\r\n\r\nPour pouvoir choisir la technique la mieux adaptée à chaque animation, il vaut mieux avoir une boîte à outils la plus complète possible. J'aimerais vous aider à construire la vôtre en vous présentant un panel le plus large possible de techniques d'animation sur le web : des APIs natives classiques (CSS, Web Animation API) aux plus complexes (Canvas API) en passant par les librairies spécialisées (FLIP, Lottie, Framer Motion, Rive...). Nous finirons avec WebGL et ses shaders GLSL, qui feraient trembler plus d'un développeur mais dont on retrouve les effets impressionnants sur tous les sites récompensés aux Awwwards.\r\n\r\nJe passerai rapidement sur toutes ces techniques, en comparant leurs performances et utilisations possibles, afin de vous laisser la liberté d'explorer plus en profondeur celles qui vous intéressent.",
+          "speakers": [
+            "Julien SULPIS"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=HKIEQM0j0u4"
+        },
+        {
+          "title": "Un Backup C'est bien, un réplica c'est mieux : démystification de la réplication sur PostgreSQL !",
+          "description": "Sauvegarder vos bases de données, c'est comme garder une photo de votre chat : c'est bien, mais si votre maison brûle, mieux vaut avoir un plan B 🔥 ! Venez découvrir les bases de la réplication avec PostgreSQL, pour que même en cas de coup dur, vos informations restent aussi cool et disponibles que les chats.",
+          "speakers": [
+            "Dan FAUDEMER"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=yPFR3xOg5MU"
+        },
+        {
+          "title": "OpenAPI (dev tools)",
+          "description": "Les contrats OpenAPI (anciennement Swagger) permettent de formaliser le fonctionnement d'une API REST. Dans un environnement de plus en plus tourné vers les API et les micro-services, ce formalisme présente de nombreux avantages, comme la génération automatique du code client et serveur, la garantie de stabilité de l'écosystème, la validation à la volée des requêtes entrantes, la génération de documentation, etc.\r\n\r\nDurant ce talk, nous vous présenterons la stratégie mise en place à Lyra pour centraliser et partager les contrats OpenAPI entre les différents produits, et simplifier les interdépendances entre services.\r\n\r\nPour cela, nous avons publié en Open-Source l' \"OpenAPI Dev Tool\", un outil tout-en-un permettant de simplifier le développement et l'utilisation des contrats de nos API. Utilisé par tous nos projets en interne, il peut être utilisé dans n'importe quel contexte.\r\n\r\nEnfin, nous conclurons par un retour d'expérience sur l'utilisation de l'écosystème OpenAPI, ses avantages et les pièges que nos 5 ans d'expérimentations nous ont permis de déceler.",
+          "speakers": [
+            "Damien GUERIN"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=t1PqyxaHriE"
+        },
+        {
+          "title": "Passer de Terraform à Pulumi : Galère ou Épopée ? 🌟",
+          "description": "Marre du YAML et du HCL ? 😡\r\nNous aussi !\r\n\r\nDans ce talk, nous explorerons le parcours pour migrer de Terraform à Pulumi, deux outils d’infrastructure as code (IaC).\r\nAprès une introduction à Terraform et Pulumi, en soulignant les similitudes et les différences clés entre les deux, nous parlerons des raisons qui peuvent nous pousser à envisager cette migration :\r\n- nécessité d’une plus grande flexibilité 🤸\r\n- meilleure gestion des états 🛂\r\n- intégration plus étroite avec les langages de programmation que nous utilisons déjà 🧑‍💻\r\n- problème de licence 😬\r\n\r\nLe cœur de ce talk est un aperçu détaillé du processus de migration lui-même.\r\nNous partagerons les défis que nous avons rencontrés, les solutions que nous avons trouvées (utilisation de la CLI, Pulumi IA, ... et quand même un peu de manuel 🙂) et les leçons que nous avons apprises en cours de route.\r\n\r\nEnfin, nous conclurons avec des conseils pour ceux qui envisageant une migration similaire et une discussion sur ce que l’avenir pourrait réserver à l’infrastructure as code.\r\n\r\nCe talk est destiné à toute personne intéressée par l’infrastructure as code, qu’elle soit déjà familière avec Terraform et Pulumi ou qu’elle cherche simplement à en savoir plus sur ces outils et les tendances actuelles en matière de gestion d’infrastructure.\r\nNous espérons que notre expérience pourra aider d’autres équipes à naviguer dans leur propre voyage vers l’infrastructure as code de nouvelle génération 🚀",
+          "speakers": [
+            "Matthieu VINCENT",
+            "Samuel MOREL"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=oQqegPNzJVg"
+        },
+        {
+          "title": "What’s new in Traefik v3?",
+          "description": "Traefik est un Ingress Controller/API Gateway/ gateway Controller capable d'exposer et de sécuriser services et APIs simplement, dynamiquement, et à grande échelle. Il a été conçu spécifiquement pour les environnements cloud native et s'impose comme une solution de choix du cas le plus simple au plus complexe.\r\n\r\nSi vous passez votre temps à gérer, exposer et sécuriser vos applications et microservices, alors cette session est faite pour vous!\r\n\r\nLors de cette session, Nicolas Mengin (Mainteneur de Traefik) vous présentera comment les nouveautés contenues dans la version 3 de Traefik simplifieront votre quotidien:\r\n\r\n- Support d’Open Telemetry pour monitorer votre infrastructure\r\n- Support des ressources GatewayAPI pour exposer vos ressources dans Kubernetes\r\n- Intégration des plugins WASM pour créer vos propres middlewares\r\n- Et plus encore…",
+          "speakers": [
+            "Nicolas MENGIN"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=a3P8ofWr3sc"
+        },
+        {
+          "title": "Façonnez Votre Cloud avec Karpenter : Les Secrets du Maître Charpentier du Numérique",
+          "description": "Découvrez les secrets de Karpenter pour optimiser votre infrastructure cloud Kubernetes. Explorez son approche innovante qui adapte automatiquement la taille des clusters en fonction de la demande, offrant des économies de coûts significatives et une meilleur efficacité opérationnelle. Rejoignez-nous pour une démonstration pratique et maîtrisez l'art de la gestion des ressources cloud.",
+          "speakers": [
+            "Nour Mestiri",
+            "Olivier Leplus",
+            "Nour Mestiri"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=q92jhU5Ezx0"
+        },
+        {
+          "title": "Compose to Kube, Same player shoot again",
+          "description": "Kubernetes est le standard _de facto_ dans notre industrie pour orchestrer des applications conteneur-izées en production. Les développeurs apprécient pourtant toujours autant la simplicité et la compacité du modèle proposé par Docker Compose, au moins pendant le développement. Une demande qui revient donc en boucle concerne une traduction auto-magique du compose.yaml en fichiers kube.yaml.\r\n\r\nCette fonctionnalité a été proposée par de nombreux outils, avec des approches diverses, y compris par Docker avec “Compose on Kubernetes” qui a finalement été déprécié. Nous avons eu une expérience similaire avec les \"Cloud Integrations\" et le traduction de Compose vers Amazon ECS.\r\n\r\nDans cette session, nous explorerons notre héritage pour comprendre les raisons de ces échecs, avant de vous présenter la nouvelle génération d'outil \"Compose to Kube\" sur laquelle nous travaillons, qui veut combiner la simplicité pour un développeur à déployer son application compose.yaml sur k8s, and la flexibilité pour les équipes plateforme de contrôler et d'adapter la conversion pour correspondre aux solutions techniques déployées sur leur cluster.",
+          "speakers": [
+            "Guillaume Lours",
+            "Nicolas De Loof"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=iN7POv7tpQA"
+        },
+        {
+          "title": "✨ Du GPU dans mes conteneurs !",
+          "description": "Après avoir validé le POC du dernier projet IA, à grands coups de requêtes vers OpenAI, la DSI met le holà, impossible d’envoyer des informations de l'entreprise à un service tiers, on va gérer nos LLMs sur nos propres clusters Kubernetes !\r\n\r\nCela demande par contre d’avoir des GPUs (sic) pour que ce soit performant, accessibles aux applications conteneurisées, mais alors comment ça marche ?! Et puis les GPUs c'est cher, c'est rare, comment les utiliser au mieux sans exploser les budgets ?\r\n\r\nJe vous propose alors de voir ensemble comment, grâce à l’opérateur “NVIDIA GPU Operator“ on peut accéder à ces fameux GPUs : installation, configuration, interaction avec l’hôte et gestion des modules noyau, mais surtout les contraintes et divers modes de partage de ressources (time-slicing, mig), et d’autres add-ons sympa comme le “node-feature-discovery” pour utiliser au mieux les ressources, le tout en mode pas-à-pas.\r\n\r\nAprès cette session, mes équipes de devs pourront enfin avoir du GPU dans leurs conteneurs !",
+          "speakers": [
+            "Rémi VERCHÈRE"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=kbEeE0qZqIk"
+        },
+        {
+          "title": "Au-delà du réel : créer une civilisation virtuelle avec les LLMs",
+          "description": "Je me rappelle que quand Siri est apparu sur les iPhones, la première chose que j’ai voulu essayer était de faire parler 2 Siri ensemble, ce n’était pas très convainquant. C’était durant la même période où Second Life était très populaire et j’y passais de nombreuses heures. Bref, les mondes virtuels avec agents autonomes m’ont toujours passionné.\r\n\r\nPar contre, il était très complexe de développer soi-même ce genre d’architecture à moins d'être expert en intelligence artificielle et en machine learning. Mais la déferlante de l’IA générative a changé la donne en amenant son lot de librairies permettant d’abstraire toute cette complexité tout en offrant une puissance d'intelligence artificielle jamais atteinte jusque-là.\r\n\r\nDans ce talk, je vais vous présenter comment j'ai réussi à développer une civilisation virtuelle qui a créé ses propres traditions, jeux mais également faune et flore. Tout cela en partant d’une simple définition de contexte.\r\n\r\nDes défis comme la gestion des souvenirs de chacun des avatars, l'interaction inter-agents ont grandement étaient facilités grâce à l’utilisation des librairies comme Langchain4j , ainsi que de la stack Quarkus.\r\n\r\nJe vous propose de découvrir ce monde passionnant qui m’a entraîné vers de nombreuses nuits blanches tellement cela était excitant et en dehors de ma zone de confort. Quelques slides mais surtout beaucoup de live coding et la possibilité d'interagir pendant la présentation avec cette civilisation virtuelle.",
+          "speakers": [
+            "Sébastien Blanc"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "complexity": "intermédiaire"
+        },
+        {
+          "title": "/e/OS, mon smartphone Android sans Google",
+          "description": "Vous avez sans doute déjà entendu (ou prononcé) les phrases suivantes :\r\n\r\n&gt; \"Je peux partager mes données, je n'ai rien à cacher\"\r\n&gt; \"Android c'est open-source, mes données sont protégées\"\r\n\r\nSauf qu'en fait, non… votre smartphone sait beaucoup de choses sur vous, et en partage énormément avec Google (Android) ou Apple (iOS). Et même si vous n'avez rien à cacher, vous n'avez pas intérêt à les donner massivement (vie privée, sécurité, dépendance, profilage, …).\r\n\r\nJe vais vous présenter /e/OS (https://e.foundation/), une distribution Android créée pour respecter votre vie privée :\r\n- suppression des services Google intégrés\r\n- applications open-source respectueuses de vos données\r\n- cloud respectueux ou auto-hébergé\r\n\r\nLe tout est facile d'accès, compatible avec un grand nombre de terminaux, et conserve une compatibilité maximale avec tous vos services.\r\n\r\nEt si vous n'avez pas envie de changer de téléphone ou de tout réinstaller du jour au lendemain, on évoquera des pistes pour reprendre progressivement la main sur vos données.",
+          "speakers": [
+            "Benoît MASSON"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=6l46YPupq-c"
+        },
+        {
+          "title": "Mieux cultiver et mieux manger grâce au logiciel : la tech au service de l'agriculture",
+          "description": "GPS Précis au centimètre, coupure de sections, tracteurs connectés, analyse de la data... Ces technologies ont un impact fort sur l'agriculture vis-à-vis des enjeux environnementaux et économiques actuels. Le monde agricole a connu une révolution technologique très forte au cours des deux dernières décennies.\r\n\r\nEn partant de la collecte de données sur le terrain, le traitement d'images satellites et aboutissant à des prédictions appliquées dans les champs par des machines hautement technologiques, embarquez avec nous à bord de ces outils.\r\n\r\nUn duo agriculteur/dev",
+          "speakers": [
+            "Bertrand Péchou",
+            "Mathieu Passenaud",
+            "Bertrand Péchou"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=cISfNkFilds"
+        },
+        {
+          "title": "Transformation numérique dans les services publics : dématérialisation, IA et inclusion.",
+          "description": "La transition vers la dématérialisation des services publics représente un tournant majeur dans l'accès aux démarches administratives, promettant efficacité et simplicité pour la majorité des usagers. Toutefois, cette évolution soulève également des défis significatifs, notamment en ce qui concerne la fracture numérique et l'exclusion d’une minorité de citoyens.\r\n\r\nÀ travers quatre exemples concrets, nous examinerons comment ces défis ont été abordés par notre équipe de designer et quelles leçons peuvent être tirées. L’IA est-elle une solution pour répondre à cette problématique d’inclusion ? Dans une démarche d'équilibre entre innovation et accessibilité, nous proposons une réflexion critique et constructive sur la manière dont le design numérique peut être utilisé pour construire des services publics plus inclusifs et accessibles.",
+          "speakers": [
+            "Ludivine DOBIGNY"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=4qCTItLmFtA"
+        },
+        {
+          "title": "SBOM, le début de la transparence",
+          "description": "Bientôt le projet de loi de l'Union Européenne, le Cyber Resilience Act exigera de la part des entreprises une transparence des logiciels et des matériels des développeurs, fabricants et éditeurs, commercialisés dans l'Union. Le SBOM est seulement un des outils qui permettra aux entreprises de se préparer à répondre aux exigences. Le SBOM devrait d'ailleurs faire partie de la documentation d'un projet et une étape incontournable pour la protection contre les attaques de type supply chain. La Poste a choisi dependency-track pour regrouper et stocker les SBOMs de chaque projet interne et ainsi centraliser et mieux identifier les vulnérabilités. Dans ce talk nous allons regarder comment créer automatiquement les SBOMs sans impacter les projets legacy et comment tirer profit au maximum des fonctionnalités dependency-track.",
+          "speakers": [
+            "Carmen Piciorus"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=4lU4SgSa9z0"
+        },
+        {
+          "title": "De l'analyse de données oui, mais en Kotlin !",
+          "description": "De nos jours l'environnement Python est devenu incontournable pour faire de l'analyse de données.\r\nAujourd'hui des alternatives émergent notamment du côté Kotlin avec Kotlin for data analysis. L'idée de cette conférence est de présenter une stack moderne basée sur Kotlin et DuckDB qui permet d'importer et d'analyser de gros volumes de données sur un simple laptop.\r\nAprès une brève présentation des différents outils, nous verrons au travers de plusieurs exemples comment importer des données dans DuckDB, comment les manipuler avec Kotlin Dataframe et afficher des résultats (tableaux, graphiques ...) de manière interactive grâce à Kotlin Notebook.",
+          "speakers": [
+            "Florian Bernard"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=hDmGy5FGzmM"
+        },
+        {
+          "title": "Histoire de l'Art Génératif",
+          "description": "\"Les ordinateurs sont inutiles. Ils ne savent que donner des réponses.\" - Pablo Picasso, dans une interview de 1959.\r\n\r\nCette citation semble paradoxale à une époque où la technologie occupe une place prépondérante dans la création artistique.\r\n\r\nÀ travers cette présentation, je vous invite à explorer les débuts de l'interaction entre les arts visuels et l'informatique, et à découvrir comment les ordinateurs ont commencé à enrichir l'expression artistique.\r\n\r\nNous verrons comment, dès le milieu du XXe siècle, des pionniers comme Vera Molnár et Frieder Nake ont utilisé les ordinateurs pour créer des œuvres d'art, ouvrant la voie à une nouvelle forme d'expression artistique. Inspirés par des artistes révolutionnaires de leur époque, tels que les surréalistes avec André Breton et les cubistes avec Juan Gris, ces pionniers ont fusionné des disciplines variées pour créer des formes artistiques inédites. Ces nouvelles formes intègrent des notions d’automatisation et d’aléatoire, permettant de créer des œuvres uniques et novatrices.\r\n\r\nRejoignez-moi pour découvrir les prémices de cette interaction entre art et informatique !",
+          "speakers": [
+            "Manon RETOURNAT"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=OHlah-0Mfik"
+        },
+        {
+          "title": "Rambo Python",
+          "description": "Comment faire du code Python méga robuste ?\r\nPython a la réputation de ne pas être axé sur la qualité logicielle. C'était vrai il y a 20 ans, mais depuis de grand noms se sont bâtis sur ce language : Instagram, Spotify, Reddit, Dropbox, ...\r\nPour arriver à allier Fiabilité, Maintenabilité, Évolutivité et Sécurité, il faut apprendre le fonctionnement du langage et de son écosystème. Nous vous présenterons donc un ensemble des connaissances et des pratiques nécessaires pour travailler en Python avec une qualité industrielle.\r\nBasé sur notre formation interne, dispensée par des professionnels du langage.",
+          "speakers": [
+            "Jonathan GAFFIOT",
+            "Julien Lenormand"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=t-f0cuOiuu0"
+        },
+        {
+          "title": "Open-source sans burn-out ? Le modèle CNCF",
+          "description": "Le logiciel libre et ouvert a permis le développement de nombreuses applications et librairies, dont certaines sont plus couramment utilisées que leur équivalent propriétaire.\r\nIl favorise les échanges, permet de partager ses idées, et lorsqu’il est correctement mis en place, améliore la sécurité des logiciels.\r\n\r\nMaintenir un logiciel ou une librairie open-source peut également être une tâche très solitaire.\r\nLes utilisateurs peuvent avoir tendance à montrer une forme d’ingratitude face au travail fourni, et il peut être difficile de trouver des co-mainteneurs.\r\nLe cas de leftpad, ou plus récemment, de xz sont de bons exemples de cette difficulté à maintenir un petit logiciel libre.\r\nD’un autre côté, certains logiciels ouverts sont aujourd’hui maintenus par des communautés très actives, utilisés par de nombreuses sociétés, et sont loin de manquer de mainteneurs. L’un des exemples les plus marquants est peut-être Kubernetes, qui comptabilise des milliers de contributeurs et des centaines d’entreprises.\r\n\r\nMais comment ces projets fonctionnent-ils ?\r\nComment des milliers de développeurs peuvent-ils réussir à collaborer ensemble et maintenir un code stable ?\r\nContribuer à ces projets est-il accessible à tout le monde ?\r\nSerait-il possible de reproduire la même recette sur d’autres projets, avec moins de collaborateurs ou des technologies vieillissantes?\r\n\r\nPour tenter de répondre à ces questions, nous analyserons la gouvernance et le fonctionnement d’OpenTelemetry, le second projet le plus actif de la CNCF (Cloud Native Computing Foundation), qui développe des SDK dans plus d’une dizaine de langages différents, tous respectant les même standards afin de fonctionner de manière similaire.",
+          "speakers": [
+            "Damien MATHIEU"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=xx2LHTJo-y8"
+        },
+        {
+          "title": "Plongez dans l'Univers XR : Du Réel à la Réalité mixte, l'Expérience Immersive de Demain !",
+          "description": "L'Extended Reality (XR) révolutionne notre manière d'interagir avec le monde numérique, offrant des opportunités sans précédent pour les entreprises. Cette présentation captivante, vise à démystifier l'univers de la XR pour un public intermédiaire voire novice, mettant en lumière sa pertinence croissante dans le milieu professionnel.\r\n\r\nEn effet, l'engouement pour la XR est en pleine expansion, soutenu par des statistiques démontrant une adoption croissante. Cette présentation explorera également l'évolution esthétique remarquable de la XR, soulignant son attrait visuel grandissant.\r\n\r\nContrairement aux idées préconçues, l'intégration de la XR en entreprise n'est pas aussi complexe qu'on pourrait le penser. Nous démontrerons la simplicité du processus de développement à l'aide d'outils populaires tels que Unity3D et UnrealEngine. Ces plateformes accessibles permettent une création aisée d'expériences immersives, ouvrant ainsi de nouvelles portes aux entreprises de tous horizons.\r\n\r\nNous mettrons en évidence la diversité des catégories XR en fonction des besoins spécifiques. En entreprise, la réalité mixte et augmentée se révèlent être des choix privilégiés, offrant des solutions innovantes pour la formation, la visualisation de produits, et la collaboration. Parallèlement, pour des applications comme la simulation, la réalité virtuelle s'impose comme un outil incontournable offrant des environnements immersifs et réalistes.\r\n\r\nCette présentation s'adresse à toute personne souhaitant saisir les opportunités que la XR offre aux entreprises. Elle invite à explorer les possibilités infinies qu'offrent ces technologies immersives pour repousser les limites de l'innovation.",
+          "speakers": [
+            "Jérôme JAMES",
+            "Axel SIMON"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=lSDD6rMjGk8"
+        },
+        {
+          "title": "Gateway API, 10 ans de maturation pour une nouvelle API Kubernetes",
+          "description": "Exposer une application Kubernetes au monde peut devenir un vrai casse tête 🧐.\r\n\r\nNous avons d'un côté les API standards avec Ingress, service de `type=LoadBalancer`, voir même les NodePorts… et de l'autre, les APIs custom proposées par les Ingress Controllers et Service-Meshes très avancées mais non standard 😅\r\n\r\nAprès tant d'années de confusion, une nouvelle API, nommée Gateway API, arrive tout juste en v1.0 (🎉) pour contenter à la fois les développeurs et les opérateurs de cluster ou d'infrastructure 🤯!\r\n\r\nNous découvrirons ensemble cette nouvelle API, ses fonctionnalités avancées et les implémentations qui vous permettrons de les utiliser dans votre cluster ⚡️!",
+          "speakers": [
+            "Kevin DAVIN"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=IYg3ZiGxwn8"
+        },
+        {
+          "title": "Anatomie d'une faille",
+          "description": "Coup de tonnerre ! Le vendredi 29 mars 2024 fut révélée une tentative d'attaque qui aurait pu avoir des conséquences désastreuses ; le projet xz-utils, fournissant des outils et bibliothèques de compression de données, était alors compromis par une ingénieuse attaque qui aurait pu donner accès à n'importe quel serveur exposé dans le monde ... attaque qui n'a pu aboutir grâce à un heureux concours de circonstances.\r\n\r\nSortez les scalpels ! Je vous propose de mettre cette attaque sur la table d'autopsie afin d'en étudier son anatomie : de son déroulement,s'écoulant sur plus de deux longues années, aux techniques d'ingénierie sociale et d'ingénierie logicielle utilisées. Nous reviendrons enfin sur les risques et conséquences liés aux attaques visant la supply-chain du monde du logiciel libre et open-source.",
+          "speakers": [
+            "Olivier Poncet"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=ccnSpR-CSHA"
+        },
+        {
+          "title": "Android, Compose, Multiplateforme & Serveur - Injection de dépendances multiplateforme en Kotlin",
+          "description": "Pour le développement d'applications Android modernes avec Jetpack Compose, pour des projets cross-platform iOS Kotlin Multiplatform, des applications natives de bureau, ou même pour la construction d'applications côté serveur avec Ktor, Koin émerge en tant que framework d'injection d'injection de dépendances et d'intégration.\r\n\r\nRejoignez-moi pour cette session à travers le monde du langage Kotlin et découvrez comment Koin, le framework open-source de gestion des dépendances Kotlin bien connu, s'intègre de manière transparente dans l'ensemble de l'écosystème.\r\n\r\nJe propose d'aborder les bases du framework Kotlin, ainsi que les bonnes pratiques d'injection dans du code Compose et Kotlin Multiplatform (pour les projets Android, iOS, etc...), et même de plonger dans le développement côté serveur.\r\n\r\nNous discuterons également des changements qu'apporte Kotlin 2, et des fonctionnalités à venir pour Koin 4. Préparez-vous pour un voyage dans le présent et le futur du développement Kotlin avec Koin !",
+          "speakers": [
+            "Arnaud Giuliani"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=PgT9lc-jWVk"
+        },
+        {
+          "title": "Anatomie d'un test, ou l'utilité d'un test front",
+          "description": "Introduction\r\n- Un test front ça sert à quoi vs coté back ?\r\nConfiguration, coverage et outils de débug d’un test\r\n- Configuration rapide\r\n- Report jasmine et coverage\r\n- Google devtools et debug\r\nInterface d’une application à tester\r\n- Comment tester des éléments simples ?\r\nSession live coding\r\nConclusion\r\n- Qualité et non régression\r\n- Aller vers du e2e ou pas ?",
+          "speakers": [
+            "Laurie GHIONE"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=WdEgu5Ma8WY"
+        },
+        {
+          "title": "Automatisons avec le Low Code et le No Code de Google Workspace",
+          "description": "Vous avez déjà entendu parler de Google Apps Script ou d'AppSheet, ces techno permettent à des grandes entreprises, mais pas que, de redonner le pouvoir et de faire gagner du temps à leurs équipes métier. Nous verrons 1 cas d'utilisation et 2 appli avec l'API de Google Calendar.",
+          "speakers": [
+            "Dararath BEAUVOIR"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=ubYQgUOvk7E"
+        },
+        {
+          "title": "SOPS, Passez un savon à vos secrets en clair !",
+          "description": "Chacun à ses secrets. Vos applications également. Cependant, tout comme nous avons droit à notre jardin secret, nos secrets aimeraient bien avoir leur petit coin ou ils peuvent indiquer leur données sensibles…​ Au vu de tous dans un dépôt Git consultable par toute votre équipe, cela s’annonce compliqué ? Venez voir comment SOPS peut vous aider, et vous pourrez ensuite passer un savon à quiconque pousse des secrets en clair sur vos dépôts !",
+          "speakers": [
+            "Sylvain MÉTAYER"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=oulAQGfdThI"
+        },
+        {
+          "title": "Compose Multiplatform : La prochaine référence du développement mobile",
+          "description": "Dans un monde nous poussant à être le plus productif et efficace possible, il est important de s'outiller pour y répondre !\r\nC'est là qu'intervient Compose Multiplatform, le candidat idéal pour devenir la référence dans le développement mobile.\r\nNous allons voir ensemble en quoi la simplicité, la réactivité, l'adaptabilité et la performance de Compose Multiplatform en font un framework qui se démarque des autres acteurs du marché.\r\nAvec mes années d'expérience en développement d'applications Android et une première expérience d'utilisation de Compose Multiplatform en production, je vais vous montrer pourquoi sa proximité avec Kotlin est un avantage considérable pour tous les développeurs Android !\r\nOn fera également un tour d'horizon du marché pour voir la tendance et où en est l'adoption de Compose Multiplatform par rapport à Flutter et React Native qui sont actuellement les leaders.\r\nVenez découvrir à mes côtés le framework mobile du futur ! Le tester c'est l'adopter !",
+          "speakers": [
+            "Julien BAJON"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=AMX_1Hr4T_U"
+        },
+        {
+          "title": "Mais en fait, WebRTC c’est le feu ?",
+          "description": "Le projet WebRTC permet aux développeurs de créer des solutions de communication audio et vidéo pairs à pairs.\r\nAu cours de cette conférence, nous découvrirons le projet, sa conception et comment implémenter une application mobile simple dans un projet Kotlin Multiplaftorm.",
+          "speakers": [
+            "Renaud Mathieu"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=eTIOORXWPIU"
+        },
+        {
+          "title": "Sarah Connor ?",
+          "description": "J'aurais aussi pu choisir ceci comme titre \"come with me if you want to live\".\r\n\r\nLe pitch de cette session: Comment éviter le soulèvement des machines avec Ollama, des bébés LLM et un Raspberry PI et un peu de Go(*)!\r\n\r\nGlossaire pour les néophytes:\r\n- Un LLM (Large Language Model) est un programme sophistiqué capable de comprendre et de générer du langage humain\r\n- Ollama est une application permettant d'exécuter un LLM en local\r\n- un Raspberry PI est un mini ordinateur basique et abordable conçu pour l'apprentissage de l'informatique\r\n\r\nDepuis décembre (2023), je travaille sur le sujet des applications \"GenAI\" (pour Generative AI) (pour mon vrai travail, pas pour un side project - rien de compliqué, mais j'ai besoin de comprendre de quoi il retourne).\r\n\r\nJe découvre que beaucoup de monde pense qu'il faut de gros moyens pour utiliser des LLMs. Donc hors ChatGPT, Gemini, Copilot, ... point de salut - Donc les GAFAM &amp; co ont le pouvoir et la connaissance. Ou alors il faut des machines de compétition pour faire tourner tout ça correctement, et là encore le pouvoir est aux mains de Nvidia, Apple, ...\r\n\r\n😳 Skynet est déjà en marche ! ... ou pas 😜\r\n\r\nJe vous propose donc de me suivre si vous souhaitez reprendre le pouvoir. Je vous expliquerais par l'exemple comment maîtriser Ollama et les bébés LLM car c'est avec la connaissance que l'on reprend le pouvoir.\r\n\r\nNous aborderons ensemble les points suivants:\r\n- Mais qui est Sarah Connor? C'est quoi Skynet?\r\n- Ollama, principes de bases + LangChainGo &amp; bébés LLM\r\n- Setup\r\n- Interroger un LLM\r\n- Streamer la réponse\r\n- Construire un prompt complexe (et l'art du prompting)\r\n- Tenir une conversation (aide moi à coder en rust)\r\n- Expliquer au LLM que Philippe Charrière est un personnage clé de Terminator\r\n- Faire exécuter des plugins WebAssembly par le LLM 🤔 (buzzword bingo mode activates)\r\n\r\nÀ la fin de cette session, vous aurez le bagage nécessaire pour vous préparer au soulèvement des machines.\r\n\r\nAh, j'oubliais, je suis joueur, donc je viendrais avec mon Raspberry Pi, et j'exécuterais les exemples dessus. Sinon ce n'est pas drôle.\r\n\r\n&gt; PS 1: il faut tout de même un Pi5 avec 8GB RAM\r\n\r\n&gt; PS 2: J'ai choisi le Go pour la lisibilité du code pour une présentation, mais je vous donnerais des pointeurs pour démarrer avec Python, JavaScript, Java et même Rust.",
+          "speakers": [
+            "Philippe Charrière"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=vgIlmvBB1H4"
+        },
+        {
+          "title": "Orchestrez vos workflows métier avec Temporal.io",
+          "description": "Créé en 2019 par deux personnes à l’origine de Cadence un autre orchestrateur de chez Uber, Temporal.io vous permet de gérer vos workflows métier de manière résiliente et scalable.\r\n\r\nAvec Temporal vous écrivez vos workflows et vos activités as-code dans l’un des langages supportés (Go, Java, PHP, Python, Typescript).\r\nLe reste : la communication ? les timeouts ? les retries ? c’est lui qui gère.\r\n\r\nJe vous propose dans ce talk une présentation de Temporal et de son fonctionnement ainsi qu’un retour d’expérience après l’avoir mis en production et fait tourner quasiment 1M d'opérations métier avec.",
+          "speakers": [
+            "Gwendal LECLERC"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=Wrr19RuKO-c"
+        },
+        {
+          "title": "Quarkus: Greener, Faster, Better, Stronger",
+          "description": "Quarkus n'est maintenant plus un nouveau venu dans l'écosystème java, et de plus en plus de projets l'adoptent comme base de travail, mais peu de développeurs comprennent vraiment à quel point la magie se cache dans ses extensions.\r\n\r\nC'est en développant l'extension Quarkus Min.io que j'ai découvert une partie de leurs capacités, et comment elles sont en fait au coeur des promesses du framework. Leur développement est simple et permet de rendre un grand nombre de services à nos utilisateurs. Mais surtout elles permettent de ne rendre que les services dont l'utilisateur à besoin nous permettant d'économiser mémoire, cpu et de raccourcir les temps de démarrage.\r\n\r\nEt si vous veniez en développer une avec moi et que nous mettions en oeuvre quelques uns de ces tours de magie ?\r\n\r\nVous pourriez peut être aussi aimer ça et repartir avec quelques idées !",
+          "speakers": [
+            "Jérôme Tama"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=vcLUOB2_89k"
+        },
+        {
+          "title": "TestContainers: la révolution pour vos tests unitaires",
+          "description": "Docker a bouleversé le monde de l'informatique (et est encore en tain de la faire). Ce n'est pas qu'une affaire d'infra ou d'ops. C'est vraiment du devOps. Et dans devOps, il y a dev.\r\nLes développeurs ont tout à gagner à utiliser docker mais parfois cela peut paraitre compliqué ou lourd. C'est là qu'entre en scène les TestContainers. Une technologie disponible pour un grand nombre de frameworks de développement (Java/Kotlin, Python, NodeJs, .Net, Ruby...) que je vous propose d'utiliser pour vos tests unitaires et d'intégration ; une bonne occasion de revenir sur le vrai sens de ces 2 termes et de parler pyramide de tests, une fois de plus.",
+          "speakers": [
+            "Guillaume SAINT-ETIENNE"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=ppxg_f_KMGE"
+        },
+        {
+          "title": "Comment j'ai trouvé le sens de la vie grâce à WebAssembly",
+          "description": "Qui d'entre nous n'a jamais traversé une période de doute existentiel..? \"Pourquoi est-ce que je me lève chaque matin ?\" \"Quel est le sens de mon passage sur Terre ?\" Voici le genre de questions qui peuvent nous assaillir. Quand elles se font trop pressantes, il faut prendre le taureau par les cornes et faire en sorte d'y répondre. C'est ce que j'ai fait, et de façon inattendue, j'ai trouvé le sens de la vie... grâce à WebAssembly !\r\n\r\nDans ce talk, je vais vous raconter ma découverte du monde du développement au travers d'un sujet fascinant, le Jeu de la vie, que j'ai tenté d'implémenter durant ma reconversion. Automates cellulaires, émergence et enjeux de performance, venez découvrir avec moi les défis relevés pendant cette implémentation !",
+          "speakers": [
+            "Théo GIANELLA"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=UtZP7r63hpQ"
+        },
+        {
+          "title": "Live-Coding: Devenez un ninja du Web Scraping avec Scrapoxy !",
+          "description": "Rejoignez-moi pour une masterclass en live-coding. Que vous soyez débutant ou expert, nous verrons les dernières techniques légales pour collecter les données et alimenter vos modèles d’IA.\r\n\r\n🔍 Temps forts 🔍\r\n\r\nDéjouer les protections anti-bots 🔒\r\n- Contournez les fingerprints et les systèmes anti-bots\r\n- Rétro-ingéniérez les protections pour comprendre les mécanismes de tracking\r\n\r\nMaîtriser les proxies et les fermes de browsers 🌐\r\n- Découvrez Scrapoxy, l’agrégateur de proxies gratuit et open-source dédié au Web Scraping\r\n- Devenez un expert de l’automatisation avec Playwright\r\n\r\nCe live-coding vous plongera dans l’univers secret de la donnée.\r\n\r\nNe manquez pas cette opportunité unique de maîtriser ces compétences et de révolutionner votre approche de la data !\r\n\r\n#data #webscraping #livecoding",
+          "speakers": [
+            "Fabien VAUCHELLES"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=aUqj0O4-qbE"
+        },
+        {
+          "title": "Live coding : créons un outil de mesure de perf pour Android",
+          "description": "Saviez-vous que l'on peut mesurer la performance de n'importe quelle app Android (même une app en production ou d'un concurrent) ?\r\nComme Android est basé sur Linux, nous allons voir toute la puissance que ça nous donne. En explorant les commandes adb et les fichiers systèmes Linux/Android, on va créer ensemble un outil qui nous permettra de mesurer la performance, avant de le tester sur vos apps favorites !",
+          "speakers": [
+            "Alexandre MOUREAUX"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=ps_iWevUFh4"
+        },
+        {
+          "title": "Gemini, le Large Language Model de Google",
+          "description": "Pas d'astrologie pour les Gémeaux aujourd'hui, mais plutôt “Gemini”, le dernier LLM de Google et DeepMind. Mais savez-vous que vous pouvez également utiliser son API au travers de Google Cloud et l’intégrer dans vos applications ? Gemini propose différentes tailles, de Nano à Ultra, en passant par Pro. Le grand différenciant, c’est aussi son côté “multimodal” : vous pouvez lui donner du texte, comme des images ou des vidéos ! De nouveaux cas d’utilisation s’ouvrent à vous !\r\n\r\nDans cette présentation, nous partirons à la découverte du modèle Gemini et nous évoquerons également sa petite soeur Gemma (en modèle ouvert). Avec notre casquette Java sur la tête, nous étudierons comment faire appel à son API, en particulier à l’aide de la librairie LangChain4j.\r\n\r\nComment tirer parti au maximum de Gemini ? Nous verrons comment extraire des données non-structurées, comment classifier du texte, comment étendre les connaissances du modèle avec l’approche RAG (Retrieval Augmented Generation) mais aussi à l’aide de “l’appel de fonction” pour invoquer des services externes lors de la génération de texte.\r\n\r\nAccrochez-vous ! Le décollage de la capsule Gemini est imminent !",
+          "speakers": [
+            "Guillaume Laforge"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=83bruscz6Qc"
+        },
+        {
+          "title": "TinyGo, petit mais costaud ! 💪",
+          "description": "Go est un langage facile à prendre en main, typé et compilé. Avec ce langage vous pouvez créer des CLI (outils en ligne de commande), des microservices, des applications REST, gRPC, des Bots pour Discord… Mais savez-vous que vous pouvez également créer des applications en Go pour des microcontrôleurs, des consoles de jeux vidéo et même générer du code en WebAssembly ?\r\n\r\nC’est possible grâce à TinyGo !\r\n\r\nTinyGo est un compilateur Go pour les systèmes embarqués et pour le Web moderne. Vous pouvez compiler et exécuter des programmes TinyGo sur de nombreuses cartes à microcontrôleur telles que le BBC micro:bit, l'Arduino Uno, la Nintendo Switch et la Game Boy Advance ;-).\r\n\r\nDans ce talk vous pourrez découvrir TinyGo ainsi que ses possibilités et usages concrets à travers des démos, en live, qui vous ferons découvrir plusieurs expérimentations de TinyGo.\r\n\r\nSpoiler alert : il se peut que des Nintendo Game Boy Advance et Gopher Badge soient utilisées durant ce talk 😜",
+          "speakers": [
+            "Thierry CHANTIER",
+            "Aurélie Vache"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=ZyjLH_e9Vyo"
+        },
+        {
+          "title": "Développer des macros en Rust",
+          "description": "Rust est un langage riche et performant mais aussi de haut niveau.\r\nVenez découvrir la méta-programmation en Rust avec son système de macros.\r\n\r\nA travers un exemple simple, découvrez pas-à-pas les techniques de développement d'une macro ainsi que mes trucs &amp; astuces.",
+          "speakers": [
+            "Logan Mauzaize"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=gq5Bek4R2WE"
+        },
+        {
+          "title": "Cracking the Quantum Code: Découvrons la révolution quantique !",
+          "description": "Depuis le début de l'année, les annonces concernant les ordinateurs quantiques se multiplient. L'informatique quantique promet une puissance de calcul sans précédent, révolutionnant des domaines allant de la science des matériaux et de la découverte de médicaments à la modélisation financière et à la cryptographie. Mais qu'est-ce que l'informatique quantique et comment fonctionne-t-elle ? Cette conférence plonge dans le monde fascinant de la mécanique quantique pour dévoiler le fonctionnement interne des ordinateurs quantiques, en explorant des éléments tels que les qubits, les portes quantiques, les circuits quantiques, les algorithmes quantiques, les hardwares quantiques et en montrant comment nous pouvons simuler et exécuter un programme quantique !",
+          "speakers": [
+            "Laurent Grangeau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=syhDBXDbNJY"
+        },
+        {
+          "title": "La recherche à l'ère de l'IA",
+          "description": "La recherche ne se contente plus de l'approche maintenant traditionnelle basée sur la fréquence des termes (TF/IDF ou BM25) mais plus sur la tendance actuelle du machine learning où les nouveaux modèles ont ouvert une nouvelle dimension pour la recherche.\r\n\r\nCette conférence donne un aperçu de :\r\n\r\n* La recherche \"Classique\" et ses limitations\r\n* Qu'est qu'un modèle de machine learning et comment vous pouvez l'utiliser\r\n* Comment utiliser la recherche vectorielle ou la recherche hybride dans Elasticsearch\r\n* Comment ChatGPT d'OpenAI ou les \"large language models\" (LLMs) similaires viennent jouer naturellement avec Elastic\r\n\r\nLa démo principale montre comment générer des embeddings à partir de musiques puis comment trouver la musique qui s'approche le plus d'une musique que nous fredonnons 🎶🎸🎻.",
+          "speakers": [
+            "David Pilato"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=FPW8nO0VGVg"
+        },
+        {
+          "title": "10 tests simples pour améliorer l'accessibilité de votre site",
+          "description": "Derrière ce titre « clickbait » se cache une vraie méthode basée sur une checklist du W3C.\r\n\r\nElle permet de tester soit même l’accessibilité d’un site en 10 tests simple, même sans avoir un profil technique.\r\n\r\nCette méthode ne remplace pas un « vrais » audit de site, mais elle va permettre de donner une idée générale de l’accessibilité d'un site. Ces tests couvrent une bonne partie des problèmes bloquants d’accessibilité. Les passer avec succès est une base essentielle pour rendre accessible un site.\r\n\r\nIls sont rapides et faciles à faire, tous les intervenants d’un projet peuvent les réaliser : Clients, PO, CP, Dev, UX/UI Designers…\r\n\r\nL’objectif de cette conférence est de présenter ces 10 tests et de les pratiquer en « live » pour que vous puissiez les mettre en places sur vos projets ou votre site.\r\n\r\nRéférences :\r\nTest basés sur les \"Easy Checks\" du W3C https://www.w3.org/WAI/test-evaluate/preliminary/\r\n\r\nSlides :\r\nhttps://speakerdeck.com/lair_net/10-tests-simples-pour-ameliorer-laccessibilite-de-votre-site-snowcamp",
+          "speakers": [
+            "François-Xavier LAIR"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant"
+        },
+        {
+          "title": "Comment nous avons transformé les Restos du Coeur en Cloud Provider",
+          "description": "Cette conférence vous plongera au cœur d'une transformation audacieuse, où les Restos du Cœur ont évolué pour devenir un fournisseur de services Cloud (en interne). À travers cette histoire captivante, nous explorerons en détail le projet de construction d'une plateforme de cloud privé reposant sur les technologies robustes d'OpenStack et de Kubernetes.\r\n\r\nNous commencerons par discuter des motivations derrière cette initiative avant-gardiste, mettant en lumière les défis uniques rencontrés dans l'adaptation de concepts de cloud computing au sein d'une organisation à but non lucratif. Nous examinerons également les raisons qui ont conduit à choisir OpenStack comme pilier fondamental de cette transformation et démontrerons pourquoi, même en 2024, il reste une option pertinente et performante.\r\n\r\nAu cours de la présentation, nous plongerons dans les détails techniques de l'infrastructure, décrivant la conception de la plateforme de cloud privé, son architecture basée sur OpenStack et Kubernetes, ainsi que les choix de configuration spécifiques qui ont été faits pour répondre aux besoins particuliers des Restos du Cœur.\r\n\r\nAinsi, vous découvrirez comment la combinaison d'OpenStack et de Kubernetes a permis de créer une infrastructure flexible, évolutive et résiliente, tout en maximisant l'efficacité opérationnelle. Des retours d'expérience concrets seront partagés, mettant en lumière les succès, les leçons apprises et les perspectives d'avenir pour cette initiative novatrice.\r\n\r\nRejoignez-nous pour explorer les coulisses de cette transformation technologique exceptionnelle, découvrir les raisons pour lesquelles OpenStack demeure une solution de choix en 2024, et apprendre comment la convergence de technologies de pointe a permis de propulser les Restos du Cœur vers de nouveaux horizons numériques au service de leur mission humanitaire.",
+          "speakers": [
+            "Julien Briault"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=z4BO6OSTYC8"
+        }
+      ]
+    },
+    "2025": {
+      "date": "2025-11-06",
+      "venue": "Centre de Congrès Diagora, Labège",
+      "speakers": [
+        {
+          "name": "Loïc Ortola",
+          "company": "Takima",
+          "city": "Paris",
+          "bio": "Loïc is the current CTO of Takima. His main field of expertise lies in distributed architectures and platform engineering. He likes sharing his vision about technology and put his hands-on expertise to good use in techy workshops",
+          "socials": []
+        },
+        {
+          "name": "Carmen Piciorus",
+          "company": "BSCC - La Poste",
+          "city": "Montpllier",
+          "bio": "Après plusieurs années de développement, et quelques années dédiés à la protection de la messagerie laposte.net, j’intègre à présent une équipe  au service des projets du SI de la branche Services Courrier - Colis de La Poste. Passionnée par la cybersécurité, je me suis dédiée à faciliter la communication entre les développeurs et la sécurité pour aider aux développement des applications sécurisées et cyber-résilientes dans le cloud.",
+          "socials": []
+        },
+        {
+          "name": "Damien Lucas",
+          "company": "",
+          "city": "",
+          "bio": "Après avoir passé une quinzaine d'années dans le développement logiciel en société de services, j'ai maintenant rejoint Mirakl et par la même occasion, l'édition de logiciel. J'adore lire la doc avant de me lancer dans le code. Et par dessus tout, j'aime échanger et transmettre sur ce que j'ai pu apprendre de mes expériences, des discussions avec mes pairs, des conférences vues ...",
+          "socials": []
+        },
+        {
+          "name": "Sylvain Gougouzian",
+          "company": "Dev'in",
+          "city": "Feurs",
+          "bio": "Dev / Formateur GreenIT\r\nSpeaker,\r\nChef d'orchestre,\r\n(Retro)Gamer,\r\nPapa geek,\r\nEleveur de GNUs",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://www.twitter.com/GouZ"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Laforge",
+          "company": "Google",
+          "city": "",
+          "bio": "Guillaume Laforge is Developer Advocate for Google Cloud Platform, at day, focusing on generative AI, LLMs, serverless technologies and event-driven architecture, and at night, he is a Java Champion and wears his Apache Groovy hat.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/glaforge"
+            },
+            {
+              "type": "website",
+              "url": "https://glaforge.dev/"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Poncet",
+          "company": "",
+          "city": "",
+          "bio": "Geek, ex-nerd repenti, je code, je teste, je bricole, je soude et parfois fait sauter les plombs. CTO et spécialiste du magiciel, je suis aussi libriste dans l'âme et très impliqué dans le mouvement des logiciels libres.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/ponceto91"
+            },
+            {
+              "type": "website",
+              "url": "https://www.emaxilde.net/"
+            }
+          ]
+        },
+        {
+          "name": "Maria-Eliza Paez",
+          "company": "",
+          "city": "",
+          "bio": "::::::::::::::::::::::::::::::::::::\r\n🐣 Product Manager\r\n::::::::::::::::::::::::::::::::::::\r\n\r\nBercée par le Lean Startup et le Design Thinking, j'accompagne les individus, les équipes et les entreprises à devenir plus agile et adopter une culture Produit :)",
+          "socials": []
+        },
+        {
+          "name": "Moustapha Agack",
+          "company": "Zenika",
+          "city": "Lyon",
+          "bio": "Smash my keyboard for a living—results vary, but sometimes cool stuff happens",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/mousstoh"
+            }
+          ]
+        },
+        {
+          "name": "Camille Roux",
+          "company": "Human Coders",
+          "city": "Montpellier, France",
+          "bio": "Démarrant ma carrière en tant que développeur web, je me suis rapidement spécialisé dans l’univers Ruby on Rails. Entrepreneur dans l’âme, il y a dizaine d’années, j’ai créé Human Coders (https://www.humancoders.com/), un centre de formation pour développeuses et développeurs. \r\nEnfin, récemment, j’ai exploré ma facette artistique en m’immergeant dans l’art génératif, mêlant technologie et esthétique. J’adore partager et échanger autour de mes expériences et découvertes.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/CamilleRoux"
+            },
+            {
+              "type": "website",
+              "url": "https://www.camilleroux.com/"
+            }
+          ]
+        },
+        {
+          "name": "Didier Plaindoux",
+          "company": "Fungus",
+          "city": "Toulouse",
+          "bio": "Talks about Java, Python, Swift, Kotlin and FP given to:\r\n\r\n- DevFestToulouse, \r\n- Voxxed Luxembourg (https://www.youtube.com/watch?v=I7n3XNpynzU), \r\n- Devoxx Morocco (https://www.youtube.com/watch?v=06GDVjQ6hPc&amp;frags=pl%2Cwn), \r\n- NewCrafts (http://ncrafts.io/speaker/dplaindoux), \r\n- SunnyTech (https://sunny-tech.io/schedule/day1?sessionId=3865)  \r\n- Scala.io (https://www.youtube.com/watch?v=7-lxIRT7sbU)\r\n- Scala.io (https://www.youtube.com/watch?v=bYcdxB3Iukc) and\r\n- more generally for GDG and JUG meetups. ",
+          "socials": []
+        },
+        {
+          "name": "Igor Laborie",
+          "company": "Darwin",
+          "city": "Préserville",
+          "bio": "Développeur passionné depuis le début du siècle.\r\n🦀 J'ai découvert mon langage préféré: Rust.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "http://twitter.com/ilaborie"
+            }
+          ]
+        },
+        {
+          "name": "Philippe Charrière",
+          "company": "Docker",
+          "city": "",
+          "bio": "- Principal Solution Architect chez Docker\r\n- WebAssembly lover\r\n- GenAI on Raspberry Pi addict\r\n- Container oriented",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/k33g_org"
+            },
+            {
+              "type": "website",
+              "url": "https://k33g.hashnode.dev/"
+            }
+          ]
+        },
+        {
+          "name": "David Pilato",
+          "company": "Elastic",
+          "city": "Cergy",
+          "bio": "David Pilato discovered Elasticsearch project in 2011. After contributed to the project and created open source plugins for it, David joined elastic the company in 2013 where he is Developer and Evangelist. He also created and still actively managing the French spoken language User Group. At elastic, he mainly worked on Elasticsearch source code, specifically on open-source plugins. In his free time, he likes talking about elasticsearch in conferences or in companies (Brown Bag Lunches AKA BBLs - https://www.elastic.co/blog/free-lunch-for-open-source-engineers). He is also author of FSCrawler (https://github.com/dadoonet/fscrawler) project which helps to index your pdf, open office, whatever documents in elasticsearch using Apache Tika behind the scene.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/dadoonet"
+            },
+            {
+              "type": "website",
+              "url": "https://david.pilato.fr/"
+            }
+          ]
+        },
+        {
+          "name": "Mathieu Passenaud",
+          "company": "please-open.it",
+          "city": "Péchabou",
+          "bio": "Après 8 ans en tant que DevOps dans les univers du Cloud et de l'IOT, j'ai découvert la nécessité absolue de bien fait l'authentification sur les applications.\r\nDepuis bientôt 4 ans, j'ai décidé de ne faire que ça avec please-open.it",
+          "socials": []
+        },
+        {
+          "name": "Julien Briault",
+          "company": "Deezer & Les Restos du Coeur",
+          "city": "Paris",
+          "bio": "Network Engineer SRE chez Deezer et IT Manager à mes heures perdues au Restos du Cœur et développeur Rust/Go sur le temps qu'il me reste, je suis un passionné d'informatique, de réseau informatique et de logiciels libres. ",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/ju_hnny5"
+            },
+            {
+              "type": "website",
+              "url": "https://blog.jbriault.fr/"
+            }
+          ]
+        },
+        {
+          "name": "Laurent Grangeau",
+          "company": "Google",
+          "city": "France",
+          "bio": "Laurent Grangeau is a Solutions Architect at Google. He is also the organiser of the Serverless Paris meetup, as well as co-organiser of the Kubernetes and Docker Paris meetups. He has developed in several languages, mainly object-oriented like Java or C#. For several years, he has been helping companies to adopt the Cloud, as well as DevOps principles. He has experienced with building microservices and distributed systems. He loves to automate things and run distributed applications at scale.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/laurentgrangeau"
+            }
+          ]
+        },
+        {
+          "name": "Alexandre Daubois",
+          "company": "Les-Tilleuls.coop",
+          "city": "Lyon",
+          "bio": "Alexandre is part of the Symfony Core Team and Symfony/PHP Expert Developer based in Lyon, France.\r\n\r\nAs well as giving talks at official Symfony events, Pimcore, PHPers and Malt Academy, Alexandre's involvement in the PHP world was strengthened by contributing to PHP and Symfony's source code and documentation. He then continued this dynamic by joining Sensiolabs (the company that created Symfony), as well as writing his first book, \"Clean Code in PHP\" in October 2022.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/alexdaubois"
+            },
+            {
+              "type": "github",
+              "url": "https://github.com/alexandre-daubois"
+            },
+            {
+              "type": "website",
+              "url": "https://alex-daubois.medium.com/"
+            }
+          ]
+        },
+        {
+          "name": "Julien Lenormand",
+          "company": "Kaizen Solutions",
+          "city": "Grenoble",
+          "bio": "Développeur Python convaincu par l'Agile, le Craft, Accelerate et la philosophie grecque antique.\r\nConsultant dans de grands groupes industriels (SNCF, EDF, Thales, Schneider).\r\nMeetupeur grenoblois investi : Human Talks, Python, Craft et Web.\r\nOrganisateur d'évènements, speaker et accompagnant technique à Kaizen Solutions.",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://lenormand-julien.fr/"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Lours",
+          "company": "Docker",
+          "city": "Rouen",
+          "bio": "Staff Software Engineer @docker, Compose Specification maintainer, working on Docker Compose and Dev Environments",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/glours"
+            },
+            {
+              "type": "website",
+              "url": "https://blog.docker.com"
+            }
+          ]
+        },
+        {
+          "name": "Florian Bernard",
+          "company": "OpenAirlines",
+          "city": "Toulouse",
+          "bio": "Après un début de carrière en 2009 en tant que développeur, j'ai peu à peu évolué sur des rôles de tech lead / architecte (dans plusieurs sociétés) et actuellement j'occupe le poste de Principal Engineer chez OpenAirlines. Passionné, j'aime apprendre et partager sur tous sujets qui touchent au développement et à l'architecture logicielle (mais pas que :-)).",
+          "socials": []
+        },
+        {
+          "name": "Alejandro Estana",
+          "company": "CNRS, mésocentre de calcul CALMIP",
+          "city": "",
+          "bio": "Je me suis orienté vers le calcul haute performance (High Performance Computing, HPC) dès ma thèse en bioinformatique. Ingénieur de recherche au CNRS depuis cinq ans, je travaille aujourd’hui au mésocentre CALMIP à Toulouse, où j’aide la communauté de chercheurs utilisant les ressources HPC à exploiter efficacement le cluster de calcul, en optimisant avec eux à la fois leurs codes et l’utilisation du matériel.",
+          "socials": []
+        },
+        {
+          "name": "Aless Hosry",
+          "company": "Berger Levrault",
+          "city": "Lyon",
+          "bio": "In the past I worked for industry as a software engineer that attempts to stay updated by learning new approaches to software architecture and development, and mastering technologies like Angular, Oracle SQL, .NET Core, RESTful APIs, and more. \r\n\r\nRecently, as a PhD candidate I focused on academic research, creating innovative software libraries like Adonis and MoTion using Pharo, an object oriented programing language, and collaborating with industry to analyze complex projects and detect external dependencies developed using various technologies.\r\n\r\nCurrently I am a research engineer and my specialty is software analysis. I work for Berger-Levrault where I combine my research background to design innovative solutions and leverage my engineering experience to implement them effectively.\r\nAnd no, I don't do AI ! I use Moose for software analysis, MoTion for pattern matching and Adonis to deal with multi-languages software.\r\n\r\nThere are many challenges ahead, but I'm ready to take them on, one by one.",
+          "socials": []
+        },
+        {
+          "name": "Alexandre Dias",
+          "company": "",
+          "city": "",
+          "bio": "Senior Site Reliability Engineer at Qonto, deeply interested in DevOps, Cloud, infrastructure, and networking. I'm also passionate about open source, conferences, and promoting the exchange of insights and expertise.",
+          "socials": []
+        },
+        {
+          "name": "Alexia Audevart",
+          "company": "datactik",
+          "city": "Toulouse",
+          "bio": "Alexia Audevart est “Data Enthusiast” et fondatrice de la société datactik. Elle baigne dans la donnée sous toutes ses formes : Big Data, Data Science, Data Visualisation, Machine Learning, Deep Learning, Intelligence Artificielle, etc.\r\n\r\nQuand elle n’accompagne pas ses clients dans la valorisation de leurs données, elle partage ses connaissances en animant des formations, en écrivant des livres ou en donnant des conférences. Depuis 2019, elle a rejoint la communauté des Google Developer Expert Machine Learning.\r\n\r\nSon premier livre est une collaboration sur l'intelligence artificielle et les neurosciences (\"Apprendre demain\" - édition Dunod). Son second ouvrage, plus technique, aborde le Deep Learning (\"Machine Learning using TensorFlow cookbook\" - édition Packt).",
+          "socials": []
+        },
+        {
+          "name": "Baruch Sadogursky",
+          "company": "Tuxcare",
+          "city": "Nashville, TN, USA",
+          "bio": "Baruch Sadogursky (@jbaruch) did Java before it had generics, DevOps before there was Docker, and DevRel before it had a name. He started DevRel at JFrog when it was ten people and took it all the way to a successful $6B IPO by helping engineers solve problems. Now, Baruch keeps helping engineers solve problems, but also helps companies help engineers solve problems. He is a co-author of the \"Liquid Software\" and \"DevOps Tools for Java Developers\" books, Java Champion and CNCF Ambassador alumni, serves on multiple conference program committees, and regularly speaks at numerous most prestigious industry conferences, such as DevNexus, DevOpsDays, Voxxed Days, Devoxx, DevRelCon, Kubecon and QCon. Today, he's taking care of developers at TuxCare.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "http://twitter.com/jbaruch"
+            },
+            {
+              "type": "website",
+              "url": "https://speaking.jbaru.ch/"
+            }
+          ]
+        },
+        {
+          "name": "Benoit Verhaeghe",
+          "company": "Berger-Levrault",
+          "city": "Lyon",
+          "bio": "Benoit Verhaeghe est titulaire d'un doctorat en informatique et travaille en tant que manager de projet scientifique chez Berger-Levrault. Sa collaboration se concentre sur la création de solutions innovantes pour la migration et l'amélioration des systèmes logiciels, en utilisant des méta-modèles. Benoit est également actif sur GitHub, où il partage ses projets publics. Au-delà de son travail technique, il a écrit plusieurs articles scientifiques et des billets de blog.\r\n\r\nPour plus d'informations sur ses recherches, vous pouvez visiter son site web personnel. N'hésitez pas à explorer davantage son travail et à suivre ses contributions passionnantes dans le domaine de l'informatique !",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://badetitou.fr"
+            }
+          ]
+        },
+        {
+          "name": "Celia Martinie",
+          "company": "IRIT, Université de Toulouse",
+          "city": "",
+          "bio": "Célia Martinie is an associate professor in Computer Science at the Université de Toulouse (France) and head of the ICS research team at IRIT lab. She is involved in research projects dealing with processes, methods, techniques and tools to analyze, design and develop large scale interactive critical systems (such as satellite ground segment applications, flight deck applications and air traffic management systems) and as well as to deal with their integration within an organisational context for safe operations.",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://www.irit.fr/recherches/ICS/people/martinie"
+            }
+          ]
+        },
+        {
+          "name": "Estéban Soubiran",
+          "company": "MaiaSpace",
+          "city": "Paris",
+          "bio": "Je suis développeur web avec plus de 7 ans d'expérience, et full-stack depuis quelques années. Ma priorité est d'optimiser l'expérience utilisateur à chaque étape du développement, et je m'efforce d'apprendre constamment, que ce soit du code, du design ou de l'administration système.\r\n\r\nCette approche m'a conduit à développer une passion pour l'open-source. Que ce soit pour étudier du code ou y contribuer activement, j'aspire à participer à la communauté de diverses manières : en rédigeant de la documentation, en améliorant le design, en corrigeant des bogues ou en proposant de nouvelles fonctionnalités. Je gravite principalement autour de UnJS, Vite, Vue.js, Nuxt, Adonis et Laravel !\r\n\r\nMa seconde grande passion est le partage des connaissances. À travers mon blog (https://soubiran.dev) et mes réseaux sociaux, je m'efforce de diffuser ce que j'apprends et découvre. Mon objectif est de transmettre des informations de manière claire et accessible, comme j'aurais souhaité les trouver lorsque j'ai débuté dans le développement web, à une époque où des milliers de questions m'envahissaient et où les réponses étaient parfois rares.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/soubiran_"
+            },
+            {
+              "type": "website",
+              "url": "https://soubiran.dev"
+            }
+          ]
+        },
+        {
+          "name": "Etienne Idoux",
+          "company": "",
+          "city": "",
+          "bio": "💁‍♂️ Jeune développeur animé par sa passion, Etienne IDOUX se présente comme un consultant web travaillant à Zenika 🔴. Entrain de parfaire ses armes en tant que Développeur Vidéo 📽️ à Bedrock ⚫, il pimente son temps libre de toute sorte de projet. Il aime se rendre à des conférences afin d'apprendre et de faire apprendre à travers des talks variés !",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/PopsIDX"
+            }
+          ]
+        },
+        {
+          "name": "Fabien Marty",
+          "company": "Botify",
+          "city": "Toulouse",
+          "bio": "Après 20 ans passés à naviguer dans l’univers informatique de Météo-France — du développement à l’architecture d’entreprise, en passant par la gestion de projet, le management et même un peu de direction — j’ai récemment pris un virage vers le monde des scale-ups.\r\n\r\nAujourd’hui staff engineer chez Botify, une entreprise internationale spécialisée dans le SEO technique, je continue à jongler entre vision d’ensemble, clarté des idées et plaisir du code et des architectures bien faites.",
+          "socials": []
+        },
+        {
+          "name": "Gaëtan Eleouet",
+          "company": "Meritis",
+          "city": "Courbevoie",
+          "bio": "Dans mes jeunes années être geek n’était pas un métier et pourtant je suis aujourd’hui développeur depuis 15 ans. Animé par des convictions fortes sur l’impact des développeurs sur le monde, je transmets et j’enseigne dans le cadre d’atelier de code et en vacation en école d’ingénieur. Au-delà de mon métier, c’est aussi une passion : je code pour le plaisir dans des projets personnels et lors de compétition de programmation (@egaetan).",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/egaetan"
+            },
+            {
+              "type": "website",
+              "url": "https://blog.egaetan.me"
+            }
+          ]
+        },
+        {
+          "name": "Guillaume Benoot",
+          "company": "",
+          "city": "",
+          "bio": "Développeur backend chez Onepoint depuis 3 ans",
+          "socials": []
+        },
+        {
+          "name": "Han Héloir",
+          "company": "",
+          "city": "",
+          "bio": "MongoDB EMEA Gen AI Solutions Architect - Passionnée par l’IA et l’innovation, je travaille chez MongoDB aux côtés d’équipes tech inspirantes dans des secteurs variés comme le retail, l’IoT, l’énergie ou la finance. Ensemble, nous relevons des défis en temps réel en mobilisant le plein potentiel de l’IA pour créer un impact durable. ",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://medium.com/@han.heloir"
+            }
+          ]
+        },
+        {
+          "name": "Ionut Mihalcea",
+          "company": "",
+          "city": "",
+          "bio": "Passionné de Linux, d’IA et de systèmes distribués, j’ai 25 ans d’expérience allant du bas niveau et l'IA à l’architecture logicielle. Co-organisateur depuis 2016 du MTG Toulouse, je milite pour une tech plus ouverte, sobre et durable.",
+          "socials": []
+        },
+        {
+          "name": "Jonathan Gaffiot",
+          "company": "",
+          "city": "",
+          "bio": "Ingénieur, développeur, analyste, formatteur, crafteur...\r\n \r\nJ'ai commencé par une thèse en physique des particules, avec beaucoup de C++ orienté performance pour la simulation et l'analyse de gros volumes de données. Sur la fin, je me suis un peu mis à Python2 pour comparer et synthétiser les résultats. Après 2 post-docs dans le même domaine, j'ai enchainé pendant 3 ans en pur Python3 (+Docker, Ansible...) à concevoir, développer, opérer et maintenir un logiciel de commande autonome de centrales solaires avec stockage, chargé de gérer en temps quasi réel les transferts d'électricité entre le champs solaire, le parc de batterie et le réseau électrique. Revenu à Grenoble, après plusieurs missions autour de la connectivité et de l'IoT en C++ et Python, je suis maintenant dans un groupe d'analyse de données et d'IA en support des services d’ingénieries chez un grand industriel de l'énergie, ou je mets en place des PoC à base d'IA pour les groupes d'ingénierie, avec du Python et du Kubernetes (+Helm, ArgoCD..).",
+          "socials": []
+        },
+        {
+          "name": "Kevin Abrioux",
+          "company": "",
+          "city": "",
+          "bio": "Développeur depuis bientôt 18 ans, je me suis spécialisé dans le développement mobile natif depuis 2014.\r\n \r\nJ'affectionne plus particulièrement la remise en cause permanente qu'offre le développement et le devoir de polyvalence allant de la UI au basse couche hardware du device mobile.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/kevinabrioux"
+            }
+          ]
+        },
+        {
+          "name": "Kevin Delcourt",
+          "company": "Université de Montréal - Département d'Informatique et de Recherche Opérationnelle",
+          "city": "Montréal",
+          "bio": "Since January 2025 I am working as a postdoctoral researcher at GEODES at the Université de Montréal. In November 2024 I got my Ph.D. from the Toulouse Research Institute of Computer Science (IRIT), where my main area of research was Ambient Intelligence and Human-AI interaction.\r\n\r\nMy current area of research is software engineering, and in particular applied to artificial intelligence and digital twins.",
+          "socials": []
+        },
+        {
+          "name": "Loïc des Rochettes",
+          "company": "Please-open.it",
+          "city": "Toulouse",
+          "bio": "J'ai commencé à jouer avec du code vers 12 ans.\r\nEPITECH puis le CNAM pour devenir pro.\r\nMoult PME et startups plus tard je m'associe avec Mathieu Passenaud pour créer une entreprise de service spécialisée dans l'authentification et keycloak.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/loicdesroc"
+            },
+            {
+              "type": "website",
+              "url": "https://blog.please-open.it"
+            }
+          ]
+        },
+        {
+          "name": "Marie Terrier",
+          "company": "Yelda",
+          "city": "Paris",
+          "bio": "Après 7 ans en de développement web entre l'Inde et la France pour l'agence KRDS, Marie est maintenant CTO de Yelda, la plateforme d'agents vocaux pour les entreprises. Sur son temps libre, elle adore participer à des événements techniques pour encourager les débutants à prendre confiance en eux ou partir à l'aventure à la montagne !",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/materrier"
+            }
+          ]
+        },
+        {
+          "name": "Mathieu Lamiot",
+          "company": "group.one",
+          "city": "Chatenay-Malabry",
+          "bio": "I am Mathieu Lamiot, a France-based tech-enthusiast engineer passionate about system design and bringing brilliant individuals together as a team. I dedicate myself to Tech &amp; Engineering management, leading teams to make an impact, deliver value and accomplish great things.",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://mathieulamiot.com"
+            }
+          ]
+        },
+        {
+          "name": "Mathilde Lorrain",
+          "company": "Takima",
+          "city": "Paris",
+          "bio": "Mathilde a percé le secret de la fusion nucléaire et ne s’éteint jamais. On raconte même qu’EDF l’a contactée pour lui proposer un raccordement au réseau pour passer l’hiver.\r\nPassionnée de DevOps et de Backend, elle aime quand les choses sont directes et efficaces. Comme elle. D’ailleurs, elle utilise volontiers son surplus d’énergie pour transmettre ses secrets. Il paraît même qu’elle va revenir faire une conf…",
+          "socials": []
+        },
+        {
+          "name": "Mazlum Tosun",
+          "company": "GroupBees",
+          "city": "Arnouville",
+          "bio": "Google Developer Expert on Google Cloud.\r\n\r\nLead and Architect Data on Google Cloud, I evangelize this platform while ensuring continuous improvement and expertise.\r\nI explore issues related to Data, Infra As Code, DevOps automation (CI/CD) and best practices.\r\n\r\nCo-founder and Head of Data &amp; Cloud at GroupBees. \r\nGroupbees is an IT freelancers group created to give freelancers access to a proven framework and a powerful community based on knowledge sharing in order to upskill them as well as give them better employability.\r\n\r\nMy Google Cloud content : \r\n- Videos : https://bit.ly/gcp-learning-mazlum-gb\r\n- Article : https://medium.com/@mazlum.tosun",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/MazlumTosun3"
+            },
+            {
+              "type": "website",
+              "url": "https://medium.com/@mazlum.tosun"
+            }
+          ]
+        },
+        {
+          "name": "Mickael Alves",
+          "company": "Zenika",
+          "city": "Lyon",
+          "bio": "👋🏼 Web Maker, application builder, and passionate speaker on web development, design, computing, and new technologies! 👨🏻‍💻\r\n\r\nCurrently a web consultant at @Zenika 🔴, DX Engineer at @BedrockStreaming 📺 , I also enjoy sharing my knowledge through teaching and speaking at conferences. I’m a co-founder of @DevFestLyon and a co-organizer of @LyonJS 🦁, an @Appwrite Hero 🦸🏼‍♂️, and a @Remotion Expert 🎬",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/CruuzAzul"
+            },
+            {
+              "type": "website",
+              "url": "https://cruuzazul.dev"
+            }
+          ]
+        },
+        {
+          "name": "Nathalie Rosenberg",
+          "company": "",
+          "city": "Toulouse",
+          "bio": "Dans le web depuis le siècle dernier, je suis UX designeuse couteau suisse, option stratégie et contenu, et je ne peux m’empêcher de mettre mon nez partout sur les projets car tout est fondamentalement imbriqué. Je collectionne les vieux sites à paillettes façon Geocities, les captures d’écran des interfaces ratées et les bouteilles de bons vins.",
+          "socials": []
+        },
+        {
+          "name": "Nejmeddine Ben Ouarred",
+          "company": "",
+          "city": "",
+          "bio": "My name is Nejmeddine BEN OUARRED, known as Nej.\r\n\r\nI am a Google Developer Expert (GDE) in Cloud Infrastructure and an Authorized Google trainer. I have 7 active Google Cloud certifications and Kubernetes Application Developer (CKAD) certification (see the complete list of certifications below).\r\n\r\nI am as a Senior Staff Engineer at \"Sfeir,\" a consulting firm specializing in digital and technological strategy, and a Google Cloud partner.\r\n\r\nAt Sfeir, I work with French and European companies on topics related to Google Cloud and also on projects involving APIs.\r\n\r\nAs a cloud architect, I guide Sfeir's clients in their roadmap for transitioning to the Cloud. I also lead the client's roadmap to setup Apigee (Google API Management product) and cover all aspects of adopting an \"API First\" approach.\r\n\r\nIn my role as a Google Trainer, I primarily deliver courses on Google infrastructure and development. I am also the lead trainer for Apigee and Apigee Hybrid at Sfeir.\r\n\r\nI am a speaker on topics related to cloud and APIs.\r\n\r\nGoogle Cloud Certifications:\r\n\r\nGoogle Cloud Certified Professional Cloud Network Engineer\r\nProfessional Cloud Security Engineer\r\nGoogle Cloud Professional Cloud Developer\r\nProfessional Cloud DevOps Engineer\r\nAssociate Cloud Engineer\r\nCloud Digital Leader",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/benouarred"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Azeau",
+          "company": "",
+          "city": "Seysses",
+          "bio": "Je code pour m'amuser et je joue pour être sérieux. Et vice-versa.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/oaz"
+            },
+            {
+              "type": "website",
+              "url": "https://contretemps.azeau.com/"
+            }
+          ]
+        },
+        {
+          "name": "Olivier Bierlaire",
+          "company": "Rebase.Green",
+          "city": "Nantes, France",
+          "bio": "Ex-first dev team of Canva, I've worked at Elastic, and now focused on founding in sustainability in IT. With Rebase.green we focus on reducing energy waste in software industry. Based in Nantes, France.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/obierlaire"
+            },
+            {
+              "type": "website",
+              "url": "https://dev.to/obierlaire/"
+            }
+          ]
+        },
+        {
+          "name": "Paul Jeannot",
+          "company": "Sêmeia",
+          "city": "Toulouse",
+          "bio": "Tombé dans l'informatique dès mon plus jeune âge, j'explore tous les sentiers de la tech en essayant de faire de belles choses avec simplicité.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://x.com/luapaj_"
+            }
+          ]
+        },
+        {
+          "name": "Paul Vulliemin",
+          "company": "Sopra Steria",
+          "city": "Nantes",
+          "bio": "Je suis un profil touche à tout/couteau suisse, passionné par tous les sujets techniques liés à l'IT.\r\nJ'aime apprendre et découvrir de nouveaux sujets techniques, et j'aime par dessus résoudre des problèmes.\r\nJ'ai commencé par le développements d'applications et maintenant je travaille principalement sur des sujets liés à l'industrialisation et à l'administration de systèmes : CI/CD, Kubernetes, Docker, Ansible, Terraform, etc. Tout en intervenant toujours ponctuellement sur d'autres sujets techniques.\r\n\r\nMes péchés mignons ce sont les PoC, et ma kryptonite, la doc.",
+          "socials": []
+        },
+        {
+          "name": "Raphaël Semeteys",
+          "company": "Worldline",
+          "city": "Paris",
+          "bio": "25 years experience in IT in several business fields and positions (dev, run, business analyst, project manager, architect, consulting, presales... and now DevRel)\r\nStrong expertise about Free and Open Source Software (9 years in a dedicated skill center, animating communities, talks and articles...)",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/RaphaelSemeteys"
+            },
+            {
+              "type": "website",
+              "url": "https://blog.worldline.tech/"
+            }
+          ]
+        },
+        {
+          "name": "Simon Gomez",
+          "company": "Yumans",
+          "city": "Toulouse",
+          "bio": "Je suis le fondateur et CEO de Yumans, une agence de design digital basée à Toulouse. Nous sommes spécialisés dans la conception UX et le design UI d'applications de services BtoB/BtoC et de solutions métiers. Je suis également responsable de FLUPA Toulouse, l’association francophone des professionnels de l’expérience utilisateur.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/_Simon_Gomez_"
+            },
+            {
+              "type": "website",
+              "url": "https://yumans.design/blog"
+            }
+          ]
+        },
+        {
+          "name": "Thibaut Cantet",
+          "company": "Néosoft",
+          "city": "Paris",
+          "bio": "Thibaut est développeur depuis plus de 18 ans. Convaincu par les pratiques craft, il s’efforce de rendre le code le plus simple et agréable à travailler.\r\nAdepte de DDD, il aime parler design et architecture.",
+          "socials": []
+        },
+        {
+          "name": "Thomas Martin",
+          "company": "Qonto",
+          "city": "",
+          "bio": "Senior SRE with responsibilities around reducing incidents MTTR and their blast radius, and improving overall platform’s reliability at low costs.",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://me-applinh.netlify.app/"
+            }
+          ]
+        },
+        {
+          "name": "Thomas Roux",
+          "company": "Fillzz",
+          "city": "Toulouse",
+          "bio": "Étudiant en Master 2 Informatique et CEO @ Fillzz",
+          "socials": []
+        },
+        {
+          "name": "Tony Jarriault",
+          "company": "Sogeti Capgemini",
+          "city": "",
+          "bio": "Responsable technique pour le build et le run de plate-forme infogérées. J'ai participé au coaching d'équipes sur le volet technique. Ce qui me permet de présenter les sujets qui me passionnent lors d’événements publique (Ex : Devoxx / DevFest / ..)\r\n  \r\nAujourd'hui, j'accompagne les clients dans l'adoption du cloud publique que ce soit pour des applications B2C que B2B devant également relevé les challenges : Securité / Finops / Green afin de limiter l'empreinte carbone des applications.\r\n",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/JarriaultTony"
+            }
+          ]
+        },
+        {
+          "name": "Trouilhet Sylvie",
+          "company": "",
+          "city": "",
+          "bio": "Titulaire d’un doctorat en informatique, je suis maître de conférences à l’Université de Toulouse et membre de l’équipe SMAC (Systèmes Multi-Agents Coopératifs) au sein de l’IRIT.\r\nMes travaux de recherche portent principalement sur les systèmes multi-agents, l’intelligence ambiante et l’ingénierie logicielle adaptée à des environnements dynamiques et ouverts.\r\nCes dernières années, je me consacre plus particulièrement au projet OppoCompo, dédié à la composition logicielle opportuniste.\r\nJ’enseigne dans le domaine du génie logiciel, principalement en BUT Informatique à Castres.",
+          "socials": []
+        },
+        {
+          "name": "Viktor Gamov",
+          "company": "Confluent",
+          "city": "New York",
+          "bio": "Viktor Gamov is a Principal Developer Advocate at Confluent, founded by the original creators of Apache Kafka®. With a rich background in implementing and advocating for distributed systems and cloud-native architectures, Viktor excels in open-source technologies. He is passionate about assisting architects, developers, and operators in crafting systems that are not only low in latency and scalable but also highly available.\r\nAs a Java Champion and an esteemed speaker, Viktor is known for his insightful presentations at top industry events like JavaOne, Devoxx, Kafka Summit, and QCon. His expertise spans distributed systems, real-time data streaming, JVM, and DevOps.\r\nViktor has co-authored \"Enterprise Web Development\" from O'Reilly and \"Apache Kafka® in Action\" from Manning. \r\nFollow Viktor on X—@gamussa to stay updated with his latest thoughts on technology, his gym and food adventures, and insights into open-source and developer advocacy.",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "http://x.com/gamussa"
+            },
+            {
+              "type": "website",
+              "url": "https://gamov.io"
+            }
+          ]
+        },
+        {
+          "name": "Audrey Gentili",
+          "company": "Zenika",
+          "city": "Lyon, France",
+          "bio": "Développeuse consultante front-end, enthousiaste de partager découvertes et expériences avec des personnes passionnées et passionnantes.",
+          "socials": []
+        },
+        {
+          "name": "Communauté Toulouse.rb",
+          "company": "",
+          "city": "",
+          "bio": "Toulouse.rb est un groupe réunissant des Rubyistes de la région Toulousaine.\r\n\r\nDes rencontres sont organisées régulièrement autour du langage Ruby pour échanger des bonnes pratiques, des conseils, des histoires, et apprendre ensemble !",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://www.meetup.com/toulouse-ruby-friends/"
+            }
+          ]
+        },
+        {
+          "name": "Communauté Agile Toulouse",
+          "company": "Agile Toulouse",
+          "city": "",
+          "bio": "<div class=\"s-item-title\">\r\n<div class=\"s-component s-text\">\r\n<div class=\"\">\r\n<div class=\"s-component-content s-font-heading\">\r\n\r\nLe but de l’association Agile Toulouse est de développer une communauté d’agilistes <em>-personnes qui s’intéressent aux méthodes agiles-</em>, à Toulouse et dans le Sud-Ouest, par des actions diverses de promotion, de rencontre et de communication.\r\n\r\n</div>\r\n</div>\r\n</div>\r\n</div>\r\n<div class=\"s-item-text\">\r\n<div class=\"s-component s-text\">\r\n<div class=\"\">\r\n<div class=\"s-component-content s-font-body\">\r\n<div class=\"s-rich-text-wrapper\">\r\n<p class=\"s-rich-text-wrapper s-rich-text-wrapper\">L’association propose des ateliers pratiques et thématiques, et aussi, avec une fréquence mensuelle, les Klubs :</p>\r\n\r\n<ul>\r\n \t<li><a href=\"http://meetu.ps/c/1NGHT/bKmn2/f\" target=\"_blank\" rel=\"noopener\" data-type=\"\">ShuHaRi Klub</a></li>\r\n \t<li><a href=\"http://meetu.ps/c/1NGHT/bKmn2/f\" target=\"_blank\" rel=\"noopener\" data-type=\"\">Klub de lecture</a></li>\r\n \t<li><a href=\"https://www.meetup.com/fr-FR/agile-toulouse/\" target=\"_blank\" rel=\"noopener\" data-type=\"undefined\">La bière agile</a></li>\r\n</ul>\r\nL’association dispose d’un bureau à la Maison des Associations de Toulouse.\r\n\r\nPour les événements prévus prochainement et éventuellement vous y inscrire, RDV sur <a href=\"https://www.meetup.com/fr-FR/Agile-Toulouse/\" target=\"_blank\" rel=\"noopener\" data-type=\"\">meetup</a>.\r\n\r\nLe plus gros événement de l'année étant l'Agile Tour Toulouse qui rassemble environ 500 personnes sur 2 jours au troisième trimestre.\r\n\r\n</div>\r\n</div>\r\n</div>\r\n</div>\r\n</div>",
+          "socials": [
+            {
+              "type": "twitter",
+              "url": "https://twitter.com/agiletoulouse"
+            },
+            {
+              "type": "website",
+              "url": "https://www.agiletoulouse.fr/"
+            }
+          ]
+        },
+        {
+          "name": "Communauté Toulouse JUG (Java User Group)",
+          "company": "",
+          "city": "",
+          "bio": "Le Toulouse JUG (Java User Group) est un groupe d'utilisateurs Java destiné à échanger des idées et de discuter des avancées technologiques de la JVM.\r\n\r\nProposer (ou voter pour) un sujet : https://github.com/ToulouseJug/call-for-paper\r\n\r\nNous nous rencontrons environ une fois par mois. Les réunions sont gratuites, ouvertes à toutes et à tous, et consistent le plus souvent en une présentation technique, une démonstration d’un produit, ou un atelier. Après la rencontre, nous nous retrouvons généralement pour discuter autour d’un mini-buffet (pizzas) et de boissons (bières et softs).",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://www.meetup.com/fr-FR/Toulouse-Java-User-Group/"
+            }
+          ]
+        },
+        {
+          "name": "Communauté MTG:Toulouse (Microsoft Tech Group)",
+          "company": "",
+          "city": "",
+          "bio": "<div class=\"fusion-content-tb fusion-content-tb-1\">\r\n\r\nLe MTG:Toulouse (Microsoft Tech Group) est une association dont le but est de créer un espace d’apprentissage et de partage technique dans la région Toulousaine, centré autour des technologies et plateformes Microsoft, plus particulièrement .NET et Azure.\r\n\r\nNous sommes aussi intéressés par le développement logiciel en général, et les différents langages de programmation.\r\n\r\nNous souhaitons créer un espace convivial pour se retrouver, rencontrer d’autres développeurs et techniques venant de tous horizons. Un espace pour apprendre de nouvelles choses et pour partager ses connaissances dans un environnement fun, inclusif et bienveillant.\r\n\r\nNous organisons des évènements de manière régulière :\r\n<ul>\r\n \t<li>Conférences sur les technologies Microsoft (.NET et Azure principalement)</li>\r\n \t<li>Conférences découvertes et ouverture d’esprit sur d’autres technologies</li>\r\n \t<li>Conférences sur les techniques de développement logiciel</li>\r\n \t<li>Apéros à la suite des conférences pour se rencontrer et boire un verre ensemble</li>\r\n \t<li>Le groupe existe depuis 2017 et a à son actif plus d’une cinquantaine d’événements.</li>\r\n</ul>\r\n</div>",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://www.meetup.com/mtg-toulouse/"
+            }
+          ]
+        },
+        {
+          "name": "Tech Speak'Her",
+          "company": "",
+          "city": "",
+          "bio": "<div class=\"fusion-content-tb fusion-content-tb-1\">\r\n\r\n🔍 Pourquoi Tech Speak’Her ?\r\n\r\nEn 2025, les femmes ne représentent que 17 % des métiers techniques en France et restent largement sous-représentées sur les scènes des conférences technologiques.\r\nPourtant, elles conçoivent, innovent et dirigent des projets au quotidien.\r\n\r\nMalgré leur expertise, elles ne constituent qu’environ 25 % des employés dans les sciences et technologies en Europe, et leur voix est encore trop souvent reléguée au second plan : seulement 3 % des postes de CTO sont occupés par des femmes, et les conférencières restent une minorité dans les grands événements tech.\r\n\r\n💡 Tech Speak’Her est né pour changer cela.\r\n\r\nNous sommes une communauté qui aide les femmes à :\r\n– Dépasser le syndrome de l’imposteur et affirmer leur légitimité.\r\n– Se préparer à prendre la parole et à briller sur scène.\r\n– Occuper l’espace qu’elles méritent dans un secteur où leur expertise est trop souvent minimisée.\r\n\r\n🤝 Soutenues par le GDG Toulouse et les Communautés Tech Toulouse, nous organisons des talks accessibles, en présentiel et en ligne, pour mettre en lumière ces voix inspirantes.\r\n\r\n</div>",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://www.linkedin.com/groups/14906056/"
+            }
+          ]
+        },
+        {
+          "name": "Communauté Python Toulouse",
+          "company": "",
+          "city": "",
+          "bio": "On échange autour de Python, de son écosystème, et autour de pizzas 😊 Que ce soit des scripts, des apps, de la data science, de l'IA, ... on en parle !",
+          "socials": [
+            {
+              "type": "website",
+              "url": "https://www.meetup.com/fr-FR/Python-Toulouse/"
+            }
+          ]
+        }
+      ],
+      "sessions": [
+        {
+          "title": "La domotique débridée, du sac poubelle au sanglier!",
+          "description": "La domotique se limite souvent au pilotage à distance des lumières, volets roulants et autres portes de garage. Mais que se passe-t-il quand on la met entre les mains de geeks créatifs ? La maison devient un terrain de jeu !\r\n\r\nVenez découvrir de la domotique non conventionnelle réalisée avec Home Assistant ! Erwan et Sylvain vous montreront certaines de leurs réalisations, qui vont du \"oh, c'est pratique ça\" au \"mais WTF\" en passant par le \"nan, ça va trop loin là (mais c'est trop cool)\".\r\n\r\nCette session est aussi la vôtre : si vous aussi vous avez domotisé des choses improbables, venez les présenter sur scène avec nous (ou si vous ne pouvez pas venir, envoyez-nous des photos ou vidéos). Vous pouvez proposer vos hacks improbables sur ce formulaire : https://forms.gle/uc6JihjMiVDx3v6v7 ",
+          "speakers": [],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=nxVhlSdwFwA"
+        },
+        {
+          "title": "Beyond agile : Dans les coulisses des licornes géantes de la Tech !",
+          "description": "On parle beaucoup d’agilité. De delivery rapide, de rituels bien huilés, d’OKRs bien définis. Et pourtant, malgré tous ces efforts, l’impact réel sur l’utilisateur reste souvent décevant, voire inexistant.\r\n\r\nDans ce talk on quitte le confort des frameworks pour explorer ce qui distingue vraiment les géants de la tech  (Google, Airbnb, Spotify, Amazon, Vinted …) de la majorité des organisations. Ce n’est ni une question de budget, ni d’outillage. C’est une autre façon de penser. Une autre manière d’apprendre.\r\n\r\nÀ travers des histoires vraies, des pratiques concrètes, et des décodages sans filtre, vous découvrirez pourquoi tant d’équipes croient innover… alors qu’elles ne font que livrer. Et comment reprogrammer votre système produit pour enfin sortir de l’illusion.\r\n\r\nPendant 45 minutes, on démonte les illusions les plus tenaces sur la discovery, le delivery et la performance produit, pour révéler ce qui distingue vraiment les leaders : non pas leur capacité à livrer, mais à apprendre plus vite que les autres. \r\n\r\nUn talk pour secouer vos certitudes, vous inspirer, et repartir avec l’envie furieuse de repenser votre orga produit.",
+          "speakers": [],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=hGSbAc7EFtk"
+        },
+        {
+          "title": "Orchestration d’agents IA : LangGraph et le benchmark GAIA",
+          "description": "Depuis 2022, une vague de librairies et de plateformes d’agents LLM a émergé, chacune explorant un angle différent :\r\n\r\n- Outils → LangChain\r\n- Données → LlamaIndex\r\n- Simplicité → Smolagents\r\n- Orchestration → LangGraph, SmythOS\r\n- Automatisation visuelle / intégrations natives → n8n\r\n\r\nLangGraph se distingue par son approche d’orchestration par graphes, entièrement open source, son riche écosystème et sa capacité à gérer des cas d’usage complexes, souvent non couverts par les solutions low code.\r\n\r\nDans ce talk, nous construirons un agent LangGraph étape par étape,\r\npuis nous le testerons sur quelques questions du benchmark GAIA, conçu par Hugging Face pour évaluer les agents IA généraux.\r\n\r\nObjectif : Découvrir LangGraph comme solution d’orchestration et explorer GAIA comme benchmark des agents IA.\r\n\r\nConférence présentée par Florian Marc - Ingénieur R&amp;D. Spécialisé dans le développement d'application Web dans les environnements Google Cloud Platform et Cloud Native, je développe mon expertise autour du Machine Learning.",
+          "speakers": [
+            "Communauté Python Toulouse"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant"
+        },
+        {
+          "title": "La méthode pour coder ce qui compte vraiment",
+          "description": "Chaque ligne de code coûte cher, mais trop souvent les devs codent sans comprendre l'objectif métier et perdent des jours sur des solutions inutiles.\r\n\r\nDans ce talk : une méthode simple en 3 piliers (Pourquoi, Prioriser, Parler) pour s'assurer que ce qu'on code a vraiment de la valeur.\r\n\r\nAvec des exemples concrets : comment poser 'Quel objectif ça sert ?' change tout, pourquoi co-concevoir évite de perdre du temps, et comment le AFIN DE des user stories devient votre meilleur allié.\r\nVous repartirez avec la permission de challenger et des outils actionnables.\r\n\r\nPrésenté par Cateline Puccetti.",
+          "speakers": [
+            "Tech Speak'Her",
+            "Tech Speak'Her"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant"
+        },
+        {
+          "title": "Threads saturés, requêtes en attente : l’asynchronisme comme levier de scalabilité",
+          "description": "Pourquoi certaines applications Web se mettent-elles à ralentir quand la charge monte, même si les serveurs ne semblent pas saturés ?\r\n\r\nLes développeurs sous-estiment souvent l’impact du modèle synchrone dans des applications Web à moyenne ou forte charge. Le résultat ? Des threads saturés, des requêtes qui s’accumulent, et inévitablement des timeouts côté utilisateur.\r\n\r\nLes démos seront en .NET mais cette problématique reste valable peu importe la technologie serveur.\r\n\r\nPrésentation par Benoît Laut",
+          "speakers": [
+            "Communauté MTG:Toulouse (Microsoft Tech Group)"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire"
+        },
+        {
+          "title": "Bien débuter avec Spring AI",
+          "description": "Spring AI est une librairie de la famille Spring servant à simplifier l'utilisation des LLM dans nos applications Spring Boot.\r\nElle supporte plusieurs fournisseurs de LLM (OpenAI, Google, Anthropic, Mistral, Ollama, etc) et de nombreuses fonctionnalités dont chatbots, RAG, MCP et agents.\r\nDans cette présentation, je vais montrer les bases de Spring AI :\r\n\r\nInstaller et utiliser Ollama pour exécuter localement des LLM\r\nImplémenter des tâches simples telles que poser des questions et traiter des documents\r\nProduire des contenus structurés\r\nDécrire des images\r\nImplémenter un chatbot basique sachant appeler nos méthodes métier\r\nMesurer la consommation en tokens et tracer les appels au LLM\r\n\r\nSession présentée par Florian Beaufumé",
+          "speakers": [
+            "Communauté Toulouse JUG (Java User Group)"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant"
+        },
+        {
+          "title": "Agile et DDD : quand devs et métiers partagent enfin la même langue et les mêmes pratiques",
+          "description": "Agilité et Développeurs, pouvons nous nous réconcilier?\r\nLe manifeste agile a été écrit par des développeurs pour des développeurs.\r\nAlors que c''est il passé depuis ce temps là ?\r\nPetit retour en arrière et mise en perspective avec des nouvelles pratiques pour unir à nouveau les 3 amigos!\r\n\r\nPrésenté par Guillaume Saint-Étienne",
+          "speakers": [
+            "Communauté Agile Toulouse"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire"
+        },
+        {
+          "title": "Pourquoi Rails est LE framework de 2025 ?",
+          "description": "Développer une application web en 2025, c’est jongler entre productivité, maintenabilité et expérience utilisateur. Dans un écosystème où les frameworks se succèdent à toute vitesse, il est crucial de miser sur des outils complets, cohérents et durables.\r\n\r\nEt si la réponse était sous nos yeux depuis 20 ans ?\r\n\r\nRuby on Rails, souvent cité comme “monolithique mais magique”, continue d’évoluer et d’intégrer tout ce qu’il faut pour créer des applications modernes — sans dépendre de dizaines de bibliothèques externes.\r\n\r\nDans ce talk, nous verrons comment Rails reste, en 2025, un framework full-stack redoutablement efficace. Nous explorerons ses fondations MVC (models, views, controllers) ainsi que ses briques intégrées : Action Cable pour le temps réel, Active Storage pour la gestion des fichiers, Active Job pour le traitement asynchrone, et Turbo/Hotwire pour un front-end ultra réactif. Le tout déployé simplement avec Kamal.\r\n\r\nPrésenté par Jason Lagarde et Adnan Aidi",
+          "speakers": [
+            "Communauté Toulouse.rb",
+            "Communauté Toulouse.rb"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire"
+        },
+        {
+          "title": "Veille technologique : ma méthode pour rester à jour",
+          "description": "Entre les fils Twitter, le flux LinkedIn, les épisodes de podcasts et les newsletters qui s’empilent, la veille techno tourne vite au bruit de fond. Pourtant, rester à jour est vital quand on écrit du code — ou qu’on pilote un produit — dans un écosystème qui bouge chaque semaine.\r\n\r\nDéveloppeur·se depuis plus de vingt ans, j’ai affûté une méthode 100 % sous votre contrôle : zéro algorithme, zéro FOMO, centrée sur les bons vieux flux RSS, orchestrés avec Inoreader et complétés par quelques agrégateurs clés (Hacker News, Lobsters, Human Coders News, etc.).\r\n\r\nCe dont nous parlerons\r\n- Composer sa “sources list” : transformer n’importe quel site, newsletter ou profil social en flux RSS et dénicher de nouvelles pépites via les agrégateurs.\r\n- Organiser et filtrer : répertoires thématiques, indice de popularité, règles automatiques, résumés IA, traduction — viser la pertinence plutôt que la quantité.\r\n- Ritualiser la veille : ménage régulier, file d’attente « lire plus tard », créneaux dédiés et astuces anti-dispersion.\r\n- Passer à l’action : publier un mémo hebdo, partager sa veille sur ses réseaux ou avec son équipe, alimenter un blog...\r\n\r\nRepartez avec une méthode pragmatique, extensible et, surtout, toujours au service de votre curiosité plutôt que d’un algorithme.",
+          "speakers": [
+            "Camille Roux"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=d8nLfDFcip4"
+        },
+        {
+          "title": "Un Pixel, puis un autre : Comment faire tourner DOOM sur une liseuse électronique 🕹️",
+          "description": "DOOM est un jeu culte qui a été porté des milliers de fois sur toutes sortes de supports, alors pourquoi ne pas essayer de le faire tourner sur ma liseuse électronique Kindle ?\r\n\r\nJe n’ai absolument aucune expérience en portage de jeux mais j’ai décidé de tenter l’expérience, un peu par curiosité, un peu pour le défi ! Je vous propose de suivre mon périple, un pixel après l’autre, pour jouer à DOOM avec de l’encre électronique.\r\n\r\nCa sera l'occasion de parler d'écrans 8 bits, d'architecture processeur et de bricolage technique pour faire marcher tout ca\r\net bien sûr d'une démo de DOOM en encre électronique 🚀",
+          "speakers": [
+            "Moustapha Agack"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=tWY7pczq9Zk"
+        },
+        {
+          "title": "Un back-end métier pour mon IDE !",
+          "description": "Du Bloc-Note à Notepad++, jusqu’aux IDE modernes comme IntelliJ IDEA ou VSCode, un long chemin a été parcouru. Aujourd’hui, ces environnements permettent une navigation rapide dans le code, ainsi qu’un retour immédiat sur les erreurs de compilation. Les plugins y ont ajouté la prise en charge de multiples langages, frameworks… et désormais, de l’intelligence artificielle.\r\n\r\n➡️ L’étape suivante ?\r\n\r\nDes plugins capables d’intégrer la compréhension du métier directement dans l’IDE, pour accompagner les développeurs dans la logique métier de leurs applications.\r\nEt cela commence par une brique essentielle : l’analyse de code.\r\nDes années de recherche ont permis le développement d’outils d’analyse ultra-performants, capables de mieux re-comprendre le code, d’en extraire des visualisations utiles pour le débogage, la réarchitecture… et pour coder différemment.\r\n\r\n🎙️ Ce que nous vous proposons dans cette conférence :\r\nDécouvrir comment nous combinons analyse de code, méta-modélisation, IDE modernes et Language Server Protocol, pour permettre à chacun d’ajouter son propre back-end aux IDE — et ainsi de mieux implémenter ses pratiques de développement, tout en intégrant la compréhension du métier directement dans son environnement de programmation.\r\n\r\n👁️‍🗨️ Avec tout cela, vous ne regarderez plus le code de la même manière.",
+          "speakers": [
+            "Benoit Verhaeghe",
+            "Aless Hosry"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=o-7-3BGj1ng"
+        },
+        {
+          "title": "toute ma stack est dans ma BDD : Postgres et quelques \"power tools\" pour mon backend",
+          "description": "\"on peut tout mettre dans postgres\" (ou presque)\r\nEn déployant Postgrest, Keycloak, Otoroshi, N8N, tous rattachés à une base Postgres nous allons voir que nous pouvons tout construire de A à Z avec notre base : \r\n- stockage\r\n- APIs\r\n- Functions\r\n- Workflows\r\n- Authentification\r\n\r\nNous allons démontrer comment faire les APIs authentifiées tout en SQL, quelques fonctions en python dans postgres, et les interactions avec d'autres produits/api tout en \"low code\" avec N8N. L'authentification sera assurée par Keycloak (évidemment) et Otoroshi.\r\n\r\nTout en live \"no coding\".",
+          "speakers": [
+            "Loïc des Rochettes",
+            "Mathieu Passenaud"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=0kDcFUIZgn0"
+        },
+        {
+          "title": "Metal-As-A-Service : Gérer votre bare-metal en MaaS, comme si c'était une machine virtuelle !",
+          "description": "Déployer tout un Datacenter en même pas 10 minutes, est-ce vraiment possible ? Et si je vous disais que oui !\r\nDans cette conférence, je rentrerai en détail de cet outil puissant, conçu pour automatiser le provisionnement et la gestion des serveurs physiques avec la même facilité que les machines virtuelles.\r\n\r\nDurant cette conférence, je vous présenterai le fonctionnement de cet outil Open Source. Comment nous l’utilisons aux Restos du Coeur pour faire « scale » le matériel et ainsi augmenter rapidement nos capacités sans avoir tout le bare-metal en permanence allumé.\r\n\r\nQuoi de mieux qu’une démonstration pour donner envie d’adopter l’outil ? Nous déploierons ensemble plusieurs serveurs en moins de 5 minutes, via l’API de MaaS et Terraform en envoyant une image Packer au préalable construite.\r\n\r\nAprès cette conférence, vous abandonnerez définitivement la clé USB pour déployer vos systèmes. ",
+          "speakers": [
+            "Julien Briault"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=12jBU55wMM8"
+        },
+        {
+          "title": "MCP et A2A : Révolutionner l'Interconnexion et la Collaboration des Agents IA",
+          "description": "    L'écosystème de l'intelligence artificielle évolue rapidement vers des systèmes d'agents plus complexes et distribués. Pour libérer tout leur potentiel, ces agents ont besoin de standards robustes pour interagir avec leur environnement et collaborer entre eux. Ce talk technique plonge au cœur de deux protocoles ouverts et complémentaires qui façonnent cet avenir : le Model Context Protocol (MCP) et l'Agent-to-Agent Protocol (A2A).\r\n\r\n    Nous explorerons d'abord MCP, initié par Anthropic, qui standardise la manière dont les agents IA (et les applications basées sur les LLM) accèdent et utilisent des outils externes, des APIs et des sources de données. Nous détaillerons son architecture client-serveur et comment il permet une intégration modulaire et sécurisée des capacités externes.\r\n\r\n    Ensuite, nous nous pencherons sur A2A, un protocole porté par Google et ses partenaires, conçu pour permettre une communication et une collaboration fluides entre des agents IA hétérogènes. Nous examinerons ses concepts clés, tels que les \"Agent Cards\" pour la découverte de capacités, la gestion des tâches distribuées et la prise en charge de communications multimodales.\r\n\r\n    Enfin, ce talk mettra en lumière la synergie entre MCP et A2A, illustrant comment leur utilisation combinée permet de construire des applications IA sophistiquées où des agents spécialisés peuvent exploiter des outils via MCP tout en collaborant via A2A pour résoudre des problèmes complexes. Les participants repartiront avec une compréhension claire de ces protocoles, de leurs cas d'usage et de leur impact sur le développement futur des systèmes d'agents intelligents.\r\n",
+          "speakers": [
+            "Tony Jarriault",
+            "Laurent Grangeau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=Cp0BHAqSeJA"
+        },
+        {
+          "title": "L'observabilité en pratique: comment devenir proactif avec les bugs",
+          "description": "\"je n'arrive pas à reproduire\", \"il va falloir ajouter des logs\", \"on ne peut pas tester ça en staging\", \"Ca semble casser depuis longtemps\", \"Ca fonctionne en local\", ...\r\nSi vous entendez ça régulièrement, cette conférence est faite pour vous.\r\nSi vous avez souvent l'impression d'avoir un temps de retard sur les bugs, cette conférence est aussi faite pour vous.\r\n\r\nDurant ce talk, j'introduis la notion d'observabilité et comment elle peut aider les développeurs à toujours avoir un temps d'avance, à augmenter la qualité des applications et donc, à avoir plus de temps pour ajouter de la valeur !\r\nJe présente ensuite les méthodes concrètes et les outils que nous avons mis en place à group.one pour maintenir et observer nos produits, utilisés sur des millions de sites web et nos services avec des mises en production chaque jour et plusieurs milliers de requêtes par secondes.\r\n\r\nL'audience découvrira:\r\n- L' error &amp; performance tracking, tracing et alertes techniques avec Sentry\r\n- Alertes fonctionnelles et data observability avec Metabase\r\n- Automatisation des tests de regression visuelle\r\n- Shadow &amp; Canary releases\r\n\r\nSi ces techniques ne vous parlent pas, si vous avez des difficultés à les mettre en place, ou si vous souhaitez simplement vous rafraichir la mémoire, ce talk est une bonne occasion d'écouter un retour d'expérience et des conseils pratiques sur l'observabilité !",
+          "speakers": [
+            "Mathieu Lamiot"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=S5CrF72KzNo"
+        },
+        {
+          "title": "L'IA et la blockchain, les alliés de la sécurité",
+          "description": "    Dans un monde où la sécurité a longtemps été conservatrice et méfiante envers les nouvelles technologies, nous assistons aujourd'hui à une transformation radicale. Les attaquants exploitent au maximum les avancées technologiques, notamment l'Intelligence Artificielle (IA), pour mener des attaques de plus en plus sophistiquées. Face à cette menace croissante, il est impératif de repenser l'approche de la sécurité.\r\n\r\n    L'IA et la Blockchain émergent comme des alliés puissants dans cette lutte. L'IA, avec sa capacité à analyser des volumes massifs de données et à détecter des anomalies en temps réel, et la Blockchain, avec sa nature décentralisée et immuable, offrent ensemble une solution robuste pour sécuriser nos systèmes et nos données. Par exemple, les Zero-Knowledge Proofs renforcent la sécurité en permettant des vérifications sans divulgations d'informations sensibles.\r\n\r\n    Cette présentation explore comment l'intégration de l'IA et de la Blockchain sont utilisés par exemple pour implémenter le framework SLSA (liste de standards et contrôles conçus pour prévenir les altérations et sécuriser les packages) et se protéger ainsi contre les attaques de type supply chain. Découvrez comment ces technologies, autrefois perçues avec scepticisme, deviennent aujourd'hui des piliers essentiels pour contrer les cybermenaces et garantir un avenir numérique sécurisé.\r\n",
+          "speakers": [
+            "Carmen Piciorus"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=epB_7irDPJ4"
+        },
+        {
+          "title": "Les coulisses de JavaScript : ce qu’on utilise sans comprendre 🎭",
+          "description": "Bienvenue dans les coulisses d’un des plus grand spectacle du développement web : JavaScript 🪄 Sur scène, tout semble magique : les animations captivent, les promesses sont tenues, et tout s’exécute sans accroc. Mais derrière le rideau, une véritable troupe travaille sans relâche pour donner vie à ce spectacle.\r\n\r\nDans cette visite guidée, nous vous invitons à lever le rideau sur la mécanique de JavaScript : son engine, la scope chain, son incontournable event loop, les contextes d’exécution, et bien sûr, ses fameuses promesses. Ces concepts vous sont peut-être familiers, mais n’est-il pas temps d’un peu mieux les comprendre ?\r\n\r\nPrenez vos billets et plongez avec nous dans les rouages fascinants de JavaScript 🎟️",
+          "speakers": [
+            "Mickael Alves",
+            "Etienne Idoux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=JoFJTwsiRlc"
+        },
+        {
+          "title": "Les codes à barres, c'est pas que de la barre !",
+          "description": "Depuis des dizaines d'années, les codes 1D tels que les EAN13 (dit code-barres) sont sur toutes nos boites de céréales, produits de consommation...\r\nDes codes 2D sont également présent dans notre quotidien ainsi que les datamatrices qui sont très utilisées dans le domaine médical.\r\n\r\nEt depuis quelques temps sont apparus les codes Aztec, QRCode...\r\n\r\nMais au fond, comment cela fonctionne ? Comme se fait-il qu'on puisse en \"dégrader\" quelques uns pour y mettre son logo ? Quel est le risque de trop le dégrader ?\r\n\r\nNous comprendrons ensemble les mécaniques de transformation, de redondance de l'information, l'histoire et l'utilisation des plus connus d'entre eux.\r\n\r\nJe vous propose de voyager dans le monde merveilleux des codes et d'en créer un en ajoutant une nouvelle dimension !",
+          "speakers": [
+            "Sylvain Gougouzian"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=fzgCNLfSnzA"
+        },
+        {
+          "title": "L'enfer des tests auto",
+          "description": "Des tests automatiques, on sait qu'il faut en faire. Mais trop souvent c'est une véritable corvée : c'est lent, pas fiable, compliqué à lancer, compliqué à maintenir, voire compliqué à écrire tout court. Pourquoi c'est si dur ? Et comment reprendre le contrôle ?\r\n\r\nIl va falloir reprendre depuis le début : pourquoi on teste ? et on test quoi ? et on teste comment ?\r\nEnsuite, il va falloir revoir un peu les bases du test : un brin de vocabulaire, et surtout de la méthodologie (dépendances, interfaces, contrat, mock, simulateur, fixture, inversion, ...).\r\nOn fera un petit détour par l'architecture, parce que la testabilité est une propriété à prendre en compte dès le design, ou bien il faudra jouer du scalpel ou du pied-de-biche par la suite pour les faire rentrer.\r\nEnfin, on passera à l'implémentation, et avec quelques bonnes pratiques et le bon outillage (framework de test, TestContainers, CI, ...), ça se passera plutôt bien.\r\n\r\nA travers des cas concrets tirés de nos expériences, suivez-nous sur le chemin pour quitter l'enfer des tests.",
+          "speakers": [
+            "Jonathan Gaffiot",
+            "Julien Lenormand"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=6O4EjKHUpEI"
+        },
+        {
+          "title": "Le monstre invisible : l'empreinte carbone de l’IA",
+          "description": "Qu'est-ce qui est silencieux, colossal et terrifiant ? Non, ce n'est pas le monstre sous votre lit, c'est bien pire : les émissions de carbone de l'IA ! Pour affronter ce monstre, nous devons d'abord le comprendre : quel est l'impact de l'IA générative et des LLM ?\r\n\r\nIl y a beaucoup de questions sur les impacts de l’IA. On estime que l'entraînement de GPT-3.5 a généré des émissions de CO2 équivalentes à 800 vols Paris-New York. Mais qu'en est-il des requêtes ? Dois-je éviter de l'utiliser pour limiter mon empreinte carbone ? Si j'utilise un assistant IA pour coder, comme GitHub Copilot ou CodeWhisperer, est-ce que cela émet beaucoup de CO2 ?\r\nDe plus, chacun veut créer son propre LLM ou IA générative. Quel est l'impact de l'entraînement, du fine-tuning et de l'utilisation de ces modèles ? De nombreuses entreprises se préoccupent de leur bilan carbone, et le développement ainsi que l'utilisation des IA ont un impact qu'il est crucial de mesurer et de réduire.\r\n\r\nAvec une démonstration sur un cas concret, je vais enfin montrer qu’il existe des outils et des bonnes pratiques de hosting et GreenOps pour maîtriser ce monstre !\r\nDécouvrons ensemble comment affronter ce monstre invisible !",
+          "speakers": [
+            "Olivier Bierlaire"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=-LaQKYSXfcs"
+        },
+        {
+          "title": "Le hasard fait bien les tests",
+          "description": "&gt; Le hasard fait bien les choses.\r\n\r\nSi on applique cette idée aux tests unitaires ou aux tests d'intégration, on peut rendre nos tests beaucoup plus imprévisibles et du coup trouver des problèmes que notre esprit n'aurait jamais osé imaginer ! Par exemple, récemment, j'ai découvert dans une bibliothèque de gestion de configuration, [un bug](https://github.com/gestalt-config/gestalt/issues/242) qui se produit lorsque la `Locale` est configuré en `AZ`. 🤦🏼‍♂️\r\n\r\nUn autre exemple encore plus simple :\r\n\r\n```java\r\nint input = generateInteger(Integer.MIN_VALUE, Integer.MAX_VALUE);\r\nint output = Math.abs(input);\r\n```\r\n\r\nPeut générer `-2147483648`... Ce qui est assez inattendu pour une valeur absolue ! 😉\r\nLes tests aléatoires peuvent découvrir ces cas tordus... C'est ce que l'équipe elasticsearch a mis en place depuis plusieurs années à l'aide du framework [RandomizedTesting](https://labs.carrotsearch.com/randomizedtesting.html) pour tester tout le code Java.\r\n\r\nAjoutez à ça de vrais tests d'intégration à l'aide de [TestContainers](https://java.testcontainers.org/modules/elasticsearch/) et vous aurez une approche complète pour des tests qui échouent régulièrement ! \r\n\r\nAprès cette conférence, vous ne verrez plus jamais la fonction `random()` comme avant  et découvrirez comment la (mal)chance peut vous aider ! 🍀",
+          "speakers": [
+            "David Pilato"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=bJqIfKFYDpE"
+        },
+        {
+          "title": "Le content design sauve vos formulaires",
+          "description": "Alors que les formulaires sont l'élément principal d'interaction entre un produit numérique et son public, les développeurs sont souvent seuls en bout de chaîne pour gérer tout ce qui les composent, notamment les labels ou messages d'erreur. Mais ce n'est pas leur boulot et ils font comme ils peuvent. \r\nEt là c'est souvent le drame...\r\n\r\nCette conférence a pour mission de vous donner des conseils pour mieux gérer la microcopie de vos formulaires si vous n'avez pas de content designer ou UX writer sous la main.",
+          "speakers": [
+            "Nathalie Rosenberg"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=pOwX0IiEzsQ"
+        },
+        {
+          "title": "La réactivité et les signaux : démystifions la magie du frontend",
+          "description": "Certaines choses dans l’univers resteront sans réponse, mais la réactivité et les signaux ne devraient pas en faire partie.\r\n\r\nDepuis plusieurs années, la réactivité (et son concept clé : les signaux) s’est imposée sur toute la scène frontend. Que ce soit dans Vue.js, Angular, React, Svelte, Solid, Qwik, ou Preact, ces notions sont partout. Pourtant, malgré leur popularité, il est souvent difficile de comprendre ce qui se cache réellement derrière les signaux.\r\n\r\nOn entend parler de tracking, de proxies, d’états dérivés, et même d’effects, mais… de quoi parle-t-on vraiment ? Comment ces mécanismes permettent-ils à des valeurs d’\"écouter\" et de réagir aux changements d’autres ? Quelle est cette \"sorcellerie\" qui met à jour nos interfaces en temps réel, simplement en assignant une nouvelle valeur à une variable ?\r\n\r\nDans cette session, plonge dans le monde fascinant (et parfois mystérieux) de la réactivité et des signaux. Ensemble, nous décortiquerons une bibliothèque comme Alien Signals, pour démystifier ces concepts et enfin comprendre la mécanique qui se cache derrière cette \"magie\" du frontend.",
+          "speakers": [
+            "Estéban Soubiran"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "confirmé",
+          "youtube": "https://www.youtube.com/watch?v=USxzteUL-Qg"
+        },
+        {
+          "title": "Kafka 4, fantastique ?",
+          "description": "Vous l'attendiez, impatiemment, depuis quatre ans et ... ça y est ! Kafka 4 est là ! À chaque release majeure, son lot de nouveautés, et on se retrouve pour explorer les évolutions clés, leurs motivations et leurs impacts.\r\n\r\nNous aborderons, entre autres :\r\n\r\n- La suppression de ZooKeeper : le passage à KRaft pour simplifier la gestion et améliorer la scalabilité\r\n- Le nouveau protocole de rééquilibrage : une optimisation des groupes de consommateurs pour plus de stabilité et de performance\r\n- Les files d'attente (Early Access) : une consommation coopérative pour des cas d'usage point-à-point, étendant la polyvalence de Kafka\r\n\r\nNous détaillerons également les changements nécessaires pour vos applications (producteurs, consommateurs) et clusters : migration de Log4j vers Log4j2, transition de ZooKeeper à KRaft, mise à jour vers Java 11 (clients/Streams) et Java 17 (brokers/Connect/tools).\r\n\r\nVous repartirez avec une compréhension claire des nouveautés de Kafka 4 et des étapes concrètes pour réussir votre migration, que vous soyez développeur, architecte ou administrateur.\r\n",
+          "speakers": [
+            "Damien Lucas"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=pC_w9EPjEtA"
+        },
+        {
+          "title": "JEP 49.3 - cette nouvelle fonctionnalité Java est validée !!!",
+          "description": "Tous les 6 mois, Java change.\r\nC'est moins souvent que le gouvernement français, mais ces changements apportent plus de nouveautés.\r\n\r\nUne JEP (JDK Enhancement Proposal) décrit de manière détaillée comment va être implémentée une nouvelle fonctionnalité dans Java.\r\n\r\nJe vous propose de voir ensemble comment sont proposées ces nouvelles fonctionnalités, qui décide qu'elles seront ajoutées dans Java, qui travaille à leur développement et quel rôle joue la communauté dans ce processus.",
+          "speakers": [
+            "Guillaume Benoot"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=wGrPlTB8jt8"
+        },
+        {
+          "title": "Je malmène ton LLM en direct avec 10 failles de sécurités",
+          "description": "Les LLM sont à la mode, et soulèvent eux aussi des problèmes de sécurité.\r\n\r\nNous en avons pourtant mis dans nos applications, sans nous sentir concernés.\r\n\r\nNotre code est pourtant souvent à l'origine de nombreuses failles que nous ignorons.\r\nAllons les découvrir et les exploiter ensemble, en live sur une application existante.\r\nEn sortant de cette session, vous serez à même de répondre à ces questions :\r\n- Qu'est-ce que qu'une faille de sécurité pour un LLM ?\r\n- Quel est le rôle du dev dans la sécurité ?\r\n- Quelles sont les bonnes pratiques à appliquer ?\r\n\r\nSoyez prêts, tous les coups seront permis !",
+          "speakers": [
+            "Gaëtan Eleouet"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=JByDb8f_fFQ"
+        },
+        {
+          "title": "IHM critiques : quand les tâches utilisateur testent le code",
+          "description": "Les systèmes interactifs critiques (cockpits d’avion, IHM de contrôle de trafic aérien, appareils médicaux interactifs…) nécessitent l’application de méthodes et outils spécifiques pour garantir leur utilisabilité et sûreté de fonctionnement. L’équipe de recherche ICS (Interactive Critical Systems) de l’IRIT (Institut de Recherche en Informatique de Toulouse) étudie depuis plus de 15 ans la modélisation des tâches utilisateur pour garantir la conformité entre les tâches utilisateurs et le comportement du logiciel.\r\n \r\nCette approche rigoureuse, issue de la recherche, peut aussi s’appliquer à vos projets. Grâce à ces modèles de tâches détaillés, vous pouvez :\r\n•  analyser les besoins utilisateurs,\r\n•  spécifier les exigences\r\n•  préparer les tests\r\n•  vérifier la cohérence entre le comportement du logiciel et les interactions utilisateurs\r\n \r\nCélia Martinie, enseignante-chercheuse et responsable de l’équipe ICS, présentera cette méthode, illustrée avec l’outil HAMSTERS en accès libre et gratuit. Vous découvrirez comment connecter vos écrans, vos composants et vos tests aux tâches des utilisateurs… qu’ils soient pilotes d’avion ou simples usagers d’une interface web.  \r\nVous repartirez avec une méthode, des cas d’usage concrets, et un outil à tester chez vous. \r\n",
+          "speakers": [
+            "Celia Martinie"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=1CES05sG-zc"
+        },
+        {
+          "title": "IA et Edge Computing : traitement du langage efficace, sobre et sans dépendance",
+          "description": "Travaillant récemment sur des projets manipulant des données sensibles, nous avons exploré des approches légères et sobres en ressources pour faire de l’IA localement, sur le poste utilisateur.\r\n\r\nDans cette session, nous verrons que l'utilisation d'un grand modèle de langage n'est pas obligatoire pour de tâches comme extraire des entités, structurer de l’information, classer des documents ou répondre à des questions simples.\r\n\r\nNous illustrerons :\r\n- comment des modèles comme BERT ou ses dérivés peuvent être exploités efficacement,\r\n- pourquoi ils sont souvent suffisants (voire préférables) dans des contextes réglementés ou avec peu de données,\r\n- un exemple atypique de classification de texte par compression (gzip + k-NN), sans aucun réseau de neurones,\r\net comment distribuer des modèles ONNX et les faire tourner avec un runtime Rust ultra-performant (et multiplateforme),\r\n- le mécanisme de distribution via un système d'agents locaux, autonomes et légers, qui s'exécutent directement sur les postes clients, sans dépendre d'un serveur central ou du cloud.\r\n\r\nNous aurons également un regard équilibré sur les limites de ces approches : nous présenterons une analyse objective des cas où les LLM ou SLM modernes s’avèrent plus efficaces, notamment pour la désambiguïsation, le \"raisonnement\" ou la manipulation de contextes complexes.",
+          "speakers": [
+            "Didier Plaindoux",
+            "Ionut Mihalcea"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=mzPTyx5SE4o"
+        },
+        {
+          "title": "Haute couture du Web : le grand défilé du CSS 🎨",
+          "description": "Venez assister au grand show du CSS, un véritable défilé des techniques pour habiller vos applications web 📸\r\n\r\nVanilla, Sass, CSS Modules, CSS-in-JS, Tailwind, frameworks… Toutes les approches sont réunies sous les feux des projecteurs, prêtes à dévoiler leurs plus belles coupes, leurs motifs distinctifs et même leurs petits défauts de couture 🪡\r\n\r\nChacune montera sur le podium pour nous révéler sa personnalité, son allure, son côté pratique… ou un peu trop tape-à-l’œil ✨\r\n\r\nVous hésitez entre un style classique et un look ultra-moderne ? Entre une tenue faite main et un ensemble prêt-à-porter ? Venez découvrir quelle méthode saura vraiment sublimer votre projet  et repartez avec une valise pleine d’accessoires pour habiller vos applications avec goût et efficacité 🎨",
+          "speakers": [
+            "Audrey Gentili",
+            "Etienne Idoux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=lEy342rfZ1w"
+        },
+        {
+          "title": "Étudiant et développeur : Rebondir après les échecs dans la création de Fillzz",
+          "description": "En tant qu’étudiant à l’Université Paul Sabatier, j’ai créé Fillzz, une app mobile aidant des milliers d’utilisateurs à trouver les stations-service les moins chères dans 7 pays, malgré un emploi du temps chargé et un budget serveur de 65 €/mois. Dans ce quickie, je partagerai mes pires échecs techniques (choix initiaux de techno inadéquats, bugs d’intégration de données) et comment je les ai transformés en succès grâce à des pivots (React Native, Mapbox, k3s sur Hetzner). \r\n\r\nAvec une démo live et des conseils concrets, repartez inspirés pour rebondir face à vos propres erreurs.",
+          "speakers": [
+            "Thomas Roux"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=t2YMa96LomA"
+        },
+        {
+          "title": "Top 3 des outils de l'OWASP",
+          "description": "L'Open Worldwide Application Security Project (OWASP) est principalement connu pour son \"TOP 10\" qui recense les 10 risques de sécurité les plus critiques dans les applications web ( Broken Access Control, Cryptographic Failures, Injections ...). \r\nMais savez-vous que l'OWASP publie également des outils open source (et gratuits) pour nous aider à mieux prévenir ces risques et à renforcer la sécurité dans nos applications ??? \r\nLors de cette session, nous examinerons 3 de ces outils en action et nous verrons comment ils peuvent contribuer à renforcer la sécurité d'une application à chaque étape de son cycle de vie (développement, test, déploiement).\r\n- Dependency-Track: Un outil permettant d'analyser, de suivre et de gérer les dépendances logicielles de vos applications\r\n- Zed Attack Proxy (ZAP): Un outil pour lancer des tests de sécurité et identifier de potentielles failles sur n'importe quelle application web.\r\n- Mod-Security: Un module qui joue le role de Web Application Firewall (WAF) et qui peut être facilement utilisé dans un proxy pour déjouer les attaques les plus courantes.",
+          "speakers": [
+            "Florian Bernard"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire"
+        },
+        {
+          "title": "Sous le capot des LLMs : toutes ces questions que vous n'avez jamais osé poser à leur sujet",
+          "description": "Les grands modèles de langage (LLM) ont pris d'assaut le monde, alimentant des applications allant des chatbots à la génération de contenu. Pourtant, sous le capot, ces modèles restent énigmatiques.\r\n\r\nCette présentation plongera dans les recoins cachés de la technologie des LLMs qui laissent souvent les développeurs perplexes. Il est temps de poser ces questions que vous n'avez jamais osé poser sur les mystères à la base des LLMs !\r\n\r\nVoici quelques questions auxquelles nous répondrons : \r\n- Vous vous demandez pourquoi les LLM crachent des tokens au lieu de mots ? D'où viennent ces tokens ? \r\n- Pourquoi ne sont-ils pas toujours très intelligents en mathématiques ? \r\n- Quelle est la différence entre un modèle \"fondamental\" / \"pré-entraîné\" et un modèle \"fine-tuné\" ? \r\n- Comment un modèle sait-il quand il a fini de répondre à votre question ? \r\n- Nous ajustons souvent des hyperparamètres comme la température, top-p, top-k, mais savez-vous vraiment comment ils affectent le choix des tokens ?\r\n- Les LLM sont bons en traduction, n'est-ce pas ? Parlez-vous aussi le langage Base64 ? Et le dauphin ?\r\n\r\nNous réaliserons ensemble que les LLM sont loin d'être parfaits : \r\n- Nous avons tous entendu parler d'hallucinations, ou devrions-nous dire de confabulations ? \r\n- Avez vous entendu parler de la “reversal curse” qui fait que les LLM ignorent certains faits d'un point de vue différent ? \r\n- On pourrait penser que les LLM sont déterministes à basse température, mais vous seriez également surpris de voir comment le contexte influence les réponses des LLM...\r\n\r\nAttachez vos ceintures, il est temps de dissiper la magie des LLM et de poser ces questions que nous n'avons jamais osé poser !\r\n",
+          "speakers": [
+            "Guillaume Laforge"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=wIM57aP-5Yw"
+        },
+        {
+          "title": "Signaux faibles d'une révolution vocale dans les IHM",
+          "description": "Cette conférence propose, en 15 minutes, un regard prospectif sur l’évolution des interactions homme-machine, en s’intéressant particulièrement à l’essor des interfaces vocales, largement encouragées par l’industrie technologique avec l’émergence des IA conversationnelles.\r\n\r\nDes premières interfaces clavier-souris aux écrans tactiles qui ont introduit de nouveaux gestes, les modes d’interaction ont toujours évolué. Si les commandes vocales peinent encore à s’imposer, les mutations des usages sociaux et les avancées de la génération d’IA pourraient bien amorcer une nouvelle ère pour les interactions vocales.\r\n\r\nÀ travers des exemples concrets et une mise en perspective d'usages sociaux émergents, cette intervention invite à réfléchir à l’avenir des interactions homme-machine. Une courte exploration pour mieux comprendre ce que la voix pourrait bientôt changer dans notre façon d’interagir avec la technologie.",
+          "speakers": [
+            "Simon Gomez"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=NbF_dnZ9na0"
+        },
+        {
+          "title": "REX: une approche moderne de gestion de clusters Kubernetes",
+          "description": "Il y a un an et demi, une question simple est arrivée sur notre Slack SRE:\r\n\"Pourquoi est-ce qu’on passe encore autant de temps à mettre à jour nos clusters Kubernetes?\"\r\n\r\nChez Qonto, ce défi était bien réel. Aujourd’hui, on opère 15 clusters Kubernetes, plus de 20 000 pods et nous déployons 200 fois en production par jour. Comme beaucoup, on avait accumulé outils, scripts et hacks, jusqu’à rendre notre infrastructure difficile à maintenir, coûteuse et peu résiliente.\r\n\r\nDans ce talk, nous vous présenterons comment nous avons repensé notre stack Kubernetes de bout en bout, de la création du cluster au déploiement applicatif:\r\n\r\n- Création des clusters via Terraform\r\n- Architecture 100 % GitOps avec ArgoCD\r\n- Déploiement multi-clusters pour la tolérance aux pannes, tout en gardant la possibilité d'avoir des configurations spécifiques par cluster\r\n- Migration sur Karpenter pour la gestion des noeuds (ARM, GPU, Spot...), avec reconstruction automatique de l'ensemble de notre infrastructure toutes les 24 heures\r\n\r\nRésultat: 50% d’économies sur la facture cloud, un temps de maintenance grandement réduit, et une production bien plus résiliente même en cas de perte complète d'un cluster.\r\n\r\nPas besoin d’avoir 15 clusters pour assister à ce talk: que vous soyez SRE, DevOps ou architecte, repartez avec des idées concrètes pour moderniser la gestion de Kubernetes.",
+          "speakers": [
+            "Thomas Martin",
+            "Alexandre Dias"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=SMeZAl3JMws"
+        },
+        {
+          "title": "Rewrite It In Rust: peut-on RIIR de tout ?",
+          "description": "Oui !  \r\nDe la startup aux multinationales, Rust a su convaincre, et ce n’est pas surprenant : il cible tout, ou presque Microcontrôleurs, systèmes distribués, CLI, applications desktop ou web.\r\n\r\nRust combine la puissance des langages système avec une sécurité qu’une JVM rêverait d’avoir.\r\n\r\nVenez découvrir ces possibilités, et comment peut-on faire cohabiter Rust avec Python, le Web ou d’autres écosystèmes.\r\n\r\n[RIIR: Have you considered Rewriting It In Rust?](https://transitiontech.ca/random/RIIR)",
+          "speakers": [
+            "Igor Laborie"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=cxVxFBw7Tio"
+        },
+        {
+          "title": "Renovate à la rescousse 🦸: Automatisez la dette technique de votre infra Kubernetes",
+          "description": "Maintenir une infrastructure moderne peut rapidement devenir chronophage. Entre la surveillance des nouvelles versions, l'analyse des changelogs, et la distinction entre mises à jour mineures et majeures, la gestion de multiples outils peut vite s'avérer complexe. \r\nAvec Kubernetes, cette complexité s'accroît : Ingress controller, Cert Manager, stacks de supervision, et bien d'autres composants techniques doivent être maintenus à jour.\r\n\r\nIl y a des chances que cette situation vous parle.\r\n\r\nAvez vous déjà entendu parler de Renovate ? \r\nC'est un outil populaire principalement connu pour automatiser les mises à jour des dépendances applicatives (Maven, NPM, etc.). \r\nMais saviez-vous qu'il excelle également dans la gestion des dépendances liées à l'Infrastructure as Code et au Continuous Delivery ?\r\n\r\nDans ce talk, je vous montrerai comment Renovate peut vous aider à automatiser la mise à jour :\r\n- De vos providers Terraform/OpenTofu.\r\n- Des requirements Ansible de vos playbooks.\r\n- De votre stack d'outils techniques.\r\n\r\nPour illustrer cela, je vous propose une démo basée sur la mise à jour des composants d'une plateforme déjà existante composée :\r\n- D'un cluster Kubernetes provisionné avec Terraform/OpenTofu et configuré avec Ansible.\r\n- D'une stack technique déployée à l'aide d'Helm et d'ArgoCD.\r\n\r\nVous n'aurez plus d'excuses pour ne pas utiliser Renovate 😉",
+          "speakers": [
+            "Paul Vulliemin"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "confirmé",
+          "youtube": "https://www.youtube.com/watch?v=1U3PwCzHYGo"
+        },
+        {
+          "title": "Quand l'IA rejoint le Calcul Haute Performance (ou High Performance Computing)",
+          "description": "L’entraînement de certains modèles d’IA nécessite une puissance de calcul considérable, souvent comparable à celle des grands codes de simulation scientifique, utilisateurs historiques du calcul haute performance (prédictions météo, modèles cosmologiques, pour ne citer qu’eux).\r\nPourtant, le monde de l’IA, dominé par les notebooks, les bibliothèques Python et les frameworks comme PyTorch ou TensorFlow, semble parfois éloigné des environnements traditionnels du calcul haute performance (HPC), avec leurs ordonnanceurs de travaux (ou batch schedulers) qui introduisent les notions de files d’attente, et leurs infrastructures complexes (supercalculateurs).\r\nJe vous propose un retour d’expérience sur les solutions mises en place dans notre mésocentre de calcul à Toulouse (CALMIP) pour faciliter l’accès à la puissance du HPC aux utilisateurs IA.\r\nGrâce à des outils qui permettent d’utiliser Jupyter Notebooks sur le cluster (ou supercalculateur), des environnements préconfigurés avec les bibliothèques IA les plus utilisées, et la possibilité d’utiliser plusieurs GPUs et plusieurs nœuds, les utilisateurs peuvent tirer parti des performances du HPC sans être experts du domaine.\r\nÀ l’aide d’outils simples, nous verrons comment l’utilisateur peut observer le comportement du cluster une fois le calcul lancé : le calcul utilise-t-il efficacement toutes les ressources allouées ? Nous aborderons les notions de performance parallèle et de scalabilité pour déterminer s’il est pertinent d’ajouter plus de GPUs ou si cela n’apporte rien. Pour finir, nous nous poserons aussi la question de l’efficacité énergétique du calcul.",
+          "speakers": [
+            "Alejandro Estana"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=GU3_WeC3gnQ"
+        },
+        {
+          "title": "Parlez à vos données (sans coder) : IA agentique et Claude avec le protocole MCP",
+          "description": "L’agent conversationnel de demain n’est pas un chatbot. C’est un collègue virtuel qui comprend vos données, déclenche des actions, et répond à vos utilisateurs métier… sans une ligne de code côté intégration.\r\nDans cette conférence, je vous montrerai comment j’ai connecté Claude Desktop à MongoDB via le Model Context Protocol (MCP) pour lancer une analyse client en langage naturel — sans prompt engineering, sans chaînes LangChain, sans SDK.\r\nDe “Montre-moi mes bases MongoDB” à “Prépare-moi des insights pour une campagne luxe”, en une seule conversation.\r\nDémo live avec configuration simple, requêtes naturelles, réponses enrichies.\r\nMais cette magie a un prix : le protocole MCP pose aussi de vrais défis de sécurité.\r\nMémoire partagée, outils non validés, absence de versioning… Une architecture agentique mal sécurisée peut devenir un cauchemar silencieux.\r\nJe partagerai également les leçons de la Agent Security Framework proposée par la communauté pour fiabiliser ces architectures.\r\nVous découvrirez :\r\n\t•\tComment brancher Claude à vos données en 5 minutes\r\n\t•\tComment MCP redéfinit l’intégration des agents IA\r\n\t•\tEt pourquoi la sécurité doit être pensée dès maintenant",
+          "speakers": [
+            "Han Héloir"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=Be_0YSvN0cU"
+        },
+        {
+          "title": "Orchestrer un Univers de Jeu de Rôle avec des Agents IA Multi-Containers",
+          "description": "Et si nous pouvions créer un univers de jeu de rôle entièrement peuplé d'agents IA \"intelligents\" 😂, chacun évoluant dans son propre container 🐳 Docker ? Dans cette présentation, nous vous montrerons comment transformer Docker Desktop en véritable plateforme de simulation RPG 🏰.\r\n\r\nÀ l'aide de **Docker Model Runner**, **Docker MCP Toolkit**, et **Docker Compose**, nous déploierons un écosystème complet où chaque protagoniste du jeu devient un agent IA autonome :\r\n\r\n- **PNJ (Personnages Non-Joueurs)** : Chaque habitant, marchand, ou allié dispose de sa propre personnalité et mémoire\r\n- **Monstres du Donjon** : Des adversaires dotés de comportements adaptatifs et d'intelligence tactique (mais en fait pas pour cette présentation, ils se contenteront de lancer des dés)\r\n- **Maître du Jeu (MDJ)** : Un agent avec la vision globale de tous le jeu gérant déplacements (et donc la carte du donjon), combats, points de vie et règles du jeu (tout cela grâce à **MCP**)\r\n\r\nGrâce au **Model Context Protocol (MCP)** et aux techniques de **RAG (Retrieval-Augmented Generation)**, nos agents partageront une mémoire collective (au moment où nous écrivons, nous ne savons pas si c'est utile dans ce contexte - mais techniquement ça a de l'intérêt - et je devine que pour le bosse de fin de niveau ça pourrait être utile). Le protocole **A2A (Agent-to-Agent)** permettra les interactions  entre protagonistes (vous savez, mes agents - ok **A2A** c'est un peu nouveau, mais d'ici Novembre, on en sera probablement à la v3 de la spécification et c'est plutôt simple à mettre en oeuvre).\r\n\r\nNous vous montrerons comment **Docker Compose** orchestre (avec brio ... avec qui?) cette horde d'agents, permettant un déploiement simple et scalable (par ex: déploie une meute de 5 jeune loups garous dans la salle des murmures). \r\n\r\nCette présentation est le prétexte de faire découvrir aux participants :\r\n\r\n- L'architecture multi-containers pour agents IA\r\n- L'intégration Docker Model Runner avec MCP (et surtout le MCP Toolkit)\r\n- Les patterns de communication inter-agents\r\n- La gestion de la persistance et de la mémoire partagée avec du RAG et Redis V8 et son support des Vecteurs\r\n- ...\r\n\r\nIl n'y aura pas de slides ! Uniquement de la démo, du code, du Markdown, du VSCode et du Docker Desktop du premier `docker compose up` jusqu'aux dernières interactions avec le boss de fin de niveau. ",
+          "speakers": [
+            "Philippe Charrière",
+            "Guillaume Lours"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=Aj1FtC6HEdY"
+        },
+        {
+          "title": "Embellir des QR Codes à l’ère de la GenAI",
+          "description": "Découvrez comment l'intelligence artificielle générative (GenAI) révolutionne la personnalisation des QR Codes. Cette présentation met en lumière les fondements techniques des QR Codes et montre, via des démonstrations pratiques, comment des outils comme Stable Diffusion et ComfyUI permettent de créer des QR Codes uniques qui allient fonctionnalité et esthétique. Le tout en local sur un PC. Plongez dans un futur où chaque scan devient une expérience visuelle engageante.",
+          "speakers": [
+            "Raphaël Semeteys"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=1052vjmxCTI"
+        },
+        {
+          "title": "Docker Bake, élégance et standardisation pour le build de vos images Docker",
+          "description": "Construire des images Docker, nous sommes nombreux à le faire avec la bonne vieille commande docker build. Ça marche, mais ça peut vite devenir verbeux, peu lisible, et pénible à maintenir, surtout lorsque l'on doit gérer plusieurs architectures comme ARM et AMD, ou passer à l’échelle dans une CI.\r\n\r\nBonne nouvelle : Docker a introduit Docker Bake, une façon standard, élégante et efficace de décrire vos builds avec du HCL ou du YAML. C’est propre, lisible, modulaire et surtout pensé pour l’automatisation.\r\n\r\nBake étant basé sur Buildx, les temps de build sont optimisés.\r\n\r\nDans ce talk, nous commencerons par la méthode classique : deux images, du multi-archi, un peu de lourdeur. Puis nous referons tout ça avec Docker Bake : des variables, des targets, une config unique et une publication dans une registry sur le cloud.\r\n\r\nNous verrons comment tout ça tourne en local, puis dans une CI comme Cloud Build, GitHub Actions et Gitlab CI.\r\n\r\nAprès ce talk, vous aurez (on l’espère !) envie de laisser tomber vos docker build à rallonge pour adopter Docker Bake dans vos projets et rendre vos builds plus simples, élégants et efficaces.",
+          "speakers": [
+            "Mazlum Tosun"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=iC5ovhVhaLI"
+        },
+        {
+          "title": "Dessine-moi un logiciel (ou l’art des schémas qui marquent les esprits)",
+          "description": "Une flèche sur un schéma, ça veut dire quoi exactement ? \"Appel de fonction\" ? \"Flux de données\" ? \"C’est compliqué mais fais-moi confiance\" ? Spoiler : personne ne lit les flèches de la même façon. Et c’est là que les ennuis commencent.\r\n\r\nDans cette session, on parlera d’impact visuel : comment faire des schémas qui ne perdent pas leur lecteur au bout de deux bulles, qui savent pitcher une idée en 10 secondes, et qui peuvent même (soyons fous) déclencher un \"OK je vois\" en réunion.\r\n\r\nJe partagerai des retours d’expérience, des erreurs vues (et faites), et des astuces simples et opérables pour rendre vos diagrammes aussi efficaces qu’un argument bien formulé : limpides, percutants, et convaincants.",
+          "speakers": [
+            "Fabien Marty"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=IX8zjvRr1Ds"
+        },
+        {
+          "title": "Démystifier OAuth2 et OIDC",
+          "description": "Avec l'utilisation de plus en plus des APIs dans les échanges entre les différentes briques applicative, que ce soit intra-application(front-to-back) ou inter-application (back-to-back), les sujets liés de l'Authentification, l'Identification et l'Authorisation arrivent très rapidement dans l'implémentation.\r\n\r\nLe protocole OAuth2 et OIDC sont les références et standard par contre leur complexité les rend compliqué à maitriser par les développeurs et les architectes.\r\n\r\nMalgré que le sujet parrait basique ou simple, les nombreux projets chez des clients j'ai mis en place OAuth2 m'ont permis de voir que la simplicité de premier abord cache une complexité dans la mise en place et dans l'utilisation.\r\n\r\nDans ce talk, je ferai une analogie avec un exemple du monde réel (une ferme de vente directe de fruit et légumes) pour expliquer les différents concepts d'OAuth (grant type, authorization server, resources, ...). Nous découvrons ensemble un arbre de décision qui vous aidera à choisir le bon grant type pour votre cas d'utilisation et présenterai l'enchainement à suivre pour l'implémentation de ces grant type.\r\n",
+          "speakers": [
+            "Nejmeddine Ben Ouarred"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=Q8KHI7t4Ws4"
+        },
+        {
+          "title": "Démêler vrais produits et hallucinations, REX d'un agent téléphonique chercheur de chaussettes",
+          "description": "Avez-vous déjà essayé de retrouver un produit au nom absurde dans un moteur de recherche ? Heureusement qu'il y a de l'auto-complétion, les filtres, les menus… Mais comment faire quand tout se passe au téléphone, sans écran, sans clics, juste avec la voix ?\r\n\r\nIl y a 18 mois, un client nous a lancé un défi : permettre à des pharmaciens de commander des produits aux noms imprononçables (des bas de contention) par téléphone, via un agent vocal, et de manière fluide.\r\n\r\nLa solution ? Des LLMs, bien sûr, mais aussi beaucoup de travail sur la structuration des agents, la recherche full-text, et l’expérience vocale en temps réel.",
+          "speakers": [
+            "Marie Terrier"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=oklVnHiILkU"
+        },
+        {
+          "title": "De zéro à Data as a Product en 60 jours : anatomie d’un lancement data produit réussi",
+          "description": "Comment transformer un gisement de données internes en véritable produit, exploité, monétisé… en moins de deux mois ?\r\nCe talk, c’est le retex brut d’un sprint mené dans un grand groupe du CAC40, avec une contrainte simple : livrer vite, sans renier l’impact.\r\n \r\nPas de framework magique, pas de buzzword. Juste un projet mené tambour battant : MVP cadré sur de l'essentiel, stack montée au plus simple, premiers retours users dès la troisième semaine. Et surtout, une lutte constante contre le piège du “on pourrait aussi faire ça…”\r\n \r\nOn parlera product thinking appliqué à la donnée, arbitrages serrés, feedback utilisateurs dès la semaine 3, et premières ventes en semaine 8, de comment chaque personne de l'équipe a vécu cette aventure et les leçons tirées par le métier, la tech, le design et le produit.\r\n\r\nMais surtout, on parlera de comment faire simple, solide et vendable dans un environnement où l’inertie est souvent la norme.\r\n \r\nÀ celles et ceux qui se demandent encore si la donnée peut devenir un vrai produit : venez voir ce que ça donne quand on arrête d’en parler et qu’on le fait.",
+          "speakers": [
+            "Maria-Eliza Paez"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=kmT__Ckz2X0"
+        },
+        {
+          "title": "Conception de logiciels : le match humains vs AI",
+          "description": "L’IA générative peut-elle vraiment rivaliser avec les humains dans les décisions de conception logicielle ?  \r\nMais, d'abord, c'est quoi une bonne conception logicielle ?\r\n\r\nJe vous propose de participer à une conférence interactive où vous serez confrontés à une série de situations concrètes et où vous devrez faire des choix de conception. Quelle solution est la plus simple ? La plus maintenable ? À chaque étape, vous voterez via une web app. Les décisions de l’assemblée seront comparées en direct à celles choisies par les IAs et nous en ferons l'analyse.\r\n\r\nNul besoin de connaître une techno ou un langage particulier - promis, il n'y aura même pas de diagramme UML. Les situations sont volontairement indépendantes de tout élément technique pour mettre tout le monde sur un pied d’égalité et se concentrer sur les principes et activités de conception : couplage/cohésion, SOLID, smells, refactoring...\r\n\r\nVenez profiter d'un moment ludique avec ce format participatif pour explorer des principes de conception, vivre des choix complexes, faire mieux que les IAs (on l'espère) et apprendre, ensemble, à mieux concevoir.",
+          "speakers": [
+            "Olivier Azeau"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=CmYN9fEeCDw"
+        },
+        {
+          "title": "Codepocalypse Now: LangChain4j vs. Spring AI",
+          "description": "Which Java framework handles AI better: LangChain4j or Spring AI? In this live coding showdown, we’ll build a semantic code search application from scratch, putting both frameworks to the test. We’ll cover project setup, using language models, setting up a retrieval-augmented generation workflow, and creating a REST API.\r\n\r\nYou’ll see how these frameworks handle embedding generation, vector database integration, and real-world development challenges. By the end, the audience decides who wins—based on which framework gets the job done faster, better, and with less hassle (and whether the demo actually works).\r\n\r\nThis isn’t just a comparison; it’s a live experiment under pressure. Come and see which one comes out on top!",
+          "speakers": [
+            "Baruch Sadogursky",
+            "Viktor Gamov"
+          ],
+          "language": "en",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=wDKzRI8bT6Y"
+        },
+        {
+          "title": "Au Coeur d'une Core Team",
+          "description": "Tous les projets majeurs en informatique open source disposent d’une « core team » : Laravel, Symfony, Doctrine, Rector… Cette équipe, composée d’une personne à plusieurs dizaines parfois, s’occupe de faire avancer le projet dans une direction commune, le maintenir, publier les releases… bref, s’assurer que tout se passe bien et que les choses avancent.\r\n\r\nAu-delà de ça, les mainteneurs font un travail véritablement titanesque dans l’obscurité, pour que vous n’ayez jamais à vous préoccuper que quoique ce soit et vous permettre de « composer update » sans jamais craindre de réécrire votre application en entier.\r\n\r\nIl est temps de mettre en lumière ce travail de l’ombre : quels sont les « chores » auxquelles s’adonnent les maintainers de logiciels libre, les challenges pour assurer une compatibilité grandissante tout en restant au top de l’innovation et des nouveautés ? En avant pour une immersion dans le quotidien d’une équipe à l’origine d’un projet à 30 000 000 de téléchargement par jour !",
+          "speakers": [
+            "Alexandre Daubois"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=kY_nDdPQaRM"
+        },
+        {
+          "title": "Du chaos à l’élégance : refactorer des workflows complexes avec des events",
+          "description": "Imaginez un tunnel de vente pour le tournoi de Roland-Garros où chaque paiement et chaque validation se déroulent de manière fluide et sans accroc, débarrassé des pièges de complexité inutile : c’est exactement ce que nous allons explorer ensemble aujourd'hui.\r\n\r\nDes nœuds au cerveau, de la complexité accidentelle, des tests illisibles, c’est ce qui m’est arrivé en implémentant le tunnel de vente du tournoi.\r\nJ’étais empêtré dans de nombreux scénarios de tests unitaires pour couvrir chaque possibilité d’erreur dont la mise en place et la maintenance étaient devenues très complexes.\r\n\r\nJ’ai alors décidé de refactorer ce workflow avec la mise en place du pattern Observer (event producer et event listener) qui m’a permis de découpler chaque étape du workflow.\r\n\r\nDans ce retour d’expérience, je vous présenterai les différents scénarios qu’il m’a fallu couvrir : paiement avec ou sans 3DS, erreur de la validation de la commande, échec de remboursement…\r\n\r\nEnfin, lors d’un live coding, je vous montrerai comment refactorer ce workflow implémenté avec un orchestrateur complexe en une chorégraphie. Vous pourrez voir comment cela simplifie l'écriture du code et des tests. Vous pourrez voir comment cela simplifie l'écriture du code et des tests.",
+          "speakers": [
+            "Thibaut Cantet"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=rMVspnnGuH4"
+        },
+        {
+          "title": "Apprentissage interactif et IA centrée utilisateur : retour d'expérience",
+          "description": "Imaginez un environnement numérique capable de composer des applications à la volée, en utilisant les objets connectés autour de vous.\r\nUn système qui s’adapte à votre contexte… et apprend de vos retours.\r\nC’est ce que nous explorons dans un projet de recherche en intelligence ambiante. Nous cherchons à développer un système basé sur une architecture multi-agent qui utilise l’apprentissage par renforcement pour s’adapter, en tenant compte des interactions avec l’utilisateur. Il assemble dynamiquement les composants logiciels disponibles dans l'environnement (capteurs, services métiers, interfaces...) pour proposer des applications qui tiennent compte des préférences apprises de  l’utilisateur.\r\nNous avons conçu un moteur de composition opportuniste – appelé OCE pour « Opportunistic Composition Engine » – capable d’adapter ses propositions en fonction du contexte et de l’utilisateur.\r\nDans un premier temps nous présenterons l’architecture distribuée et le fonctionnement d’OCE. Nous détaillerons comment le système apprend et s’améliore grâce aux interactions avec l’utilisateur.\r\nPuis nous nous focaliserons sur une de nos questions de recherche portant sur l’interaction humain-IA. Nous traiterons en particulier du cas de l’incertitude, c’est-à-dire des méthodes d’interaction possibles lorsque le système hésite entre plusieurs choix et de l’impact sur l’expérience utilisateur.\r\nPour illustrer cette question, nous partagerons une expérimentation menée auprès de plus de 150 utilisateurs, dans laquelle un utilisateur assisté d’OCE se déplace dans un campus universitaire simulé.\r\nÀ l’issue de la présentation, vous aurez un aperçu concret des défis liés à  la conception et à l’évaluation de systèmes à base de machine learning interactif.",
+          "speakers": [
+            "Trouilhet Sylvie",
+            "Kevin Delcourt"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=HX_ohsFjoQQ"
+        },
+        {
+          "title": "Another World, une belle leçon d’architecture logicielle",
+          "description": "Sorti il y a près de 35 ans, en 1991, le jeu Another World est bien plus qu’un jeu culte : c’est une prouesse tant technique qu'artistique. Portée par la vision singulière d’Éric Chahi, alors jeune développeur d'à peine 22 ans, sa réalisation cache une architecture logicielle très audacieuse et résolument moderne : une machine virtuelle sur mesure pensée pour contourner les limites matérielles de l’époque, faciliter le développement et le portage, tout en offrant une expérience de qualité cinématographique jusqu'alors inédite.\r\n\r\nDans ce talk nous décortiquerons l’architecture logicielle de ce jeu vidéo culte, en explorant les choix de conception, sa machine virtuelle et son langage intermédiaire. Nous verrons comment cette approche visionnaire a permis à ce jeu culte d’être porté à travers les décennies, jusqu'à mon portage pour le faire fonctionner dans un navigateur web grâce au WebAssembly.\r\n\r\nUne belle leçon d'architecture logicielle qui pourrait vous inspirer pour vos développements ...",
+          "speakers": [
+            "Olivier Poncet"
+          ],
+          "language": "fr",
+          "format": "keynote",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=QCnYO5bOmmY"
+        },
+        {
+          "title": "Accroître l’accessibilité de son application pour l’optimiser à l’ensemble de ses utilisateurs",
+          "description": "L'accessibilité est une obligation légale depuis 20 ans et concerne jusqu'à 30 millions de personnes en France. Elle consiste en la conception d'une application utilisable par tous, même par les utilisateurs en situation de handicap.\r\n\r\nLe handicap peut avoir beaucoup de formes, aussi bien physiques (par exemple cécité, motricité, etc.) que numériques (utilisateurs en zone blanche, téléphone obsolète, etc.).\r\n\r\nEn travaillant sur une application grand public de la métropole toulousaine, j'ai été confronté à ces différentes problématiques liées à l'accessibilité.\r\n\r\nCette présentation va être l'occasion de faire un retour d'expérience sur leur prise en compte et l'impact positif sur la qualité globale de l'application, même pour les utilisateurs n'ayant aucun handicap.\r\n\r\nPour ce faire, une liste non exhaustive des handicaps va être présentée et pour chaque handicap, nous allons voir : \r\n\r\n\r\n- La proportion d'utilisateurs concernés\r\n- Les outils à utiliser\r\n- Des exemples d'implémentation de solutions sur iOS\r\n- Comment tester ces solutions \r\n- Des bests practices\r\n- Les pièges à éviter\r\n\r\nMais surtout, pour chaque point, vous verrez comment la prise en compte du handicap bénéficie à l'ensemble des utilisateurs de votre application.\r\n\r\nAprès cette présentation, vous pourrez auditer vous même votre application et l'améliorer pour la rendre plus accessible.\r\n\r\nEn outre, vous aurez les clés pour vous rendre compte qu'améliorer l'accessibilité ne fait pas que rendre votre application plus inclusive, mais améliore grandement l'UI/UX, diminue les coûts de maintenance ou encore augmente la rétention des utilisateurs.",
+          "speakers": [
+            "Kevin Abrioux"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=GnBpk9UemBA"
+        },
+        {
+          "title": "A la découverte de la famille des modèles BERT",
+          "description": "Pionnier des grands modèles de langage (LLM), BERT, développé par Google en 2018, a ouvert de nouvelles perspectives dans le domaine du NLP et est aujourd’hui considéré comme la base de nombreuses avancées en traitement automatique du langage.\r\n\r\nNous déconstruirons son architecture fondée sur les transformers puis, nous plongerons dans les détails de son entraînement : masquage de mots (Masked LM - MLM) et prédiction de la phrase suivante (NSP - Next Sentence Prediction).\r\n\r\nNous illustrerons ses capacités à travers deux cas d'usage en utilisant des modèles pré-entrainés disponible dans Keras Hub :\r\n- la détection de catastrophes dans des tweets,\r\n- l'inférence de relations sémantiques entre des paires de phrases (implication/contradiction/neutralité de textes multilingues avec le jeu de données \"Elémentaire, mon cher Watson\")\r\n\r\nRoBERTa, CamemBERT, FlauBERT, DistilBERT n'auront plus aucun secret pour vous !\r\n",
+          "speakers": [
+            "Alexia Audevart"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=LRLmZp7gEPA"
+        },
+        {
+          "title": "45 min pour mettre son application à genoux : le guide complet du test de charge",
+          "description": "“Le test de charge, c’est souvent celui qu’on fait trop tard”\r\nDans notre quotidien, on a rencontré beaucoup de contextes où les équipes se sentaient démunies face à des incidents de prod, et n’avaient pas forcément la culture du test de charge.\r\nQuand on entend autour de nous qu’il faut tester son code, on parle la plupart du temps de Tests Unitaires ou d’Intégration. Et pourtant, à l’heure des architectures micro-services, il n’a jamais été aussi important de rester en maitrise de son système distribué. Dans un système critique, il est vital de connaitre ses limites et sa capacité, d’avoir une compétence sur ce qu’il se passe lorsqu’un système “chauffe”, et c’est là que les tests de charge prennent toute leur importance.\r\nNon seulement les équipes qu’on a formées au test de charge trouvent ça très ludique, mais surtout elles progressent beaucoup dans la maitrise de leur environnement technique (Threads, JVM, DB, configuration, isolation de bottlenecks etc…).\r\nL’objectif de ce talk est d’offrir cette première maitrise qui permettra à chacun de repartir avec une nouvelle compétence : la capacité de mettre en oeuvre un test de charge sur un environnement complexe.",
+          "speakers": [
+            "Loïc Ortola",
+            "Mathilde Lorrain"
+          ],
+          "language": "fr",
+          "format": "conference",
+          "complexity": "intermédiaire",
+          "youtube": "https://www.youtube.com/watch?v=rBlG3Rsb3YI"
+        },
+        {
+          "title": "\"Sésame, ouvre-toi\" : sécurise ton serveur SSH avec du Port Knocking !",
+          "description": "• Vous exposez un port SSH publiquement ?\r\n• Vous vous faites spammer par des robots qui tentent désespérément de se connecter à votre serveur ?\r\n• Vous suez à chaque nouvelle CVE concernant OpenSSH ?\r\n\r\nLe port knocking peut être une solution à vos maux !\r\n\r\nDans ce talk vulgarisé et pédagogique de 15 minutes, vous apprendrez à utiliser une séquence secrète, à la manière d’Ali Baba prononçant le fameux \"Sésame, ouvre-toi\", pour révéler votre port SSH uniquement sur demande.\r\n\r\nMais attention ! Pour éviter la même erreur que les 40 voleurs (qui gardaient la même séquence, permettant à Ali Baba de la réutiliser), nous irons plus loin en rendant cette formule magique dynamique, à la manière d’un mot de passe à usage unique (TOTP), pour rendre votre système plus sécurisé.",
+          "speakers": [
+            "Paul Jeannot"
+          ],
+          "language": "fr",
+          "format": "quickie",
+          "complexity": "débutant",
+          "youtube": "https://www.youtube.com/watch?v=OsUaE4kSoc8"
+        }
+      ]
+    }
+  }
+}

--- a/src/backend/prisma/import-history.ts
+++ b/src/backend/prisma/import-history.ts
@@ -1,0 +1,208 @@
+// Import past editions (2016-2025) from data/devfest-history.json into the
+// Speaker / Talk / Edition tables (issue #63). Idempotent and re-runnable on any
+// instance (local / beta / prod): entities are matched by (editionId, slug), so
+// running it twice updates instead of duplicating.
+//
+// Usage (from src/backend/):
+//   pnpm exec tsx prisma/import-history.ts [path-to-history.json]
+//   default path: prisma/devfest-history.json (shipped alongside the script so
+//   it is present on every deployed instance — local, beta, prod).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { prisma } from "../src/lib/prisma.js";
+import { slugify, uniqueSlug } from "../src/lib/slug.js";
+import {
+  buildSocialLinks,
+  normalizeFormat,
+  normalizeLevel,
+  normalizeLanguage,
+  normalizePhotoUrl,
+  type HistoryData,
+} from "../src/lib/history-import.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const defaultPath = resolve(here, "devfest-history.json");
+const jsonPath = process.argv[2] ? resolve(process.argv[2]) : defaultPath;
+
+interface Report {
+  editions: { created: number; updated: number };
+  speakers: { created: number; updated: number };
+  talks: { created: number; updated: number };
+  links: number;
+  warnings: string[];
+}
+
+async function main() {
+  const raw = readFileSync(jsonPath, "utf8");
+  const data = JSON.parse(raw) as HistoryData;
+  if (!data.editions || typeof data.editions !== "object") {
+    throw new Error("Invalid history file: missing `editions` object.");
+  }
+
+  const report: Report = {
+    editions: { created: 0, updated: 0 },
+    speakers: { created: 0, updated: 0 },
+    talks: { created: 0, updated: 0 },
+    links: 0,
+    warnings: [],
+  };
+
+  for (const [yearStr, ed] of Object.entries(data.editions)) {
+    const year = Number(yearStr);
+    if (!Number.isInteger(year)) {
+      report.warnings.push(`Édition ignorée: année invalide "${yearStr}".`);
+      continue;
+    }
+
+    // 1. Upsert the Edition. Past editions are completed → SEE_YOU_NEXT_YEAR.
+    const startDate = ed.date ? new Date(`${ed.date}T09:00:00.000Z`) : null;
+    const existingEdition = await prisma.edition.findUnique({ where: { year } });
+    const edition = await prisma.edition.upsert({
+      where: { year },
+      create: {
+        year,
+        startDate,
+        status: "SEE_YOU_NEXT_YEAR",
+        venueName: ed.venue || null,
+      },
+      update: {
+        // Only fill venue/date if missing, to avoid clobbering manually-set data.
+        ...(existingEdition?.venueName ? {} : { venueName: ed.venue || null }),
+        ...(existingEdition?.startDate ? {} : { startDate }),
+      },
+    });
+    if (existingEdition) report.editions.updated++;
+    else report.editions.created++;
+
+    // 2. Upsert speakers, keyed by slug; remember name -> db id for linking.
+    const existingSpeakers = await prisma.speaker.findMany({
+      where: { editionId: edition.id },
+      select: { id: true, slug: true },
+    });
+    const takenSpeakerSlugs = new Set(existingSpeakers.map((s) => s.slug));
+    const speakerSlugToId = new Map(existingSpeakers.map((s) => [s.slug, s.id]));
+    const idByName = new Map<string, number>();
+
+    for (const sp of ed.speakers) {
+      const name = sp.name?.trim();
+      if (!name) {
+        report.warnings.push(`${year}: speaker sans nom ignoré.`);
+        continue;
+      }
+      const baseSlug = slugify(name);
+      const social = buildSocialLinks(sp.socials);
+      report.links += Object.keys(social).length;
+      const photoUrl = normalizePhotoUrl(sp.photoUrl);
+      const bioFr = sp.bio?.trim() || null;
+
+      const existingId = speakerSlugToId.get(baseSlug);
+      if (existingId) {
+        await prisma.speaker.update({
+          where: { id: existingId },
+          data: {
+            name,
+            company: sp.company?.trim() || null,
+            city: sp.city?.trim() || null,
+            bioFr,
+            photoUrl,
+            socialLinks: Object.keys(social).length ? JSON.stringify(social) : null,
+            publicationStatus: "PUBLISHED",
+          },
+        });
+        idByName.set(name.toLowerCase(), existingId);
+        report.speakers.updated++;
+      } else {
+        const slug = uniqueSlug(baseSlug, takenSpeakerSlugs);
+        takenSpeakerSlugs.add(slug);
+        const created = await prisma.speaker.create({
+          data: {
+            editionId: edition.id,
+            slug,
+            name,
+            company: sp.company?.trim() || null,
+            city: sp.city?.trim() || null,
+            bioFr,
+            photoUrl,
+            socialLinks: Object.keys(social).length ? JSON.stringify(social) : null,
+            publicationStatus: "PUBLISHED",
+          },
+        });
+        speakerSlugToId.set(slug, created.id);
+        idByName.set(name.toLowerCase(), created.id);
+        report.speakers.created++;
+      }
+    }
+
+    // 3. Upsert sessions (talks), keyed by slug, linking speakers by name.
+    const existingTalks = await prisma.talk.findMany({
+      where: { editionId: edition.id },
+      select: { id: true, slug: true },
+    });
+    const takenTalkSlugs = new Set(existingTalks.map((t) => t.slug));
+    const talkSlugToId = new Map(existingTalks.map((t) => [t.slug, t.id]));
+
+    for (const s of ed.sessions) {
+      const title = s.title?.trim();
+      if (!title) {
+        report.warnings.push(`${year}: session sans titre ignorée.`);
+        continue;
+      }
+      const baseSlug = slugify(title);
+      const description = s.description?.trim() ?? "";
+      const speakerDbIds = (s.speakers ?? [])
+        .map((n) => idByName.get(n.trim().toLowerCase()))
+        .filter((id): id is number => id !== undefined);
+
+      const talkData = {
+        titleFr: title,
+        titleEn: title,
+        descriptionFr: description,
+        descriptionEn: description,
+        format: normalizeFormat(s.format),
+        level: normalizeLevel(s.complexity),
+        language: normalizeLanguage(s.language),
+        videoUrl: s.youtube?.trim() || null,
+        publicationStatus: "PUBLISHED" as const,
+      };
+
+      const existingId = talkSlugToId.get(baseSlug);
+      if (existingId) {
+        await prisma.talk.update({
+          where: { id: existingId },
+          data: { ...talkData, speakers: { set: speakerDbIds.map((id) => ({ id })) } },
+        });
+        report.talks.updated++;
+      } else {
+        const slug = uniqueSlug(baseSlug, takenTalkSlugs);
+        takenTalkSlugs.add(slug);
+        await prisma.talk.create({
+          data: {
+            editionId: edition.id,
+            slug,
+            ...talkData,
+            speakers: { connect: speakerDbIds.map((id) => ({ id })) },
+          },
+        });
+        report.talks.created++;
+      }
+    }
+
+    console.log(
+      `${year}: speakers +${report.speakers.created}/~${report.speakers.updated}, ` +
+        `talks +${report.talks.created}/~${report.talks.updated}`,
+    );
+  }
+
+  console.log("\n=== Import history report ===");
+  console.log(JSON.stringify(report, null, 2));
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error("Import failed:", err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/src/backend/prisma/migrations/20260617110927_lot4_talk_video_url/migration.sql
+++ b/src/backend/prisma/migrations/20260617110927_lot4_talk_video_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Talk" ADD COLUMN     "videoUrl" TEXT;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -486,6 +486,9 @@ model Talk {
   level            TalkLevel?
   // Spoken language of the talk, e.g. "fr" | "en".
   language         String
+  // Optional replay / recording URL (e.g. YouTube). Used for past editions
+  // (issue #63) and future ones once recordings are available.
+  videoUrl         String?
   publicationStatus PublicationStatus @default(DRAFT)
 
   // Room and time slot are assigned in Lot 3 (Programme) — optional here (RG-216).

--- a/src/backend/src/lib/history-import.test.ts
+++ b/src/backend/src/lib/history-import.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeSocial,
+  buildSocialLinks,
+  normalizeFormat,
+  normalizeLevel,
+  normalizeLanguage,
+  normalizePhotoUrl,
+} from "./history-import.js";
+
+describe("normalizeSocial", () => {
+  it("maps modern { type, url } shape", () => {
+    expect(normalizeSocial({ type: "twitter", url: "https://x" })).toEqual(["twitter", "https://x"]);
+  });
+
+  it("maps old { name, link } shape", () => {
+    expect(normalizeSocial({ name: "Twitter", link: "https://twitter.com/foo" })).toEqual([
+      "twitter",
+      "https://twitter.com/foo",
+    ]);
+  });
+
+  it("falls back to URL host when hint is generic", () => {
+    expect(normalizeSocial({ name: "@foo", link: "https://github.com/foo" })).toEqual([
+      "github",
+      "https://github.com/foo",
+    ]);
+  });
+
+  it("treats unknown links as website", () => {
+    expect(normalizeSocial({ link: "https://blog.example.com" })).toEqual(["website", "https://blog.example.com"]);
+  });
+
+  it("returns null when no url/link", () => {
+    expect(normalizeSocial({ name: "Twitter" })).toBeNull();
+  });
+});
+
+describe("buildSocialLinks", () => {
+  it("merges mixed shapes, first wins per key", () => {
+    const out = buildSocialLinks([
+      { type: "twitter", url: "https://x.com/a" },
+      { name: "github", link: "https://github.com/a" },
+      { type: "twitter", url: "https://x.com/duplicate" },
+    ]);
+    expect(out).toEqual({ twitter: "https://x.com/a", github: "https://github.com/a" });
+  });
+
+  it("handles undefined", () => {
+    expect(buildSocialLinks(undefined)).toEqual({});
+  });
+});
+
+describe("normalizeFormat", () => {
+  it("maps known formats", () => {
+    expect(normalizeFormat("keynote")).toBe("KEYNOTE");
+    expect(normalizeFormat("quickie")).toBe("QUICKIE");
+    expect(normalizeFormat("conference")).toBe("CONFERENCE");
+  });
+  it("defaults to CONFERENCE", () => {
+    expect(normalizeFormat(undefined)).toBe("CONFERENCE");
+    expect(normalizeFormat("workshop")).toBe("CONFERENCE");
+  });
+});
+
+describe("normalizeLevel", () => {
+  it("maps accented French levels", () => {
+    expect(normalizeLevel("débutant")).toBe("DEBUTANT");
+    expect(normalizeLevel("intermédiaire")).toBe("INTERMEDIAIRE");
+    expect(normalizeLevel("confirmé")).toBe("CONFIRME");
+  });
+  it("returns null for unknown/missing", () => {
+    expect(normalizeLevel(undefined)).toBeNull();
+    expect(normalizeLevel("expert")).toBeNull();
+  });
+});
+
+describe("normalizeLanguage", () => {
+  it("returns en only for en, fr otherwise", () => {
+    expect(normalizeLanguage("en")).toBe("en");
+    expect(normalizeLanguage("fr")).toBe("fr");
+    expect(normalizeLanguage(undefined)).toBe("fr");
+  });
+});
+
+describe("normalizePhotoUrl", () => {
+  it("drops local /images paths (not shipped, would 404)", () => {
+    expect(normalizePhotoUrl("/images/speakers/foo.png")).toBeNull();
+  });
+  it("keeps absolute http(s) URLs", () => {
+    expect(normalizePhotoUrl("https://cdn/foo.jpg")).toBe("https://cdn/foo.jpg");
+  });
+  it("returns null for missing", () => {
+    expect(normalizePhotoUrl(undefined)).toBeNull();
+  });
+});

--- a/src/backend/src/lib/history-import.ts
+++ b/src/backend/src/lib/history-import.ts
@@ -1,0 +1,105 @@
+// Normalization helpers for importing data/devfest-history.json into the
+// Speaker/Talk models (issue #63). The historical JSON has inconsistent shapes
+// across editions (old 2016-2019 vs WordPress 2023-2025), so everything funnels
+// through these pure mappers before hitting the database.
+
+export interface HistorySocial {
+  // Modern shape (2023+): { type, url }. Old shape (2016-2019): { name|icon, link }.
+  type?: string;
+  url?: string;
+  name?: string;
+  icon?: string;
+  link?: string;
+}
+
+export interface HistorySpeaker {
+  name: string;
+  company?: string;
+  city?: string;
+  bio?: string;
+  photoUrl?: string;
+  socials?: HistorySocial[];
+}
+
+export interface HistorySession {
+  title: string;
+  description?: string;
+  speakers?: string[];
+  language?: string;
+  format?: string;
+  complexity?: string;
+  tags?: string[];
+  youtube?: string;
+}
+
+export interface HistoryEdition {
+  date?: string;
+  venue?: string;
+  speakers: HistorySpeaker[];
+  sessions: HistorySession[];
+}
+
+export interface HistoryData {
+  editions: Record<string, HistoryEdition>;
+}
+
+// Map a single social entry (either shape) to a [key, url] pair, or null.
+export function normalizeSocial(s: HistorySocial): [string, string] | null {
+  const url = (s.url || s.link || "").trim();
+  if (!url) return null;
+  const hint = `${s.type || ""} ${s.name || ""} ${s.icon || ""}`.toLowerCase();
+  const u = url.toLowerCase();
+
+  if (hint.includes("twitter") || u.includes("twitter.com") || u.includes("x.com")) return ["twitter", url];
+  if (hint.includes("github") || u.includes("github.com")) return ["github", url];
+  if (hint.includes("linkedin") || u.includes("linkedin.com")) return ["linkedin", url];
+  if (u.includes("bsky.app") || hint.includes("bluesky")) return ["bluesky", url];
+  // Everything else (blog, personal site, "website") becomes the website link.
+  return ["website", url];
+}
+
+// Build the socialLinks JSON object from a list of history socials.
+export function buildSocialLinks(socials: HistorySocial[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const s of socials ?? []) {
+    const pair = normalizeSocial(s);
+    if (pair && !out[pair[0]]) out[pair[0]] = pair[1];
+  }
+  return out;
+}
+
+export function normalizeFormat(format: string | undefined): "CONFERENCE" | "QUICKIE" | "KEYNOTE" {
+  switch ((format || "").toLowerCase()) {
+    case "keynote":
+      return "KEYNOTE";
+    case "quickie":
+      return "QUICKIE";
+    default:
+      return "CONFERENCE";
+  }
+}
+
+export function normalizeLevel(complexity: string | undefined): "DEBUTANT" | "INTERMEDIAIRE" | "CONFIRME" | null {
+  const c = (complexity || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "");
+  if (c.includes("debutant")) return "DEBUTANT";
+  if (c.includes("intermediaire")) return "INTERMEDIAIRE";
+  if (c.includes("confirme")) return "CONFIRME";
+  return null;
+}
+
+export function normalizeLanguage(language: string | undefined): string {
+  const l = (language || "").toLowerCase();
+  return l === "en" ? "en" : "fr";
+}
+
+// Photos for 2016-2019 reference paths (/images/speakers/...) that are not
+// shipped with this repo, so they would 404. Drop them and rely on the initial
+// fallback rendered by the speaker pages (documented JSON limitation).
+export function normalizePhotoUrl(photoUrl: string | undefined): string | null {
+  if (!photoUrl) return null;
+  if (photoUrl.startsWith("/images/")) return null;
+  return photoUrl.startsWith("http") ? photoUrl : null;
+}

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -102,6 +102,64 @@ export default async function editionRoutes(app: FastifyInstance) {
     };
   });
 
+  // GET /api/editions/:year/speakers — published speakers of any edition by year
+  // (issue #63: past editions history, not scoped to the featured edition).
+  app.get<{ Params: { year: string } }>("/editions/:year/speakers", {
+    schema: { params: { type: "object", required: ["year"], properties: { year: { type: "string" } } } },
+  }, async (request, reply) => {
+    const yearNum = Number(request.params.year);
+    if (isNaN(yearNum)) return reply.status(400).send({ error: "Invalid year" });
+
+    const edition = await prisma.edition.findUnique({ where: { year: yearNum }, select: { id: true } });
+    if (!edition) return reply.status(404).send({ error: "Edition not found" });
+
+    const speakers = await prisma.speaker.findMany({
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+      orderBy: { name: "asc" },
+      select: { slug: true, name: true, photoUrl: true, company: true },
+    });
+    return speakers;
+  });
+
+  // GET /api/editions/:year/talks — published talks of any edition by year,
+  // with speakers, category and replay video (issue #63).
+  app.get<{ Params: { year: string } }>("/editions/:year/talks", {
+    schema: { params: { type: "object", required: ["year"], properties: { year: { type: "string" } } } },
+  }, async (request, reply) => {
+    const yearNum = Number(request.params.year);
+    if (isNaN(yearNum)) return reply.status(400).send({ error: "Invalid year" });
+
+    const edition = await prisma.edition.findUnique({ where: { year: yearNum }, select: { id: true } });
+    if (!edition) return reply.status(404).send({ error: "Edition not found" });
+
+    const talks = await prisma.talk.findMany({
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+      orderBy: { titleFr: "asc" },
+      include: {
+        speakers: {
+          where: { publicationStatus: "PUBLISHED" },
+          select: { slug: true, name: true },
+          orderBy: { name: "asc" },
+        },
+        category: { select: { nameFr: true, nameEn: true, color: true } },
+      },
+    });
+
+    return talks.map((t) => ({
+      slug: t.slug,
+      titleFr: t.titleFr,
+      titleEn: t.titleEn,
+      descriptionFr: t.descriptionFr,
+      descriptionEn: t.descriptionEn,
+      format: t.format,
+      level: t.level,
+      language: t.language,
+      videoUrl: t.videoUrl,
+      category: t.category,
+      speakers: t.speakers,
+    }));
+  });
+
   // GET /api/editions/current — returns the featured edition
   app.get("/editions/current", async (_request, reply) => {
     const edition = await getFeaturedEdition();

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -195,7 +195,16 @@
     "noEdition": "No edition found for this year.",
     "allEditions": "All editions",
     "previousEdition": "Previous edition",
-    "nextEdition": "Next edition"
+    "nextEdition": "Next edition",
+    "speakers": "Speakers ({count})",
+    "sessions": "Talks ({count})",
+    "replay": "Watch"
+  },
+  "editionsList": {
+    "home": "Home",
+    "pageTitle": "Previous editions",
+    "description": "Relive past DevFest Toulouse editions: speakers, talks and replays.",
+    "empty": "No previous edition yet."
   },
   "sponsor": {
     "pageTitle": "Become a sponsor",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -195,7 +195,16 @@
     "noEdition": "Aucune édition trouvée pour cette année.",
     "allEditions": "Toutes les éditions",
     "previousEdition": "Édition précédente",
-    "nextEdition": "Édition suivante"
+    "nextEdition": "Édition suivante",
+    "speakers": "Speakers ({count})",
+    "sessions": "Conférences ({count})",
+    "replay": "Revoir"
+  },
+  "editionsList": {
+    "home": "Accueil",
+    "pageTitle": "Éditions précédentes",
+    "description": "Revivez les éditions passées du DevFest Toulouse : speakers, conférences et replays.",
+    "empty": "Aucune édition précédente pour le moment."
   },
   "sponsor": {
     "pageTitle": "Devenir sponsor",

--- a/src/frontend/src/app/[locale]/editions/[year]/page.tsx
+++ b/src/frontend/src/app/[locale]/editions/[year]/page.tsx
@@ -3,11 +3,13 @@ import Image from "next/image";
 import { getLocale, getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 
-import { getEditionByYear, getEditions } from "@/lib/api";
+import { getEditionByYear, getEditions, getEditionSpeakers, getEditionTalks } from "@/lib/api";
 import { localizedField } from "@/lib/i18n-helpers";
 import Breadcrumb from "@/components/Breadcrumb";
 import YouTubeFacade from "@/components/YouTubeFacade";
 import StatIcon from "@/components/home/StatIcon";
+import EditionSpeakersGrid from "@/components/editions/EditionSpeakersGrid";
+import EditionTalksList from "@/components/editions/EditionTalksList";
 import { Link } from "@/i18n/navigation";
 
 interface PageProps {
@@ -95,9 +97,11 @@ export default async function BilanPage({ params }: PageProps) {
   const locale = await getLocale();
   const t = await getTranslations("bilan");
 
-  const [edition, allEditions] = await Promise.all([
+  const [edition, allEditions, speakers, talks] = await Promise.all([
     getEditionByYear(Number(year)),
     getEditions(),
+    getEditionSpeakers(Number(year)),
+    getEditionTalks(Number(year)),
   ]);
   if (!edition) notFound();
 
@@ -124,6 +128,16 @@ export default async function BilanPage({ params }: PageProps) {
       : edition.venueName || null;
 
   const eventJsonLd = buildCompletedEventJsonLd(edition);
+  const speakersJsonLd =
+    speakers.length > 0
+      ? speakers.map((s) => ({
+          "@context": "https://schema.org",
+          "@type": "Person",
+          name: s.name,
+          ...(s.company ? { worksFor: { "@type": "Organization", name: s.company } } : {}),
+          ...(s.photoUrl ? { image: s.photoUrl } : {}),
+        }))
+      : null;
 
   return (
     <div>
@@ -131,6 +145,12 @@ export default async function BilanPage({ params }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(eventJsonLd) }}
       />
+      {speakersJsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(speakersJsonLd) }}
+        />
+      )}
       {/* Hero banner */}
       <div
         className="relative w-full h-[280px] lg:h-[380px] bg-cover bg-center"
@@ -255,6 +275,26 @@ export default async function BilanPage({ params }: PageProps) {
                   </Link>
                 ))}
               </div>
+            </section>
+          )}
+
+          {/* Speakers of this edition */}
+          {speakers.length > 0 && (
+            <section className="mt-16">
+              <h2 className="text-2xl lg:text-4xl font-bold text-noir mb-8">
+                {t("speakers", { count: speakers.length })}
+              </h2>
+              <EditionSpeakersGrid speakers={speakers} />
+            </section>
+          )}
+
+          {/* Sessions of this edition (with replays) */}
+          {talks.length > 0 && (
+            <section className="mt-16">
+              <h2 className="text-2xl lg:text-4xl font-bold text-noir mb-8">
+                {t("sessions", { count: talks.length })}
+              </h2>
+              <EditionTalksList talks={talks} locale={locale} replayLabel={t("replay")} />
             </section>
           )}
 

--- a/src/frontend/src/app/[locale]/editions/page.tsx
+++ b/src/frontend/src/app/[locale]/editions/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { getEditions } from "@/lib/api";
+import Breadcrumb from "@/components/Breadcrumb";
+import { Link } from "@/i18n/navigation";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  const t = await getTranslations("editionsList");
+  return {
+    title: t("pageTitle"),
+    description: t("description"),
+    alternates: {
+      canonical: `/${locale}/editions`,
+      languages: {
+        fr: `/fr/editions`,
+        en: `/en/editions`,
+        "x-default": `/fr/editions`,
+      },
+    },
+  };
+}
+
+export default async function EditionsListPage() {
+  const locale = await getLocale();
+  const t = await getTranslations("editionsList");
+
+  // Past editions only (the upcoming one has its own home page).
+  const editions = (await getEditions())
+    .filter((e) => e.status === "SEE_YOU_NEXT_YEAR")
+    .sort((a, b) => b.year - a.year);
+
+  const breadcrumbItems = [
+    { label: t("home"), href: `/${locale}` },
+    { label: t("pageTitle"), href: `/${locale}/editions` },
+  ];
+
+  return (
+    <div className="px-6 py-8 lg:py-12">
+      <div className="mx-auto max-w-6xl">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <h1 className="mt-6 text-3xl lg:text-5xl font-bold text-noir">{t("pageTitle")}</h1>
+        <p className="mt-3 text-lg text-gris">{t("description")}</p>
+
+        {editions.length === 0 ? (
+          <p className="mt-12 text-gris">{t("empty")}</p>
+        ) : (
+          <ul className="mt-10 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
+            {editions.map((e) => (
+              <li key={e.year}>
+                <Link
+                  href={`/editions/${e.year}`}
+                  className="group flex aspect-square flex-col items-center justify-center rounded-2xl bg-blanc shadow-card hover:shadow-lg transition-shadow"
+                >
+                  <span className="text-4xl lg:text-5xl font-bold text-malachite group-hover:scale-105 transition-transform">
+                    {e.year}
+                  </span>
+                  <span className="mt-2 text-sm text-gris">DevFest Toulouse</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/Footer.tsx
+++ b/src/frontend/src/components/Footer.tsx
@@ -130,9 +130,12 @@ export default async function Footer() {
             {/* Previous editions — from database */}
             {previousEditions.length > 0 && (
               <div>
-                <p className="text-blanc text-xl font-bold mb-2 leading-snug">
+                <Link
+                  href="/editions"
+                  className="block text-blanc text-xl font-bold mb-2 leading-snug hover:opacity-70 transition-opacity"
+                >
                   {tFooter("previousEditions")}
-                </p>
+                </Link>
                 <ul className="flex flex-col gap-1">
                   {previousEditions.map((e) => (
                     <li key={e.id}>

--- a/src/frontend/src/components/editions/EditionSpeakersGrid.tsx
+++ b/src/frontend/src/components/editions/EditionSpeakersGrid.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+
+import type { EditionSpeaker } from "@/lib/types";
+
+interface EditionSpeakersGridProps {
+  speakers: EditionSpeaker[];
+}
+
+// Read-only speaker grid for a past edition (issue #63). No link to a detail
+// page: speaker detail pages are scoped to the featured edition, and historical
+// speakers carry no detail beyond name/company here.
+export default function EditionSpeakersGrid({ speakers }: EditionSpeakersGridProps) {
+  return (
+    <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
+      {speakers.map((s) => (
+        <li key={s.slug} className="flex flex-col items-center text-center">
+          {s.photoUrl ? (
+            <div className="relative h-24 w-24 rounded-full overflow-hidden bg-blanc-casse">
+              <Image src={s.photoUrl} alt={s.name} fill sizes="96px" className="object-cover" />
+            </div>
+          ) : (
+            <span className="flex h-24 w-24 items-center justify-center rounded-full bg-blanc-casse text-2xl font-bold text-gris">
+              {s.name.charAt(0)}
+            </span>
+          )}
+          <p className="mt-3 font-bold text-noir">{s.name}</p>
+          {s.company && <p className="text-sm text-gris">{s.company}</p>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/frontend/src/components/editions/EditionTalksList.tsx
+++ b/src/frontend/src/components/editions/EditionTalksList.tsx
@@ -1,0 +1,54 @@
+import type { EditionTalk } from "@/lib/types";
+import { localizedField } from "@/lib/i18n-helpers";
+
+interface EditionTalksListProps {
+  talks: EditionTalk[];
+  locale: string;
+  replayLabel: string;
+}
+
+// Read-only session list for a past edition (issue #63): title, speakers,
+// category badge and a replay link when a recording is available.
+export default function EditionTalksList({ talks, locale, replayLabel }: EditionTalksListProps) {
+  return (
+    <ul className="space-y-4">
+      {talks.map((talk) => {
+        const title = localizedField(talk, "title", locale);
+        const speakerNames = talk.speakers.map((s) => s.name).join(", ");
+        return (
+          <li
+            key={talk.slug}
+            className="flex flex-col gap-2 rounded-2xl bg-blanc shadow-card p-5 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                {talk.category && (
+                  <span
+                    className="inline-block h-2.5 w-2.5 rounded-full"
+                    style={{ backgroundColor: talk.category.color }}
+                    aria-hidden="true"
+                  />
+                )}
+                <h3 className="font-bold text-noir">{title}</h3>
+              </div>
+              {speakerNames && <p className="mt-1 text-sm text-gris">{speakerNames}</p>}
+            </div>
+            {talk.videoUrl && (
+              <a
+                href={talk.videoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="shrink-0 inline-flex items-center gap-2 self-start sm:self-auto px-4 py-2 rounded-[12px] bg-bismarck text-blanc text-sm font-bold hover:bg-bismarck/90 transition-colors"
+              >
+                <svg viewBox="0 0 24 24" className="w-4 h-4" fill="currentColor" aria-hidden="true">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                {replayLabel}
+              </a>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -18,6 +18,8 @@ import type {
   SpeakerPublic,
   SpeakerDetail,
   TalkDetail,
+  EditionSpeaker,
+  EditionTalk,
   EcosystemPartner,
 } from "./types";
 
@@ -154,4 +156,14 @@ export async function getSpeakerBySlug(slug: string): Promise<SpeakerDetail | nu
 
 export async function getTalkBySlug(slug: string): Promise<TalkDetail | null> {
   return fetchAPI<TalkDetail>(`/api/talks/${slug}`);
+}
+
+// Past-edition history (issue #63): speakers/talks of a given year, regardless
+// of which edition is currently featured.
+export async function getEditionSpeakers(year: number): Promise<EditionSpeaker[]> {
+  return (await fetchAPI<EditionSpeaker[]>(`/api/editions/${year}/speakers`)) || [];
+}
+
+export async function getEditionTalks(year: number): Promise<EditionTalk[]> {
+  return (await fetchAPI<EditionTalk[]>(`/api/editions/${year}/talks`)) || [];
 }

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -200,6 +200,28 @@ export interface SpeakerDetail {
 export type TalkFormat = "CONFERENCE" | "QUICKIE" | "KEYNOTE";
 export type TalkLevel = "DEBUTANT" | "INTERMEDIAIRE" | "CONFIRME";
 
+// Past-edition history items (issue #63), keyed by year (not by featured edition).
+export interface EditionSpeaker {
+  slug: string;
+  name: string;
+  photoUrl: string | null;
+  company: string | null;
+}
+
+export interface EditionTalk {
+  slug: string;
+  titleFr: string;
+  titleEn: string;
+  descriptionFr: string;
+  descriptionEn: string;
+  format: TalkFormat;
+  level: TalkLevel | null;
+  language: string;
+  videoUrl: string | null;
+  category: { nameFr: string; nameEn: string; color: string } | null;
+  speakers: { slug: string; name: string }[];
+}
+
 // Public talk detail.
 export interface TalkDetail {
   id: number;


### PR DESCRIPTION
## Résumé
Implémente l'issue #63 : héberger l'historique des conférences (327 speakers, 282 sessions, 7 éditions) sur le site, sans dépendre des sites archivés.

### Import (ré-exécutable par instance)
- **Script** `backend/prisma/import-history.ts` : idempotent, upsert par slug. Crée/complète les éditions 2016-2025 (`SEE_YOU_NEXT_YEAR`), importe speakers + talks en **PUBLISHED**. Lançable sur chaque instance : `pnpm exec tsx prisma/import-history.ts`.
- Le JSON est embarqué dans `prisma/devfest-history.json` (présent sur toute instance déployée).
- **Migration** `lot4_talk_video_url` : nouveau champ `Talk.videoUrl` (replays YouTube).
- **Lib** `history-import.ts` : normalisation des socials (formats anciens `{name,link}` / modernes `{type,url}`), format, niveau, langue, photos locales manquantes écartées. **15 tests unitaires.**

### Affichage
- **`/editions`** : liste des éditions précédentes.
- **`/editions/[year]`** : recap enrichi avec grille speakers + liste des sessions, chaque session liant son **replay vidéo**.
- API publique par année : `GET /api/editions/:year/speakers` et `/:year/talks` (dé-scopées de l'édition featured).
- SEO : `Person` JSON-LD pour les speakers historiques (Event JSON-LD déjà présent).
- Footer : le titre « Éditions précédentes » pointe vers `/editions`.

## Test plan
- [x] `tsc --noEmit` back + front OK
- [x] `eslint` OK
- [x] Tests unitaires : 15 (history) + 13 (sessionize) = 28 OK *(les 37 échecs d'intégration `__tests__/*` pré-existent sur dev-j, non liés — vérifié par stash)*
- [x] Import en local : 327 speakers / 279 talks / 7 éditions, **idempotent** (2e run = 0 doublon)
- [x] Données vérifiées : format/niveau/langue/vidéo/speakers liés, socials normalisés, PUBLISHED
- [x] `/fr/editions` → 200 (7 éditions), `/fr/editions/2025` → 200 (Speakers 64, Conférences 55, 97 « Revoir »)
- [x] `/en/editions` → 200 ; édition ancienne `/fr/editions/2017` → OK
- [x] Pas d'erreur de rendu, JSON-LD EventCompleted + Person présents

## Déploiement
Après merge + déploiement, lancer le script d'import **une fois par instance** pour peupler la base :
`pnpm exec tsx prisma/import-history.ts`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)