### PR TITLE
fix(home): équilibrer le carrousel « Derrière le DevFest »

### DIFF
--- a/src/frontend/src/components/home/AboutCarousel.tsx
+++ b/src/frontend/src/components/home/AboutCarousel.tsx
@@ -28,16 +28,16 @@ export default function AboutCarousel({ slides, prevLabel, nextLabel }: AboutCar
   if (slides.length === 0) return null;
 
   return (
-    <div className="relative">
+    <div className="relative flex h-full flex-col">
       <ul
         ref={trackRef}
         tabIndex={0}
-        className="flex gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory rounded-m [scrollbar-width:none] [&::-webkit-scrollbar]:hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-blanc"
+        className="flex flex-1 min-h-[260px] gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory rounded-m [scrollbar-width:none] [&::-webkit-scrollbar]:hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-blanc"
       >
         {slides.map((slide, i) => (
           <li
             key={slide.url}
-            className="relative shrink-0 snap-start w-full sm:w-[80%] aspect-[16/10] overflow-hidden rounded-m bg-noir/20"
+            className="relative shrink-0 snap-start w-full sm:w-[85%] h-full overflow-hidden rounded-m bg-noir/20"
           >
             <Image
               src={slide.url}
@@ -52,7 +52,7 @@ export default function AboutCarousel({ slides, prevLabel, nextLabel }: AboutCar
       </ul>
 
       {slides.length > 1 && (
-        <div className="mt-4 flex justify-end gap-2">
+        <div className="mt-4 flex shrink-0 justify-end gap-2">
           <button
             type="button"
             onClick={() => scrollByDir(-1)}

--- a/src/frontend/src/components/home/AboutSection.tsx
+++ b/src/frontend/src/components/home/AboutSection.tsx
@@ -24,7 +24,7 @@ export default async function AboutSection() {
 
           <div
             className={`relative z-10 p-8 lg:p-16 w-full ${
-              hasCarousel ? "grid gap-8 lg:grid-cols-2 lg:items-center" : "max-w-2xl"
+              hasCarousel ? "grid gap-8 lg:grid-cols-2 lg:items-stretch" : "max-w-2xl"
             }`}
           >
             <div className="max-w-2xl">


### PR DESCRIPTION
## Problème
Le carrousel était centré verticalement (`items-center`) dans une colonne plus courte que la colonne texte (titre + encart), laissant un vide en haut et en bas → encart déséquilibré.

## Solution
`items-center` → `items-stretch` + carrousel en flex-col pleine hauteur (track `flex-1`, slides `h-full`). L'image s'aligne désormais du **titre** jusqu'au **bas de l'encart texte**.

## Test plan
- [x] `tsc` + `eslint` OK
- [x] Desktop (1440px) : haut image aligné au titre, bas image aligné au bas de l'encart — vérifié via Chrome DevTools
- [x] Mobile : empilement inchangé
- [x] Console propre

🤖 Generated with [Claude Code](https://claude.com/claude-code)