### PR TITLE
feat(admin): gestion des images du carrousel en back-office (#99)

### DIFF
--- a/src/backend/src/routes/admin/settings.ts
+++ b/src/backend/src/routes/admin/settings.ts
@@ -10,7 +10,7 @@ interface CfpBody {
   closeDate?: string;
 }
 
-const GENERAL_PREFIXES = ["contact_", "social_", "seo_", "identity_", "ecosystem_"];
+const GENERAL_PREFIXES = ["contact_", "social_", "seo_", "identity_", "ecosystem_", "about_"];
 
 export default async function adminSettingsRoutes(app: FastifyInstance) {
   // GET /api/admin/settings/general
@@ -39,10 +39,10 @@ export default async function adminSettingsRoutes(app: FastifyInstance) {
         update: { value },
         create: { key, value },
       });
-      // Identity assets (logos/favicons) and ecosystem partners both affect
-      // the home render (layout identity + EcosystemSection). Purge the
-      // home so visitors see the change without waiting for the cache TTL.
-      if (key.startsWith("identity_") || key.startsWith("ecosystem_")) {
+      // Identity assets (logos/favicons), ecosystem partners and the about
+      // carousel all affect the home render. Purge the home so visitors see
+      // the change without waiting for the cache TTL.
+      if (key.startsWith("identity_") || key.startsWith("ecosystem_") || key.startsWith("about_")) {
         touchedHomeRender = true;
       }
     }

--- a/src/backend/src/routes/settings.ts
+++ b/src/backend/src/routes/settings.ts
@@ -84,6 +84,30 @@ export default async function settingsRoutes(app: FastifyInstance) {
     return result;
   });
 
+  // GET /api/settings/carousel — returns the ordered list of ambiance images
+  // for the home "Derrière le DevFest" block (#99). Stored as a JSON-encoded
+  // array under the single key `about_carousel`.
+  app.get("/settings/carousel", async () => {
+    const setting = await prisma.siteSetting.findUnique({
+      where: { key: "about_carousel" },
+    });
+    if (!setting?.value) return [];
+    try {
+      const parsed = JSON.parse(setting.value) as unknown;
+      if (!Array.isArray(parsed)) return [];
+      return parsed
+        .filter(
+          (s): s is { url: string; alt?: string } =>
+            typeof s === "object" &&
+            s !== null &&
+            typeof (s as { url?: unknown }).url === "string",
+        )
+        .map((s) => ({ url: s.url, alt: typeof s.alt === "string" ? s.alt : "" }));
+    } catch {
+      return [];
+    }
+  });
+
   // GET /api/settings/ecosystem — returns the ordered list of ecosystem partners
   // displayed on the home page and in the footer. Stored as a JSON-encoded
   // array under the single key `ecosystem_partners`.

--- a/src/frontend/public/images/about-carousel/README.md
+++ b/src/frontend/public/images/about-carousel/README.md
@@ -1,21 +1,19 @@
 # Carrousel « Derrière le DevFest Toulouse »
 
 Photos d'ambiance affichées dans le bloc « Derrière le DevFest Toulouse » de la
-page d'accueil (issue #59), uniquement pendant la phase **annonce**.
+page d'accueil (issues #59 / #99), uniquement pendant la phase **annonce**.
 
-## Ajouter des photos
+## Gestion des images
 
-1. Déposez vos images dans ce dossier (`public/images/about-carousel/`).
-   - Format conseillé : JPG/WebP, ratio **16:10**, ~1200×750 px, optimisées.
-2. Listez-les dans `CAROUSEL_SLIDES` de
-   `src/components/home/AboutSection.tsx`, avec un `alt` descriptif :
+Depuis #99, les images se gèrent **depuis le back-office** — plus besoin de
+toucher au code :
 
-   ```ts
-   const CAROUSEL_SLIDES: CarouselSlide[] = [
-     { src: "/images/about-carousel/ambiance-2024-1.jpg", alt: "Le public du DevFest Toulouse 2024" },
-     { src: "/images/about-carousel/ambiance-2024-2.jpg", alt: "Atelier pendant le DevFest Toulouse 2024" },
-   ];
-   ```
+1. Admin → **Paramètres → Carrousel**.
+2. Ajouter une image (upload ou bibliothèque), renseigner son texte alternatif,
+   réordonner / supprimer.
+3. Enregistrer : la page d'accueil est revalidée automatiquement.
 
-Tant que `CAROUSEL_SLIDES` est vide, le bloc reste en texte seul (aucun
-carrousel affiché) — pas de régression.
+Les images uploadées atterrissent dans `public/uploads/`. Ce dossier
+(`about-carousel/`) n'est plus utilisé pour stocker des fichiers ; la liste est
+persistée dans le réglage `about_carousel`. Tant qu'aucune image n'est
+configurée, le bloc reste en texte seul.

--- a/src/frontend/src/app/admin/settings/page.tsx
+++ b/src/frontend/src/app/admin/settings/page.tsx
@@ -10,6 +10,7 @@ const TABS = [
   { key: "identity", label: "Identité" },
   { key: "contacts", label: "Contacts" },
   { key: "ecosystem", label: "Écosystème" },
+  { key: "carousel", label: "Carrousel" },
   { key: "seo", label: "SEO" },
   { key: "cache", label: "Cache" },
 ] as const;
@@ -737,6 +738,193 @@ function EcosystemTab({
   );
 }
 
+// ─── Carousel tab (#99) ────────────────────────────────────────────
+
+interface CarouselSlide {
+  url: string;
+  alt: string;
+}
+
+function parseSlides(raw: string | undefined): CarouselSlide[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((s): s is Record<string, unknown> => typeof s === "object" && s !== null)
+      .map((s) => ({
+        url: typeof s.url === "string" ? s.url : "",
+        alt: typeof s.alt === "string" ? s.alt : "",
+      }))
+      .filter((s) => s.url);
+  } catch {
+    return [];
+  }
+}
+
+function CarouselTab({
+  settings,
+  onSave,
+}: {
+  settings: Record<string, string>;
+  onSave: (data: Record<string, string>) => Promise<void>;
+}) {
+  const [slides, setSlides] = useState<CarouselSlide[]>(() => parseSlides(settings.about_carousel));
+  const [isSaving, setIsSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+
+  function updateAlt(index: number, alt: string) {
+    setSlides((prev) => prev.map((s, i) => (i === index ? { ...s, alt } : s)));
+    setSaved(false);
+  }
+
+  function addSlide(url: string) {
+    setSlides((prev) => [...prev, { url, alt: "" }]);
+    setSaved(false);
+  }
+
+  function removeSlide(index: number) {
+    setSlides((prev) => prev.filter((_, i) => i !== index));
+    setSaved(false);
+  }
+
+  function move(index: number, delta: -1 | 1) {
+    const target = index + delta;
+    if (target < 0 || target >= slides.length) return;
+    setSlides((prev) => {
+      const next = [...prev];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+    setSaved(false);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const cleaned = slides
+      .map((s) => ({ url: s.url.trim(), alt: s.alt.trim() }))
+      .filter((s) => s.url);
+
+    for (const s of cleaned) {
+      if (!s.alt) {
+        setError("Chaque image doit avoir un texte alternatif (accessibilité).");
+        return;
+      }
+    }
+
+    setIsSaving(true);
+    await onSave({ about_carousel: JSON.stringify(cleaned) });
+    setSlides(cleaned);
+    setIsSaving(false);
+    setSaved(true);
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="bg-blanc rounded-xl shadow-card p-6 mb-6">
+        <p className="text-sm text-gris mb-6">
+          Images d&apos;ambiance du bloc « Derrière le DevFest Toulouse » de la page d&apos;accueil
+          (affichées pendant la phase d&apos;annonce). Ajoutez vos photos, renseignez un texte
+          alternatif pour chacune, et réordonnez-les. Sans image, le bloc reste en texte seul.
+        </p>
+
+        {slides.length === 0 && (
+          <p className="text-sm text-gris italic mb-4">Aucune image configurée.</p>
+        )}
+
+        <ul className="space-y-3 mb-4">
+          {slides.map((slide, index) => (
+            <li
+              key={`${slide.url}-${index}`}
+              className="border border-gris/20 rounded-lg p-4 flex flex-col md:flex-row gap-3 md:items-center"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={slide.url}
+                alt={slide.alt}
+                className="h-16 w-24 shrink-0 rounded object-cover bg-blanc-casse"
+              />
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gris mb-1">Texte alternatif</label>
+                <input
+                  type="text"
+                  value={slide.alt}
+                  onChange={(e) => updateAlt(index, e.target.value)}
+                  placeholder="Le public du DevFest Toulouse 2024"
+                  className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                />
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => move(index, -1)}
+                  disabled={index === 0}
+                  title="Monter"
+                  className="px-2 py-1 text-xs rounded border border-gris/30 text-noir hover:bg-blanc-casse disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  onClick={() => move(index, 1)}
+                  disabled={index === slides.length - 1}
+                  title="Descendre"
+                  className="px-2 py-1 text-xs rounded border border-gris/30 text-noir hover:bg-blanc-casse disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeSlide(index)}
+                  title="Supprimer"
+                  className="px-2 py-1 text-xs rounded border border-terre-cuite/30 text-terre-cuite hover:bg-terre-cuite/10"
+                >
+                  Supprimer
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <button
+          type="button"
+          onClick={() => setIsPickerOpen(true)}
+          className="px-3 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+        >
+          + Ajouter une image
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-4">
+        <button
+          type="submit"
+          disabled={isSaving}
+          className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+        >
+          {isSaving ? "Enregistrement..." : "Enregistrer"}
+        </button>
+        {saved && <span className="text-sm text-malachite">Enregistré !</span>}
+      </div>
+
+      <ImagePickerDialog
+        open={isPickerOpen}
+        onClose={() => setIsPickerOpen(false)}
+        onSelect={(url) => addSlide(url)}
+      />
+    </form>
+  );
+}
+
 // ─── SEO tab ───────────────────────────────────────────────────────
 
 function SeoTab({
@@ -945,6 +1133,7 @@ export default function SettingsPage() {
       {activeTab === "identity" && <IdentityTab settings={settings} onSave={handleSave} />}
       {activeTab === "contacts" && <ContactsTab settings={settings} onSave={handleSave} />}
       {activeTab === "ecosystem" && <EcosystemTab settings={settings} onSave={handleSave} />}
+      {activeTab === "carousel" && <CarouselTab settings={settings} onSave={handleSave} />}
       {activeTab === "seo" && <SeoTab settings={settings} onSave={handleSave} />}
       {activeTab === "cache" && <CacheTab />}
     </div>

--- a/src/frontend/src/components/home/AboutCarousel.tsx
+++ b/src/frontend/src/components/home/AboutCarousel.tsx
@@ -3,10 +3,7 @@
 import { useRef } from "react";
 import Image from "next/image";
 
-export interface CarouselSlide {
-  src: string;
-  alt: string;
-}
+import type { CarouselSlide } from "@/lib/types";
 
 interface AboutCarouselProps {
   slides: CarouselSlide[];
@@ -39,11 +36,11 @@ export default function AboutCarousel({ slides, prevLabel, nextLabel }: AboutCar
       >
         {slides.map((slide, i) => (
           <li
-            key={slide.src}
+            key={slide.url}
             className="relative shrink-0 snap-start w-full sm:w-[80%] aspect-[16/10] overflow-hidden rounded-m bg-noir/20"
           >
             <Image
-              src={slide.src}
+              src={slide.url}
               alt={slide.alt}
               fill
               sizes="(min-width: 640px) 60vw, 90vw"

--- a/src/frontend/src/components/home/AboutSection.tsx
+++ b/src/frontend/src/components/home/AboutSection.tsx
@@ -1,21 +1,16 @@
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 
-import AboutCarousel, { type CarouselSlide } from "./AboutCarousel";
+import { getAboutCarousel } from "@/lib/api";
+import AboutCarousel from "./AboutCarousel";
 
-// Ambiance photos shown in the "Derrière le DevFest Toulouse" carousel (#59).
-// Drop the images in public/images/about-carousel/ and list them here; the
-// carousel renders only when this array is non-empty, so the block degrades
-// gracefully to text-only until photos are added. `alt` keys are resolved from
-// the home.about namespace.
-const CAROUSEL_SLIDES: CarouselSlide[] = [
-  // Example once photos are available:
-  // { src: "/images/about-carousel/ambiance-2024-1.jpg", alt: "Le public du DevFest Toulouse 2024" },
-];
+// "Derrière le DevFest Toulouse" home block. The ambiance carousel images are
+// managed from the back-office (#99) and stored under the `about_carousel`
+// setting; the block degrades to text-only when no image is configured.
+export default async function AboutSection() {
+  const t = await getTranslations("home.about");
+  const slides = await getAboutCarousel();
 
-export default function AboutSection() {
-  const t = useTranslations("home.about");
-
-  const hasCarousel = CAROUSEL_SLIDES.length > 0;
+  const hasCarousel = slides.length > 0;
 
   return (
     <section className="px-6 py-10 lg:py-14">
@@ -45,7 +40,7 @@ export default function AboutSection() {
 
             {hasCarousel && (
               <AboutCarousel
-                slides={CAROUSEL_SLIDES}
+                slides={slides}
                 prevLabel={t("carouselPrev")}
                 nextLabel={t("carouselNext")}
               />

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   EditionSpeaker,
   EditionTalk,
   EcosystemPartner,
+  CarouselSlide,
 } from "./types";
 
 const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:4000";
@@ -128,6 +129,10 @@ export async function getIdentitySettings(): Promise<Record<string, string>> {
 
 export async function getEcosystemPartners(): Promise<EcosystemPartner[]> {
   return (await fetchAPI<EcosystemPartner[]>("/api/settings/ecosystem")) || [];
+}
+
+export async function getAboutCarousel(): Promise<CarouselSlide[]> {
+  return (await fetchAPI<CarouselSlide[]>("/api/settings/carousel")) || [];
 }
 
 export async function getSponsorPlans(): Promise<SponsorPlan[]> {

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -46,6 +46,12 @@ export interface EcosystemPartner {
   isFeatured: boolean;
 }
 
+// Ambiance image for the home "Derrière le DevFest" carousel (#99).
+export interface CarouselSlide {
+  url: string;
+  alt: string;
+}
+
 export interface Article {
   id: number;
   slug: string;


### PR DESCRIPTION
## Résumé
Les images du carrousel « Derrière le DevFest Toulouse » se gèrent désormais **depuis le back-office** au lieu d'être en dur dans le code (#99, suite de #59).

- **Backend** : route publique `GET /api/settings/carousel` (liste validée `[{url, alt}]` depuis le réglage `about_carousel`). Les settings admin persistent le préfixe `about_` et **revalident la home** au changement.
- **Admin** : nouvel onglet **« Carrousel »** dans Paramètres → ajout via `ImagePickerDialog`, texte alternatif par image, réordonnancement, suppression (même pattern que l'onglet Écosystème).
- **Public** : `AboutSection` lit les slides depuis le backend ; **plus de constante en dur**. Bloc en texte seul si aucune image.
- `AboutCarousel` utilise le type partagé `CarouselSlide` (`{url, alt}`).

## Test plan
- [x] `tsc` front + back OK, `eslint` OK
- [x] `GET /api/settings/carousel` → `[]` par défaut
- [x] Onglet admin « Carrousel » : aperçus, alt préremplis, réordon. (↑/↓ désactivés aux extrémités), suppression, ajout
- [x] Réordonnancement + Enregistrer → **persisté** (API publique reflète le nouvel ordre)
- [x] Carrousel rendu sur la home depuis les données back-office (vérifié via Chrome DevTools, connecté en admin)
- [x] Console propre (admin + home)
- [x] Liste vide → bloc texte seul (zéro régression)

## Note
L'`alt` est obligatoire à l'enregistrement (accessibilité). L'upload d'images passe par l'infra `files.ts` existante (`ImagePickerDialog`).

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)