### PR TITLE
feat(articles): import WordPress, normalisation HTML, rendu & images

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -50,6 +50,7 @@
     "@types/nodemailer": "^7.0.11",
     "@types/pg": "^8.15.6",
     "@types/sanitize-html": "^2.16.1",
+    "node-html-parser": "^8.0.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@types/sanitize-html':
         specifier: ^2.16.1
         version: 2.16.1
+      node-html-parser:
+        specifier: ^8.0.2
+        version: 8.0.2
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1079,6 +1082,9 @@ packages:
   better-result@2.9.2:
     resolution: {integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -1133,6 +1139,13 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1219,6 +1232,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
@@ -1533,9 +1550,15 @@ packages:
     resolution: {integrity: sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  node-html-parser@8.0.2:
+    resolution: {integrity: sha512-fhG4Ne6moYy00jI3SkBEJzEa/pMX/RLLxnvlvu8x0OvsiegHdw5Q8brbe+AhZHqHFi2PZnSYObQ/x+cQXuNg0Q==}
+
   nodemailer@8.0.4:
     resolution: {integrity: sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==}
     engines: {node: '>=6.0.0'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2853,6 +2876,8 @@ snapshots:
 
   better-result@2.9.2: {}
 
+  boolbase@1.0.0: {}
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -2908,6 +2933,16 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
 
   csstype@3.2.3: {}
 
@@ -2981,6 +3016,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@3.0.0: {}
 
@@ -3289,7 +3326,16 @@ snapshots:
 
   nanostores@1.2.0: {}
 
+  node-html-parser@8.0.2:
+    dependencies:
+      css-select: 5.2.2
+      entities: 8.0.0
+
   nodemailer@8.0.4: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   obug@2.1.1: {}
 

--- a/src/backend/scripts/import-wordpress-articles.ts
+++ b/src/backend/scripts/import-wordpress-articles.ts
@@ -268,18 +268,20 @@ async function rewriteImages(html: string): Promise<string> {
 // Decode the most common HTML entities WordPress emits in titles/excerpts.
 function decodeEntities(text: string): string {
   return text
-    .replace(/&#8217;|&#039;|&#39;/g, "'")
-    .replace(/&#8216;/g, "'")
-    .replace(/&#8230;/g, "…")
-    .replace(/&#8211;/g, "–")
-    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;|&#039;|&#39;|&rsquo;/g, "'")
+    .replace(/&#8216;|&lsquo;/g, "'")
+    .replace(/&#8220;|&ldquo;/g, "“")
+    .replace(/&#8221;|&rdquo;/g, "”")
+    .replace(/&#8230;|&hellip;/g, "…")
+    .replace(/&#8211;|&ndash;/g, "–")
+    .replace(/&#8212;|&mdash;/g, "—")
     .replace(/&laquo;/g, "«")
     .replace(/&raquo;/g, "»")
     .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
     .replace(/&quot;/g, '"')
     .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">");
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
 }
 
 // WordPress slugs can be URL-encoded and carry trailing emojis; clean them up.

--- a/src/backend/scripts/import-wordpress-articles.ts
+++ b/src/backend/scripts/import-wordpress-articles.ts
@@ -46,6 +46,9 @@ const shouldUpdate = process.argv.includes("--update");
 
 const IGNORED_CATEGORY_SLUGS = new Set(["non-classe"]);
 
+// Author shown for imported articles when WordPress exposes none.
+const DEFAULT_AUTHOR = "GDG Toulouse";
+
 // Image mimes the backend upload endpoint accepts (see admin/files.ts). We
 // only re-host these; anything else is left as-is (and likely dropped).
 const ALLOWED_IMAGE_MIMES = new Set([
@@ -434,7 +437,9 @@ async function main() {
       const cleaned = normalizeWordpressHtml(stripEmojiImages(post.content.rendered));
       const contentFr = await rewriteImages(rewriteIframes(cleaned));
       const excerptFr = stripHtml(post.excerpt.rendered) || undefined;
-      const author = post._embedded?.author?.[0]?.name || undefined;
+      // WordPress no longer exposes post authors (they come back null), so
+      // fall back to the organizing team for imported articles.
+      const author = post._embedded?.author?.[0]?.name || DEFAULT_AUTHOR;
 
       // Re-host the cover image so the frontend (next/image) never points at
       // the old WordPress host. On failure we drop to undefined rather than

--- a/src/backend/scripts/import-wordpress-articles.ts
+++ b/src/backend/scripts/import-wordpress-articles.ts
@@ -35,6 +35,8 @@
  *   WP_BASE        (default https://devfesttoulouse.fr) source WordPress site.
  */
 
+import { normalizeWordpressHtml } from "./lib/normalize-wordpress-html.js";
+
 const WP_BASE = process.env.WP_BASE || "https://devfesttoulouse.fr";
 const TARGET_API = process.env.TARGET_API || "http://localhost:4000";
 const ADMIN_API_KEY = process.env.ADMIN_API_KEY || "";
@@ -43,6 +45,29 @@ const isDryRun = process.argv.includes("--dry-run");
 const shouldUpdate = process.argv.includes("--update");
 
 const IGNORED_CATEGORY_SLUGS = new Set(["non-classe"]);
+
+// Image mimes the backend upload endpoint accepts (see admin/files.ts). We
+// only re-host these; anything else is left as-is (and likely dropped).
+const ALLOWED_IMAGE_MIMES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "image/svg+xml",
+  "image/x-icon",
+]);
+const MAX_UPLOAD_BYTES = 20_000_000;
+
+// Maps an accepted mime to a file extension, used only to name the multipart
+// upload (the server derives the stored filename's extension from it).
+const MIME_TO_EXT: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/svg+xml": "svg",
+  "image/x-icon": "ico",
+};
 
 interface WpRendered {
   rendered: string;
@@ -119,12 +144,124 @@ async function adminFetch<T>(path: string, init?: RequestInit): Promise<{ status
   return { status: res.status, body: body as T };
 }
 
+// WordPress turns text emojis into <img class="emoji"> whose real src is a
+// data:-URI placeholder (the true glyph sits in data-orig-src). The backend
+// sanitizer strips data: schemes, leaving a src-less <img> that renders as a
+// broken image. The alt attribute already holds the Unicode character, so we
+// restore it as plain text before the rest of the pipeline runs.
+function stripEmojiImages(html: string): string {
+  return html.replace(
+    /<img\b[^>]*\bclass=["'][^"']*\bemoji\b[^"']*["'][^>]*>/gi,
+    (tag) => {
+      const alt = tag.match(/\balt=["']([^"']*)["']/i);
+      return alt ? alt[1] : "";
+    },
+  );
+}
+
 // Replace YouTube/Vimeo <iframe> embeds with clickable links so the URL
 // survives the backend sanitizer (which strips iframes entirely).
 function rewriteIframes(html: string): string {
   return html.replace(/<iframe\b[^>]*\bsrc=["']([^"']+)["'][^>]*>\s*<\/iframe>/gi, (_match, src) => {
     const url = String(src).replace(/^\/\//, "https://");
     return `<p><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></p>`;
+  });
+}
+
+// Matches every <img> tag and captures its src attribute. Shared by the
+// collection and replacement passes of rewriteImages.
+const IMG_SRC_REGEX = /<img\b[^>]*?\bsrc=["']([^"']+)["'][^>]*>/gi;
+
+// Dedup cache across the whole run: a remote image URL maps to its local
+// /uploads/... URL once re-hosted, or null if it failed (never retried).
+const uploadedImages = new Map<string, string | null>();
+
+// Build a filename for the multipart upload. The server names the stored file
+// from this extension, so we must preserve a sensible one.
+function deriveFilename(remoteUrl: string, mime: string): string {
+  let base = "";
+  try {
+    base = decodeURIComponent(new URL(remoteUrl).pathname.split("/").pop() || "");
+  } catch {
+    base = "";
+  }
+  if (base && /\.[a-z0-9]+$/i.test(base)) return base;
+  return `image.${MIME_TO_EXT[mime] ?? "bin"}`;
+}
+
+// Download a remote image and re-host it through the backend upload endpoint.
+// Returns the local /uploads/... URL, or null on any failure (logged, never
+// throws — this is a best-effort per-item step in a batch import).
+async function uploadRemoteImage(remoteUrl: string): Promise<string | null> {
+  if (uploadedImages.has(remoteUrl)) return uploadedImages.get(remoteUrl) ?? null;
+
+  try {
+    const res = await fetch(remoteUrl);
+    if (!res.ok) {
+      console.warn(`  ! image fetch failed (${res.status}): ${remoteUrl}`);
+      uploadedImages.set(remoteUrl, null);
+      return null;
+    }
+    const mime = (res.headers.get("content-type") || "").split(";")[0].trim().toLowerCase();
+    if (!ALLOWED_IMAGE_MIMES.has(mime)) {
+      console.warn(`  ! image skipped (mime ${mime || "unknown"}): ${remoteUrl}`);
+      uploadedImages.set(remoteUrl, null);
+      return null;
+    }
+    const bytes = Buffer.from(await res.arrayBuffer());
+    if (bytes.length > MAX_UPLOAD_BYTES) {
+      console.warn(`  ! image too large (${bytes.length} bytes): ${remoteUrl}`);
+      uploadedImages.set(remoteUrl, null);
+      return null;
+    }
+
+    const form = new FormData();
+    form.append("file", new Blob([bytes], { type: mime }), deriveFilename(remoteUrl, mime));
+    // Do NOT set Content-Type: fetch adds the multipart boundary itself.
+    const upload = await fetch(`${TARGET_API}/api/admin/files`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${ADMIN_API_KEY}` },
+      body: form,
+    });
+    if (!upload.ok) {
+      console.warn(`  ! image upload failed (${upload.status}): ${remoteUrl}`);
+      uploadedImages.set(remoteUrl, null);
+      return null;
+    }
+    const { url } = (await upload.json()) as { url: string };
+    uploadedImages.set(remoteUrl, url);
+    return url;
+  } catch (err) {
+    console.warn(`  ! image error (${(err as Error).message}): ${remoteUrl}`);
+    uploadedImages.set(remoteUrl, null);
+    return null;
+  }
+}
+
+// Re-host every inline <img> whose src is an absolute http(s) URL, rewriting
+// the src to the local /uploads/... path. Non-http(s) srcs (relative,
+// protocol-relative, data:, already-local) are left untouched. In dry-run we
+// only log the candidates and return the HTML unchanged.
+async function rewriteImages(html: string): Promise<string> {
+  const srcs = new Set<string>();
+  for (const match of html.matchAll(IMG_SRC_REGEX)) {
+    if (/^https?:\/\//i.test(match[1])) srcs.add(match[1]);
+  }
+  if (srcs.size === 0) return html;
+
+  if (isDryRun) {
+    for (const src of srcs) console.log(`  [dry-run] would re-host inline image ${src}`);
+    return html;
+  }
+
+  const rewrites = new Map<string, string>();
+  for (const src of srcs) {
+    const local = await uploadRemoteImage(src);
+    if (local) rewrites.set(src, local);
+  }
+  return html.replace(IMG_SRC_REGEX, (tag, src) => {
+    const local = rewrites.get(src);
+    return local ? tag.replace(src, local) : tag;
   });
 }
 
@@ -292,10 +429,23 @@ async function main() {
       }
 
       const titleFr = decodeEntities(stripHtml(post.title.rendered));
-      const contentFr = rewriteIframes(post.content.rendered);
+      const cleaned = normalizeWordpressHtml(stripEmojiImages(post.content.rendered));
+      const contentFr = await rewriteImages(rewriteIframes(cleaned));
       const excerptFr = stripHtml(post.excerpt.rendered) || undefined;
-      const imageUrl = post._embedded?.["wp:featuredmedia"]?.[0]?.source_url || undefined;
       const author = post._embedded?.author?.[0]?.name || undefined;
+
+      // Re-host the cover image so the frontend (next/image) never points at
+      // the old WordPress host. On failure we drop to undefined rather than
+      // keeping the external URL, which would crash next/image.
+      const rawImageUrl = post._embedded?.["wp:featuredmedia"]?.[0]?.source_url || undefined;
+      let imageUrl: string | undefined = undefined;
+      if (rawImageUrl) {
+        if (isDryRun) {
+          console.log(`  [dry-run] would download cover ${rawImageUrl}`);
+        } else {
+          imageUrl = (await uploadRemoteImage(rawImageUrl)) ?? undefined;
+        }
+      }
 
       const payload: ArticlePayload = {
         slug,
@@ -318,7 +468,7 @@ async function main() {
         console.log(
           `- ${slug}: would ${alreadyExists ? "update" : "create"} ` +
             `(date=${post.date.slice(0, 10)}, editions=[${editionIds}], tags=${tagIds.length}, ` +
-            `img=${imageUrl ? "yes" : "no"}, author=${author ?? "—"})`,
+            `img=${rawImageUrl ? "yes" : "no"}, author=${author ?? "—"})`,
         );
         alreadyExists ? (updated += 1) : (created += 1);
         continue;

--- a/src/backend/scripts/import-wordpress-articles.ts
+++ b/src/backend/scripts/import-wordpress-articles.ts
@@ -1,0 +1,379 @@
+/**
+ * Import published articles from the current WordPress site (devfesttoulouse.fr)
+ * into the new backend through its admin REST API.
+ *
+ * The script talks HTTP only — it does NOT touch Prisma directly — so it can run
+ * against any environment (local, beta) that exposes the admin API.
+ *
+ * Source: WordPress REST API (public, no key needed): {WP_BASE}/wp-json/wp/v2
+ * Target: {TARGET_API}/api/admin/articles, authenticated with an ADMIN API key.
+ *
+ * Mapping decisions:
+ *   - FR content is copied into the EN fields with autoTranslatedEn=true
+ *     (a human translates later via the existing Gemini button).
+ *   - status = PUBLISHED, publishedAt = the original WordPress date.
+ *   - "Edition 20XX" categories -> Edition relation (matched by year).
+ *   - Other categories (Annonces, CFP, Les coulisses, Sponsoring, CoC) -> Tags.
+ *   - "Non classé" is ignored.
+ *   - <iframe> embeds (YouTube) are rewritten to clickable <a> links before
+ *     sending, because the backend sanitizer strips iframes.
+ *   - Idempotent: an article whose slug already exists is skipped (or updated
+ *     with --update).
+ *
+ * Usage (from src/backend):
+ *   ADMIN_API_KEY="dft_live_xxx" \
+ *   TARGET_API="https://beta.site.devfesttoulouse.fr" \
+ *   npx tsx scripts/import-wordpress-articles.ts --dry-run
+ *
+ * Flags:
+ *   --dry-run   Print what would happen, send nothing.
+ *   --update    PUT existing articles instead of skipping them.
+ *
+ * Env:
+ *   ADMIN_API_KEY  (required unless --dry-run) Bearer token of an ADMIN account.
+ *   TARGET_API     (default http://localhost:4000) base URL of the target API.
+ *   WP_BASE        (default https://devfesttoulouse.fr) source WordPress site.
+ */
+
+const WP_BASE = process.env.WP_BASE || "https://devfesttoulouse.fr";
+const TARGET_API = process.env.TARGET_API || "http://localhost:4000";
+const ADMIN_API_KEY = process.env.ADMIN_API_KEY || "";
+
+const isDryRun = process.argv.includes("--dry-run");
+const shouldUpdate = process.argv.includes("--update");
+
+const IGNORED_CATEGORY_SLUGS = new Set(["non-classe"]);
+
+interface WpRendered {
+  rendered: string;
+}
+
+interface WpPost {
+  id: number;
+  slug: string;
+  date: string;
+  status: string;
+  title: WpRendered;
+  content: WpRendered;
+  excerpt: WpRendered;
+  categories: number[];
+  _embedded?: {
+    author?: Array<{ name?: string }>;
+    "wp:featuredmedia"?: Array<{ source_url?: string }>;
+  };
+}
+
+interface WpCategory {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface TargetTag {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface TargetEdition {
+  id: number;
+  year: number;
+}
+
+interface ArticlePayload {
+  slug: string;
+  titleFr: string;
+  titleEn: string;
+  contentFr: string;
+  contentEn: string;
+  excerptFr?: string;
+  excerptEn?: string;
+  imageUrl?: string;
+  author?: string;
+  publicationStatus: "PUBLISHED";
+  publishedAt: string;
+  editionIds: number[];
+  tagIds: number[];
+  autoTranslatedEn: boolean;
+}
+
+async function wpFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${WP_BASE}/wp-json/wp/v2${path}`);
+  if (!res.ok) {
+    throw new Error(`WordPress GET ${path} failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function adminFetch<T>(path: string, init?: RequestInit): Promise<{ status: number; body: T }> {
+  const res = await fetch(`${TARGET_API}/api/admin${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${ADMIN_API_KEY}`,
+      ...(init?.headers || {}),
+    },
+  });
+  const text = await res.text();
+  const body = text ? JSON.parse(text) : null;
+  return { status: res.status, body: body as T };
+}
+
+// Replace YouTube/Vimeo <iframe> embeds with clickable links so the URL
+// survives the backend sanitizer (which strips iframes entirely).
+function rewriteIframes(html: string): string {
+  return html.replace(/<iframe\b[^>]*\bsrc=["']([^"']+)["'][^>]*>\s*<\/iframe>/gi, (_match, src) => {
+    const url = String(src).replace(/^\/\//, "https://");
+    return `<p><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></p>`;
+  });
+}
+
+// Decode the most common HTML entities WordPress emits in titles/excerpts.
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&#8217;|&#039;|&#39;/g, "'")
+    .replace(/&#8216;/g, "'")
+    .replace(/&#8230;/g, "…")
+    .replace(/&#8211;/g, "–")
+    .replace(/&#8212;/g, "—")
+    .replace(/&laquo;/g, "«")
+    .replace(/&raquo;/g, "»")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+// WordPress slugs can be URL-encoded and carry trailing emojis; clean them up.
+function cleanSlug(rawSlug: string): string {
+  let slug = rawSlug;
+  try {
+    slug = decodeURIComponent(rawSlug);
+  } catch {
+    // keep the raw value if it is not valid percent-encoding
+  }
+  return slug
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function stripHtml(html: string): string {
+  return decodeEntities(html.replace(/<[^>]+>/g, "")).replace(/\s+/g, " ").trim();
+}
+
+function parseEditionYear(categorySlug: string): number | null {
+  const match = categorySlug.match(/^edition-(\d{4})$/);
+  return match ? Number(match[1]) : null;
+}
+
+// Ensure a Tag exists on the target for the given WP category name, returning
+// its id. Reuses the preloaded map; creates the tag on first encounter.
+async function ensureTag(
+  category: WpCategory,
+  tagsByName: Map<string, number>,
+): Promise<number | null> {
+  const existing = tagsByName.get(category.name.toLowerCase());
+  if (existing) return existing;
+
+  if (isDryRun) {
+    console.log(`    [dry-run] would create tag "${category.name}"`);
+    return -1;
+  }
+
+  const { status, body } = await adminFetch<TargetTag | { error: string }>("/tags", {
+    method: "POST",
+    body: JSON.stringify({ name: category.name }),
+  });
+
+  if (status === 201) {
+    const tag = body as TargetTag;
+    tagsByName.set(tag.name.toLowerCase(), tag.id);
+    console.log(`    created tag "${tag.name}" (#${tag.id})`);
+    return tag.id;
+  }
+  // 409: created concurrently or name/slug collision — refetch to resolve.
+  console.warn(`    could not create tag "${category.name}" (status ${status}); skipping tag`);
+  return null;
+}
+
+async function main() {
+  if (!isDryRun && !ADMIN_API_KEY) {
+    throw new Error("ADMIN_API_KEY is required (or pass --dry-run).");
+  }
+
+  console.log(`Source : ${WP_BASE}`);
+  console.log(`Target : ${TARGET_API}${isDryRun ? "  (dry-run)" : ""}`);
+  console.log("");
+
+  // 1. Fetch source data.
+  const posts = await wpFetch<WpPost[]>("/posts?per_page=100&_embed=1");
+  const categories = await wpFetch<WpCategory[]>("/categories?per_page=100&_fields=id,name,slug");
+  const categoriesById = new Map(categories.map((c) => [c.id, c]));
+  console.log(`WordPress: ${posts.length} posts, ${categories.length} categories.`);
+
+  // 2. Preload target state. Editions require an ADMIN key; degrade gracefully.
+  const tagsByName = new Map<string, number>();
+  const editionsByYear = new Map<number, number>();
+  const existingSlugs = new Set<string>();
+
+  if (!isDryRun) {
+    const tagsRes = await adminFetch<TargetTag[]>("/tags");
+    if (tagsRes.status !== 200) {
+      throw new Error(`Could not list target tags (status ${tagsRes.status}). Check ADMIN_API_KEY.`);
+    }
+    for (const t of tagsRes.body) tagsByName.set(t.name.toLowerCase(), t.id);
+
+    const editionsRes = await adminFetch<TargetEdition[]>("/editions");
+    if (editionsRes.status === 200) {
+      for (const e of editionsRes.body) editionsByYear.set(e.year, e.id);
+    } else {
+      console.warn(
+        `  Warning: could not list editions (status ${editionsRes.status}). ` +
+          `Edition links will be skipped — use an ADMIN key to enable them.`,
+      );
+    }
+
+    // Page through existing articles to know which slugs are already present.
+    let page = 1;
+    for (;;) {
+      const res = await adminFetch<{ articles: { slug: string }[]; totalPages: number }>(
+        `/articles?page=${page}&limit=100`,
+      );
+      if (res.status !== 200) break;
+      for (const a of res.body.articles) existingSlugs.add(a.slug);
+      if (page >= res.body.totalPages) break;
+      page += 1;
+    }
+  }
+
+  // 3 + 4. Transform and upsert each post.
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const post of posts) {
+    const slug = cleanSlug(post.slug);
+    try {
+      if (post.status !== "publish") {
+        console.log(`- ${slug}: skipped (status=${post.status})`);
+        skipped += 1;
+        continue;
+      }
+
+      const alreadyExists = existingSlugs.has(slug);
+      if (alreadyExists && !shouldUpdate) {
+        console.log(`- ${slug}: skipped (already exists)`);
+        skipped += 1;
+        continue;
+      }
+
+      // Categories -> editions + tags.
+      const editionIds: number[] = [];
+      const tagIds: number[] = [];
+      for (const catId of post.categories) {
+        const category = categoriesById.get(catId);
+        if (!category || IGNORED_CATEGORY_SLUGS.has(category.slug)) continue;
+
+        const year = parseEditionYear(category.slug);
+        if (year !== null) {
+          const editionId = editionsByYear.get(year);
+          if (editionId) editionIds.push(editionId);
+          else console.warn(`    edition ${year} not found in target; skipping edition link`);
+          continue;
+        }
+
+        const tagId = await ensureTag(category, tagsByName);
+        if (tagId && tagId > 0) tagIds.push(tagId);
+      }
+
+      const titleFr = decodeEntities(stripHtml(post.title.rendered));
+      const contentFr = rewriteIframes(post.content.rendered);
+      const excerptFr = stripHtml(post.excerpt.rendered) || undefined;
+      const imageUrl = post._embedded?.["wp:featuredmedia"]?.[0]?.source_url || undefined;
+      const author = post._embedded?.author?.[0]?.name || undefined;
+
+      const payload: ArticlePayload = {
+        slug,
+        titleFr,
+        titleEn: titleFr,
+        contentFr,
+        contentEn: contentFr,
+        excerptFr,
+        excerptEn: excerptFr,
+        imageUrl,
+        author,
+        publicationStatus: "PUBLISHED",
+        publishedAt: post.date,
+        editionIds,
+        tagIds,
+        autoTranslatedEn: true,
+      };
+
+      if (isDryRun) {
+        console.log(
+          `- ${slug}: would ${alreadyExists ? "update" : "create"} ` +
+            `(date=${post.date.slice(0, 10)}, editions=[${editionIds}], tags=${tagIds.length}, ` +
+            `img=${imageUrl ? "yes" : "no"}, author=${author ?? "—"})`,
+        );
+        alreadyExists ? (updated += 1) : (created += 1);
+        continue;
+      }
+
+      if (alreadyExists && shouldUpdate) {
+        // Resolve the article id from its slug via the admin detail lookup.
+        const listRes = await adminFetch<{ articles: { id: number; slug: string }[] }>(
+          `/articles?page=1&limit=100&status=PUBLISHED`,
+        );
+        const match = listRes.body.articles.find((a) => a.slug === slug);
+        if (!match) {
+          console.warn(`- ${slug}: marked existing but id not found; creating instead`);
+        } else {
+          const res = await adminFetch(`/articles/${match.id}`, {
+            method: "PUT",
+            body: JSON.stringify(payload),
+          });
+          if (res.status === 200) {
+            console.log(`- ${slug}: updated`);
+            updated += 1;
+          } else {
+            console.error(`- ${slug}: update failed (status ${res.status})`, res.body);
+            errors += 1;
+          }
+          continue;
+        }
+      }
+
+      const res = await adminFetch<{ id: number } | { error: string }>("/articles", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 201) {
+        console.log(`- ${slug}: created (#${(res.body as { id: number }).id})`);
+        created += 1;
+      } else if (res.status === 409) {
+        console.log(`- ${slug}: skipped (slug conflict)`);
+        skipped += 1;
+      } else {
+        console.error(`- ${slug}: create failed (status ${res.status})`, res.body);
+        errors += 1;
+      }
+    } catch (err) {
+      console.error(`- ${slug}: error`, err instanceof Error ? err.message : err);
+      errors += 1;
+    }
+  }
+
+  console.log("");
+  console.log(`Done. created=${created} updated=${updated} skipped=${skipped} errors=${errors}`);
+  if (errors > 0) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/src/backend/scripts/lib/normalize-wordpress-html.test.ts
+++ b/src/backend/scripts/lib/normalize-wordpress-html.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+
+import { normalizeWordpressHtml } from "./normalize-wordpress-html.js";
+import { sanitizeRichHtml } from "../../src/lib/sanitize.js";
+
+function column(fraction: string, inner: string): string {
+  return (
+    `<div class="fusion-layout-column fusion_builder_column_${fraction} ${fraction.replace("_", "-")}">` +
+    `<div class="fusion-column-wrapper"><div class="fusion-text fusion-text-1">${inner}</div></div>` +
+    `</div>`
+  );
+}
+
+function row(columns: string): string {
+  return `<div class="fusion-fullwidth"><div class="fusion-builder-row fusion-row">${columns}</div></div>`;
+}
+
+describe("normalizeWordpressHtml", () => {
+  it("turns four 1/4 columns into a 4-col grid and drops fusion noise", () => {
+    const input = row(
+      ["1_4", "1_4", "1_4", "1_4"]
+        .map((f, i) => column(f, `<p>Person ${i}</p><img src="https://x/p${i}.png">`))
+        .join(""),
+    );
+    const out = normalizeWordpressHtml(input);
+
+    expect(out).toContain("md:grid-cols-4");
+    expect(out).not.toMatch(/fusion[-_]/);
+    expect(out).not.toContain("style=");
+    expect(out.match(/<img/g)).toHaveLength(4);
+  });
+
+  it("turns a 3/5 + 2/5 row into a 5-col grid with col-spans", () => {
+    const input = row(
+      column("3_5", "<h2>Title</h2><p>Text</p>") +
+        column("2_5", '<img src="https://x/img.png">'),
+    );
+    const out = normalizeWordpressHtml(input);
+
+    expect(out).toContain("md:grid-cols-5");
+    expect(out).toContain("md:col-span-3");
+    expect(out).toContain("md:col-span-2");
+  });
+
+  it("unwraps a single full-width column without emitting a grid", () => {
+    const out = normalizeWordpressHtml(row(column("1_1", "<p>Just text</p><h2>Heading</h2>")));
+    expect(out).toContain("<p>Just text</p>");
+    expect(out).toContain("<h2>Heading</h2>");
+    expect(out).not.toContain("grid-cols");
+  });
+
+  it("converts a Gutenberg wp-block-columns into a grid", () => {
+    const input =
+      '<div class="wp-block-columns is-layout-flex">' +
+      '<div class="wp-block-column"><p>A</p></div>' +
+      '<div class="wp-block-column"><p>B</p></div>' +
+      "</div>";
+    const out = normalizeWordpressHtml(input);
+
+    expect(out).toContain("md:grid-cols-2");
+    expect(out).not.toContain("wp-block");
+  });
+
+  it("strips leaked markdown hashes from headings", () => {
+    expect(normalizeWordpressHtml("<h2>## Montaine</h2>")).toBe("<h2>Montaine</h2>");
+  });
+
+  it("drops empty paragraphs and empty headings", () => {
+    const out = normalizeWordpressHtml("<p>&nbsp;</p><h2></h2><p>real</p>");
+    expect(out).toBe("<p>real</p>");
+  });
+
+  it("preserves blockquotes", () => {
+    const out = normalizeWordpressHtml("<blockquote><p>A quote</p></blockquote>");
+    expect(out).toContain("<blockquote>");
+    expect(out).toContain("A quote");
+  });
+
+  it("maps inline text-align:center to a utility class", () => {
+    const out = normalizeWordpressHtml('<p style="text-align: center;">Centered</p>');
+    expect(out).toContain("text-center");
+    expect(out).not.toContain("style=");
+  });
+
+  it("centers classic aligned images", () => {
+    const out = normalizeWordpressHtml('<img class="aligncenter wp-image-12 size-large" src="https://x/a.png">');
+    expect(out).toContain("mx-auto");
+    expect(out).not.toContain("wp-image");
+  });
+
+  it("never throws on malformed input", () => {
+    expect(() => normalizeWordpressHtml("<div><p>unclosed <img src=")).not.toThrow();
+    expect(normalizeWordpressHtml("")).toBe("");
+  });
+
+  it("produces output whose layout classes survive the sanitizer", () => {
+    const input = row(
+      column("3_5", "<h2>Title</h2><p>Text</p>") + column("2_5", '<img src="https://x/img.png">'),
+    );
+    const sanitized = sanitizeRichHtml(normalizeWordpressHtml(input));
+    expect(sanitized).toContain("md:grid-cols-5");
+    expect(sanitized).toContain("md:col-span-3");
+    expect(sanitized).not.toMatch(/fusion[-_]/);
+  });
+});

--- a/src/backend/scripts/lib/normalize-wordpress-html.ts
+++ b/src/backend/scripts/lib/normalize-wordpress-html.ts
@@ -1,0 +1,352 @@
+import { parse, HTMLElement } from "node-html-parser";
+
+/**
+ * Converts legacy WordPress markup (Avada Fusion Builder, Gutenberg blocks and
+ * classic-editor HTML) into clean, theme-independent HTML using Tailwind
+ * utility classes. Runs at import time, before image re-hosting.
+ *
+ * The function is pure, synchronous and never throws: on any parsing error it
+ * falls back to a regex-based cleanup so a malformed post still imports with
+ * flattened-but-readable content instead of aborting the batch.
+ *
+ * Note: the backend sanitizer strips inline `style` and keeps only `class`, so
+ * every layout decision here is expressed through classes, never inline style.
+ * The emitted classes must be safelisted in the frontend (globals.css
+ * `@source inline(...)`) because Tailwind v4 does not scan DB-stored HTML.
+ */
+
+// Allowlist of utility classes the normalizer itself emits. Every other class
+// (theme chrome from Avada/Gutenberg, lazyload hints, social-embed bookkeeping,
+// etc.) is stripped. An allowlist is used rather than a deny-list because the
+// universe of legacy classes is open-ended, while the classes we emit are a
+// small fixed set — and these are exactly the ones safelisted in globals.css.
+const ALLOWED_CLASSES = new Set([
+  "grid",
+  "grid-cols-1",
+  "sm:grid-cols-2",
+  "md:grid-cols-2",
+  "md:grid-cols-4",
+  "md:grid-cols-5",
+  "gap-6",
+  "gap-8",
+  "items-center",
+  "md:col-span-2",
+  "md:col-span-3",
+  "w-full",
+  "rounded-lg",
+  "mx-auto",
+  "block",
+  "inline-block",
+  "no-underline",
+  "px-5",
+  "py-2",
+  "font-bold",
+  "text-center",
+  "text-left",
+  "text-right",
+  "text-sm",
+  "text-gris",
+  "p-4",
+  "bg-bismarck",
+  "text-blanc",
+  "bg-blanc-casse",
+]);
+
+const CAPTION_CLASS = "text-sm text-gris text-center";
+const BUTTON_CLASS =
+  "inline-block rounded-lg bg-bismarck text-blanc no-underline px-5 py-2 font-bold";
+const CALLOUT_CLASS = "rounded-lg bg-blanc-casse p-4";
+const IMG_CLASS = "w-full rounded-lg";
+const CENTERED_IMG_CLASS = "mx-auto block rounded-lg";
+
+export function normalizeWordpressHtml(html: string): string {
+  if (!html || !html.trim()) return "";
+  try {
+    const root = parse(html, { comment: false });
+    // Structural passes run first: they read fusion-*/wp-block-* classes to
+    // rebuild grids. Class scrubbing happens last so those markers survive.
+    stripStyles(root);
+    rebuildFusion(root);
+    cleanupGutenberg(root);
+    cleanupGlobal(root);
+    cleanupClassic(root);
+    tidy(root);
+    return root.toString();
+  } catch {
+    return fallbackClean(html);
+  }
+}
+
+// --- Pass A1: strip inline styles (runs first; maps text-align to a class) --
+
+function stripStyles(root: HTMLElement): void {
+  for (const el of root.querySelectorAll("[style]")) {
+    const style = el.getAttribute("style") ?? "";
+    if (/text-align:\s*center/i.test(style)) addClass(el, "text-center");
+    else if (/text-align:\s*right/i.test(style)) addClass(el, "text-right");
+    else if (/text-align:\s*left/i.test(style)) addClass(el, "text-left");
+    el.removeAttribute("style");
+  }
+  // FontAwesome icons carry no content on the new site.
+  for (const icon of root.querySelectorAll("i")) icon.remove();
+}
+
+// --- Pass A2: attribute + class scrub (runs last, after grids are rebuilt) --
+
+function cleanupGlobal(root: HTMLElement): void {
+  for (const el of root.querySelectorAll("*")) {
+    for (const attr of ["decoding", "loading", "srcset", "sizes"]) {
+      el.removeAttribute(attr);
+    }
+    for (const name of Object.keys(el.attributes)) {
+      if (name.startsWith("data-")) el.removeAttribute(name);
+    }
+    scrubClasses(el);
+  }
+  removeEmptyTextNodes(root);
+}
+
+// --- Pass B: Avada Fusion grid rebuild --------------------------------------
+
+function rebuildFusion(root: HTMLElement): void {
+  for (const row of root.querySelectorAll(".fusion-builder-row, .fusion-row")) {
+    const columns = directColumns(row);
+    if (columns.length === 0) continue;
+
+    const cells = columns
+      .map((col) => ({ fraction: columnFraction(col), node: unwrapColumn(col) }))
+      .filter((c) => c.node && hasContent(c.node));
+    if (cells.length === 0) {
+      row.remove();
+      continue;
+    }
+
+    // Avada lays every column in one flat flex row and relies on width % +
+    // flex-wrap for visual rows. Segment consecutive same-fraction columns:
+    // full-width (1/1) columns become flow content, runs of narrower columns
+    // become a responsive grid.
+    const container = parse("<div></div>").querySelector("div") as HTMLElement;
+    for (const segment of segmentByFraction(cells)) {
+      if (segment[0].fraction === 1) {
+        for (const cell of segment) container.appendChild(flowOf(cell.node));
+      } else {
+        container.appendChild(buildGrid(segment));
+      }
+    }
+    row.replaceWith(container);
+  }
+
+  // Atoms that may live outside a row too.
+  for (const title of root.querySelectorAll(".fusion-title")) renameTag(title, "h2");
+  for (const sep of root.querySelectorAll(".fusion-separator")) sep.replaceWith(parse("<hr>"));
+  for (const btn of root.querySelectorAll("a.fusion-button")) styleButton(btn);
+  for (const box of root.querySelectorAll(".fusion-content-boxes, .content-box")) {
+    box.setAttribute("class", CALLOUT_CLASS);
+  }
+  for (const frame of root.querySelectorAll(".fusion-image-element, .fusion-imageframe")) {
+    const img = frame.querySelector("img");
+    if (img) frame.replaceWith(img);
+    else frame.remove();
+  }
+}
+
+function directColumns(row: HTMLElement): HTMLElement[] {
+  return row
+    .querySelectorAll(".fusion-layout-column")
+    .filter((col) => col.closest(".fusion-builder-row, .fusion-row") === row);
+}
+
+// Reads the displayed fraction from the trailing `_X_Y` of the column class.
+function columnFraction(col: HTMLElement): number {
+  const match = col.classNames.match(/fusion_builder_column_(\d+)_(\d+)\b/);
+  if (!match) return 1;
+  const num = Number(match[1]);
+  const den = Number(match[2]);
+  return den > 0 ? num / den : 1;
+}
+
+// Lifts a column's real content out of the fusion-text/column-wrapper chrome
+// and returns the resulting fragment element (a plain <div>).
+function unwrapColumn(col: HTMLElement): HTMLElement {
+  for (const wrapper of col.querySelectorAll(".fusion-text, .fusion-column-wrapper")) {
+    wrapper.replaceWith(parse(wrapper.innerHTML));
+  }
+  const cell = parse("<div></div>").querySelector("div") as HTMLElement;
+  cell.set_content(col.innerHTML);
+  return cell;
+}
+
+type Cell = { fraction: number; node: HTMLElement };
+
+// Splits a row's columns into consecutive runs of the same KIND: full-width
+// (1/1) columns flow on their own; narrower columns group into one grid run.
+function segmentByFraction(cells: Cell[]): Cell[][] {
+  const segments: Cell[][] = [];
+  for (const cell of cells) {
+    const isFull = cell.fraction === 1;
+    const last = segments[segments.length - 1];
+    const lastIsFull = last && last[0].fraction === 1;
+    if (last && isFull === lastIsFull) last.push(cell);
+    else segments.push([cell]);
+  }
+  return segments;
+}
+
+function flowOf(node: HTMLElement): HTMLElement {
+  const flow = parse("<div></div>").querySelector("div") as HTMLElement;
+  flow.set_content(node.innerHTML);
+  return flow;
+}
+
+// Builds a responsive grid from a run of sub-full-width columns. Quarters →
+// 4-col, halves → 2-col, fifths → 5-col with col-spans; anything else stacks.
+function buildGrid(cells: Cell[]): HTMLElement {
+  const fractions = cells.map((c) => c.fraction);
+  const allQuarters = fractions.every((f) => f === 0.25);
+  const allHalves = fractions.every((f) => f === 0.5);
+  const fifths = fractions.every((f) => Math.abs(f * 5 - Math.round(f * 5)) < 1e-9);
+
+  let wrapperClass: string;
+  let spanFor: (f: number) => string | null;
+
+  if (allQuarters) {
+    wrapperClass = "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6";
+    spanFor = () => null;
+  } else if (allHalves) {
+    wrapperClass = "grid grid-cols-1 md:grid-cols-2 gap-6";
+    spanFor = () => null;
+  } else if (fifths) {
+    wrapperClass = "grid grid-cols-1 md:grid-cols-5 gap-8 items-center";
+    spanFor = (f) => `md:col-span-${Math.round(f * 5)}`;
+  } else {
+    // Mixed/unknown denominators: stack full-width — readable, never broken.
+    const stack = parse("<div></div>").querySelector("div") as HTMLElement;
+    for (const cell of cells) stack.appendChild(cell.node);
+    return stack;
+  }
+
+  const grid = parse(`<div class="${wrapperClass}"></div>`).querySelector("div") as HTMLElement;
+  for (const { fraction, node } of cells) {
+    styleCardImages(node);
+    const span = spanFor(fraction);
+    if (span) node.setAttribute("class", span);
+    else node.removeAttribute("class");
+    grid.appendChild(node);
+  }
+  return grid;
+}
+
+function styleCardImages(cell: HTMLElement): void {
+  for (const img of cell.querySelectorAll("img")) img.setAttribute("class", IMG_CLASS);
+}
+
+function styleButton(btn: HTMLElement): void {
+  // Drop the fusion-button-text <span> wrapper, keep the label.
+  const label = btn.querySelector(".fusion-button-text");
+  if (label) label.replaceWith(parse(label.innerHTML));
+  btn.setAttribute("class", BUTTON_CLASS);
+}
+
+// --- Pass C: Gutenberg cleanup ----------------------------------------------
+
+function cleanupGutenberg(root: HTMLElement): void {
+  for (const fig of root.querySelectorAll("figure")) {
+    const caption = fig.querySelector("figcaption");
+    if (caption) renameTag(caption, "p", CAPTION_CLASS);
+    renameTag(fig, "div");
+  }
+
+  for (const cols of root.querySelectorAll(".wp-block-columns")) {
+    const inner = cols.querySelectorAll(".wp-block-column").filter(
+      (c) => c.closest(".wp-block-columns") === cols,
+    );
+    const n = Math.min(Math.max(inner.length, 1), 4);
+    const grid = parse(
+      `<div class="grid grid-cols-1 md:grid-cols-${n} gap-6"></div>`,
+    ).querySelector("div") as HTMLElement;
+    for (const c of inner) {
+      c.removeAttribute("class");
+      grid.appendChild(c);
+    }
+    cols.replaceWith(grid);
+  }
+
+  for (const mt of root.querySelectorAll(".wp-block-media-text")) {
+    mt.setAttribute("class", "grid grid-cols-1 md:grid-cols-2 gap-8 items-center");
+  }
+
+  for (const link of root.querySelectorAll("a.wp-block-button__link")) {
+    link.setAttribute("class", BUTTON_CLASS);
+  }
+}
+
+// --- Pass D: classic-editor cleanup -----------------------------------------
+
+function cleanupClassic(root: HTMLElement): void {
+  for (const img of root.querySelectorAll("img")) {
+    if (img.getAttribute("class")) continue; // already styled (cards)
+    img.setAttribute("class", CENTERED_IMG_CLASS);
+  }
+
+  // Strip leaked markdown hashes at the start of heading text.
+  for (const h of root.querySelectorAll("h1, h2, h3, h4, h5, h6")) {
+    const text = h.innerHTML;
+    const stripped = text.replace(/^\s*#{1,6}\s+/, "");
+    if (stripped !== text) h.set_content(stripped);
+  }
+}
+
+// --- Pass E: final tidy ------------------------------------------------------
+
+function tidy(root: HTMLElement): void {
+  // Remove wrappers left empty by unwrapping (run twice for nested cases).
+  for (let i = 0; i < 2; i++) {
+    for (const el of root.querySelectorAll("div, span")) {
+      if (!el.getAttribute("class") && !hasContent(el)) el.remove();
+    }
+  }
+  removeEmptyTextNodes(root);
+}
+
+// --- helpers -----------------------------------------------------------------
+
+function scrubClasses(el: HTMLElement): void {
+  const classNames = el.getAttribute("class");
+  if (!classNames) return;
+  const kept = classNames.split(/\s+/).filter((c) => ALLOWED_CLASSES.has(c));
+  if (kept.length) el.setAttribute("class", kept.join(" "));
+  else el.removeAttribute("class");
+}
+
+function addClass(el: HTMLElement, value: string): void {
+  const existing = el.getAttribute("class");
+  el.setAttribute("class", existing ? `${existing} ${value}` : value);
+}
+
+function renameTag(el: HTMLElement, tag: string, className?: string): void {
+  el.rawTagName = tag;
+  if (className) el.setAttribute("class", className);
+  else el.removeAttribute("class");
+}
+
+function hasContent(el: HTMLElement): boolean {
+  if (el.querySelector("img, iframe, hr, a")) return true;
+  return el.text.replace(/ /g, "").trim().length > 0;
+}
+
+function removeEmptyTextNodes(root: HTMLElement): void {
+  for (const p of root.querySelectorAll("p")) {
+    if (!hasContent(p)) p.remove();
+  }
+  for (const h of root.querySelectorAll("h1, h2, h3, h4, h5, h6")) {
+    if (!h.text.trim()) h.remove();
+  }
+}
+
+// Regex fallback when DOM parsing throws — never worse than the input.
+function fallbackClean(html: string): string {
+  return html
+    .replace(/\sstyle="[^"]*"/gi, "")
+    .replace(/--awb-[^;"]*;?/gi, "")
+    .replace(/\sclass="[^"]*(fusion|awb|wp-block|lazyload)[^"]*"/gi, "");
+}

--- a/src/backend/src/__tests__/admin-articles.test.ts
+++ b/src/backend/src/__tests__/admin-articles.test.ts
@@ -68,6 +68,62 @@ describe("Admin Articles API", () => {
     await app.close();
   });
 
+  it("POST with an explicit publishedAt should preserve that date", async () => {
+    const app = await buildAdminApp();
+    const slug = `dated-article-${Date.now()}`;
+    const originalDate = "2023-04-10T08:00:00.000Z";
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/api/admin/articles",
+      payload: {
+        slug,
+        titleFr: "Daté FR",
+        titleEn: "Dated EN",
+        contentFr: "",
+        contentEn: "",
+        publicationStatus: "PUBLISHED",
+        publishedAt: originalDate,
+      },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const { id } = createRes.json();
+
+    const getRes = await app.inject({ method: "GET", url: `/api/admin/articles/${id}` });
+    expect(new Date(getRes.json().publishedAt).toISOString()).toBe(originalDate);
+
+    await app.inject({ method: "DELETE", url: `/api/admin/articles/${id}` });
+    await app.close();
+  });
+
+  it("POST without publishedAt stamps the current date when published", async () => {
+    const app = await buildAdminApp();
+    const slug = `now-article-${Date.now()}`;
+    const before = Date.now();
+
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/api/admin/articles",
+      payload: {
+        slug,
+        titleFr: "Now FR",
+        titleEn: "Now EN",
+        contentFr: "",
+        contentEn: "",
+        publicationStatus: "PUBLISHED",
+      },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const { id } = createRes.json();
+
+    const getRes = await app.inject({ method: "GET", url: `/api/admin/articles/${id}` });
+    const published = new Date(getRes.json().publishedAt).getTime();
+    expect(published).toBeGreaterThanOrEqual(before);
+
+    await app.inject({ method: "DELETE", url: `/api/admin/articles/${id}` });
+    await app.close();
+  });
+
   it("POST /api/admin/articles should reject duplicate slug", async () => {
     const app = await buildAdminApp();
     const slug = `dup-test-${Date.now()}`;

--- a/src/backend/src/routes/admin/articles.ts
+++ b/src/backend/src/routes/admin/articles.ts
@@ -10,6 +10,15 @@ import {
   type Lang,
 } from "../../lib/translation/index.js";
 
+// Returns a valid Date when an ISO string is supplied, otherwise null.
+// Used to let callers (e.g. content imports) preserve an original date
+// instead of stamping "now".
+function parsePublishedAt(value: string | undefined): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? null : date;
+}
+
 interface ArticleBody {
   slug: string;
   titleFr: string;
@@ -21,6 +30,9 @@ interface ArticleBody {
   imageUrl?: string;
   author?: string;
   publicationStatus?: "DRAFT" | "PUBLISHED";
+  // ISO date string. When provided (e.g. imports preserving an original
+  // publication date), it overrides the default "now" stamp.
+  publishedAt?: string;
   editionIds?: number[];
   tagIds?: number[];
   // When the editor manually edits a field that was AI-translated, the UI
@@ -123,6 +135,7 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
     }
 
     const isPublished = body.publicationStatus === "PUBLISHED";
+    const overrideDate = parsePublishedAt(body.publishedAt);
 
     const article = await prisma.article.create({
       data: {
@@ -136,7 +149,7 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
         imageUrl: body.imageUrl?.trim() || null,
         author: body.author?.trim() || null,
         publicationStatus: body.publicationStatus || "DRAFT",
-        publishedAt: isPublished ? new Date() : null,
+        publishedAt: isPublished ? overrideDate ?? new Date() : null,
         editions: body.editionIds?.length ? { connect: body.editionIds.map((id) => ({ id })) } : undefined,
         tags: body.tagIds?.length ? { connect: body.tagIds.map((id) => ({ id })) } : undefined,
       },
@@ -161,6 +174,7 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
     const body = request.body;
     const isPublished = body.publicationStatus === "PUBLISHED";
     const wasPublished = existing.publicationStatus === "PUBLISHED";
+    const overrideDate = parsePublishedAt(body.publishedAt);
 
     const newContentFr = body.contentFr !== undefined ? sanitizeRichHtml(body.contentFr) : existing.contentFr;
     const newContentEn = body.contentEn !== undefined ? sanitizeRichHtml(body.contentEn) : existing.contentEn;
@@ -188,7 +202,7 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
         imageUrl: body.imageUrl?.trim() ?? existing.imageUrl,
         author: body.author?.trim() ?? existing.author,
         publicationStatus: body.publicationStatus || existing.publicationStatus,
-        publishedAt: isPublished && !wasPublished ? new Date() : existing.publishedAt,
+        publishedAt: overrideDate ?? (isPublished && !wasPublished ? new Date() : existing.publishedAt),
         autoTranslatedFr: nextAutoFr,
         autoTranslatedEn: nextAutoEn,
         editions: body.editionIds !== undefined

--- a/src/backend/src/routes/admin/articles.ts
+++ b/src/backend/src/routes/admin/articles.ts
@@ -150,6 +150,8 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
         author: body.author?.trim() || null,
         publicationStatus: body.publicationStatus || "DRAFT",
         publishedAt: isPublished ? overrideDate ?? new Date() : null,
+        autoTranslatedFr: body.autoTranslatedFr ?? false,
+        autoTranslatedEn: body.autoTranslatedEn ?? false,
         editions: body.editionIds?.length ? { connect: body.editionIds.map((id) => ({ id })) } : undefined,
         tags: body.tagIds?.length ? { connect: body.tagIds.map((id) => ({ id })) } : undefined,
       },

--- a/src/backend/vitest.config.ts
+++ b/src/backend/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     // Only run the TypeScript source tests — the compiled `dist/` output
     // is a stale artefact of an earlier build and re-running those
     // generated .js copies produces duplicate, outdated results.
-    include: ["src/**/*.{test,spec}.ts"],
+    include: ["src/**/*.{test,spec}.ts", "scripts/**/*.{test,spec}.ts"],
     exclude: ["node_modules", "dist"],
   },
 });

--- a/src/frontend/src/app/[locale]/actualites/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/actualites/[slug]/page.tsx
@@ -123,13 +123,7 @@ export default async function ArticleDetailPage({
         )}
 
         <div
-          className="mt-8 prose prose-lg max-w-none text-noir
-            [&_h4]:text-2xl [&_h4]:font-bold [&_h4]:mt-8 [&_h4]:mb-4
-            [&_h5]:text-xl [&_h5]:font-bold [&_h5]:mt-6 [&_h5]:mb-3
-            [&_p]:leading-relaxed [&_p]:mb-4
-            [&_a]:text-bismarck [&_a]:underline
-            [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:mb-4
-            [&_li]:mb-1"
+          className="article-content mt-8 max-w-none text-noir"
           dangerouslySetInnerHTML={{ __html: content }}
         />
 

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -1,5 +1,31 @@
 @import "tailwindcss";
 
+/* Safelist for utility classes emitted by the WordPress import normalizer
+ * (scripts/lib/normalize-wordpress-html.ts in the backend). Article content is
+ * stored as HTML in the database and rendered via dangerouslySetInnerHTML, so
+ * Tailwind's source scanner never sees these classes — they must be declared
+ * here or the imported article layout (grids, captions, buttons) won't render.
+ * @source inline() treats each directive as a single class/pattern, so the
+ * classes are grouped with brace expansion rather than space-separated. */
+@source inline("grid");
+@source inline("grid-cols-1");
+@source inline("{sm:,md:}grid-cols-{2,4,5}");
+@source inline("md:col-span-{2,3}");
+@source inline("gap-{6,8}");
+@source inline("items-center");
+@source inline("w-full");
+@source inline("rounded-lg");
+@source inline("mx-auto");
+@source inline("block");
+@source inline("inline-block");
+@source inline("no-underline");
+@source inline("px-5");
+@source inline("py-2");
+@source inline("font-bold");
+@source inline("text-{center,left,right,sm,blanc,gris}");
+@source inline("p-4");
+@source inline("bg-{bismarck,blanc-casse}");
+
 /* ========================================
  * DevFest Toulouse 2026 — Design Tokens
  * Source: docs/design-system.md
@@ -87,71 +113,70 @@ body {
 }
 
 /* --- TipTap editor content — mirrors public prose styles --- */
-.tiptap-content {
-  min-height: inherit;
-  padding: 0.5rem 0.75rem;
-  outline: none;
-}
-.tiptap-content h2 {
+/* Shared article body typography — applied both in the TipTap admin editor
+ * (.tiptap-content) and on the public article page (.article-content) so the
+ * rendering is identical in both. The editor adds its own chrome (padding,
+ * outline) on top via .tiptap-content below. */
+.article-content h2 {
   font-size: 2rem;
   font-weight: 700;
   margin-top: 2.5rem;
   margin-bottom: 1rem;
 }
-.tiptap-content h3 {
+.article-content h3 {
   font-size: 1.75rem;
   font-weight: 700;
   margin-top: 2rem;
   margin-bottom: 1rem;
 }
-.tiptap-content h4 {
+.article-content h4 {
   font-size: 1.5rem;
   font-weight: 700;
   margin-top: 2rem;
   margin-bottom: 1rem;
 }
-.tiptap-content h5 {
+.article-content h5 {
   font-size: 1.25rem;
   font-weight: 700;
   margin-top: 1.5rem;
   margin-bottom: 0.75rem;
 }
-.tiptap-content p {
+.article-content p {
   line-height: 1.625;
   margin-bottom: 1rem;
 }
-.tiptap-content a {
+.article-content a {
   color: var(--color-bismarck);
   text-decoration: underline;
 }
-.tiptap-content ul {
+.article-content ul {
   list-style-type: disc;
   padding-left: 1.5rem;
   margin-bottom: 1rem;
 }
-.tiptap-content ol {
+.article-content ol {
   list-style-type: decimal;
   padding-left: 1.5rem;
   margin-bottom: 1rem;
 }
-.tiptap-content li {
+.article-content li {
   margin-bottom: 0.25rem;
 }
-.tiptap-content blockquote {
+.article-content blockquote {
   border-left: 4px solid var(--color-gris-placeholder);
   padding-left: 1rem;
   margin: 1rem 0;
   color: var(--color-gris);
   font-style: italic;
 }
-.tiptap-content code {
+.article-content code {
   background: var(--color-blanc-casse);
   border-radius: 4px;
   padding: 0.15rem 0.4rem;
   font-size: 0.9em;
   font-family: ui-monospace, monospace;
 }
-.tiptap-content pre {
+.article-content pre {
   background: var(--color-noir);
   color: var(--color-blanc);
   border-radius: 0.5rem;
@@ -161,6 +186,13 @@ body {
   font-family: ui-monospace, monospace;
   font-size: 0.9em;
   line-height: 1.6;
+}
+
+/* Editor-only chrome layered on top of the shared body styles. */
+.tiptap-content {
+  min-height: inherit;
+  padding: 0.5rem 0.75rem;
+  outline: none;
 }
 .tiptap-content pre code {
   background: none;

--- a/src/frontend/src/components/admin/RichTextEditor.tsx
+++ b/src/frontend/src/components/admin/RichTextEditor.tsx
@@ -78,7 +78,7 @@ export default function RichTextEditor({
     },
     editorProps: {
       attributes: {
-        class: "tiptap-content",
+        class: "article-content tiptap-content",
       },
     },
   });


### PR DESCRIPTION
## Summary

Import des articles publiés depuis l'ancien site WordPress (devfesttoulouse.fr) vers le nouveau backend, avec un contenu **durable et indépendant des thèmes legacy** :

- **Import** via l'API admin (HTTP only) : 20 articles, dates d'origine préservées, `autoTranslatedEn=true`, auteur par défaut « GDG Toulouse ».
- **Images rapatriées** en local (`/uploads/`) au lieu de hotlinker l'ancien WordPress ; emojis WordPress (`<img class=emoji>`) reconvertis en texte Unicode.
- **Normalisation du markup** (Avada Fusion Builder, Gutenberg, éditeur classique) en HTML sémantique + classes Tailwind : grilles de colonnes reconstruites (`md:grid-cols-4`, `md:grid-cols-5` + `col-span`), suppression du bruit de thème, allowlist stricte des classes émises (`scripts/lib/normalize-wordpress-html.ts`).
- **Rendu public corrigé** : style partagé `.article-content` (titres h2/h3 désormais stylés, identiques à l'éditeur) + safelist Tailwind `@source inline` pour les grilles stockées en BDD.
- **Entités HTML** des titres décodées (`c&rsquo;est` → `c'est`).

Nouvelle dépendance : `node-html-parser` (dev) pour la normalisation DOM.

## Test Plan

- ✅ Tests unitaires normaliseur (`normalize-wordpress-html.test.ts`, 11 cas) + admin-articles — 18/18 verts.
- ✅ Typecheck backend & frontend.
- ✅ Import de contrôle (dry-run + réel) : 20 créés, 0 erreur ; BDD sans bruit legacy, grilles présentes, images `/uploads/`, dates 2023→2026.
- ✅ Vérification visuelle (Chrome DevTools) : grilles 4-col & texte|image, titres stylés, boutons/encarts, auteur « by GDG Toulouse », aucune erreur console liée aux articles importés.

## Notes

- Issue de suivi pour l'édition de colonnes côté éditeur : #144.
- Le normaliseur tourne désormais via le conteneur backend (dépend de `node-html-parser`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)