### PR TITLE
Admin — synthèse de la page édition (#122c)

### DIFF
--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -90,7 +90,18 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
 
       const edition = await prisma.edition.findUnique({
         where: { id },
-        include: { _count: { select: { ticketTiers: true, articles: true } } },
+        include: {
+          _count: {
+            select: {
+              ticketTiers: true,
+              articles: true,
+              speakers: true,
+              talks: true,
+              sponsors: true,
+              categories: true,
+            },
+          },
+        },
       });
 
       if (!edition) return reply.status(404).send({ error: "Edition not found" });
@@ -115,6 +126,10 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         openSponsorLevels: edition.openSponsorLevels ? JSON.parse(edition.openSponsorLevels) : [],
         ticketTiersCount: edition._count.ticketTiers,
         articlesCount: edition._count.articles,
+        speakersCount: edition._count.speakers,
+        talksCount: edition._count.talks,
+        sponsorsCount: edition._count.sponsors,
+        categoriesCount: edition._count.categories,
       };
     }
   );

--- a/src/frontend/src/app/admin/categories/page.tsx
+++ b/src/frontend/src/app/admin/categories/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { adminFetch } from "@/lib/admin-api";
 import type { Category } from "@/lib/types";
@@ -13,9 +13,10 @@ interface CategoryRow extends Category {
 
 export default function CategoriesDataPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [categories, setCategories] = useState<CategoryRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [year, setYear] = useState<string>("");
+  const [year, setYear] = useState<string>(searchParams.get("year") ?? "");
   const [search, setSearch] = useState("");
 
   useEffect(() => {

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -10,6 +10,7 @@ import TicketingTab from "@/components/admin/edition-detail/TicketingTab";
 import CfpTab from "@/components/admin/edition-detail/CfpTab";
 import KeyFiguresTab from "@/components/admin/edition-detail/KeyFiguresTab";
 import SponsoringTab from "@/components/admin/edition-detail/SponsoringTab";
+import SynthesisOverview from "@/components/admin/edition-detail/SynthesisOverview";
 
 interface EditionData {
   id: number;
@@ -26,6 +27,10 @@ interface EditionData {
   archivedSiteUrl: string | null;
   ticketTiersCount: number;
   articlesCount: number;
+  speakersCount: number;
+  talksCount: number;
+  sponsorsCount: number;
+  categoriesCount: number;
 }
 
 const STATUS_LABELS: Record<string, { label: string; variant: "green" | "orange" | "gray" }> = {
@@ -91,6 +96,17 @@ export default function EditionDetailPage() {
         <h1 className="text-3xl font-bold text-noir">DevFest {edition.year}</h1>
         <StatusBadge status={statusInfo.label} variant={statusInfo.variant} />
       </div>
+
+      <SynthesisOverview
+        editionId={edition.id}
+        year={edition.year}
+        counts={{
+          speakers: edition.speakersCount,
+          talks: edition.talksCount,
+          sponsors: edition.sponsorsCount,
+          categories: edition.categoriesCount,
+        }}
+      />
 
       <div className="bg-blanc rounded-xl shadow-card p-6">
         <Tabs tabs={TABS} activeTab={activeTab} onTabChange={handleTabChange} />

--- a/src/frontend/src/app/admin/speakers/page.tsx
+++ b/src/frontend/src/app/admin/speakers/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { adminFetch } from "@/lib/admin-api";
 import type { Speaker } from "@/lib/types";
@@ -14,9 +14,10 @@ interface SpeakerRow extends Speaker {
 
 export default function SpeakersDataPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [speakers, setSpeakers] = useState<SpeakerRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [year, setYear] = useState<string>("");
+  const [year, setYear] = useState<string>(searchParams.get("year") ?? "");
   const [search, setSearch] = useState("");
 
   useEffect(() => {

--- a/src/frontend/src/app/admin/sponsors/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { adminFetch } from "@/lib/admin-api";
 import type { Sponsor, SponsorLevel } from "@/lib/types";
@@ -22,9 +22,10 @@ const LEVEL_LABELS: Record<SponsorLevel, string> = {
 
 export default function SponsorsDataPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [sponsors, setSponsors] = useState<SponsorRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [year, setYear] = useState<string>("");
+  const [year, setYear] = useState<string>(searchParams.get("year") ?? "");
   const [level, setLevel] = useState<string>("");
   const [search, setSearch] = useState("");
 

--- a/src/frontend/src/app/admin/talks/page.tsx
+++ b/src/frontend/src/app/admin/talks/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { adminFetch } from "@/lib/admin-api";
 import type { Talk, TalkFormat } from "@/lib/types";
@@ -20,9 +20,10 @@ const FORMAT_LABELS: Record<TalkFormat, string> = {
 
 export default function TalksDataPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [talks, setTalks] = useState<TalkRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [year, setYear] = useState<string>("");
+  const [year, setYear] = useState<string>(searchParams.get("year") ?? "");
   const [format, setFormat] = useState<string>("");
   const [search, setSearch] = useState("");
 

--- a/src/frontend/src/components/admin/edition-detail/SynthesisOverview.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SynthesisOverview.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { Speaker, Talk } from "@/lib/types";
+
+interface SynthesisOverviewProps {
+  editionId: number;
+  year: number;
+  counts: {
+    speakers: number;
+    talks: number;
+    sponsors: number;
+    categories: number;
+  };
+}
+
+const TOP_N = 5;
+
+export default function SynthesisOverview({ editionId, year, counts }: SynthesisOverviewProps) {
+  const router = useRouter();
+  const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const [talks, setTalks] = useState<Talk[]>([]);
+
+  useEffect(() => {
+    void Promise.all([
+      adminFetch<Speaker[]>(`/speakers?editionId=${editionId}`),
+      adminFetch<Talk[]>(`/talks?editionId=${editionId}`),
+    ]).then(([{ data: s }, { data: t }]) => {
+      if (s) setSpeakers(s);
+      if (t) setTalks(t);
+    });
+  }, [editionId]);
+
+  const publishedSpeakers = speakers.filter((s) => s.publicationStatus === "PUBLISHED");
+
+  function openAllSocialCards() {
+    for (const s of publishedSpeakers) {
+      window.open(`/speakers/${s.slug}/social-card`, "_blank", "noopener");
+    }
+  }
+
+  const cards = [
+    { label: "Speakers", count: counts.speakers, href: `/admin/speakers?year=${year}` },
+    { label: "Conférences", count: counts.talks, href: `/admin/talks?year=${year}` },
+    { label: "Sponsors", count: counts.sponsors, href: `/admin/sponsors?year=${year}` },
+    { label: "Catégories", count: counts.categories, href: `/admin/categories?year=${year}` },
+  ];
+
+  return (
+    <div className="mb-6 space-y-6">
+      {/* Clickable counters */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {cards.map((c) => (
+          <Link
+            key={c.label}
+            href={c.href}
+            className="rounded-xl bg-blanc shadow-card p-4 transition-colors hover:bg-blanc-casse/60"
+          >
+            <p className="text-3xl font-bold text-noir">{c.count}</p>
+            <p className="mt-1 text-sm text-gris">{c.label}</p>
+          </Link>
+        ))}
+      </div>
+
+      {/* Action shortcuts */}
+      <div className="flex flex-wrap gap-3">
+        <button
+          onClick={() => router.push(`/admin/speakers/new?editionId=${editionId}`)}
+          className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+        >
+          + Speaker
+        </button>
+        <button
+          onClick={() => router.push(`/admin/talks/new?editionId=${editionId}`)}
+          className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+        >
+          + Conférence
+        </button>
+        <button
+          onClick={() => router.push(`/admin/sponsors/new?editionId=${editionId}`)}
+          className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+        >
+          + Sponsor
+        </button>
+        <button
+          onClick={() => router.push(`/admin/import?editionId=${editionId}`)}
+          className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+        >
+          Importer (Sessionize)
+        </button>
+        {publishedSpeakers.length > 0 && (
+          <button
+            onClick={openAllSocialCards}
+            title="Ouvre le visuel de chaque speaker publié dans un nouvel onglet"
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+          >
+            Générer les visuels ({publishedSpeakers.length})
+          </button>
+        )}
+      </div>
+
+      {/* Short lists */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <ShortList
+          title="Speakers"
+          allHref={`/admin/speakers?year=${year}`}
+          items={speakers.slice(0, TOP_N).map((s) => ({
+            id: s.id,
+            label: s.name,
+            href: `/admin/speakers/${s.id}`,
+          }))}
+          emptyLabel="Aucun speaker pour cette édition."
+        />
+        <ShortList
+          title="Conférences"
+          allHref={`/admin/talks?year=${year}`}
+          items={talks.slice(0, TOP_N).map((t) => ({
+            id: t.id,
+            label: t.titleFr,
+            href: `/admin/talks/${t.id}`,
+          }))}
+          emptyLabel="Aucune conférence pour cette édition."
+        />
+      </div>
+    </div>
+  );
+}
+
+interface ShortListProps {
+  title: string;
+  allHref: string;
+  items: { id: number; label: string; href: string }[];
+  emptyLabel: string;
+}
+
+function ShortList({ title, allHref, items, emptyLabel }: ShortListProps) {
+  return (
+    <div className="rounded-xl bg-blanc shadow-card p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-bold text-noir">{title}</h3>
+        <Link href={allHref} className="text-xs text-bleu hover:underline">Voir tout</Link>
+      </div>
+      {items.length === 0 ? (
+        <p className="py-4 text-center text-sm text-gris">{emptyLabel}</p>
+      ) : (
+        <ul className="divide-y divide-gris/10">
+          {items.map((it) => (
+            <li key={it.id}>
+              <Link href={it.href} className="block py-2 text-sm text-noir hover:text-malachite truncate">
+                {it.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Dernière sous-étape de #122. Donne à la page édition une **vue d'ensemble** des contenus de l'année, au-dessus des onglets de configuration.

- **Bloc synthèse** (`SynthesisOverview`) au-dessus des 5 onglets :
  - **Compteurs cliquables** : Speakers / Conférences / Sponsors / Catégories → renvoient vers la vue transverse pré-filtrée `/admin/<entité>?year=<année>`.
  - **Raccourcis** : + Speaker / + Conférence / + Sponsor (→ `/admin/<entité>/new?editionId=`, édition pré-sélectionnée), Importer (Sessionize) (→ `/admin/import?editionId=`).
  - **Listes top 5** : aperçu lecture des speakers et conférences de l'édition, chaque item → page d'édition, + « Voir tout ».
  - **Générer les visuels (N)** : ouvre les social-cards des speakers publiés (repris de l'ex-onglet Speakers).
- **Backend** : `GET /editions/:id` renvoie 4 compteurs supplémentaires via `_count` (une requête).
- **Vues transverses** : lisent `?year=` depuis l'URL pour atterrir pré-filtrées.

Clôt le chantier #122 (122a pages d'édition → 122b page allégée → 122c synthèse).

## Test plan

- [x] `tsc` front + back, `lint` front : 0 erreur (warnings préexistants seulement).
- [x] Page édition 2026 : bloc synthèse au-dessus des onglets ; compteurs 5/4/2/4 corrects ; top 5 listes ; raccourcis ; « Générer les visuels (2) ».
- [x] Compteur Speakers → `/admin/speakers?year=2026` : filtre d'édition pré-positionné sur 2026, liste restreinte.
- [x] Onglets de config (Général…) intacts (régression). Console propre.
- [x] Vérif Chrome DevTools MCP.

## Liens

- Synthèse : [SynthesisOverview.tsx](src/frontend/src/components/admin/edition-detail/SynthesisOverview.tsx) · Page : [editions/[id]/page.tsx](src/frontend/src/app/admin/editions/[id]/page.tsx)
- Back : [editions.ts](src/backend/src/routes/admin/editions.ts)
- Vues : `app/admin/{speakers,talks,sponsors,categories}/page.tsx` (lecture `?year=`)
- Issue : #122 (étape c/3 — clôt l'issue)
