### PR TITLE
feat(home): carrousel d'ambiance bloc « Derrière le DevFest » (#59)

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -46,7 +46,9 @@
     "about": {
       "behindTitle": "Behind #DevFestToulouse",
       "gdgDescription": "DevFest Toulouse is organized by GDG Toulouse, a passionate developer community. Since 2016, we bring together the Toulouse tech community every year around talks, workshops, and networking.",
-      "ecosystemTitle": "Dive into our ecosystem"
+      "ecosystemTitle": "Dive into our ecosystem",
+      "carouselPrev": "Previous photo",
+      "carouselNext": "Next photo"
     },
     "news": {
       "title": "Latest news",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -46,7 +46,9 @@
     "about": {
       "behindTitle": "Derrière le #DevFestToulouse",
       "gdgDescription": "Le DevFest Toulouse est organisé par le GDG Toulouse, une communauté de développeurs passionnés. Depuis 2016, nous rassemblons chaque année les acteurs de la tech toulousaine autour de conférences, de workshops et de moments de partage.",
-      "ecosystemTitle": "Plongez dans notre écosystème"
+      "ecosystemTitle": "Plongez dans notre écosystème",
+      "carouselPrev": "Photo précédente",
+      "carouselNext": "Photo suivante"
     },
     "news": {
       "title": "Dernières actualités",

--- a/src/frontend/public/images/about-carousel/README.md
+++ b/src/frontend/public/images/about-carousel/README.md
@@ -1,0 +1,21 @@
+# Carrousel « Derrière le DevFest Toulouse »
+
+Photos d'ambiance affichées dans le bloc « Derrière le DevFest Toulouse » de la
+page d'accueil (issue #59), uniquement pendant la phase **annonce**.
+
+## Ajouter des photos
+
+1. Déposez vos images dans ce dossier (`public/images/about-carousel/`).
+   - Format conseillé : JPG/WebP, ratio **16:10**, ~1200×750 px, optimisées.
+2. Listez-les dans `CAROUSEL_SLIDES` de
+   `src/components/home/AboutSection.tsx`, avec un `alt` descriptif :
+
+   ```ts
+   const CAROUSEL_SLIDES: CarouselSlide[] = [
+     { src: "/images/about-carousel/ambiance-2024-1.jpg", alt: "Le public du DevFest Toulouse 2024" },
+     { src: "/images/about-carousel/ambiance-2024-2.jpg", alt: "Atelier pendant le DevFest Toulouse 2024" },
+   ];
+   ```
+
+Tant que `CAROUSEL_SLIDES` est vide, le bloc reste en texte seul (aucun
+carrousel affiché) — pas de régression.

--- a/src/frontend/src/components/home/AboutCarousel.tsx
+++ b/src/frontend/src/components/home/AboutCarousel.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useRef } from "react";
+import Image from "next/image";
+
+export interface CarouselSlide {
+  src: string;
+  alt: string;
+}
+
+interface AboutCarouselProps {
+  slides: CarouselSlide[];
+  prevLabel: string;
+  nextLabel: string;
+}
+
+// Lightweight, dependency-free carousel (CSS scroll-snap + arrow buttons) for
+// the "Derrière le DevFest Toulouse" block (#59). Keyboard-accessible: the
+// track is focusable and scrolls with arrow keys; buttons scroll by one slide.
+export default function AboutCarousel({ slides, prevLabel, nextLabel }: AboutCarouselProps) {
+  const trackRef = useRef<HTMLUListElement>(null);
+
+  function scrollByDir(dir: 1 | -1) {
+    const track = trackRef.current;
+    if (!track) return;
+    const slide = track.querySelector("li");
+    const step = slide ? slide.clientWidth + 16 : track.clientWidth * 0.8;
+    track.scrollBy({ left: dir * step, behavior: "smooth" });
+  }
+
+  if (slides.length === 0) return null;
+
+  return (
+    <div className="relative">
+      <ul
+        ref={trackRef}
+        tabIndex={0}
+        className="flex gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory rounded-m [scrollbar-width:none] [&::-webkit-scrollbar]:hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-blanc"
+      >
+        {slides.map((slide, i) => (
+          <li
+            key={slide.src}
+            className="relative shrink-0 snap-start w-full sm:w-[80%] aspect-[16/10] overflow-hidden rounded-m bg-noir/20"
+          >
+            <Image
+              src={slide.src}
+              alt={slide.alt}
+              fill
+              sizes="(min-width: 640px) 60vw, 90vw"
+              className="object-cover"
+              priority={i === 0}
+            />
+          </li>
+        ))}
+      </ul>
+
+      {slides.length > 1 && (
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => scrollByDir(-1)}
+            aria-label={prevLabel}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-blanc/90 text-noir hover:bg-blanc transition-colors"
+          >
+            <span aria-hidden="true">←</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => scrollByDir(1)}
+            aria-label={nextLabel}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-blanc/90 text-noir hover:bg-blanc transition-colors"
+          >
+            <span aria-hidden="true">→</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/home/AboutSection.tsx
+++ b/src/frontend/src/components/home/AboutSection.tsx
@@ -1,7 +1,21 @@
 import { useTranslations } from "next-intl";
 
+import AboutCarousel, { type CarouselSlide } from "./AboutCarousel";
+
+// Ambiance photos shown in the "Derrière le DevFest Toulouse" carousel (#59).
+// Drop the images in public/images/about-carousel/ and list them here; the
+// carousel renders only when this array is non-empty, so the block degrades
+// gracefully to text-only until photos are added. `alt` keys are resolved from
+// the home.about namespace.
+const CAROUSEL_SLIDES: CarouselSlide[] = [
+  // Example once photos are available:
+  // { src: "/images/about-carousel/ambiance-2024-1.jpg", alt: "Le public du DevFest Toulouse 2024" },
+];
+
 export default function AboutSection() {
   const t = useTranslations("home.about");
+
+  const hasCarousel = CAROUSEL_SLIDES.length > 0;
 
   return (
     <section className="px-6 py-10 lg:py-14">
@@ -13,15 +27,29 @@ export default function AboutSection() {
           <div className="absolute inset-0 bg-gradient-to-br from-terre-cuite to-bismarck" />
           <div className="absolute inset-0 bg-terre-cuite/40 mix-blend-multiply" />
 
-          <div className="relative z-10 p-8 lg:p-16 max-w-2xl">
-            <h2 className="text-3xl lg:text-5xl font-bold text-blanc mb-6">
-              {t("behindTitle")}
-            </h2>
-            <div className="bg-blanc/90 rounded-m p-6 lg:p-8">
-              <p className="text-base lg:text-lg text-noir leading-relaxed">
-                {t("gdgDescription")}
-              </p>
+          <div
+            className={`relative z-10 p-8 lg:p-16 w-full ${
+              hasCarousel ? "grid gap-8 lg:grid-cols-2 lg:items-center" : "max-w-2xl"
+            }`}
+          >
+            <div className="max-w-2xl">
+              <h2 className="text-3xl lg:text-5xl font-bold text-blanc mb-6">
+                {t("behindTitle")}
+              </h2>
+              <div className="bg-blanc/90 rounded-m p-6 lg:p-8">
+                <p className="text-base lg:text-lg text-noir leading-relaxed">
+                  {t("gdgDescription")}
+                </p>
+              </div>
             </div>
+
+            {hasCarousel && (
+              <AboutCarousel
+                slides={CAROUSEL_SLIDES}
+                prevLabel={t("carouselPrev")}
+                nextLabel={t("carouselNext")}
+              />
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Résumé
Débloque la partie carrousel de #59 sans dépendre d'une maquette : implémentation maison, prête à recevoir les photos.

- **AboutCarousel** : carrousel léger, **zéro dépendance** (CSS scroll-snap + boutons fléchés, piste focusable au clavier, défilement par slide).
- **AboutSection** : passe en layout texte + carrousel côte à côte quand des slides existent ; reste en texte seul sinon → **aucune régression** tant qu'il n'y a pas de photos.
- Les slides se déclarent dans `CAROUSEL_SLIDES` (vide pour l'instant). Un **README** dans `public/images/about-carousel/` explique comment ajouter les photos et les brancher.
- i18n : `carouselPrev` / `carouselNext` (fr/en).

## Pourquoi sans Fab
Fab ne pourra pas produire la maquette. Le composant est générique : l'équipe contenu n'a plus qu'à **déposer des photos** et les lister — aucune dev supplémentaire.

## Test plan
- [x] `tsc --noEmit` + `eslint` OK
- [x] Rendu vérifié en local avec 2 slides de démo : carrousel affiché (slides + boutons accessibles)
- [x] Liste vide (état livré) : bloc en texte seul, carrousel absent → zéro régression
- [ ] À revérifier visuellement une fois de vraies photos ajoutées

## Reste de #59
La piste « filtre orangé » était déjà livrée (commit c33d645). Avec ce carrousel, les 2 pistes de #59 sont couvertes — il ne manque que les **photos** (contenu).

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)