### PR TITLE
feat(home): premier écran plein hauteur, chiffres sous le pli (#134)

### DIFF
--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/lib/api";
 
 import HeroSection from "@/components/home/HeroSection";
-import KeyFiguresSection from "@/components/home/KeyFiguresSection";
 import TicketingSection from "@/components/home/TicketingSection";
 import ReplaySection from "@/components/home/ReplaySection";
 import LatestNewsSection from "@/components/home/LatestNewsSection";
@@ -125,7 +124,14 @@ export default async function HomePage() {
         />
       )}
 
-      <HeroSection edition={edition} cfp={cfp} locale={locale} />
+      {/* Key figures live inside the hero (announcement only) so the
+          catch-phrase title shows on the first screen (#134). */}
+      <HeroSection
+        edition={edition}
+        cfp={cfp}
+        locale={locale}
+        figures={isAnnouncement ? figures : []}
+      />
 
       {/* PREPARATION: teasing + replay from previous edition */}
       {isPreparation && edition?.previousAfterMovieUrl && (
@@ -134,11 +140,6 @@ export default async function HomePage() {
           galleryUrl={edition.previousGalleryUrl}
           editionYear={edition.previousYear}
         />
-      )}
-
-      {/* ANNOUNCEMENT: full content */}
-      {isAnnouncement && figures.length > 0 && (
-        <KeyFiguresSection figures={figures} locale={locale} />
       )}
 
       {isAnnouncement && tiers.length > 0 && (

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -220,13 +220,16 @@ body {
   --hero-radius: clamp(24px, 3vw, 48px);
   --header-h: 60px;
   position: relative;
-  padding: clamp(16px, 2vw, 28px) var(--hero-pad) clamp(28px, 3.5vw, 56px);
+  padding: 0 var(--hero-pad) clamp(28px, 3.5vw, 56px);
 }
 /* First screen: header (60px sticky) + this block fill the viewport, so the
    catch-phrase lands at the bottom of the fold and the stats card needs a
-   scroll (#134). */
+   scroll (#134). Its own vertical padding is included in the min-height
+   (border-box), so header + .hero-screen = exactly 100vh. */
 .hero-screen {
   min-height: calc(100dvh - var(--header-h));
+  box-sizing: border-box;
+  padding-block: clamp(16px, 2vw, 28px);
   display: flex;
   flex-direction: column;
   gap: clamp(24px, 3vw, 48px);

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -218,8 +218,21 @@ body {
   --hero-pad: clamp(20px, 4vw, 56px);
   --hero-gap: clamp(20px, 3vw, 48px);
   --hero-radius: clamp(24px, 3vw, 48px);
+  --header-h: 60px;
   position: relative;
   padding: clamp(16px, 2vw, 28px) var(--hero-pad) clamp(28px, 3.5vw, 56px);
+}
+/* First screen: header (60px sticky) + this block fill the viewport, so the
+   catch-phrase lands at the bottom of the fold and the stats card needs a
+   scroll (#134). */
+.hero-screen {
+  min-height: calc(100dvh - var(--header-h));
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 3vw, 48px);
+}
+.hero-screen > .hero-inner {
+  flex: 1 1 auto;
 }
 .hero-inner {
   display: grid;
@@ -367,16 +380,16 @@ body {
   }
 }
 
-/* Key-figures block rendered inside the hero (#134) — the big centred
- * catch-phrase title + stats card, kept compact so the whole hero fits on
- * the first screen of a 1366x768 laptop. */
-.hero-figures {
-  margin-top: clamp(8px, 1vw, 16px);
-}
+/* Key-figures inside the hero (#134). The catch-phrase title is pinned at the
+ * bottom of the first screen (.hero-screen flex column); the stats card flows
+ * just below the fold, so reaching the figures requires a scroll. */
 .hero-figures-title {
-  margin-bottom: clamp(28px, 4vw, 56px);
+  margin: 0;
   line-height: 1.1;
   text-wrap: balance;
+}
+.hero-figures {
+  margin-top: clamp(24px, 3vw, 48px);
 }
 
 /* ========================================

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -236,6 +236,13 @@ body {
 }
 .hero-screen > .hero-inner {
   flex: 1 1 auto;
+  /* In a flex column, margin:0 auto on the grid cancels the default stretch
+     and shrinks it to content width; force full width so the hero spans the
+     row (max-width still caps it, margin auto still centres it). */
+  width: 100%;
+}
+.hero-screen > .hero-figures-title {
+  align-self: stretch;
 }
 .hero-inner {
   display: grid;

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -219,7 +219,7 @@ body {
   --hero-gap: clamp(20px, 3vw, 48px);
   --hero-radius: clamp(24px, 3vw, 48px);
   position: relative;
-  padding: clamp(16px, 2vw, 28px) var(--hero-pad) clamp(24px, 3vw, 48px);
+  padding: clamp(10px, 1.2vw, 16px) var(--hero-pad) clamp(16px, 1.8vw, 24px);
 }
 .hero-inner {
   display: grid;
@@ -233,11 +233,11 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: clamp(20px, 2.4vw, 36px);
-  padding-block: clamp(12px, 2vw, 32px);
+  gap: clamp(8px, 1vw, 14px);
+  padding-block: clamp(4px, 0.8vw, 12px);
 }
 .hero-title {
-  font-size: clamp(56px, 9.5vw, 168px);
+  font-size: clamp(40px, 5.9vw, 100px);
   line-height: 0.92;
   letter-spacing: -0.02em;
   font-weight: 700;
@@ -255,15 +255,6 @@ body {
 }
 .hero-tagline strong {
   font-weight: 700;
-}
-.hero-catchphrase {
-  font-size: clamp(22px, 2.6vw, 40px);
-  line-height: 1.15;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  max-width: 22ch;
-  margin: 0;
-  text-wrap: balance;
 }
 .hero-meta {
   display: flex;
@@ -295,7 +286,7 @@ body {
 }
 .hero-photo {
   position: relative;
-  min-height: clamp(280px, 42vw, 640px);
+  min-height: clamp(200px, 19vw, 300px);
   background-size: cover;
   background-position: center;
   border-radius: var(--hero-radius);
@@ -363,7 +354,7 @@ body {
 /* Ultra-wide — cap the type so it doesn't blow up past 1900px */
 @media (min-width: 1900px) {
   .hero-title {
-    font-size: 168px;
+    font-size: 100px;
   }
   .hero-photo-wordmark {
     font-size: 240px;
@@ -374,6 +365,18 @@ body {
   .hero-photo-badge::before {
     animation: none;
   }
+}
+
+/* Key-figures block rendered inside the hero (#134) — the big centred
+ * catch-phrase title + stats card, kept compact so the whole hero fits on
+ * the first screen of a 1366x768 laptop. */
+.hero-figures {
+  margin-top: clamp(8px, 1vw, 16px);
+}
+.hero-figures-title {
+  margin-bottom: clamp(10px, 1.4vw, 18px);
+  line-height: 1.1;
+  text-wrap: balance;
 }
 
 /* ========================================

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -219,7 +219,7 @@ body {
   --hero-gap: clamp(20px, 3vw, 48px);
   --hero-radius: clamp(24px, 3vw, 48px);
   position: relative;
-  padding: clamp(10px, 1.2vw, 16px) var(--hero-pad) clamp(16px, 1.8vw, 24px);
+  padding: clamp(16px, 2vw, 28px) var(--hero-pad) clamp(28px, 3.5vw, 56px);
 }
 .hero-inner {
   display: grid;
@@ -233,11 +233,11 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: clamp(8px, 1vw, 14px);
-  padding-block: clamp(4px, 0.8vw, 12px);
+  gap: clamp(16px, 2vw, 30px);
+  padding-block: clamp(8px, 1.4vw, 24px);
 }
 .hero-title {
-  font-size: clamp(40px, 5.9vw, 100px);
+  font-size: clamp(48px, 8vw, 140px);
   line-height: 0.92;
   letter-spacing: -0.02em;
   font-weight: 700;
@@ -286,7 +286,7 @@ body {
 }
 .hero-photo {
   position: relative;
-  min-height: clamp(200px, 19vw, 300px);
+  min-height: clamp(260px, 34vw, 500px);
   background-size: cover;
   background-position: center;
   border-radius: var(--hero-radius);
@@ -354,7 +354,7 @@ body {
 /* Ultra-wide — cap the type so it doesn't blow up past 1900px */
 @media (min-width: 1900px) {
   .hero-title {
-    font-size: 100px;
+    font-size: 140px;
   }
   .hero-photo-wordmark {
     font-size: 240px;
@@ -374,7 +374,7 @@ body {
   margin-top: clamp(8px, 1vw, 16px);
 }
 .hero-figures-title {
-  margin-bottom: clamp(10px, 1.4vw, 18px);
+  margin-bottom: clamp(28px, 4vw, 56px);
   line-height: 1.1;
   text-wrap: balance;
 }

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -256,6 +256,15 @@ body {
 .hero-tagline strong {
   font-weight: 700;
 }
+.hero-catchphrase {
+  font-size: clamp(22px, 2.6vw, 40px);
+  line-height: 1.15;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  max-width: 22ch;
+  margin: 0;
+  text-wrap: balance;
+}
 .hero-meta {
   display: flex;
   flex-wrap: wrap;

--- a/src/frontend/src/components/home/HeroSection.tsx
+++ b/src/frontend/src/components/home/HeroSection.tsx
@@ -1,7 +1,8 @@
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
+import KeyFiguresSection from "./KeyFiguresSection";
 import { getCfpCtaUrl } from "@/lib/cfp";
-import type { CfpSettings, Edition } from "@/lib/types";
+import type { CfpSettings, Edition, KeyFigure } from "@/lib/types";
 
 function formatDate(dateStr: string, locale: string): string {
   const date = new Date(dateStr);
@@ -16,11 +17,11 @@ interface HeroSectionProps {
   edition: Edition | null;
   cfp: CfpSettings | null;
   locale: string;
+  figures?: KeyFigure[];
 }
 
-export default function HeroSection({ edition, cfp, locale }: HeroSectionProps) {
+export default function HeroSection({ edition, cfp, locale, figures = [] }: HeroSectionProps) {
   const t = useTranslations("home.hero");
-  const tStats = useTranslations("home.stats");
 
   const heroImageUrl = edition?.heroImageUrl || null;
   const dateLabel = edition?.startDate ? formatDate(edition.startDate, locale) : null;
@@ -61,15 +62,6 @@ export default function HeroSection({ edition, cfp, locale }: HeroSectionProps) 
             {t("subtitleLine1")} <strong>{t("subtitleLine2devs")}</strong>
             {t("subtitleLine2end")}
             <strong>{t("subtitleLine2devs2")}</strong>
-          </p>
-
-          {/* Catch-phrase moved up from the key-figures section so it shows on
-              the first screen (#134). Same i18n key (home.stats.title). */}
-          <p className="hero-catchphrase text-noir">
-            {tStats.rich("title", {
-              tech: (chunks) => <span className="text-malachite">{chunks}</span>,
-              toulousain: (chunks) => <span className="text-terre-cuite">{chunks}</span>,
-            })}
           </p>
 
           {(dateLabel || venueLabel) && (
@@ -121,6 +113,11 @@ export default function HeroSection({ edition, cfp, locale }: HeroSectionProps) 
           {yearMonogram && <span className="hero-photo-wordmark">{yearMonogram}</span>}
         </div>
       </div>
+
+      {/* Key-figures (title + stats card) rendered inside the hero so the
+          catch-phrase stays big and centred yet shows on the first screen
+          without scrolling (#134). */}
+      {figures.length > 0 && <KeyFiguresSection figures={figures} locale={locale} />}
     </section>
   );
 }

--- a/src/frontend/src/components/home/HeroSection.tsx
+++ b/src/frontend/src/components/home/HeroSection.tsx
@@ -20,6 +20,7 @@ interface HeroSectionProps {
 
 export default function HeroSection({ edition, cfp, locale }: HeroSectionProps) {
   const t = useTranslations("home.hero");
+  const tStats = useTranslations("home.stats");
 
   const heroImageUrl = edition?.heroImageUrl || null;
   const dateLabel = edition?.startDate ? formatDate(edition.startDate, locale) : null;
@@ -60,6 +61,15 @@ export default function HeroSection({ edition, cfp, locale }: HeroSectionProps) 
             {t("subtitleLine1")} <strong>{t("subtitleLine2devs")}</strong>
             {t("subtitleLine2end")}
             <strong>{t("subtitleLine2devs2")}</strong>
+          </p>
+
+          {/* Catch-phrase moved up from the key-figures section so it shows on
+              the first screen (#134). Same i18n key (home.stats.title). */}
+          <p className="hero-catchphrase text-noir">
+            {tStats.rich("title", {
+              tech: (chunks) => <span className="text-malachite">{chunks}</span>,
+              toulousain: (chunks) => <span className="text-terre-cuite">{chunks}</span>,
+            })}
           </p>
 
           {(dateLabel || venueLabel) && (

--- a/src/frontend/src/components/home/HeroSection.tsx
+++ b/src/frontend/src/components/home/HeroSection.tsx
@@ -22,6 +22,7 @@ interface HeroSectionProps {
 
 export default function HeroSection({ edition, cfp, locale, figures = [] }: HeroSectionProps) {
   const t = useTranslations("home.hero");
+  const tStats = useTranslations("home.stats");
 
   const heroImageUrl = edition?.heroImageUrl || null;
   const dateLabel = edition?.startDate ? formatDate(edition.startDate, locale) : null;
@@ -42,8 +43,14 @@ export default function HeroSection({ edition, cfp, locale, figures = [] }: Hero
     ? `linear-gradient(0deg, rgba(29,29,27,0.28), rgba(29,29,27,0.28)), url('${heroImageUrl}')`
     : "linear-gradient(0deg, rgba(29,29,27,0.28), rgba(29,29,27,0.28)), url('https://picsum.photos/1600/1000?random=devfest')";
 
+  const hasFigures = figures.length > 0;
+
   return (
     <section className="hero w-full bg-blanc" aria-label="DevFest Toulouse">
+      {/* First screen: header + this block are sized to fill 100vh so the
+          catch-phrase sits at the bottom of the fold and the figures card
+          below it requires a scroll (#134). */}
+      <div className="hero-screen">
       <div className="hero-inner">
         <div className="hero-content">
           {/* Visually hidden H1 holds the semantic page heading so crawlers
@@ -114,10 +121,19 @@ export default function HeroSection({ edition, cfp, locale, figures = [] }: Hero
         </div>
       </div>
 
-      {/* Key-figures (title + stats card) rendered inside the hero so the
-          catch-phrase stays big and centred yet shows on the first screen
-          without scrolling (#134). */}
-      {figures.length > 0 && <KeyFiguresSection figures={figures} locale={locale} />}
+        {/* Catch-phrase pinned at the bottom of the first screen. */}
+        {hasFigures && (
+          <h2 className="hero-figures-title text-2xl sm:text-3xl lg:text-4xl font-bold text-noir text-center px-6">
+            {tStats.rich("title", {
+              tech: (chunks) => <span className="text-malachite">{chunks}</span>,
+              toulousain: (chunks) => <span className="text-terre-cuite">{chunks}</span>,
+            })}
+          </h2>
+        )}
+      </div>
+
+      {/* Stats card — sits just below the fold so it needs a scroll (#134). */}
+      {hasFigures && <KeyFiguresSection figures={figures} locale={locale} />}
     </section>
   );
 }

--- a/src/frontend/src/components/home/KeyFiguresSection.tsx
+++ b/src/frontend/src/components/home/KeyFiguresSection.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 
 import StatIcon from "./StatIcon";
 import { localizedField } from "@/lib/i18n-helpers";
@@ -9,13 +10,16 @@ interface KeyFiguresSectionProps {
   locale: string;
 }
 
+// Rendered inside the hero (#134): big centred catch-phrase title above the
+// stats card, sized to fit on the first screen without scrolling. Uses a div
+// (not a <section>) since it lives within the hero <section>.
 export default function KeyFiguresSection({ figures, locale }: KeyFiguresSectionProps) {
+  const t = useTranslations("home.stats");
+
   if (figures.length === 0) return null;
 
-  // The catch-phrase title now lives in the hero (#134); this section keeps
-  // the figures card only. Shared section rhythm via .section-y (#135).
   return (
-    <section className="section-y relative px-6">
+    <div className="hero-figures relative px-6">
       {/* La Grave illustration — sits on the page background, behind the card,
           peeking out from the bottom-left rather than being boxed inside the
           white card. */}
@@ -31,18 +35,25 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
       </div>
 
       <div className="relative z-10 mx-auto max-w-6xl">
-        <div className="relative bg-blanc rounded-4xl shadow-section p-8 lg:p-12">
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-12">
+        <h2 className="hero-figures-title text-2xl sm:text-3xl lg:text-4xl font-bold text-noir text-center">
+          {t.rich("title", {
+            tech: (chunks) => <span className="text-malachite">{chunks}</span>,
+            toulousain: (chunks) => <span className="text-terre-cuite">{chunks}</span>,
+          })}
+        </h2>
+
+        <div className="relative bg-blanc rounded-4xl shadow-section p-5 lg:p-6">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-8">
             {figures.map((figure) => (
               <div
                 key={figure.icon}
-                className="flex flex-col items-center text-center p-6 rounded-xl"
+                className="flex flex-col items-center text-center p-2 rounded-xl"
               >
-                <StatIcon name={figure.icon} className="text-4xl lg:text-[56px]" />
-                <span className="mt-3 text-4xl lg:text-[56px] lg:leading-[140%] font-bold text-noir">
+                <StatIcon name={figure.icon} className="text-2xl lg:text-4xl" />
+                <span className="mt-1 text-3xl lg:text-[40px] font-bold text-noir">
                   {figure.value}
                 </span>
-                <span className="mt-2 text-lg lg:text-2xl text-gris">
+                <span className="mt-1 text-sm lg:text-lg text-gris">
                   {localizedField(figure, "label", locale)}
                 </span>
               </div>
@@ -50,6 +61,6 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
           </div>
         </div>
       </div>
-    </section>
+    </div>
   );
 }

--- a/src/frontend/src/components/home/KeyFiguresSection.tsx
+++ b/src/frontend/src/components/home/KeyFiguresSection.tsx
@@ -1,5 +1,4 @@
 import Image from "next/image";
-import { useTranslations } from "next-intl";
 
 import StatIcon from "./StatIcon";
 import { localizedField } from "@/lib/i18n-helpers";
@@ -10,12 +9,9 @@ interface KeyFiguresSectionProps {
   locale: string;
 }
 
-// Rendered inside the hero (#134): big centred catch-phrase title above the
-// stats card, sized to fit on the first screen without scrolling. Uses a div
-// (not a <section>) since it lives within the hero <section>.
+// Stats card only (#134). The catch-phrase title is rendered by the hero so it
+// can pin to the bottom of the first screen; this card sits just below the fold.
 export default function KeyFiguresSection({ figures, locale }: KeyFiguresSectionProps) {
-  const t = useTranslations("home.stats");
-
   if (figures.length === 0) return null;
 
   return (
@@ -35,13 +31,6 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
       </div>
 
       <div className="relative z-10 mx-auto max-w-6xl">
-        <h2 className="hero-figures-title text-2xl sm:text-3xl lg:text-4xl font-bold text-noir text-center">
-          {t.rich("title", {
-            tech: (chunks) => <span className="text-malachite">{chunks}</span>,
-            toulousain: (chunks) => <span className="text-terre-cuite">{chunks}</span>,
-          })}
-        </h2>
-
         <div className="relative bg-blanc rounded-4xl shadow-section p-5 lg:p-6">
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-8">
             {figures.map((figure) => (

--- a/src/frontend/src/components/home/KeyFiguresSection.tsx
+++ b/src/frontend/src/components/home/KeyFiguresSection.tsx
@@ -1,5 +1,4 @@
 import Image from "next/image";
-import { useTranslations } from "next-intl";
 
 import StatIcon from "./StatIcon";
 import { localizedField } from "@/lib/i18n-helpers";
@@ -11,14 +10,12 @@ interface KeyFiguresSectionProps {
 }
 
 export default function KeyFiguresSection({ figures, locale }: KeyFiguresSectionProps) {
-  const t = useTranslations("home.stats");
-
   if (figures.length === 0) return null;
 
-  // Reduced top padding keeps the title on the first PC screen (#134);
-  // bottom padding matches the shared section rhythm (.section-y, #135).
+  // The catch-phrase title now lives in the hero (#134); this section keeps
+  // the figures card only. Shared section rhythm via .section-y (#135).
   return (
-    <section className="relative px-6 pt-6 lg:pt-8 pb-[clamp(40px,5vw,72px)]">
+    <section className="section-y relative px-6">
       {/* La Grave illustration — sits on the page background, behind the card,
           peeking out from the bottom-left rather than being boxed inside the
           white card. */}
@@ -34,13 +31,6 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
       </div>
 
       <div className="relative z-10 mx-auto max-w-6xl">
-        <h2 className="section-title text-3xl sm:text-4xl lg:text-[64px] lg:leading-[120%] font-bold text-noir text-center">
-          {t.rich("title", {
-            tech: (chunks) => <span className="text-malachite">{chunks}</span>,
-            toulousain: (chunks) => <span className="text-terre-cuite">{chunks}</span>,
-          })}
-        </h2>
-
         <div className="relative bg-blanc rounded-4xl shadow-section p-8 lg:p-12">
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-12">
             {figures.map((figure) => (


### PR DESCRIPTION
## Summary

- Le premier écran de la home occupe désormais **100% de la hauteur de la fenêtre** : `header (60px) + hero + phrase « La plus grande conférence tech du bassin Toulousain »`.
- La phrase d'accroche est **épinglée en bas** de ce premier écran ; la **carte des chiffres démarre sous la ligne de flottaison** → il faut scroller pour la voir (comportement voulu).
- Le titre des chiffres est remonté dans le hero (réutilise la clé i18n `home.stats.title`) ; `KeyFiguresSection` ne rend plus que la carte.

## Implémentation

- Nouveau bloc `.hero-screen` : `min-height: calc(100dvh - var(--header-h))` (header sticky = 60px), `box-sizing: border-box`, flex column. La grille hero grandit, la phrase se cale en bas.
- `100dvh` (et non `100vh`) pour la fiabilité mobile ; padding vertical déplacé dans `.hero-screen` pour que `header + .hero-screen = exactement 100vh` quelle que soit la taille de fenêtre.

## Contexte

Itérations successives sur le retour beta « le titre des chiffres doit être visible au premier écran » : on a finalement choisi de faire occuper tout l'écran au hero + phrase, les chiffres devenant accessibles au scroll.

⚠️ **Remplace #140** (autre approche du même besoin #134, par compactage). Si cette PR est retenue, fermer #140.

Closes #134

## Test plan

- [x] `pnpm lint` + `tsc --noEmit` : 0 erreur.
- [x] **1366×768** : `.hero-screen` se termine pile à 768 (header 60 + 708) → 100% ; phrase visible (bottom 741) ; carte sous le pli (top 809). Mesuré via Chrome DevTools MCP.
- [x] **1366×660** (laptop réel) : se termine pile à 660 → s'ajuste automatiquement ; phrase visible, carte sous le pli.
- [x] FR + EN corrects (clé i18n partagée, segments colorés conservés).
- [x] Mobile 390px : stack propre, pas de débordement.
- [x] Console propre.
