### PR TITLE
feat(home): rythme vertical commun pour toutes les sections (#135)

### DIFF
--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -174,9 +174,9 @@ export default async function HomePage() {
       )}
 
       {isSeeYouNextYear && edition?.galleryUrl && (
-        <section className="px-6 py-16 lg:py-24 bg-blanc-casse">
+        <section className="section-y px-6 bg-blanc-casse">
           <div className="mx-auto max-w-6xl text-center">
-            <h2 className="text-3xl lg:text-5xl font-bold text-noir mb-6">
+            <h2 className="section-title text-3xl lg:text-5xl font-bold text-noir">
               {locale === "fr" ? "Galerie photos" : "Photo gallery"}
             </h2>
             <a

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -366,3 +366,16 @@ body {
     animation: none;
   }
 }
+
+/* ========================================
+ * Home — vertical rhythm
+ * Single source of truth for section spacing so every home section shares
+ * the same responsive vertical padding and title spacing instead of ad-hoc
+ * per-section values. Densified from the previous py-16 lg:py-24 (#135).
+ * ======================================== */
+.section-y {
+  padding-block: clamp(40px, 5vw, 72px);
+}
+.section-title {
+  margin-bottom: clamp(24px, 3vw, 40px);
+}

--- a/src/frontend/src/components/home/AboutSection.tsx
+++ b/src/frontend/src/components/home/AboutSection.tsx
@@ -4,7 +4,7 @@ export default function AboutSection() {
   const t = useTranslations("home.about");
 
   return (
-    <section className="px-6 py-10 lg:py-14">
+    <section className="section-y px-6">
       <div className="mx-auto max-w-6xl">
         <div className="relative overflow-hidden rounded-3xl bg-bismarck min-h-[400px] flex items-center">
           {/* Warm orange filter over the (future) background photo, replacing

--- a/src/frontend/src/components/home/EcosystemSection.tsx
+++ b/src/frontend/src/components/home/EcosystemSection.tsx
@@ -11,9 +11,9 @@ export default async function EcosystemSection() {
   if (partners.length === 0) return null;
 
   return (
-    <section className="px-6 py-10 lg:py-14">
+    <section className="section-y px-6">
       <div className="mx-auto max-w-6xl text-center">
-        <h2 className="text-2xl lg:text-4xl font-bold text-noir mb-8">
+        <h2 className="section-title text-2xl lg:text-4xl font-bold text-noir">
           {t("ecosystemTitle")}
         </h2>
         <div className="flex flex-wrap justify-center gap-4">

--- a/src/frontend/src/components/home/FeaturedSpeakersSection.tsx
+++ b/src/frontend/src/components/home/FeaturedSpeakersSection.tsx
@@ -14,9 +14,9 @@ export default async function FeaturedSpeakersSection() {
   if (speakers.length === 0) return null;
 
   return (
-    <section className="px-6 py-10 lg:py-14">
+    <section className="section-y px-6">
       <div className="mx-auto max-w-6xl">
-        <h2 className="mb-8 text-2xl font-bold text-noir lg:text-4xl">{t("title")}</h2>
+        <h2 className="section-title text-2xl font-bold text-noir lg:text-4xl">{t("title")}</h2>
 
         <div className="grid grid-cols-2 gap-8 sm:grid-cols-3 lg:grid-cols-4">
           {speakers.map((s) => (

--- a/src/frontend/src/components/home/KeyFiguresSection.tsx
+++ b/src/frontend/src/components/home/KeyFiguresSection.tsx
@@ -15,8 +15,10 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
 
   if (figures.length === 0) return null;
 
+  // Reduced top padding keeps the title on the first PC screen (#134);
+  // bottom padding matches the shared section rhythm (.section-y, #135).
   return (
-    <section className="relative px-6 py-16 lg:py-24">
+    <section className="relative px-6 pt-6 lg:pt-8 pb-[clamp(40px,5vw,72px)]">
       {/* La Grave illustration — sits on the page background, behind the card,
           peeking out from the bottom-left rather than being boxed inside the
           white card. */}
@@ -32,7 +34,7 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
       </div>
 
       <div className="relative z-10 mx-auto max-w-6xl">
-        <h2 className="text-3xl sm:text-4xl lg:text-[64px] lg:leading-[120%] font-bold text-noir text-center mb-12 lg:mb-20">
+        <h2 className="section-title text-3xl sm:text-4xl lg:text-[64px] lg:leading-[120%] font-bold text-noir text-center">
           {t.rich("title", {
             tech: (chunks) => <span className="text-malachite">{chunks}</span>,
             toulousain: (chunks) => <span className="text-terre-cuite">{chunks}</span>,

--- a/src/frontend/src/components/home/LatestNewsSection.tsx
+++ b/src/frontend/src/components/home/LatestNewsSection.tsx
@@ -15,9 +15,9 @@ export default function LatestNewsSection({ articles, locale }: LatestNewsSectio
   if (articles.length === 0) return null;
 
   return (
-    <section className="px-6 py-10 lg:py-14">
+    <section className="section-y px-6">
       <div className="mx-auto max-w-6xl">
-        <div className="flex items-center justify-between mb-10">
+        <div className="section-title flex items-center justify-between">
           <h2 className="text-3xl lg:text-5xl font-bold text-noir">
             {t("title")}
           </h2>

--- a/src/frontend/src/components/home/ReplaySection.tsx
+++ b/src/frontend/src/components/home/ReplaySection.tsx
@@ -18,9 +18,9 @@ export default function ReplaySection({
   const hasCtas = Boolean(galleryUrl) || Boolean(editionYear);
 
   return (
-    <section className="px-6 py-16 lg:py-24">
+    <section className="section-y px-6">
       <div className="mx-auto max-w-4xl">
-        <h2 className="text-3xl lg:text-5xl font-bold text-noir text-center mb-10">
+        <h2 className="section-title text-3xl lg:text-5xl font-bold text-noir text-center">
           {editionYear ? t("title", { year: editionYear }) : t("titleFallback")}
         </h2>
         <YouTubeFacade videoUrl={aftermovieUrl} title="DevFest Toulouse Aftermovie" />

--- a/src/frontend/src/components/home/SponsorsSection.tsx
+++ b/src/frontend/src/components/home/SponsorsSection.tsx
@@ -22,7 +22,7 @@ export default async function SponsorsSection() {
   })).filter((g) => g.items.length > 0);
 
   return (
-    <section className="relative overflow-hidden px-6 py-10 lg:py-14">
+    <section className="section-y relative overflow-hidden px-6">
       {/* Croix occitane decoration (top-right). Placeholder geometric mark
           until the brand asset is provided; kept subtle and decorative. */}
       <div
@@ -35,7 +35,7 @@ export default async function SponsorsSection() {
       </div>
 
       <div className="relative mx-auto max-w-6xl">
-        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+        <div className="section-title flex flex-wrap items-center justify-between gap-4">
           <h2 className="text-2xl font-bold text-noir lg:text-4xl">{t("title")}</h2>
           <Link
             href="/devenir-sponsor"

--- a/src/frontend/src/components/home/TicketingSection.tsx
+++ b/src/frontend/src/components/home/TicketingSection.tsx
@@ -24,9 +24,9 @@ export default function TicketingSection({ tiers, locale }: TicketingSectionProp
   const smCols = tiers.length === 1 ? "sm:grid-cols-1" : "sm:grid-cols-2";
 
   return (
-    <section className="px-6 py-16 lg:py-24 bg-blanc-casse">
+    <section className="section-y px-6 bg-blanc-casse">
       <div className="mx-auto max-w-6xl text-center">
-        <h2 className="text-3xl lg:text-5xl font-bold text-noir mb-10">
+        <h2 className="section-title text-3xl lg:text-5xl font-bold text-noir">
           {t("title")}
         </h2>
 


### PR DESCRIPTION
## Summary

- Introduit deux classes utilitaires `.section-y` (padding vertical) et `.section-title` (marge basse de titre) dans [globals.css](src/frontend/src/app/globals.css) comme **source unique de vérité** du rythme vertical de la home.
- Les applique à **toutes** les sections de la home, en remplacement des deux barèmes ad hoc (`py-16 lg:py-24` et `py-10 lg:py-14`) et des quatre marges de titre différentes (`mb-6/8/10/12 lg:mb-20`).
- Résultat : un rythme unique et plus dense — `clamp(40px, 5vw, 72px)` (~72px desktop, plancher 40px mobile) au lieu de 56–96px disparates.
- Correctif beta : la home était jugée « trop aérée ».

Closes #135

## Détails

Sections converties : KeyFigures, Billetterie, Replay, Sponsors, Speakers, Actualités, About, Écosystème, + la section inline « Galerie photos » de `page.tsx`.

`KeyFiguresSection` conserve un **padding haut réduit** (`pt-6 lg:pt-8`) pour garder son titre au premier écran PC : se combine avec la réduction du hero de #134.

## Test plan

- [x] `tsc --noEmit` : 0 erreur.
- [x] `pnpm lint` : 0 erreur (warnings préexistants uniquement).
- [x] Barème appliqué partout, **aucune valeur ad hoc résiduelle** (`grep py-16 lg:py-24 / py-10 lg:py-14` → plus aucune occurrence dans les composants).
- [x] Rythme vertical uniforme mesuré à 1366×768 : toutes les `.section-y` à 68px haut/bas ; KeyFigures à 32px haut (premier écran préservé) / 68px bas.
- [x] Composition avec #134 vérifiée (hero réduit + rythme #135 → titre chiffres clés `top` 734px < 768, visible).
- [x] Mobile 375px : plancher 40px, sections respirent, pas de régression.
- [x] FR vérifié au navigateur, console propre.

## Note — couplage de PR

- Touche les mêmes fichiers que **#133** (PR #137, `globals.css`) et **#134** (PR #138, `globals.css` + `KeyFiguresSection.tsx`).
- Conflit attendu sur `KeyFiguresSection.tsx` avec #134 (les deux retravaillent le `<section>` et le `<h2>`). Cette PR intègre déjà l'intention de #134 (top réduit) ; à merger après #137/#138 ou à arbitrer au merge.
