### PR TITLE
Admin — vues transverses "Données" + onglets édition adressables (#121)

### DIFF
--- a/src/backend/src/routes/admin/categories.ts
+++ b/src/backend/src/routes/admin/categories.ts
@@ -21,16 +21,16 @@ interface CategoryListQuery {
 }
 
 export default async function adminCategoryRoutes(app: FastifyInstance) {
-  // GET /api/admin/categories?editionId=X
+  // GET /api/admin/categories?editionId=X — editionId omitted lists all editions
   app.get<{ Querystring: CategoryListQuery }>("/categories", {
     schema: { querystring: { type: "object", properties: { editionId: { type: "string" } } } },
-  }, async (request, reply) => {
+  }, async (request) => {
     const { editionId } = request.query;
-    if (!editionId) return reply.code(400).send({ error: "editionId required" });
 
     return prisma.category.findMany({
-      where: { editionId: Number(editionId) },
-      orderBy: { sortOrder: "asc" },
+      where: editionId ? { editionId: Number(editionId) } : {},
+      include: editionId ? undefined : { edition: { select: { id: true, year: true } } },
+      orderBy: editionId ? { sortOrder: "asc" } : [{ edition: { year: "desc" } }, { sortOrder: "asc" }],
     });
   });
 

--- a/src/backend/src/routes/admin/speakers.ts
+++ b/src/backend/src/routes/admin/speakers.ts
@@ -35,16 +35,16 @@ function serialize(s: { socialLinks: string | null; [k: string]: unknown }) {
 }
 
 export default async function adminSpeakerRoutes(app: FastifyInstance) {
-  // GET /api/admin/speakers?editionId=X
+  // GET /api/admin/speakers?editionId=X — editionId omitted lists all editions
   app.get<{ Querystring: SpeakerListQuery }>("/speakers", {
     schema: { querystring: { type: "object", properties: { editionId: { type: "string" } } } },
-  }, async (request, reply) => {
+  }, async (request) => {
     const { editionId } = request.query;
-    if (!editionId) return reply.code(400).send({ error: "editionId required" });
 
     const speakers = await prisma.speaker.findMany({
-      where: { editionId: Number(editionId) },
-      orderBy: { name: "asc" },
+      where: editionId ? { editionId: Number(editionId) } : {},
+      include: editionId ? undefined : { edition: { select: { id: true, year: true } } },
+      orderBy: editionId ? { name: "asc" } : [{ edition: { year: "desc" } }, { name: "asc" }],
     });
     return speakers.map(serialize);
   });

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -39,18 +39,20 @@ function serialize(s: {
 }
 
 export default async function adminSponsorRoutes(app: FastifyInstance) {
-  // GET /api/admin/sponsors?editionId=X
+  // GET /api/admin/sponsors?editionId=X — editionId omitted lists all editions
   app.get<{ Querystring: SponsorListQuery }>("/sponsors", {
     schema: {
       querystring: { type: "object", properties: { editionId: { type: "string" } } },
     },
-  }, async (request, reply) => {
+  }, async (request) => {
     const { editionId } = request.query;
-    if (!editionId) return reply.code(400).send({ error: "editionId required" });
 
     const sponsors = await prisma.sponsor.findMany({
-      where: { editionId: Number(editionId) },
-      orderBy: [{ level: "asc" }, { name: "asc" }],
+      where: editionId ? { editionId: Number(editionId) } : {},
+      include: editionId ? undefined : { edition: { select: { id: true, year: true } } },
+      orderBy: editionId
+        ? [{ level: "asc" }, { name: "asc" }]
+        : [{ edition: { year: "desc" } }, { level: "asc" }, { name: "asc" }],
     });
     return sponsors.map(serialize);
   });

--- a/src/backend/src/routes/admin/talks.ts
+++ b/src/backend/src/routes/admin/talks.ts
@@ -44,19 +44,19 @@ function serialize(t: {
 }
 
 export default async function adminTalkRoutes(app: FastifyInstance) {
-  // GET /api/admin/talks?editionId=X
+  // GET /api/admin/talks?editionId=X — editionId omitted lists all editions
   app.get<{ Querystring: TalkListQuery }>("/talks", {
     schema: { querystring: { type: "object", properties: { editionId: { type: "string" } } } },
-  }, async (request, reply) => {
+  }, async (request) => {
     const { editionId } = request.query;
-    if (!editionId) return reply.code(400).send({ error: "editionId required" });
 
     const talks = await prisma.talk.findMany({
-      where: { editionId: Number(editionId) },
-      orderBy: { titleFr: "asc" },
+      where: editionId ? { editionId: Number(editionId) } : {},
+      orderBy: editionId ? { titleFr: "asc" } : [{ edition: { year: "desc" } }, { titleFr: "asc" }],
       include: {
         speakers: { select: { id: true, name: true } },
         category: { select: { id: true, nameFr: true, color: true } },
+        ...(editionId ? {} : { edition: { select: { id: true, year: true } } }),
       },
     });
     return talks.map(serialize);

--- a/src/frontend/src/app/admin/categories/page.tsx
+++ b/src/frontend/src/app/admin/categories/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Category } from "@/lib/types";
+import DataTable from "@/components/admin/DataTable";
+
+interface CategoryRow extends Category {
+  edition?: { id: number; year: number };
+}
+
+export default function CategoriesDataPage() {
+  const router = useRouter();
+  const [categories, setCategories] = useState<CategoryRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [year, setYear] = useState<string>("");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    adminFetch<CategoryRow[]>("/categories").then(({ data }) => {
+      if (data) setCategories(data);
+      setIsLoading(false);
+    });
+  }, []);
+
+  const years = useMemo(
+    () => [...new Set(categories.map((c) => c.edition?.year).filter((y): y is number => y != null))].sort((a, b) => b - a),
+    [categories],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return categories.filter((c) => {
+      if (year && String(c.edition?.year) !== year) return false;
+      if (q && !c.nameFr.toLowerCase().includes(q) && !c.nameEn.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [categories, year, search]);
+
+  const columns = [
+    {
+      key: "name",
+      label: "Catégorie",
+      render: (c: CategoryRow) => (
+        <span className="inline-flex items-center gap-2">
+          <span className="h-4 w-4 rounded-full" style={{ backgroundColor: c.color }} />
+          <span className="font-medium text-noir">{c.nameFr}</span>
+          <span className="text-gris">/ {c.nameEn}</span>
+        </span>
+      ),
+    },
+    { key: "sortOrder", label: "Ordre", render: (c: CategoryRow) => c.sortOrder },
+    { key: "edition", label: "Édition", render: (c: CategoryRow) => c.edition?.year ?? "—" },
+  ];
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-noir">Catégories</h1>
+        <p className="mt-1 text-sm text-gris">Toutes éditions confondues. La modification se fait dans l&apos;édition concernée.</p>
+      </div>
+
+      {isLoading ? (
+        <p className="text-gris">Chargement...</p>
+      ) : (
+        <>
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Rechercher une catégorie…"
+              className="w-64 rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            />
+            <select
+              value={year}
+              onChange={(e) => setYear(e.target.value)}
+              className="rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              <option value="">Toutes les éditions</option>
+              {years.map((y) => (
+                <option key={y} value={y}>{y}</option>
+              ))}
+            </select>
+            <span className="text-sm text-gris">{filtered.length} catégorie{filtered.length > 1 ? "s" : ""}</span>
+          </div>
+
+          <DataTable<CategoryRow>
+            columns={columns}
+            data={filtered}
+            emptyMessage="Aucune catégorie"
+            onEdit={(c) => router.push(`/admin/editions/${c.editionId}?tab=categories`)}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { adminFetch } from "@/lib/admin-api";
 import StatusBadge from "@/components/admin/StatusBadge";
 import Tabs from "@/components/admin/Tabs";
@@ -55,11 +55,20 @@ const TABS = [
 export default function EditionDetailPage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const editionId = Number(params.id);
+
+  const tabFromUrl = searchParams.get("tab");
+  const initialTab = TABS.some((t) => t.key === tabFromUrl) ? (tabFromUrl as string) : "general";
 
   const [edition, setEdition] = useState<EditionData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState("general");
+  const [activeTab, setActiveTab] = useState(initialTab);
+
+  function handleTabChange(tab: string) {
+    setActiveTab(tab);
+    router.replace(`/admin/editions/${editionId}?tab=${tab}`, { scroll: false });
+  }
 
   async function loadEdition() {
     const { data, status } = await adminFetch<EditionData>(`/editions/${editionId}`);
@@ -94,7 +103,7 @@ export default function EditionDetailPage() {
       </div>
 
       <div className="bg-blanc rounded-xl shadow-card p-6">
-        <Tabs tabs={TABS} activeTab={activeTab} onTabChange={setActiveTab} />
+        <Tabs tabs={TABS} activeTab={activeTab} onTabChange={handleTabChange} />
 
         {activeTab === "general" && (
           <GeneralTab edition={edition} onSaved={loadEdition} />

--- a/src/frontend/src/app/admin/speakers/page.tsx
+++ b/src/frontend/src/app/admin/speakers/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Speaker } from "@/lib/types";
+import DataTable from "@/components/admin/DataTable";
+import StatusBadge from "@/components/admin/StatusBadge";
+
+interface SpeakerRow extends Speaker {
+  edition?: { id: number; year: number };
+}
+
+export default function SpeakersDataPage() {
+  const router = useRouter();
+  const [speakers, setSpeakers] = useState<SpeakerRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [year, setYear] = useState<string>("");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    adminFetch<SpeakerRow[]>("/speakers").then(({ data }) => {
+      if (data) setSpeakers(data);
+      setIsLoading(false);
+    });
+  }, []);
+
+  const years = useMemo(
+    () => [...new Set(speakers.map((s) => s.edition?.year).filter((y): y is number => y != null))].sort((a, b) => b - a),
+    [speakers],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return speakers.filter((s) => {
+      if (year && String(s.edition?.year) !== year) return false;
+      if (q && !s.name.toLowerCase().includes(q) && !(s.company ?? "").toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [speakers, year, search]);
+
+  const columns = [
+    {
+      key: "name",
+      label: "Speaker",
+      render: (s: SpeakerRow) => (
+        <span className="font-medium text-noir">{s.name}</span>
+      ),
+    },
+    { key: "company", label: "Société", render: (s: SpeakerRow) => s.company ?? "—" },
+    {
+      key: "status",
+      label: "Statut",
+      render: (s: SpeakerRow) => (
+        <StatusBadge
+          status={s.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+          variant={s.publicationStatus === "PUBLISHED" ? "green" : "gray"}
+        />
+      ),
+    },
+    { key: "featured", label: "À la une", render: (s: SpeakerRow) => (s.isFeatured ? "★" : "") },
+    { key: "edition", label: "Édition", render: (s: SpeakerRow) => s.edition?.year ?? "—" },
+  ];
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-noir">Speakers</h1>
+        <p className="mt-1 text-sm text-gris">Toutes éditions confondues. La modification se fait dans l&apos;édition concernée.</p>
+      </div>
+
+      {isLoading ? (
+        <p className="text-gris">Chargement...</p>
+      ) : (
+        <>
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Rechercher un nom, une société…"
+              className="w-64 rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            />
+            <select
+              value={year}
+              onChange={(e) => setYear(e.target.value)}
+              className="rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              <option value="">Toutes les éditions</option>
+              {years.map((y) => (
+                <option key={y} value={y}>{y}</option>
+              ))}
+            </select>
+            <span className="text-sm text-gris">{filtered.length} speaker{filtered.length > 1 ? "s" : ""}</span>
+          </div>
+
+          <DataTable<SpeakerRow>
+            columns={columns}
+            data={filtered}
+            emptyMessage="Aucun speaker"
+            onEdit={(s) => router.push(`/admin/editions/${s.editionId}?tab=speakers`)}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/sponsors/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Sponsor, SponsorLevel } from "@/lib/types";
+import DataTable from "@/components/admin/DataTable";
+import StatusBadge from "@/components/admin/StatusBadge";
+
+interface SponsorRow extends Sponsor {
+  edition?: { id: number; year: number };
+}
+
+const LEVEL_LABELS: Record<SponsorLevel, string> = {
+  PLATINUM: "Platinum",
+  GOLD: "Gold",
+  SILVER: "Silver",
+  SOUTIEN: "Soutien",
+  COMMUNAUTE: "Communauté",
+};
+
+export default function SponsorsDataPage() {
+  const router = useRouter();
+  const [sponsors, setSponsors] = useState<SponsorRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [year, setYear] = useState<string>("");
+  const [level, setLevel] = useState<string>("");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    adminFetch<SponsorRow[]>("/sponsors").then(({ data }) => {
+      if (data) setSponsors(data);
+      setIsLoading(false);
+    });
+  }, []);
+
+  const years = useMemo(
+    () => [...new Set(sponsors.map((s) => s.edition?.year).filter((y): y is number => y != null))].sort((a, b) => b - a),
+    [sponsors],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return sponsors.filter((s) => {
+      if (year && String(s.edition?.year) !== year) return false;
+      if (level && s.level !== level) return false;
+      if (q && !s.name.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [sponsors, year, level, search]);
+
+  const columns = [
+    { key: "name", label: "Sponsor", render: (s: SponsorRow) => <span className="font-medium text-noir">{s.name}</span> },
+    { key: "level", label: "Niveau", render: (s: SponsorRow) => LEVEL_LABELS[s.level] },
+    {
+      key: "status",
+      label: "Statut",
+      render: (s: SponsorRow) => (
+        <StatusBadge
+          status={s.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+          variant={s.publicationStatus === "PUBLISHED" ? "green" : "gray"}
+        />
+      ),
+    },
+    { key: "edition", label: "Édition", render: (s: SponsorRow) => s.edition?.year ?? "—" },
+  ];
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-noir">Sponsors</h1>
+        <p className="mt-1 text-sm text-gris">Toutes éditions confondues. La modification se fait dans l&apos;édition concernée.</p>
+      </div>
+
+      {isLoading ? (
+        <p className="text-gris">Chargement...</p>
+      ) : (
+        <>
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Rechercher un sponsor…"
+              className="w-64 rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            />
+            <select
+              value={year}
+              onChange={(e) => setYear(e.target.value)}
+              className="rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              <option value="">Toutes les éditions</option>
+              {years.map((y) => (
+                <option key={y} value={y}>{y}</option>
+              ))}
+            </select>
+            <select
+              value={level}
+              onChange={(e) => setLevel(e.target.value)}
+              className="rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              <option value="">Tous les niveaux</option>
+              {(Object.keys(LEVEL_LABELS) as SponsorLevel[]).map((l) => (
+                <option key={l} value={l}>{LEVEL_LABELS[l]}</option>
+              ))}
+            </select>
+            <span className="text-sm text-gris">{filtered.length} sponsor{filtered.length > 1 ? "s" : ""}</span>
+          </div>
+
+          <DataTable<SponsorRow>
+            columns={columns}
+            data={filtered}
+            emptyMessage="Aucun sponsor"
+            onEdit={(s) => router.push(`/admin/editions/${s.editionId}?tab=sponsors`)}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/talks/page.tsx
+++ b/src/frontend/src/app/admin/talks/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Talk, TalkFormat } from "@/lib/types";
+import DataTable from "@/components/admin/DataTable";
+import StatusBadge from "@/components/admin/StatusBadge";
+
+interface TalkRow extends Talk {
+  edition?: { id: number; year: number };
+}
+
+const FORMAT_LABELS: Record<TalkFormat, string> = {
+  CONFERENCE: "Conférence",
+  QUICKIE: "Quickie",
+  KEYNOTE: "Keynote",
+};
+
+export default function TalksDataPage() {
+  const router = useRouter();
+  const [talks, setTalks] = useState<TalkRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [year, setYear] = useState<string>("");
+  const [format, setFormat] = useState<string>("");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    adminFetch<TalkRow[]>("/talks").then(({ data }) => {
+      if (data) setTalks(data);
+      setIsLoading(false);
+    });
+  }, []);
+
+  const years = useMemo(
+    () => [...new Set(talks.map((t) => t.edition?.year).filter((y): y is number => y != null))].sort((a, b) => b - a),
+    [talks],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return talks.filter((t) => {
+      if (year && String(t.edition?.year) !== year) return false;
+      if (format && t.format !== format) return false;
+      if (q && !t.titleFr.toLowerCase().includes(q) && !t.speakers.some((s) => s.name.toLowerCase().includes(q))) return false;
+      return true;
+    });
+  }, [talks, year, format, search]);
+
+  const columns = [
+    { key: "title", label: "Titre", render: (t: TalkRow) => <span className="font-medium text-noir">{t.titleFr}</span> },
+    { key: "format", label: "Format", render: (t: TalkRow) => FORMAT_LABELS[t.format] },
+    {
+      key: "category",
+      label: "Catégorie",
+      render: (t: TalkRow) =>
+        t.category ? (
+          <span className="inline-flex items-center gap-2">
+            <span className="h-3 w-3 rounded-full" style={{ backgroundColor: t.category.color }} />
+            {t.category.nameFr}
+          </span>
+        ) : (
+          "—"
+        ),
+    },
+    {
+      key: "speakers",
+      label: "Speakers",
+      render: (t: TalkRow) => (t.speakers.length ? t.speakers.map((s) => s.name).join(", ") : "—"),
+    },
+    {
+      key: "status",
+      label: "Statut",
+      render: (t: TalkRow) => (
+        <StatusBadge
+          status={t.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+          variant={t.publicationStatus === "PUBLISHED" ? "green" : "gray"}
+        />
+      ),
+    },
+    { key: "edition", label: "Édition", render: (t: TalkRow) => t.edition?.year ?? "—" },
+  ];
+
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-noir">Conférences</h1>
+        <p className="mt-1 text-sm text-gris">Toutes éditions confondues. La modification se fait dans l&apos;édition concernée.</p>
+      </div>
+
+      {isLoading ? (
+        <p className="text-gris">Chargement...</p>
+      ) : (
+        <>
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Rechercher un titre, un speaker…"
+              className="w-64 rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            />
+            <select
+              value={year}
+              onChange={(e) => setYear(e.target.value)}
+              className="rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              <option value="">Toutes les éditions</option>
+              {years.map((y) => (
+                <option key={y} value={y}>{y}</option>
+              ))}
+            </select>
+            <select
+              value={format}
+              onChange={(e) => setFormat(e.target.value)}
+              className="rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              <option value="">Tous les formats</option>
+              {(Object.keys(FORMAT_LABELS) as TalkFormat[]).map((f) => (
+                <option key={f} value={f}>{FORMAT_LABELS[f]}</option>
+              ))}
+            </select>
+            <span className="text-sm text-gris">{filtered.length} conférence{filtered.length > 1 ? "s" : ""}</span>
+          </div>
+
+          <DataTable<TalkRow>
+            columns={columns}
+            data={filtered}
+            emptyMessage="Aucune conférence"
+            onEdit={(t) => router.push(`/admin/editions/${t.editionId}?tab=conferences`)}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -24,10 +24,10 @@ export const adminNavGroups: AdminNavGroup[] = [
   {
     title: "Données",
     items: [
-      { label: "Speakers", path: "/admin/speakers", icon: "user", roles: ["ADMIN", "EDITOR"], disabled: true, badge: "Bientôt" },
-      { label: "Conférences", path: "/admin/talks", icon: "microphone", roles: ["ADMIN", "EDITOR"], disabled: true, badge: "Bientôt" },
-      { label: "Sponsors", path: "/admin/sponsors", icon: "handshake", roles: ["ADMIN", "EDITOR"], disabled: true, badge: "Bientôt" },
-      { label: "Catégories", path: "/admin/categories", icon: "tag", roles: ["ADMIN", "EDITOR"], disabled: true, badge: "Bientôt" },
+      { label: "Speakers", path: "/admin/speakers", icon: "user", roles: ["ADMIN", "EDITOR"] },
+      { label: "Conférences", path: "/admin/talks", icon: "microphone", roles: ["ADMIN", "EDITOR"] },
+      { label: "Sponsors", path: "/admin/sponsors", icon: "handshake", roles: ["ADMIN", "EDITOR"] },
+      { label: "Catégories", path: "/admin/categories", icon: "tag", roles: ["ADMIN", "EDITOR"] },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Crée 4 **vues transverses** dans le groupe « Données » de l'admin : `/admin/speakers`, `/admin/talks`, `/admin/sponsors`, `/admin/categories` — chacune liste l'entité **toutes éditions confondues** (table + colonne Édition + filtre année + recherche, et filtres format/niveau pour talks/sponsors).
- Rend les **routes API** correspondantes capables de lister toutes éditions : `editionId` devient optionnel (omis → toutes éditions + relation `edition` incluse, tri année desc). Le mode `?editionId=` existant est **inchangé**.
- Rend les **onglets de la page édition adressables par URL** (`?tab=`) pour que « Modifier » depuis une vue transverse ouvre le bon onglet (`/admin/editions/{id}?tab=<entité>`).
- Active le groupe **Données** de la sidebar (retrait des badges « Bientôt » de #120).

2ᵉ des 4 issues du chantier nav admin (#120 ✅ → **#121** → #122 → #123).

## Détails

- **Édition d'une fiche** = renvoi vers l'onglet d'édition existant (zéro duplication de formulaire CRUD). Pas de bouton « Nouveau » au niveau transverse en V1 (une entité exige une édition).
- Réutilise `DataTable` + `StatusBadge` + `adminFetch` existants.
- Backend : un seul `include: { edition }` (pas de N+1).

## Test plan

- [x] `pnpm tsc --noEmit` front + back : 0 erreur
- [x] `pnpm lint` front : 0 erreur (warnings préexistants seulement)
- [x] **ADMIN** : `/admin/speakers` (332, multi-éditions), `/admin/talks` (283), `/admin/sponsors`, `/admin/categories` — colonne Édition, tri année desc, filtres + recherche OK.
- [x] « Modifier » → `/admin/editions/{id}?tab=<entité>` ouvre le bon onglet (testé categories → onglet Catégories sélectionné).
- [x] Onglets adressables : `?tab=sponsors` sélectionne Sponsors au chargement ; changer d'onglet met l'URL à jour ; sans `?tab=` = Général (pas de régression).
- [x] Sidebar : groupe Données sans badge, liens actifs.
- [x] Console propre. Vérif Chrome DevTools MCP (desktop 1440px), captures.

## ⚠️ Point UX à trancher (suivi)

Un **EDITOR** voit le groupe Données (ADMIN+EDITOR) et peut lister, mais « Modifier » renvoie vers `/admin/editions/*` qui est **ADMIN-only** → écran « Accès réservé ». Incohérence à résoudre dans #122/#123 : soit restreindre Données/édition au même rôle, soit aligner les droits. Hors périmètre de cette PR (les vues transverses elles-mêmes fonctionnent pour les deux rôles).

## Liens

- Back : [speakers.ts](src/backend/src/routes/admin/speakers.ts) · [talks.ts](src/backend/src/routes/admin/talks.ts) · [sponsors.ts](src/backend/src/routes/admin/sponsors.ts) · [categories.ts](src/backend/src/routes/admin/categories.ts)
- Front : [admin/speakers/page.tsx](src/frontend/src/app/admin/speakers/page.tsx) + talks/sponsors/categories · [editions/[id]/page.tsx](src/frontend/src/app/admin/editions/[id]/page.tsx) · [nav-items.ts](src/frontend/src/components/admin/nav-items.ts)
- Issue : #121
