### PR TITLE
feat(home): alternance des fonds robuste aux sections conditionnelles (#135)

### DIFF
--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -1,3 +1,4 @@
+import { Fragment, type ReactNode } from "react";
 import { getLocale } from "next-intl/server";
 
 import {
@@ -7,7 +8,12 @@ import {
   getLatestArticles,
   getCurrentTicketTiers,
   getKeyFigures,
+  getSponsors,
+  getFeaturedSpeakers,
+  getEcosystemPartners,
 } from "@/lib/api";
+
+import type { SectionSurface } from "@/components/home/section-surface";
 
 import HeroSection from "@/components/home/HeroSection";
 import KeyFiguresSection from "@/components/home/KeyFiguresSection";
@@ -95,12 +101,15 @@ function buildEventJsonLd(
 export default async function HomePage() {
   const locale = await getLocale();
 
-  const [edition, tiers, figures, cfp, editions] = await Promise.all([
+  const [edition, tiers, figures, cfp, editions, sponsors, speakers, partners] = await Promise.all([
     getCurrentEdition(),
     getCurrentTicketTiers(),
     getKeyFigures(),
     getCfpSettings(),
     getEditions(),
+    getSponsors(),
+    getFeaturedSpeakers(),
+    getEcosystemPartners(),
   ]);
 
   const articles = await getLatestArticles(4, edition?.id);
@@ -113,6 +122,114 @@ export default async function HomePage() {
   const isPreparation = edition?.status === "PREPARATION";
   const isAnnouncement = edition?.status === "ANNOUNCEMENT";
   const isSeeYouNextYear = edition?.status === "SEE_YOU_NEXT_YEAR";
+
+  // Background alternation is computed at render over the sections that are
+  // actually visible, so the blanc / blanc-cassé rhythm stays regular even when
+  // a conditional section (sponsors, speakers, news…) is empty (#135). The
+  // key-figures section is an "accent" outside the binary alternation (#136).
+  type HomeSection = {
+    show: boolean;
+    accent?: boolean;
+    render: (surface: SectionSurface) => ReactNode;
+  };
+
+  function renderWithAlternation(sections: HomeSection[]): ReactNode[] {
+    let i = 0;
+    return sections
+      .filter((s) => s.show)
+      .map((s, idx) => {
+        // The accent section (key figures, #136) is a tinted slot of its own:
+        // it still advances the parity so the next section flips and we never
+        // get two tinted backgrounds in a row.
+        if (s.accent) {
+          i += 1;
+          return <Fragment key={idx}>{s.render("accent")}</Fragment>;
+        }
+        const surface: SectionSurface = i % 2 === 0 ? "blanc-casse" : "blanc";
+        i += 1;
+        return <Fragment key={idx}>{s.render(surface)}</Fragment>;
+      });
+  }
+
+  const announcementSections: HomeSection[] = [
+    {
+      show: figures.length > 0,
+      accent: true,
+      render: (surface) => <KeyFiguresSection figures={figures} locale={locale} surface={surface} />,
+    },
+    {
+      show: tiers.length > 0,
+      render: (surface) => <TicketingSection tiers={tiers} locale={locale} surface={surface} />,
+    },
+    {
+      show: Boolean(edition?.previousAfterMovieUrl),
+      render: (surface) => (
+        <ReplaySection
+          aftermovieUrl={edition!.previousAfterMovieUrl!}
+          galleryUrl={edition?.previousGalleryUrl}
+          editionYear={edition?.previousYear}
+          surface={surface}
+        />
+      ),
+    },
+    {
+      show: sponsors.length > 0,
+      render: (surface) => <SponsorsSection sponsors={sponsors} surface={surface} />,
+    },
+    {
+      show: speakers.length > 0,
+      render: (surface) => <FeaturedSpeakersSection speakers={speakers} surface={surface} />,
+    },
+    {
+      show: articles.length > 0,
+      render: (surface) => <LatestNewsSection articles={articles} locale={locale} surface={surface} />,
+    },
+    {
+      show: true,
+      render: (surface) => <AboutSection surface={surface} />,
+    },
+    {
+      show: partners.length > 0,
+      render: (surface) => <EcosystemSection partners={partners} surface={surface} />,
+    },
+  ];
+
+  const seeYouNextYearSections: HomeSection[] = [
+    {
+      show: Boolean(edition?.aftermovieUrl),
+      render: (surface) => (
+        <ReplaySection
+          aftermovieUrl={edition!.aftermovieUrl!}
+          editionYear={edition?.year}
+          surface={surface}
+        />
+      ),
+    },
+    {
+      show: Boolean(edition?.galleryUrl),
+      render: (surface) => (
+        <section className={`section-y px-6 ${surface === "blanc" ? "bg-blanc" : "bg-blanc-casse"}`}>
+          <div className="mx-auto max-w-6xl text-center">
+            <h2 className="section-title text-3xl lg:text-5xl font-bold text-noir">
+              {locale === "fr" ? "Galerie photos" : "Photo gallery"}
+            </h2>
+            <a
+              href={edition!.galleryUrl!}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block rounded-[12px] bg-bleu px-8 py-3 text-lg font-bold text-blanc hover:bg-bleu/90 transition-colors"
+            >
+              {locale === "fr" ? "Voir les photos" : "View photos"}
+            </a>
+          </div>
+        </section>
+      ),
+    },
+    {
+      show: articles.length > 0,
+      render: (surface) => <LatestNewsSection articles={articles} locale={locale} surface={surface} />,
+    },
+  ];
 
   return (
     <>
@@ -136,64 +253,11 @@ export default async function HomePage() {
         />
       )}
 
-      {/* ANNOUNCEMENT: full content */}
-      {isAnnouncement && figures.length > 0 && (
-        <KeyFiguresSection figures={figures} locale={locale} />
-      )}
-
-      {isAnnouncement && tiers.length > 0 && (
-        <TicketingSection tiers={tiers} locale={locale} />
-      )}
-
-      {isAnnouncement && edition?.previousAfterMovieUrl && (
-        <ReplaySection
-          aftermovieUrl={edition.previousAfterMovieUrl}
-          galleryUrl={edition.previousGalleryUrl}
-          editionYear={edition.previousYear}
-        />
-      )}
-
-      {isAnnouncement && <SponsorsSection />}
-
-      {isAnnouncement && <FeaturedSpeakersSection />}
-
-      {isAnnouncement && articles.length > 0 && (
-        <LatestNewsSection articles={articles} locale={locale} />
-      )}
-
-      {isAnnouncement && <AboutSection />}
-
-      {isAnnouncement && <EcosystemSection />}
+      {/* ANNOUNCEMENT: full content, with computed background alternation */}
+      {isAnnouncement && renderWithAlternation(announcementSections)}
 
       {/* SEE_YOU_NEXT_YEAR: bilan + aftermovie + gallery + news */}
-      {isSeeYouNextYear && edition?.aftermovieUrl && (
-        <ReplaySection
-          aftermovieUrl={edition.aftermovieUrl}
-          editionYear={edition.year}
-        />
-      )}
-
-      {isSeeYouNextYear && edition?.galleryUrl && (
-        <section className="section-y px-6 bg-blanc-casse">
-          <div className="mx-auto max-w-6xl text-center">
-            <h2 className="section-title text-3xl lg:text-5xl font-bold text-noir">
-              {locale === "fr" ? "Galerie photos" : "Photo gallery"}
-            </h2>
-            <a
-              href={edition.galleryUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-block rounded-[12px] bg-bleu px-8 py-3 text-lg font-bold text-blanc hover:bg-bleu/90 transition-colors"
-            >
-              {locale === "fr" ? "Voir les photos" : "View photos"}
-            </a>
-          </div>
-        </section>
-      )}
-
-      {isSeeYouNextYear && articles.length > 0 && (
-        <LatestNewsSection articles={articles} locale={locale} />
-      )}
+      {isSeeYouNextYear && renderWithAlternation(seeYouNextYearSections)}
     </>
   );
 }

--- a/src/frontend/src/components/home/AboutSection.tsx
+++ b/src/frontend/src/components/home/AboutSection.tsx
@@ -1,10 +1,16 @@
 import { useTranslations } from "next-intl";
 
-export default function AboutSection() {
+import { surfaceBgClass, type SectionSurface } from "./section-surface";
+
+interface AboutSectionProps {
+  surface?: SectionSurface;
+}
+
+export default function AboutSection({ surface = "blanc" }: AboutSectionProps) {
   const t = useTranslations("home.about");
 
   return (
-    <section className="section-y px-6">
+    <section className={`section-y px-6 ${surfaceBgClass(surface)}`}>
       <div className="mx-auto max-w-6xl">
         <div className="relative overflow-hidden rounded-3xl bg-bismarck min-h-[400px] flex items-center">
           {/* Warm orange filter over the (future) background photo, replacing

--- a/src/frontend/src/components/home/EcosystemSection.tsx
+++ b/src/frontend/src/components/home/EcosystemSection.tsx
@@ -1,17 +1,22 @@
 import { getTranslations } from "next-intl/server";
 
-import { getEcosystemPartners } from "@/lib/api";
+import { surfaceBgClass, type SectionSurface } from "./section-surface";
+import type { EcosystemPartner } from "@/lib/types";
 
-export default async function EcosystemSection() {
-  const [t, partners] = await Promise.all([
-    getTranslations("home.about"),
-    getEcosystemPartners(),
-  ]);
+interface EcosystemSectionProps {
+  partners: EcosystemPartner[];
+  surface?: SectionSurface;
+}
+
+// Partners are fetched by the page so it can compute the section alternation
+// over the visible sections (#135).
+export default async function EcosystemSection({ partners, surface = "blanc" }: EcosystemSectionProps) {
+  const t = await getTranslations("home.about");
 
   if (partners.length === 0) return null;
 
   return (
-    <section className="section-y px-6">
+    <section className={`section-y px-6 ${surfaceBgClass(surface)}`}>
       <div className="mx-auto max-w-6xl text-center">
         <h2 className="section-title text-2xl lg:text-4xl font-bold text-noir">
           {t("ecosystemTitle")}

--- a/src/frontend/src/components/home/FeaturedSpeakersSection.tsx
+++ b/src/frontend/src/components/home/FeaturedSpeakersSection.tsx
@@ -1,20 +1,28 @@
 import { getTranslations } from "next-intl/server";
 
-import { getFeaturedSpeakers } from "@/lib/api";
 import { Link } from "@/i18n/navigation";
 import SpeakerCard from "@/components/speakers/SpeakerCard";
+import { surfaceBgClass, type SectionSurface } from "./section-surface";
+import type { SpeakerPublic } from "@/lib/types";
 
-export default async function FeaturedSpeakersSection() {
-  const [t, speakers] = await Promise.all([
-    getTranslations("home.featuredSpeakers"),
-    getFeaturedSpeakers(),
-  ]);
+interface FeaturedSpeakersSectionProps {
+  speakers: SpeakerPublic[];
+  surface?: SectionSurface;
+}
+
+// Speakers are fetched by the page so it can compute the section alternation
+// over the visible sections (#135).
+export default async function FeaturedSpeakersSection({
+  speakers,
+  surface = "blanc",
+}: FeaturedSpeakersSectionProps) {
+  const t = await getTranslations("home.featuredSpeakers");
 
   // Hidden when no speaker is featured (US-202).
   if (speakers.length === 0) return null;
 
   return (
-    <section className="section-y px-6">
+    <section className={`section-y px-6 ${surfaceBgClass(surface)}`}>
       <div className="mx-auto max-w-6xl">
         <h2 className="section-title text-2xl font-bold text-noir lg:text-4xl">{t("title")}</h2>
 

--- a/src/frontend/src/components/home/KeyFiguresSection.tsx
+++ b/src/frontend/src/components/home/KeyFiguresSection.tsx
@@ -3,14 +3,16 @@ import { useTranslations } from "next-intl";
 
 import StatIcon from "./StatIcon";
 import { localizedField } from "@/lib/i18n-helpers";
+import { surfaceBgClass, type SectionSurface } from "./section-surface";
 import type { KeyFigure } from "@/lib/types";
 
 interface KeyFiguresSectionProps {
   figures: KeyFigure[];
   locale: string;
+  surface?: SectionSurface;
 }
 
-export default function KeyFiguresSection({ figures, locale }: KeyFiguresSectionProps) {
+export default function KeyFiguresSection({ figures, locale, surface = "accent" }: KeyFiguresSectionProps) {
   const t = useTranslations("home.stats");
 
   if (figures.length === 0) return null;
@@ -18,7 +20,7 @@ export default function KeyFiguresSection({ figures, locale }: KeyFiguresSection
   // Reduced top padding keeps the title on the first PC screen (#134);
   // bottom padding matches the shared section rhythm (.section-y, #135).
   return (
-    <section className="relative px-6 pt-6 lg:pt-8 pb-[clamp(40px,5vw,72px)]">
+    <section className={`relative px-6 pt-6 lg:pt-8 pb-[clamp(40px,5vw,72px)] ${surfaceBgClass(surface)}`}>
       {/* La Grave illustration — sits on the page background, behind the card,
           peeking out from the bottom-left rather than being boxed inside the
           white card. */}

--- a/src/frontend/src/components/home/LatestNewsSection.tsx
+++ b/src/frontend/src/components/home/LatestNewsSection.tsx
@@ -2,20 +2,22 @@ import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 
 import ArticleCard from "@/components/ArticleCard";
+import { surfaceBgClass, type SectionSurface } from "./section-surface";
 import type { Article } from "@/lib/types";
 
 interface LatestNewsSectionProps {
   articles: Article[];
   locale: string;
+  surface?: SectionSurface;
 }
 
-export default function LatestNewsSection({ articles, locale }: LatestNewsSectionProps) {
+export default function LatestNewsSection({ articles, locale, surface = "blanc" }: LatestNewsSectionProps) {
   const t = useTranslations("home.news");
 
   if (articles.length === 0) return null;
 
   return (
-    <section className="section-y px-6">
+    <section className={`section-y px-6 ${surfaceBgClass(surface)}`}>
       <div className="mx-auto max-w-6xl">
         <div className="section-title flex items-center justify-between">
           <h2 className="text-3xl lg:text-5xl font-bold text-noir">

--- a/src/frontend/src/components/home/ReplaySection.tsx
+++ b/src/frontend/src/components/home/ReplaySection.tsx
@@ -2,23 +2,26 @@ import { useTranslations } from "next-intl";
 
 import YouTubeFacade from "@/components/YouTubeFacade";
 import { Link } from "@/i18n/navigation";
+import { surfaceBgClass, type SectionSurface } from "./section-surface";
 
 interface ReplaySectionProps {
   aftermovieUrl: string;
   galleryUrl?: string | null;
   editionYear?: number | null;
+  surface?: SectionSurface;
 }
 
 export default function ReplaySection({
   aftermovieUrl,
   galleryUrl,
   editionYear,
+  surface = "blanc",
 }: ReplaySectionProps) {
   const t = useTranslations("home.replay");
   const hasCtas = Boolean(galleryUrl) || Boolean(editionYear);
 
   return (
-    <section className="section-y px-6">
+    <section className={`section-y px-6 ${surfaceBgClass(surface)}`}>
       <div className="mx-auto max-w-4xl">
         <h2 className="section-title text-3xl lg:text-5xl font-bold text-noir text-center">
           {editionYear ? t("title", { year: editionYear }) : t("titleFallback")}

--- a/src/frontend/src/components/home/SponsorsSection.tsx
+++ b/src/frontend/src/components/home/SponsorsSection.tsx
@@ -1,17 +1,21 @@
 import { getTranslations } from "next-intl/server";
 
-import { getSponsors } from "@/lib/api";
-import type { SponsorLevel } from "@/lib/types";
+import type { SponsorLevel, SponsorPublic } from "@/lib/types";
 import { Link } from "@/i18n/navigation";
 import SponsorCard from "@/components/sponsors/SponsorCard";
+import { surfaceBgClass, type SectionSurface } from "./section-surface";
 
 const LEVEL_ORDER: SponsorLevel[] = ["PLATINUM", "GOLD", "SILVER", "SOUTIEN", "COMMUNAUTE"];
 
-export default async function SponsorsSection() {
-  const [t, sponsors] = await Promise.all([
-    getTranslations("home.sponsors"),
-    getSponsors(),
-  ]);
+interface SponsorsSectionProps {
+  sponsors: SponsorPublic[];
+  surface?: SectionSurface;
+}
+
+// Sponsors are fetched by the page so it can compute the section alternation
+// over the visible sections (#135).
+export default async function SponsorsSection({ sponsors, surface = "blanc" }: SponsorsSectionProps) {
+  const t = await getTranslations("home.sponsors");
 
   // Hidden when no sponsor is published (US-212).
   if (sponsors.length === 0) return null;
@@ -22,7 +26,7 @@ export default async function SponsorsSection() {
   })).filter((g) => g.items.length > 0);
 
   return (
-    <section className="section-y relative overflow-hidden px-6">
+    <section className={`section-y relative overflow-hidden px-6 ${surfaceBgClass(surface)}`}>
       {/* Croix occitane decoration (top-right). Placeholder geometric mark
           until the brand asset is provided; kept subtle and decorative. */}
       <div

--- a/src/frontend/src/components/home/TicketingSection.tsx
+++ b/src/frontend/src/components/home/TicketingSection.tsx
@@ -1,14 +1,16 @@
 import { useTranslations } from "next-intl";
 
 import { localizedField } from "@/lib/i18n-helpers";
+import { surfaceBgClass, type SectionSurface } from "./section-surface";
 import type { TicketTier } from "@/lib/types";
 
 interface TicketingSectionProps {
   tiers: TicketTier[];
   locale: string;
+  surface?: SectionSurface;
 }
 
-export default function TicketingSection({ tiers, locale }: TicketingSectionProps) {
+export default function TicketingSection({ tiers, locale, surface = "blanc-casse" }: TicketingSectionProps) {
   const t = useTranslations("home.ticketing");
 
   if (tiers.length === 0) return null;
@@ -24,7 +26,7 @@ export default function TicketingSection({ tiers, locale }: TicketingSectionProp
   const smCols = tiers.length === 1 ? "sm:grid-cols-1" : "sm:grid-cols-2";
 
   return (
-    <section className="section-y px-6 bg-blanc-casse">
+    <section className={`section-y px-6 ${surfaceBgClass(surface)}`}>
       <div className="mx-auto max-w-6xl text-center">
         <h2 className="section-title text-3xl lg:text-5xl font-bold text-noir">
           {t("title")}

--- a/src/frontend/src/components/home/section-surface.ts
+++ b/src/frontend/src/components/home/section-surface.ts
@@ -1,0 +1,19 @@
+// Background "surface" for a home section. The page computes the alternating
+// rhythm at render time over the sections that are actually visible (#135), so
+// a section never needs to know its own position — it just receives a surface.
+export type SectionSurface = "blanc" | "blanc-casse" | "accent";
+
+// Maps a surface to its background utility class. "accent" is reserved for the
+// key-figures highlight whose exact colour is decided in #136; until then it
+// falls back to blanc-casse.
+export function surfaceBgClass(surface: SectionSurface): string {
+  switch (surface) {
+    case "blanc-casse":
+      return "bg-blanc-casse";
+    case "accent":
+      return "bg-blanc-casse";
+    case "blanc":
+    default:
+      return "bg-blanc";
+  }
+}


### PR DESCRIPTION
## Summary

- Met en place l'**alternance des fonds** (blanc / blanc-cassé) de la home, **calculée au rendu serveur sur les sections réellement visibles**, pour que le rythme reste régulier même quand une section conditionnelle (sponsors, speakers, actualités, replay…) est absente.
- Corrige le problème remonté : certaines sections n'apparaissant pas cassaient le rythme (deux fonds identiques côte à côte).

## Implémentation

- Nouveau helper `section-surface.ts` : type `SectionSurface` + `surfaceBgClass`.
- Chaque section de la home reçoit une prop `surface` qui pilote son `bg-*`.
- `page.tsx` fetch désormais `getSponsors` / `getFeaturedSpeakers` / `getEcosystemPartners` (ajoutés au `Promise.all`, donc sans coût) afin de connaître la visibilité de **toutes** les sections, puis attribue les fonds via `renderWithAlternation` sur la liste filtrée. Même mécanique pour le mode `SEE_YOU_NEXT_YEAR`.
- La section **Chiffres clés** est un slot **accent** (couleur décidée en #136) ; elle fait avancer la parité pour qu'on n'ait jamais deux fonds teintés consécutifs. En attendant le vote A–E, l'accent retombe sur `blanc-cassé`.

## Robustesse (vérifiée)

Algorithme testé sur 6 scénarios de sections manquantes (no speakers, no sponsors+news, no replay, no figures, only about, all) → **jamais deux fonds teintés côte à côte** dans aucun cas.

## Test plan

- [x] `pnpm lint` + `tsc --noEmit` : 0 erreur.
- [x] Alternance régulière vérifiée au navigateur (Chrome DevTools MCP) : Hero blanc → Chiffres (accent) → Billetterie blanc → Replay cassé → … (aucun double-tint).
- [x] FR + EN : alternance correcte, `doubleTint=false`.
- [x] Mobile 390px : stack propre, pas de régression.
- [x] Console propre.

## Lien

- Mécanique d'alternance indépendante du **vote de variante de #136** (couleur de la section Chiffres clés). La variante accent sera branchée ensuite via `surfaceBgClass("accent")`.
- Analyse détaillée postée en commentaire sur #135.
