### PR TITLE
Admin — pages d'édition par entité (#122a)

### DIFF
--- a/src/backend/src/routes/admin/categories.ts
+++ b/src/backend/src/routes/admin/categories.ts
@@ -34,6 +34,18 @@ export default async function adminCategoryRoutes(app: FastifyInstance) {
     });
   });
 
+  // GET /api/admin/categories/:id
+  app.get<{ Params: CategoryIdParams }>("/categories/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const category = await prisma.category.findUnique({
+      where: { id: Number(request.params.id) },
+      include: { edition: { select: { id: true, year: true } } },
+    });
+    if (!category) return reply.code(404).send({ error: "Category not found" });
+    return category;
+  });
+
   // POST /api/admin/categories
   app.post<{ Body: CategoryCreateBody }>("/categories", async (request, reply) => {
     const body = request.body;

--- a/src/backend/src/routes/admin/speakers.ts
+++ b/src/backend/src/routes/admin/speakers.ts
@@ -49,6 +49,18 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
     return speakers.map(serialize);
   });
 
+  // GET /api/admin/speakers/:id
+  app.get<{ Params: SpeakerIdParams }>("/speakers/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const speaker = await prisma.speaker.findUnique({
+      where: { id: Number(request.params.id) },
+      include: { edition: { select: { id: true, year: true } } },
+    });
+    if (!speaker) return reply.code(404).send({ error: "Speaker not found" });
+    return serialize(speaker);
+  });
+
   // POST /api/admin/speakers
   app.post<{ Body: SpeakerCreateBody }>("/speakers", async (request, reply) => {
     const body = request.body;

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -57,6 +57,18 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     return sponsors.map(serialize);
   });
 
+  // GET /api/admin/sponsors/:id
+  app.get<{ Params: SponsorIdParams }>("/sponsors/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const sponsor = await prisma.sponsor.findUnique({
+      where: { id: Number(request.params.id) },
+      include: { edition: { select: { id: true, year: true } } },
+    });
+    if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
+    return serialize(sponsor);
+  });
+
   // POST /api/admin/sponsors
   app.post<{ Body: SponsorCreateBody }>("/sponsors", async (request, reply) => {
     const body = request.body;

--- a/src/backend/src/routes/admin/talks.ts
+++ b/src/backend/src/routes/admin/talks.ts
@@ -62,6 +62,22 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
     return talks.map(serialize);
   });
 
+  // GET /api/admin/talks/:id
+  app.get<{ Params: TalkIdParams }>("/talks/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const talk = await prisma.talk.findUnique({
+      where: { id: Number(request.params.id) },
+      include: {
+        speakers: { select: { id: true, name: true } },
+        category: { select: { id: true, nameFr: true, color: true } },
+        edition: { select: { id: true, year: true } },
+      },
+    });
+    if (!talk) return reply.code(404).send({ error: "Talk not found" });
+    return serialize(talk);
+  });
+
   // POST /api/admin/talks
   app.post<{ Body: TalkCreateBody }>("/talks", async (request, reply) => {
     const body = request.body;

--- a/src/frontend/src/app/admin/categories/[id]/page.tsx
+++ b/src/frontend/src/app/admin/categories/[id]/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import CategoryForm, { emptyCategoryForm, type CategoryFormValue } from "@/components/admin/categories/CategoryForm";
+
+interface CategoryData {
+  id: number;
+  nameFr: string;
+  nameEn: string;
+  color: string;
+  sortOrder: number;
+  editionId: number;
+  edition?: { id: number; year: number };
+}
+
+export default function CategoryEditorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isNew = params.id === "new";
+  const categoryId = isNew ? null : Number(params.id);
+
+  const [form, setForm] = useState<CategoryFormValue>(emptyCategoryForm);
+  const [editions, setEditions] = useState<{ id: number; year: number }[]>([]);
+  const [editionId, setEditionId] = useState<number | null>(null);
+  const [editionYear, setEditionYear] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(!isNew);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isNew) {
+      adminFetch<{ id: number; year: number }[]>("/editions").then(({ data }) => {
+        if (data) {
+          setEditions(data);
+          const preset = Number(searchParams.get("editionId"));
+          const chosen = data.find((e) => e.id === preset) ?? data[0];
+          if (chosen) setEditionId(chosen.id);
+        }
+      });
+    } else if (categoryId) {
+      adminFetch<CategoryData>(`/categories/${categoryId}`).then(({ data, status }) => {
+        if (status === 404 || !data) {
+          router.push("/admin/categories");
+          return;
+        }
+        setForm({ nameFr: data.nameFr, nameEn: data.nameEn, color: data.color, sortOrder: String(data.sortOrder) });
+        setEditionId(data.editionId);
+        setEditionYear(data.edition?.year ?? null);
+        setIsLoading(false);
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [categoryId, isNew]);
+
+  async function handleSave() {
+    if (!form.nameFr.trim() || !form.nameEn.trim() || !editionId) return;
+    setIsSaving(true);
+    setError(null);
+    const payload = {
+      editionId,
+      nameFr: form.nameFr.trim(),
+      nameEn: form.nameEn.trim(),
+      color: form.color,
+      sortOrder: Number(form.sortOrder) || 0,
+    };
+    if (isNew) {
+      const { data, status } = await adminFetch<{ id: number }>("/categories", { method: "POST", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400 || !data) {
+        setError("Échec de la création.");
+        return;
+      }
+      router.push(`/admin/categories/${data.id}`);
+    } else {
+      const { status } = await adminFetch(`/categories/${categoryId}`, { method: "PUT", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400) {
+        setError("Échec de l'enregistrement.");
+        return;
+      }
+      router.push("/admin/categories");
+    }
+  }
+
+  if (isLoading) return <p className="text-gris">Chargement...</p>;
+
+  return (
+    <div className="max-w-2xl">
+      <div className="mb-8 flex items-center gap-4">
+        <button onClick={() => router.push("/admin/categories")} className="text-gris hover:text-noir" title="Retour">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+        </button>
+        <h1 className="text-3xl font-bold text-noir">{isNew ? "Nouvelle catégorie" : "Modifier la catégorie"}</h1>
+      </div>
+
+      <div className="bg-blanc rounded-xl shadow-card p-6 space-y-4">
+        {isNew ? (
+          <label className="block max-w-[240px]">
+            <span className="block text-sm font-medium text-noir mb-1">Édition *</span>
+            <select
+              value={editionId ?? ""}
+              onChange={(e) => setEditionId(Number(e.target.value))}
+              className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              {editions.map((e) => (
+                <option key={e.id} value={e.id}>{e.year}</option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <p className="text-sm text-gris">Édition : <span className="font-medium text-noir">{editionYear ?? "—"}</span></p>
+        )}
+
+        <CategoryForm value={form} onChange={setForm} />
+
+        {error && <p className="text-sm text-terre-cuite">{error}</p>}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            onClick={handleSave}
+            disabled={isSaving || !form.nameFr.trim() || !form.nameEn.trim() || !editionId}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {isSaving ? "Enregistrement…" : "Enregistrer"}
+          </button>
+          <button
+            onClick={() => router.push("/admin/categories")}
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+          >
+            Annuler
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/speakers/[id]/page.tsx
+++ b/src/frontend/src/app/admin/speakers/[id]/page.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Speaker, Sponsor } from "@/lib/types";
+import EditLinkActions from "@/components/admin/EditLinkActions";
+import SpeakerForm, { emptySpeakerForm, type SpeakerFormValue } from "@/components/admin/speakers/SpeakerForm";
+
+interface SpeakerData extends Speaker {
+  slug: string;
+  edition?: { id: number; year: number };
+}
+
+export default function SpeakerEditorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isNew = params.id === "new";
+  const speakerId = isNew ? null : Number(params.id);
+
+  const [form, setForm] = useState<SpeakerFormValue>(emptySpeakerForm);
+  const [current, setCurrent] = useState<SpeakerData | null>(null);
+  const [editions, setEditions] = useState<{ id: number; year: number }[]>([]);
+  const [editionId, setEditionId] = useState<number | null>(null);
+  const [editionYear, setEditionYear] = useState<number | null>(null);
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [isLoading, setIsLoading] = useState(!isNew);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isNew) {
+      adminFetch<{ id: number; year: number }[]>("/editions").then(({ data }) => {
+        if (data) {
+          setEditions(data);
+          const preset = Number(searchParams.get("editionId"));
+          const chosen = data.find((e) => e.id === preset) ?? data[0];
+          if (chosen) setEditionId(chosen.id);
+        }
+      });
+    } else if (speakerId) {
+      adminFetch<SpeakerData>(`/speakers/${speakerId}`).then(({ data, status }) => {
+        if (status === 404 || !data) {
+          router.push("/admin/speakers");
+          return;
+        }
+        setCurrent(data);
+        setForm({
+          name: data.name,
+          photoUrl: data.photoUrl || "",
+          company: data.company || "",
+          city: data.city || "",
+          bioFr: data.bioFr || "",
+          bioEn: data.bioEn || "",
+          linkedin: data.socialLinks?.linkedin || "",
+          twitter: data.socialLinks?.twitter || "",
+          github: data.socialLinks?.github || "",
+          website: data.socialLinks?.website || "",
+          isFeatured: data.isFeatured,
+          sponsorId: data.sponsorId ? String(data.sponsorId) : "",
+          publicationStatus: data.publicationStatus,
+        });
+        setEditionId(data.editionId);
+        setEditionYear(data.edition?.year ?? null);
+        setIsLoading(false);
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [speakerId, isNew]);
+
+  // Sponsor list is edition-scoped (for the "sponsor associé" select).
+  useEffect(() => {
+    if (!editionId) return;
+    adminFetch<Sponsor[]>(`/sponsors?editionId=${editionId}`).then(({ data }) => {
+      if (data) setSponsors(data);
+    });
+  }, [editionId]);
+
+  async function handleSave() {
+    if (!form.name.trim() || !editionId) return;
+    setIsSaving(true);
+    setError(null);
+    const socialLinks: Record<string, string> = {};
+    if (form.linkedin.trim()) socialLinks.linkedin = form.linkedin.trim();
+    if (form.twitter.trim()) socialLinks.twitter = form.twitter.trim();
+    if (form.github.trim()) socialLinks.github = form.github.trim();
+    if (form.website.trim()) socialLinks.website = form.website.trim();
+
+    const payload = {
+      editionId,
+      name: form.name.trim(),
+      photoUrl: form.photoUrl || undefined,
+      company: form.company || undefined,
+      city: form.city || undefined,
+      bioFr: form.bioFr || undefined,
+      bioEn: form.bioEn || undefined,
+      socialLinks,
+      isFeatured: form.isFeatured,
+      sponsorId: form.sponsorId ? Number(form.sponsorId) : null,
+      publicationStatus: form.publicationStatus,
+    };
+
+    if (isNew) {
+      const { data, status } = await adminFetch<{ id: number }>("/speakers", { method: "POST", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400 || !data) {
+        setError("Échec de la création.");
+        return;
+      }
+      router.push(`/admin/speakers/${data.id}`);
+    } else {
+      const { status } = await adminFetch(`/speakers/${speakerId}`, { method: "PUT", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400) {
+        setError("Échec de l'enregistrement.");
+        return;
+      }
+      router.push("/admin/speakers");
+    }
+  }
+
+  if (isLoading) return <p className="text-gris">Chargement...</p>;
+
+  return (
+    <div className="max-w-3xl">
+      <div className="mb-8 flex items-center gap-4">
+        <button onClick={() => router.push("/admin/speakers")} className="text-gris hover:text-noir" title="Retour">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+        </button>
+        <h1 className="text-3xl font-bold text-noir">{isNew ? "Nouveau speaker" : "Modifier le speaker"}</h1>
+        {!isNew && current?.publicationStatus === "PUBLISHED" && (
+          <a
+            href={`/speakers/${current.slug}/social-card`}
+            target="_blank"
+            rel="noopener"
+            className="ml-auto text-sm text-malachite hover:underline"
+          >
+            Voir le visuel
+          </a>
+        )}
+      </div>
+
+      <div className="bg-blanc rounded-xl shadow-card p-6 space-y-4">
+        {isNew ? (
+          <label className="block max-w-[240px]">
+            <span className="block text-sm font-medium text-noir mb-1">Édition *</span>
+            <select
+              value={editionId ?? ""}
+              onChange={(e) => setEditionId(Number(e.target.value))}
+              className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              {editions.map((e) => (
+                <option key={e.id} value={e.id}>{e.year}</option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <p className="text-sm text-gris">Édition : <span className="font-medium text-noir">{editionYear ?? "—"}</span></p>
+        )}
+
+        <SpeakerForm value={form} onChange={setForm} sponsors={sponsors} />
+
+        {!isNew && current && (
+          <EditLinkActions
+            resource="speakers"
+            entityId={current.id}
+            initialEmail={current.contactEmail ?? ""}
+            initialLocked={current.editLinkLocked}
+          />
+        )}
+
+        {error && <p className="text-sm text-terre-cuite">{error}</p>}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            onClick={handleSave}
+            disabled={isSaving || !form.name.trim() || !editionId}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {isSaving ? "Enregistrement…" : "Enregistrer"}
+          </button>
+          <button
+            onClick={() => router.push("/admin/speakers")}
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+          >
+            Annuler
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/sponsors/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/[id]/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Sponsor } from "@/lib/types";
+import EditLinkActions from "@/components/admin/EditLinkActions";
+import SponsorForm, { emptySponsorForm, type SponsorFormValue } from "@/components/admin/sponsors/SponsorForm";
+
+interface SponsorData extends Sponsor {
+  edition?: { id: number; year: number };
+}
+
+export default function SponsorEditorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isNew = params.id === "new";
+  const sponsorId = isNew ? null : Number(params.id);
+
+  const [form, setForm] = useState<SponsorFormValue>(emptySponsorForm);
+  const [current, setCurrent] = useState<SponsorData | null>(null);
+  const [editions, setEditions] = useState<{ id: number; year: number }[]>([]);
+  const [editionId, setEditionId] = useState<number | null>(null);
+  const [editionYear, setEditionYear] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(!isNew);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isNew) {
+      adminFetch<{ id: number; year: number }[]>("/editions").then(({ data }) => {
+        if (data) {
+          setEditions(data);
+          const preset = Number(searchParams.get("editionId"));
+          const chosen = data.find((e) => e.id === preset) ?? data[0];
+          if (chosen) setEditionId(chosen.id);
+        }
+      });
+    } else if (sponsorId) {
+      adminFetch<SponsorData>(`/sponsors/${sponsorId}`).then(({ data, status }) => {
+        if (status === 404 || !data) {
+          router.push("/admin/sponsors");
+          return;
+        }
+        setCurrent(data);
+        setForm({
+          name: data.name,
+          level: data.level,
+          logoUrl: data.logoUrl || "",
+          websiteUrl: data.websiteUrl || "",
+          descriptionFr: data.descriptionFr || "",
+          descriptionEn: data.descriptionEn || "",
+          linkedin: data.socialLinks?.linkedin || "",
+          twitter: data.socialLinks?.twitter || "",
+          publicationStatus: data.publicationStatus,
+        });
+        setEditionId(data.editionId);
+        setEditionYear(data.edition?.year ?? null);
+        setIsLoading(false);
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sponsorId, isNew]);
+
+  async function handleSave() {
+    if (!form.name.trim() || !editionId) return;
+    setIsSaving(true);
+    setError(null);
+    const socialLinks: Record<string, string> = {};
+    if (form.linkedin.trim()) socialLinks.linkedin = form.linkedin.trim();
+    if (form.twitter.trim()) socialLinks.twitter = form.twitter.trim();
+
+    const payload = {
+      editionId,
+      name: form.name.trim(),
+      level: form.level,
+      logoUrl: form.logoUrl || undefined,
+      websiteUrl: form.websiteUrl || undefined,
+      descriptionFr: form.descriptionFr || undefined,
+      descriptionEn: form.descriptionEn || undefined,
+      socialLinks,
+      publicationStatus: form.publicationStatus,
+    };
+
+    if (isNew) {
+      const { data, status } = await adminFetch<{ id: number }>("/sponsors", { method: "POST", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400 || !data) {
+        setError("Échec de la création.");
+        return;
+      }
+      router.push(`/admin/sponsors/${data.id}`);
+    } else {
+      const { status } = await adminFetch(`/sponsors/${sponsorId}`, { method: "PUT", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400) {
+        setError("Échec de l'enregistrement.");
+        return;
+      }
+      router.push("/admin/sponsors");
+    }
+  }
+
+  if (isLoading) return <p className="text-gris">Chargement...</p>;
+
+  return (
+    <div className="max-w-3xl">
+      <div className="mb-8 flex items-center gap-4">
+        <button onClick={() => router.push("/admin/sponsors")} className="text-gris hover:text-noir" title="Retour">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+        </button>
+        <h1 className="text-3xl font-bold text-noir">{isNew ? "Nouveau sponsor" : "Modifier le sponsor"}</h1>
+      </div>
+
+      <div className="bg-blanc rounded-xl shadow-card p-6 space-y-4">
+        {isNew ? (
+          <label className="block max-w-[240px]">
+            <span className="block text-sm font-medium text-noir mb-1">Édition *</span>
+            <select
+              value={editionId ?? ""}
+              onChange={(e) => setEditionId(Number(e.target.value))}
+              className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              {editions.map((e) => (
+                <option key={e.id} value={e.id}>{e.year}</option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <p className="text-sm text-gris">Édition : <span className="font-medium text-noir">{editionYear ?? "—"}</span></p>
+        )}
+
+        <SponsorForm value={form} onChange={setForm} />
+
+        {!isNew && current && (
+          <EditLinkActions
+            resource="sponsors"
+            entityId={current.id}
+            initialEmail={current.contactEmail ?? ""}
+            initialLocked={current.editLinkLocked}
+          />
+        )}
+
+        {error && <p className="text-sm text-terre-cuite">{error}</p>}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            onClick={handleSave}
+            disabled={isSaving || !form.name.trim() || !editionId}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {isSaving ? "Enregistrement…" : "Enregistrer"}
+          </button>
+          <button
+            onClick={() => router.push("/admin/sponsors")}
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+          >
+            Annuler
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/talks/[id]/page.tsx
+++ b/src/frontend/src/app/admin/talks/[id]/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Talk, Category, Speaker } from "@/lib/types";
+import TalkForm, { emptyTalkForm, type TalkFormValue } from "@/components/admin/talks/TalkForm";
+
+interface TalkData extends Talk {
+  edition?: { id: number; year: number };
+}
+
+export default function TalkEditorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isNew = params.id === "new";
+  const talkId = isNew ? null : Number(params.id);
+
+  const [form, setForm] = useState<TalkFormValue>(emptyTalkForm);
+  const [editions, setEditions] = useState<{ id: number; year: number }[]>([]);
+  const [editionId, setEditionId] = useState<number | null>(null);
+  const [editionYear, setEditionYear] = useState<number | null>(null);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const [isLoading, setIsLoading] = useState(!isNew);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isNew) {
+      adminFetch<{ id: number; year: number }[]>("/editions").then(({ data }) => {
+        if (data) {
+          setEditions(data);
+          const preset = Number(searchParams.get("editionId"));
+          const chosen = data.find((e) => e.id === preset) ?? data[0];
+          if (chosen) setEditionId(chosen.id);
+        }
+      });
+    } else if (talkId) {
+      adminFetch<TalkData>(`/talks/${talkId}`).then(({ data, status }) => {
+        if (status === 404 || !data) {
+          router.push("/admin/talks");
+          return;
+        }
+        setForm({
+          titleFr: data.titleFr,
+          titleEn: data.titleEn,
+          descriptionFr: data.descriptionFr,
+          descriptionEn: data.descriptionEn,
+          format: data.format,
+          level: data.level ?? "",
+          language: data.language,
+          categoryId: data.categoryId ? String(data.categoryId) : "",
+          speakerIds: data.speakerIds,
+          publicationStatus: data.publicationStatus,
+        });
+        setEditionId(data.editionId);
+        setEditionYear(data.edition?.year ?? null);
+        setIsLoading(false);
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [talkId, isNew]);
+
+  // Categories and speakers are edition-scoped (for the pickers).
+  useEffect(() => {
+    if (!editionId) return;
+    void Promise.all([
+      adminFetch<Category[]>(`/categories?editionId=${editionId}`),
+      adminFetch<Speaker[]>(`/speakers?editionId=${editionId}`),
+    ]).then(([{ data: c }, { data: s }]) => {
+      if (c) setCategories(c);
+      if (s) setSpeakers(s);
+    });
+  }, [editionId]);
+
+  async function handleSave() {
+    if (!form.titleFr.trim() || !form.titleEn.trim() || !editionId) return;
+    setIsSaving(true);
+    setError(null);
+    const payload = {
+      editionId,
+      titleFr: form.titleFr.trim(),
+      titleEn: form.titleEn.trim(),
+      descriptionFr: form.descriptionFr,
+      descriptionEn: form.descriptionEn,
+      format: form.format,
+      level: form.level || null,
+      language: form.language,
+      categoryId: form.categoryId ? Number(form.categoryId) : null,
+      speakerIds: form.speakerIds,
+      publicationStatus: form.publicationStatus,
+    };
+
+    if (isNew) {
+      const { data, status } = await adminFetch<{ id: number }>("/talks", { method: "POST", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400 || !data) {
+        setError("Échec de la création.");
+        return;
+      }
+      router.push(`/admin/talks/${data.id}`);
+    } else {
+      const { status } = await adminFetch(`/talks/${talkId}`, { method: "PUT", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400) {
+        setError("Échec de l'enregistrement.");
+        return;
+      }
+      router.push("/admin/talks");
+    }
+  }
+
+  if (isLoading) return <p className="text-gris">Chargement...</p>;
+
+  return (
+    <div className="max-w-3xl">
+      <div className="mb-8 flex items-center gap-4">
+        <button onClick={() => router.push("/admin/talks")} className="text-gris hover:text-noir" title="Retour">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+        </button>
+        <h1 className="text-3xl font-bold text-noir">{isNew ? "Nouvelle conférence" : "Modifier la conférence"}</h1>
+      </div>
+
+      <div className="bg-blanc rounded-xl shadow-card p-6 space-y-4">
+        {isNew ? (
+          <label className="block max-w-[240px]">
+            <span className="block text-sm font-medium text-noir mb-1">Édition *</span>
+            <select
+              value={editionId ?? ""}
+              onChange={(e) => setEditionId(Number(e.target.value))}
+              className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              {editions.map((e) => (
+                <option key={e.id} value={e.id}>{e.year}</option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <p className="text-sm text-gris">Édition : <span className="font-medium text-noir">{editionYear ?? "—"}</span></p>
+        )}
+
+        <TalkForm value={form} onChange={setForm} categories={categories} speakers={speakers} />
+
+        {error && <p className="text-sm text-terre-cuite">{error}</p>}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            onClick={handleSave}
+            disabled={isSaving || !form.titleFr.trim() || !form.titleEn.trim() || !editionId}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {isSaving ? "Enregistrement…" : "Enregistrer"}
+          </button>
+          <button
+            onClick={() => router.push("/admin/talks")}
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+          >
+            Annuler
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/categories/CategoryForm.tsx
+++ b/src/frontend/src/components/admin/categories/CategoryForm.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+const COLOR_PRESETS = ["#109E6E", "#EC6839", "#509EE3", "#F8AB06", "#EE7CAD", "#9A6CB8"];
+
+export interface CategoryFormValue {
+  nameFr: string;
+  nameEn: string;
+  color: string;
+  sortOrder: string;
+}
+
+export const emptyCategoryForm: CategoryFormValue = {
+  nameFr: "",
+  nameEn: "",
+  color: "#109E6E",
+  sortOrder: "0",
+};
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+interface CategoryFormProps {
+  value: CategoryFormValue;
+  onChange: (value: CategoryFormValue) => void;
+}
+
+export default function CategoryForm({ value, onChange }: CategoryFormProps) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Nom (FR) *</span>
+          <input value={value.nameFr} onChange={(e) => onChange({ ...value, nameFr: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Nom (EN) *</span>
+          <input value={value.nameEn} onChange={(e) => onChange({ ...value, nameEn: e.target.value })} className={inputClass} />
+        </label>
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-noir mb-1">Couleur</span>
+        <div className="flex items-center gap-3">
+          {COLOR_PRESETS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => onChange({ ...value, color: c })}
+              className={`h-8 w-8 rounded-full border-2 ${value.color === c ? "border-noir" : "border-transparent"}`}
+              style={{ backgroundColor: c }}
+              aria-label={c}
+            />
+          ))}
+          <input
+            type="color"
+            value={value.color}
+            onChange={(e) => onChange({ ...value, color: e.target.value })}
+            className="h-8 w-12 rounded border border-gris/30"
+          />
+        </div>
+      </div>
+
+      <label className="block max-w-[160px]">
+        <span className="block text-sm font-medium text-noir mb-1">Ordre</span>
+        <input
+          type="number"
+          value={value.sortOrder}
+          onChange={(e) => onChange({ ...value, sortOrder: e.target.value })}
+          className={inputClass}
+        />
+      </label>
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/speakers/SpeakerForm.tsx
+++ b/src/frontend/src/components/admin/speakers/SpeakerForm.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Sponsor } from "@/lib/types";
+import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
+
+export interface SpeakerFormValue {
+  name: string;
+  photoUrl: string;
+  company: string;
+  city: string;
+  bioFr: string;
+  bioEn: string;
+  linkedin: string;
+  twitter: string;
+  github: string;
+  website: string;
+  isFeatured: boolean;
+  sponsorId: string;
+  publicationStatus: "DRAFT" | "PUBLISHED";
+}
+
+export const emptySpeakerForm: SpeakerFormValue = {
+  name: "",
+  photoUrl: "",
+  company: "",
+  city: "",
+  bioFr: "",
+  bioEn: "",
+  linkedin: "",
+  twitter: "",
+  github: "",
+  website: "",
+  isFeatured: false,
+  sponsorId: "",
+  publicationStatus: "DRAFT",
+};
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+interface SpeakerFormProps {
+  value: SpeakerFormValue;
+  onChange: (value: SpeakerFormValue) => void;
+  sponsors: Sponsor[];
+}
+
+export default function SpeakerForm({ value, onChange, sponsors }: SpeakerFormProps) {
+  const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Nom *</span>
+          <input value={value.name} onChange={(e) => onChange({ ...value, name: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Entreprise</span>
+          <input value={value.company} onChange={(e) => onChange({ ...value, company: e.target.value })} className={inputClass} />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Ville</span>
+          <input value={value.city} onChange={(e) => onChange({ ...value, city: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Sponsor associé</span>
+          <select value={value.sponsorId} onChange={(e) => onChange({ ...value, sponsorId: e.target.value })} className={inputClass}>
+            <option value="">— Aucun —</option>
+            {sponsors.map((sp) => (
+              <option key={sp.id} value={sp.id}>{sp.name}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-noir mb-1">Photo</span>
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => setIsImagePickerOpen(true)}
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+          >
+            {value.photoUrl ? "Changer la photo" : "Choisir une photo"}
+          </button>
+          {value.photoUrl && (
+            <>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={value.photoUrl} alt="Photo" className="h-12 w-12 rounded-full object-cover" />
+              <button
+                type="button"
+                onClick={() => onChange({ ...value, photoUrl: "" })}
+                className="text-sm text-terre-cuite hover:underline"
+              >
+                Retirer
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Bio (FR)</span>
+          <textarea value={value.bioFr} onChange={(e) => onChange({ ...value, bioFr: e.target.value })} rows={3} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Bio (EN)</span>
+          <textarea value={value.bioEn} onChange={(e) => onChange({ ...value, bioEn: e.target.value })} rows={3} className={inputClass} />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">LinkedIn</span>
+          <input type="url" value={value.linkedin} onChange={(e) => onChange({ ...value, linkedin: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">GitHub</span>
+          <input type="url" value={value.github} onChange={(e) => onChange({ ...value, github: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">X / Twitter</span>
+          <input type="url" value={value.twitter} onChange={(e) => onChange({ ...value, twitter: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Site web</span>
+          <input type="url" value={value.website} onChange={(e) => onChange({ ...value, website: e.target.value })} className={inputClass} />
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-6">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={value.isFeatured}
+            onChange={(e) => onChange({ ...value, isFeatured: e.target.checked })}
+            className="rounded border-gris/30 text-malachite focus:ring-malachite"
+          />
+          <span className="text-sm text-noir">En vedette (page d&apos;accueil)</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={value.publicationStatus === "PUBLISHED"}
+            onChange={(e) => onChange({ ...value, publicationStatus: e.target.checked ? "PUBLISHED" : "DRAFT" })}
+            className="rounded border-gris/30 text-malachite focus:ring-malachite"
+          />
+          <span className="text-sm text-noir">Publié (visible sur le site)</span>
+        </label>
+      </div>
+
+      <ImagePickerDialog
+        open={isImagePickerOpen}
+        onClose={() => setIsImagePickerOpen(false)}
+        onSelect={(url) => onChange({ ...value, photoUrl: url })}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
+++ b/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+
+import type { SponsorLevel } from "@/lib/types";
+import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
+
+const LEVELS: { value: SponsorLevel; label: string }[] = [
+  { value: "PLATINUM", label: "Platinum" },
+  { value: "GOLD", label: "Gold" },
+  { value: "SILVER", label: "Silver" },
+  { value: "SOUTIEN", label: "Soutien" },
+  { value: "COMMUNAUTE", label: "Communauté" },
+];
+
+export interface SponsorFormValue {
+  name: string;
+  level: SponsorLevel;
+  logoUrl: string;
+  websiteUrl: string;
+  descriptionFr: string;
+  descriptionEn: string;
+  linkedin: string;
+  twitter: string;
+  publicationStatus: "DRAFT" | "PUBLISHED";
+}
+
+export const emptySponsorForm: SponsorFormValue = {
+  name: "",
+  level: "PLATINUM",
+  logoUrl: "",
+  websiteUrl: "",
+  descriptionFr: "",
+  descriptionEn: "",
+  linkedin: "",
+  twitter: "",
+  publicationStatus: "DRAFT",
+};
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+interface SponsorFormProps {
+  value: SponsorFormValue;
+  onChange: (value: SponsorFormValue) => void;
+}
+
+export default function SponsorForm({ value, onChange }: SponsorFormProps) {
+  const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Nom *</span>
+          <input value={value.name} onChange={(e) => onChange({ ...value, name: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Niveau *</span>
+          <select value={value.level} onChange={(e) => onChange({ ...value, level: e.target.value as SponsorLevel })} className={inputClass}>
+            {LEVELS.map((l) => (
+              <option key={l.value} value={l.value}>{l.label}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-noir mb-1">Logo</span>
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => setIsImagePickerOpen(true)}
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+          >
+            {value.logoUrl ? "Changer le logo" : "Choisir un logo"}
+          </button>
+          {value.logoUrl && (
+            <>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={value.logoUrl} alt="Logo" className="h-12 rounded object-contain" />
+              <button
+                type="button"
+                onClick={() => onChange({ ...value, logoUrl: "" })}
+                className="text-sm text-terre-cuite hover:underline"
+              >
+                Retirer
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <label className="block">
+        <span className="block text-sm font-medium text-noir mb-1">Site web</span>
+        <input type="url" value={value.websiteUrl} onChange={(e) => onChange({ ...value, websiteUrl: e.target.value })} className={inputClass} />
+      </label>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Description (FR)</span>
+          <textarea value={value.descriptionFr} onChange={(e) => onChange({ ...value, descriptionFr: e.target.value })} rows={3} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Description (EN)</span>
+          <textarea value={value.descriptionEn} onChange={(e) => onChange({ ...value, descriptionEn: e.target.value })} rows={3} className={inputClass} />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">LinkedIn</span>
+          <input type="url" value={value.linkedin} onChange={(e) => onChange({ ...value, linkedin: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">X / Twitter</span>
+          <input type="url" value={value.twitter} onChange={(e) => onChange({ ...value, twitter: e.target.value })} className={inputClass} />
+        </label>
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={value.publicationStatus === "PUBLISHED"}
+          onChange={(e) => onChange({ ...value, publicationStatus: e.target.checked ? "PUBLISHED" : "DRAFT" })}
+          className="rounded border-gris/30 text-malachite focus:ring-malachite"
+        />
+        <span className="text-sm text-noir">Publié (visible sur le site)</span>
+      </label>
+
+      <ImagePickerDialog
+        open={isImagePickerOpen}
+        onClose={() => setIsImagePickerOpen(false)}
+        onSelect={(url) => onChange({ ...value, logoUrl: url })}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/talks/TalkForm.tsx
+++ b/src/frontend/src/components/admin/talks/TalkForm.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import type { TalkFormat, TalkLevel, Category, Speaker } from "@/lib/types";
+
+const FORMATS: { value: TalkFormat; label: string }[] = [
+  { value: "CONFERENCE", label: "Conférence (40 min)" },
+  { value: "QUICKIE", label: "Quickie (15 min)" },
+  { value: "KEYNOTE", label: "Keynote" },
+];
+const LEVELS: { value: TalkLevel; label: string }[] = [
+  { value: "DEBUTANT", label: "Débutant" },
+  { value: "INTERMEDIAIRE", label: "Intermédiaire" },
+  { value: "CONFIRME", label: "Confirmé" },
+];
+
+export interface TalkFormValue {
+  titleFr: string;
+  titleEn: string;
+  descriptionFr: string;
+  descriptionEn: string;
+  format: TalkFormat;
+  level: "" | TalkLevel;
+  language: string;
+  categoryId: string;
+  speakerIds: number[];
+  publicationStatus: "DRAFT" | "PUBLISHED";
+}
+
+export const emptyTalkForm: TalkFormValue = {
+  titleFr: "",
+  titleEn: "",
+  descriptionFr: "",
+  descriptionEn: "",
+  format: "CONFERENCE",
+  level: "",
+  language: "fr",
+  categoryId: "",
+  speakerIds: [],
+  publicationStatus: "DRAFT",
+};
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+interface TalkFormProps {
+  value: TalkFormValue;
+  onChange: (value: TalkFormValue) => void;
+  categories: Category[];
+  speakers: Speaker[];
+}
+
+export default function TalkForm({ value, onChange, categories, speakers }: TalkFormProps) {
+  function toggleSpeaker(id: number) {
+    onChange({
+      ...value,
+      speakerIds: value.speakerIds.includes(id)
+        ? value.speakerIds.filter((x) => x !== id)
+        : [...value.speakerIds, id],
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Titre (FR) *</span>
+          <input value={value.titleFr} onChange={(e) => onChange({ ...value, titleFr: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Titre (EN) *</span>
+          <input value={value.titleEn} onChange={(e) => onChange({ ...value, titleEn: e.target.value })} className={inputClass} />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Description (FR)</span>
+          <textarea value={value.descriptionFr} onChange={(e) => onChange({ ...value, descriptionFr: e.target.value })} rows={3} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Description (EN)</span>
+          <textarea value={value.descriptionEn} onChange={(e) => onChange({ ...value, descriptionEn: e.target.value })} rows={3} className={inputClass} />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Format *</span>
+          <select value={value.format} onChange={(e) => onChange({ ...value, format: e.target.value as TalkFormat })} className={inputClass}>
+            {FORMATS.map((f) => <option key={f.value} value={f.value}>{f.label}</option>)}
+          </select>
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Niveau</span>
+          <select value={value.level} onChange={(e) => onChange({ ...value, level: e.target.value as "" | TalkLevel })} className={inputClass}>
+            <option value="">Tous niveaux</option>
+            {LEVELS.map((l) => <option key={l.value} value={l.value}>{l.label}</option>)}
+          </select>
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Langue</span>
+          <select value={value.language} onChange={(e) => onChange({ ...value, language: e.target.value })} className={inputClass}>
+            <option value="fr">Français</option>
+            <option value="en">English</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Catégorie</span>
+          <select value={value.categoryId} onChange={(e) => onChange({ ...value, categoryId: e.target.value })} className={inputClass}>
+            <option value="">— Aucune —</option>
+            {categories.map((c) => <option key={c.id} value={c.id}>{c.nameFr}</option>)}
+          </select>
+        </label>
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-noir mb-1">Speakers</span>
+        {speakers.length === 0 ? (
+          <p className="text-sm text-gris">Aucun speaker disponible pour cette édition.</p>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {speakers.map((sp) => (
+              <label key={sp.id} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={value.speakerIds.includes(sp.id)}
+                  onChange={() => toggleSpeaker(sp.id)}
+                  className="rounded border-gris/30 text-malachite focus:ring-malachite"
+                />
+                <span className="text-sm text-noir">{sp.name}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={value.publicationStatus === "PUBLISHED"}
+          onChange={(e) => onChange({ ...value, publicationStatus: e.target.checked ? "PUBLISHED" : "DRAFT" })}
+          className="rounded border-gris/30 text-malachite focus:ring-malachite"
+        />
+        <span className="text-sm text-noir">Publié (visible sur le site)</span>
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Première sous-étape de #122 (édition = synthèse). Crée des **pages d'édition par entité** pour speakers / conférences / sponsors / catégories, en extrayant les formulaires CRUD aujourd'hui inline dans les onglets de l'édition.

- **Backend** : `GET /:id` sur les 4 routes (`speakers`/`talks`/`sponsors`/`categories`), avec relation `edition`. Talks incluent speakers + catégorie.
- **Frontend** : composants `<Entity>Form` réutilisables + pages `/admin/<entité>/[id]` (new + edit), miroir du pattern articles.
  - **New** : sélecteur d'édition (défaut = édition en cours, pré-sélection via `?editionId=`).
  - **Edit** : hydratation via `GET /:id`, édition affichée en lecture seule.
  - Speakers/sponsors gardent `EditLinkActions` en édition ; lien « Voir le visuel » pour un speaker publié.

**Rien n'est supprimé** : les onglets de l'édition restent fonctionnels (voie d'édition actuelle), les nouvelles pages coexistent. Le rebranchement des vues #121 + suppression des onglets = **#122b**. La synthèse = **#122c**.

Bénéfice immédiat : le **problème de droits EDITOR** de #121 se dissout — `/admin/<entité>/[id]` est hors `/admin/editions/*` et le groupe « Données » est ADMIN+EDITOR, donc un EDITOR édite désormais une fiche sans tomber sur « Accès réservé ».

## Test plan

- [x] `tsc` front + back, `lint` front : 0 erreur (warnings préexistants seulement).
- [x] **ADMIN** : `/admin/speakers/new` → sélecteur édition (2026 par défaut) + sponsors edition-scoped ; création → redirige vers `/admin/speakers/{id}` ; fiche hydrate + EditLinkActions ; speaker visible dans l'onglet d'édition (même source).
- [x] Régression : onglets de l'édition **intacts et fonctionnels** (création/édition/suppression OK).
- [x] Suppression du speaker de test (données dev propres).
- [x] Console propre. Vérif Chrome DevTools MCP.

## Liens

- Back : [speakers.ts](src/backend/src/routes/admin/speakers.ts) · [talks.ts](src/backend/src/routes/admin/talks.ts) · [sponsors.ts](src/backend/src/routes/admin/sponsors.ts) · [categories.ts](src/backend/src/routes/admin/categories.ts)
- Front : `app/admin/{speakers,talks,sponsors,categories}/[id]/page.tsx` + `components/admin/{speakers,talks,sponsors,categories}/<Entity>Form.tsx`
- Issue : #122 (étape a/3)
