### PR TITLE
fix(home): titre chiffres clés visible sur viewport laptop réel (#134)

### DIFF
--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -219,7 +219,7 @@ body {
   --hero-gap: clamp(20px, 3vw, 48px);
   --hero-radius: clamp(24px, 3vw, 48px);
   position: relative;
-  padding: clamp(16px, 2vw, 28px) var(--hero-pad) clamp(24px, 3vw, 48px);
+  padding: clamp(14px, 1.6vw, 24px) var(--hero-pad) clamp(20px, 2.4vw, 32px);
 }
 .hero-inner {
   display: grid;
@@ -233,8 +233,8 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: clamp(20px, 2.4vw, 36px);
-  padding-block: clamp(12px, 2vw, 32px);
+  gap: clamp(16px, 1.8vw, 24px);
+  padding-block: clamp(4px, 1vw, 16px);
 }
 .hero-title {
   font-size: clamp(56px, 9.5vw, 168px);
@@ -286,7 +286,7 @@ body {
 }
 .hero-photo {
   position: relative;
-  min-height: clamp(280px, 42vw, 640px);
+  min-height: clamp(260px, 35vw, 520px);
   background-size: cover;
   background-position: center;
   border-radius: var(--hero-radius);


### PR DESCRIPTION
## Summary

- Le correctif initial de #134 (PR #138) était calibré sur un viewport de **768px**, mais un laptop réel 1366×768 n'expose que **~660px** de hauteur de contenu (barres du navigateur). Le titre « La plus grande conférence... » repassait donc sous la ligne de flottaison pour les utilisateurs.
- Réduit davantage la hauteur du hero pour ramener le titre à **~624px**, confortablement au-dessus de la ligne de flottaison réelle (~660px) :
  - `.hero-photo` min-height `clamp(280px, 42vw, 640px)` → `clamp(260px, 35vw, 520px)`
  - `.hero-content` gap et padding-block réduits
  - `.hero` padding bas réduit

## Contexte

Retour : « la 134 n'est plus valable ». Le titre était sous la ligne de flottaison sur un vrai écran. Erreur de calibration d'origine corrigée ici (viewport réel vs valeur MCP).

Closes #134

## Test plan

- [x] `pnpm lint` : 0 erreur.
- [x] **1366×660** (viewport laptop réel) : titre `top` = 624px < 660 → **visible** (mesuré via Chrome DevTools MCP).
- [x] 1366×768 : titre à 624px, visible avec marge.
- [x] Hero équilibré : titre, tagline (1 ligne), date/lieu, CTA, photo intacts.
- [x] Mobile 390px : stack en colonne propre, pas de régression.
- [x] Console propre (hors warning préexistant du logo).
