### PR TITLE
fix(home): la tagline hero ne coupe plus "devs" prématurément (#133)

### DIFF
--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -250,7 +250,7 @@ body {
 .hero-tagline {
   font-size: clamp(16px, 1.4vw, 22px);
   line-height: 1.45;
-  max-width: 36ch;
+  max-width: 50ch;
   margin: 0;
 }
 .hero-tagline strong {


### PR DESCRIPTION
## Summary

- Élargit `.hero-tagline` (`max-width` 36ch → 50ch) pour que la tagline du hero tienne sur sa ligne sous le titre, au lieu d'orpheliner « les devs » / « devs. » alors qu'il reste de la place à droite.
- Correctif beta issu d'un retour sur le site live.

Closes #133

## Test plan

- [x] `pnpm lint` front : 0 erreur (warnings préexistants uniquement).
- [x] PC 1366×768 FR : tagline sur une seule ligne, plus d'orphelin « les devs » / « devs. ».
- [x] PC 1366×768 EN : « The Toulouse conference by devs, for devs. » sur une seule ligne.
- [x] Mobile 375px : la tagline wrappe proprement, pas de débordement (non-régression).
- [x] Console navigateur propre (Chrome DevTools MCP).
