### PR TITLE
fix(home): titre chiffres clés visible au premier écran PC (#134)

### DIFF
--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -219,7 +219,7 @@ body {
   --hero-gap: clamp(20px, 3vw, 48px);
   --hero-radius: clamp(24px, 3vw, 48px);
   position: relative;
-  padding: clamp(20px, 3vw, 40px) var(--hero-pad) clamp(48px, 6vw, 96px);
+  padding: clamp(16px, 2vw, 28px) var(--hero-pad) clamp(24px, 3vw, 48px);
 }
 .hero-inner {
   display: grid;

--- a/src/frontend/src/components/home/KeyFiguresSection.tsx
+++ b/src/frontend/src/components/home/KeyFiguresSection.tsx
@@ -16,7 +16,7 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
   if (figures.length === 0) return null;
 
   return (
-    <section className="relative px-6 py-16 lg:py-24">
+    <section className="relative px-6 pt-6 pb-12 lg:pt-8 lg:pb-16">
       {/* La Grave illustration — sits on the page background, behind the card,
           peeking out from the bottom-left rather than being boxed inside the
           white card. */}
@@ -32,7 +32,7 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
       </div>
 
       <div className="relative z-10 mx-auto max-w-6xl">
-        <h2 className="text-3xl sm:text-4xl lg:text-[64px] lg:leading-[120%] font-bold text-noir text-center mb-12 lg:mb-20">
+        <h2 className="text-3xl sm:text-4xl lg:text-[64px] lg:leading-[120%] font-bold text-noir text-center mb-8 lg:mb-12">
           {t.rich("title", {
             tech: (chunks) => <span className="text-malachite">{chunks}</span>,
             toulousain: (chunks) => <span className="text-terre-cuite">{chunks}</span>,


### PR DESCRIPTION
## Summary

- Réduit l'espacement vertical du hero (padding haut/bas de `.hero`) et de la section chiffres clés (padding haut + marge basse du titre) pour que « La plus grande conférence tech du bassin Toulousain » apparaisse dès le premier écran PC, sans scroll.
- Correctif beta issu d'un retour sur le site live (« trop aéré »).

Closes #134

## Test plan

- [x] `pnpm lint` front : 0 erreur (warnings préexistants uniquement).
- [x] PC **1366×768** (viewport réel mesuré : 768px) : le titre est visible au premier écran — `top` du `<h2>` à 734px (< 768). Vérifié au `getBoundingClientRect()` via Chrome DevTools MCP.
- [x] Hero équilibré : titre, tagline, date/lieu, CTA et photo intacts, aucun chevauchement.
- [x] Mobile 375px : stack en colonne propre, pas de débordement (non-régression).
- [x] FR vérifié au navigateur, console propre.

## Note

- Le titre est **partiellement** visible (première ligne) au premier écran, conformément au critère « (au moins en partie) visible ». Aller jusqu'à le rendre intégralement visible exigerait de réduire la photo/le titre du hero — hors scope.
- La densification verticale des **autres** sections de la home est traitée séparément dans #135.
