### PR TITLE
Admin — réorganisation de la sidebar (groupes + édition en cours) (#120)

### DIFF
--- a/src/frontend/src/components/admin/AdminShell.tsx
+++ b/src/frontend/src/components/admin/AdminShell.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 
-import { getAdminSession, signOut } from "@/lib/admin-api";
+import { adminFetch, getAdminSession, signOut } from "@/lib/admin-api";
 import AdminLogin from "./AdminLogin";
 import AdminSidebar from "./AdminSidebar";
 import { isAdminPathAllowed, type AdminRole } from "./nav-items";
@@ -17,6 +17,28 @@ interface AdminUser {
   role: AdminRole;
 }
 
+interface CurrentEdition {
+  id: number;
+  year: number;
+}
+
+interface EditionSummary {
+  id: number;
+  year: number;
+  status: string;
+}
+
+// The "current edition" is the one being actively worked on: an edition in the
+// ANNOUNCEMENT phase, otherwise one in PREPARATION, otherwise the most recent.
+function pickCurrentEdition(editions: EditionSummary[]): CurrentEdition | null {
+  if (editions.length === 0) return null;
+  const byPriority =
+    editions.find((e) => e.status === "ANNOUNCEMENT") ??
+    editions.find((e) => e.status === "PREPARATION") ??
+    [...editions].sort((a, b) => b.year - a.year)[0];
+  return { id: byPriority.id, year: byPriority.year };
+}
+
 // Public admin paths that render their own content without requiring a session.
 // A user resetting their password precisely does NOT have a valid session.
 const PUBLIC_ADMIN_PATHS = ["/admin/reset-password"];
@@ -26,14 +48,20 @@ export default function AdminShell({ children }: { children: React.ReactNode }) 
   const isPublicPath = PUBLIC_ADMIN_PATHS.some((p) => pathname.startsWith(p));
 
   const [user, setUser] = useState<AdminUser | null>(null);
+  const [currentEdition, setCurrentEdition] = useState<CurrentEdition | null>(null);
   const [isLoading, setIsLoading] = useState(!isPublicPath);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   useEffect(() => {
     if (isPublicPath) return;
     getAdminSession()
-      .then((session) => {
+      .then(async (session) => {
         setUser(session);
+        // Editions are ADMIN-only; skip the call for editors to avoid a 403.
+        if (session?.role === "ADMIN") {
+          const { data } = await adminFetch<EditionSummary[]>("/editions");
+          if (data) setCurrentEdition(pickCurrentEdition(data));
+        }
         setIsLoading(false);
       })
       .catch(() => {
@@ -84,6 +112,7 @@ export default function AdminShell({ children }: { children: React.ReactNode }) 
       >
         <AdminSidebar
           user={user}
+          currentEdition={currentEdition}
           onLogout={handleLogout}
           onNavigate={() => setIsSidebarOpen(false)}
         />

--- a/src/frontend/src/components/admin/AdminSidebar.tsx
+++ b/src/frontend/src/components/admin/AdminSidebar.tsx
@@ -13,10 +13,15 @@ import {
   faUsers,
   faGear,
   faKey,
+  faUser,
+  faMicrophone,
+  faHandshake,
+  faTag,
+  faStar,
 } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
-import { adminNavItems, type AdminRole } from "./nav-items";
+import { adminNavGroups, type AdminNavItem, type AdminRole } from "./nav-items";
 
 interface AdminUser {
   email: string;
@@ -24,8 +29,14 @@ interface AdminUser {
   role: AdminRole;
 }
 
+interface CurrentEdition {
+  id: number;
+  year: number;
+}
+
 interface AdminSidebarProps {
   user: AdminUser;
+  currentEdition?: CurrentEdition | null;
   onLogout: () => void;
   onNavigate?: () => void;
 }
@@ -40,13 +51,65 @@ const iconMap: Record<string, IconDefinition> = {
   users: faUsers,
   settings: faGear,
   key: faKey,
+  user: faUser,
+  microphone: faMicrophone,
+  handshake: faHandshake,
+  tag: faTag,
+  star: faStar,
 };
 
-export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSidebarProps) {
+function SectionTitle({ title }: { title: string }) {
+  return (
+    <p className="px-6 pt-5 pb-2 text-[11px] font-bold uppercase tracking-wider text-blanc/40">
+      {title}
+    </p>
+  );
+}
+
+export default function AdminSidebar({ user, currentEdition, onLogout, onNavigate }: AdminSidebarProps) {
   const pathname = usePathname();
-  const visibleItems = adminNavItems
-    .filter((item) => item.roles.includes(user.role))
-    .map((item) => ({ ...item, href: item.path }));
+
+  function renderItem(item: AdminNavItem) {
+    const icon = iconMap[item.icon];
+
+    if (item.disabled) {
+      return (
+        <span
+          key={item.path}
+          aria-disabled="true"
+          className="flex items-center gap-3 px-6 py-3 text-sm border-l-4 border-transparent text-blanc/30 cursor-not-allowed"
+        >
+          {icon && <FontAwesomeIcon icon={icon} className="w-4 h-4" aria-hidden="true" />}
+          {item.label}
+          {item.badge && (
+            <span className="ml-auto rounded-full bg-blanc/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-blanc/40">
+              {item.badge}
+            </span>
+          )}
+        </span>
+      );
+    }
+
+    const isActive = pathname === item.path || (item.path !== "/admin" && pathname.startsWith(item.path));
+    return (
+      <Link
+        key={item.path}
+        href={item.path}
+        onClick={onNavigate}
+        className={`flex items-center gap-3 px-6 py-3 text-sm transition-colors border-l-4 ${
+          isActive
+            ? "bg-blanc/10 text-blanc font-bold border-malachite"
+            : "text-blanc/70 hover:bg-blanc/5 hover:text-blanc border-transparent"
+        }`}
+      >
+        {icon && <FontAwesomeIcon icon={icon} className="w-4 h-4" aria-hidden="true" />}
+        {item.label}
+      </Link>
+    );
+  }
+
+  const editionHref = currentEdition ? `/admin/editions/${currentEdition.id}` : null;
+  const isEditionActive = editionHref ? pathname.startsWith(editionHref) : false;
 
   return (
     <aside className="w-64 bg-noir text-blanc flex flex-col h-full">
@@ -64,25 +127,35 @@ export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSideba
         </Link>
       </div>
 
-      <nav className="flex-1 py-4 overflow-y-auto">
-        {visibleItems.map((item) => {
-          const isActive = pathname === item.href || (item.href !== "/admin" && pathname.startsWith(item.href));
+      <nav className="flex-1 py-2 overflow-y-auto">
+        {adminNavGroups.map((group, index) => {
+          const visibleItems = group.items.filter((item) => item.roles.includes(user.role));
+          if (visibleItems.length === 0) return null;
+
           return (
-            <Link
-              key={item.href}
-              href={item.href}
-              onClick={onNavigate}
-              className={`flex items-center gap-3 px-6 py-3 text-sm transition-colors border-l-4 ${
-                isActive
-                  ? "bg-blanc/10 text-blanc font-bold border-malachite"
-                  : "text-blanc/70 hover:bg-blanc/5 hover:text-blanc border-transparent"
-              }`}
-            >
-              {iconMap[item.icon] && (
-                <FontAwesomeIcon icon={iconMap[item.icon]} className="w-4 h-4" aria-hidden="true" />
+            <div key={group.title ?? `group-${index}`}>
+              {group.title && <SectionTitle title={group.title} />}
+              {visibleItems.map(renderItem)}
+
+              {/* Dynamic "current edition" block, right after the top group */}
+              {index === 0 && currentEdition && editionHref && (
+                <>
+                  <SectionTitle title={`Édition en cours · ${currentEdition.year}`} />
+                  <Link
+                    href={editionHref}
+                    onClick={onNavigate}
+                    className={`flex items-center gap-3 px-6 py-3 text-sm transition-colors border-l-4 ${
+                      isEditionActive
+                        ? "bg-blanc/10 text-blanc font-bold border-malachite"
+                        : "text-blanc/70 hover:bg-blanc/5 hover:text-blanc border-transparent"
+                    }`}
+                  >
+                    <FontAwesomeIcon icon={faStar} className="w-4 h-4" aria-hidden="true" />
+                    Voir l&apos;édition
+                  </Link>
+                </>
               )}
-              {item.label}
-            </Link>
+            </div>
           );
         })}
       </nav>

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -5,22 +5,59 @@ export interface AdminNavItem {
   path: string;
   icon: string;
   roles: AdminRole[];
+  disabled?: boolean;
+  badge?: string;
 }
 
-export const adminNavItems: AdminNavItem[] = [
-  { label: "Dashboard", path: "/admin", icon: "grid", roles: ["ADMIN", "EDITOR"] },
-  { label: "Éditions", path: "/admin/editions", icon: "calendar", roles: ["ADMIN"] },
-  { label: "Articles", path: "/admin/articles", icon: "file-text", roles: ["ADMIN", "EDITOR"] },
-  { label: "Pages", path: "/admin/pages", icon: "book", roles: ["ADMIN", "EDITOR"] },
-  { label: "Fichiers", path: "/admin/files", icon: "image", roles: ["ADMIN", "EDITOR"] },
-  { label: "Messages", path: "/admin/contact/messages", icon: "mail", roles: ["ADMIN", "EDITOR"] },
-  { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
-  { label: "Clés API", path: "/admin/api-keys", icon: "key", roles: ["ADMIN"] },
-  { label: "Paramètres", path: "/admin/settings", icon: "settings", roles: ["ADMIN"] },
+export interface AdminNavGroup {
+  title: string | null;
+  items: AdminNavItem[];
+}
+
+export const adminNavGroups: AdminNavGroup[] = [
+  {
+    title: null,
+    items: [
+      { label: "Tableau de bord", path: "/admin", icon: "grid", roles: ["ADMIN", "EDITOR"] },
+    ],
+  },
+  {
+    title: "Données",
+    items: [
+      { label: "Speakers", path: "/admin/speakers", icon: "user", roles: ["ADMIN", "EDITOR"], disabled: true, badge: "Bientôt" },
+      { label: "Conférences", path: "/admin/talks", icon: "microphone", roles: ["ADMIN", "EDITOR"], disabled: true, badge: "Bientôt" },
+      { label: "Sponsors", path: "/admin/sponsors", icon: "handshake", roles: ["ADMIN", "EDITOR"], disabled: true, badge: "Bientôt" },
+      { label: "Catégories", path: "/admin/categories", icon: "tag", roles: ["ADMIN", "EDITOR"], disabled: true, badge: "Bientôt" },
+    ],
+  },
+  {
+    title: "Contenu éditorial",
+    items: [
+      { label: "Articles", path: "/admin/articles", icon: "file-text", roles: ["ADMIN", "EDITOR"] },
+      { label: "Pages", path: "/admin/pages", icon: "book", roles: ["ADMIN", "EDITOR"] },
+      { label: "Fichiers", path: "/admin/files", icon: "image", roles: ["ADMIN", "EDITOR"] },
+    ],
+  },
+  {
+    title: "Communication",
+    items: [
+      { label: "Messages", path: "/admin/contact/messages", icon: "mail", roles: ["ADMIN", "EDITOR"] },
+    ],
+  },
+  {
+    title: "Administration",
+    items: [
+      { label: "Éditions", path: "/admin/editions", icon: "calendar", roles: ["ADMIN"] },
+      { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
+      { label: "Clés API", path: "/admin/api-keys", icon: "key", roles: ["ADMIN"] },
+      { label: "Paramètres", path: "/admin/settings", icon: "settings", roles: ["ADMIN"] },
+    ],
+  },
 ];
 
 export function isAdminPathAllowed(pathname: string, role: AdminRole): boolean {
-  const match = adminNavItems
+  const match = adminNavGroups
+    .flatMap((group) => group.items)
     .filter((item) => item.path !== "/admin" && pathname.startsWith(item.path))
     .sort((a, b) => b.path.length - a.path.length)[0];
   if (!match) return true;


### PR DESCRIPTION
## Summary

- Remplace la liste plate de 9 entrées de la sidebar admin par des **groupes** avec titres de section (non cliquables) : Données · Contenu éditorial · Communication · Administration.
- Ajoute un bloc dynamique **« Édition en cours · {année} »** (lien vers l'édition active, priorité ANNOUNCEMENT > PREPARATION > plus récente), chargé côté ADMIN uniquement.
- Le groupe **Données** (Speakers, Conférences, Sponsors, Catégories) affiche des entrées désactivées avec badge **« Bientôt »** jusqu'à l'arrivée des vues transverses (#121).

Première des 4 issues du chantier nav admin (#120 → #121 → #122 → #123).

## Détails

- `nav-items.ts` : passage de `adminNavItems` (plat) à `adminNavGroups` (groupé) + champs `disabled`/`badge` ; `isAdminPathAllowed` adapté (comportement d'autorisation inchangé).
- `AdminSidebar.tsx` : rendu groupé, titres de section gris, items désactivés non cliquables, bloc édition en cours, nouvelles icônes FontAwesome (user/microphone/handshake/tag/star).
- `AdminShell.tsx` : récupère l'édition en cours via `/editions` (ADMIN only, pas d'appel pour EDITOR → pas de 403) et la passe à la sidebar.

## Test plan

- [x] `pnpm tsc --noEmit` : 0 erreur
- [x] `pnpm lint` : 0 erreur (warnings préexistants seulement)
- [x] **ADMIN** : groupes + ordre OK, bloc « Édition en cours · 2026 » → `/admin/editions/1`, items Données grisés « Bientôt » non cliquables, état actif correct (Tableau de bord / Articles), console propre.
- [x] **EDITOR** : entrées ADMIN masquées, groupe Administration absent (pas de titre vide), pas de bloc édition en cours, aucun appel `/editions` émis par la sidebar (vérifié via l'onglet réseau).
- [x] Vérif Chrome DevTools MCP (desktop 1440px + mobile), captures à l'appui.

Note : les 403 sur `/editions` et `/editions/current` observés sur le **Dashboard** EDITOR sont **préexistants** (appels de `admin/page.tsx` sans garde de rôle) — hors périmètre de cette PR, dégradation gracieuse (compteur à 0).
