### PR TITLE
fix(home): aligne le padding bas du hero sur le rythme des sections (#135)

### DIFF
--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -454,5 +454,5 @@ body {
    box gap below the card. Add that overshoot back to the top padding so the
    visible space under the card matches the space above the first title (#135). */
 .hero + section.section-y {
-  padding-top: clamp(46px, 5vw, 78px);
+  padding-top: calc(clamp(40px, 5vw, 72px) + 6px);
 }

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -448,3 +448,11 @@ body {
 .section-title {
   margin-bottom: clamp(24px, 3vw, 40px);
 }
+/* The first section after the hero sits right under the stats card. Its title
+   (48px / line-height 1) has ~6px of cap-height overshoot above the text box,
+   so the *perceived* gap above the heading reads smaller than the equal 72px
+   box gap below the card. Add that overshoot back to the top padding so the
+   visible space under the card matches the space above the first title (#135). */
+.hero + section.section-y {
+  padding-top: clamp(46px, 5vw, 78px);
+}

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -448,11 +448,3 @@ body {
 .section-title {
   margin-bottom: clamp(24px, 3vw, 40px);
 }
-/* The first section after the hero sits right under the stats card. Its title
-   (48px / line-height 1) has ~6px of cap-height overshoot above the text box,
-   so the *perceived* gap above the heading reads smaller than the equal 72px
-   box gap below the card. Add that overshoot back to the top padding so the
-   visible space under the card matches the space above the first title (#135). */
-.hero + section.section-y {
-  padding-top: calc(clamp(40px, 5vw, 72px) + 6px);
-}

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -252,7 +252,9 @@ body {
   --hero-radius: clamp(24px, 3vw, 48px);
   --header-h: 60px;
   position: relative;
-  padding: 0 var(--hero-pad) clamp(28px, 3.5vw, 56px);
+  /* Bottom padding matches .section-y so the space under the stats card has the
+     same vertical rhythm as the gap above the first section's title (#135). */
+  padding: 0 var(--hero-pad) clamp(40px, 5vw, 72px);
 }
 /* First screen: header (60px sticky) + this block fill the viewport, so the
    catch-phrase lands at the bottom of the fold and the stats card needs a


### PR DESCRIPTION
## Résumé

Aligne l'espace vertical sous la carte des chiffres (dans le hero) sur le rythme des sections.

La carte des chiffres vit dans le hero, donc l'espace sous elle dépendait du padding-bas du hero (`clamp(28px, 3.5vw, 56px)`) et non du rythme partagé `.section-y` (`clamp(40px, 5vw, 72px)`). On aligne le padding-bas du hero sur `.section-y` : **padding-bas hero = padding-haut section = 72px** (strictement égaux à toute largeur).

## Résultat (desktop 1440px)

| Mesure | Avant | Après |
|---|---|---|
| Padding-bas hero (sous la carte chiffres) | 50px | **72px** |
| Padding-haut première section | 72px | 72px |
| Paddings égaux | non | **oui (72=72)** |

Note : les capitales du titre (line-height 1) démarrent ~6px sous le haut de leur box, donc l'espace *au-dessus des lettres* paraît légèrement plus grand à l'œil. C'est inhérent au line-height des titres et identique sur toutes les sections — décision retenue : garder les paddings numériquement égaux plutôt que compenser cet effet optique.

## Test plan

- [x] `pnpm lint` — 0 erreur (warnings préexistants sans rapport)
- [x] `tsc --noEmit` — 0 erreur
- [x] Vérif navigateur (Chrome DevTools MCP) : padding-bas hero === padding-haut section === 72px à 1440px
- [x] Vérif responsive : les deux suivent le même `clamp(40px, 5vw, 72px)`

## Liens

- #135
