### PR TITLE
feat(home): comportement du premier écran selon la taille d'écran (#134)

### DIFF
--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -256,17 +256,23 @@ body {
      same vertical rhythm as the gap above the first section's title (#135). */
   padding: 0 var(--hero-pad) clamp(40px, 5vw, 72px);
 }
-/* First screen: header (60px sticky) + this block fill the viewport, so the
-   catch-phrase lands at the bottom of the fold and the stats card needs a
-   scroll (#134). Its own vertical padding is included in the min-height
-   (border-box), so header + .hero-screen = exactly 100vh. */
+/* First screen layout. The min-height that fills the viewport (header + this
+   block = 100vh, catch-phrase pinned to the fold, stats card just below) is
+   applied only on tablet / standard screens (768–1600px). On phones (<768px)
+   and large screens (>1600px) the block keeps its natural content height so
+   the hero shows at its own size and as much content as fits is visible
+   without a forced full-height fold (#134). */
 .hero-screen {
-  min-height: calc(100dvh - var(--header-h));
   box-sizing: border-box;
   padding-block: clamp(16px, 2vw, 28px);
   display: flex;
   flex-direction: column;
   gap: clamp(24px, 3vw, 48px);
+}
+@media (min-width: 768px) and (max-width: 1600px) {
+  .hero-screen {
+    min-height: calc(100dvh - var(--header-h));
+  }
 }
 .hero-screen > .hero-inner {
   flex: 1 1 auto;


### PR DESCRIPTION
## Résumé

Le fold plein écran (100vh : header + hero + catch-phrase remplissent la fenêtre, carte chiffres sous le fold) était appliqué à **toutes** les largeurs. On le restreint à la plage tablette / écran standard :

| Palier | Largeur | Comportement |
|---|---|---|
| **Smartphone** | < 768px | hero à hauteur naturelle, pas de fold 100vh forcé |
| **Tablette / standard** | 768–1600px | inchangé : fold 100vh (catch-phrase au bas du fold, carte sous le fold) |
| **Grand écran** | > 1600px | hauteur naturelle → la carte chiffres peut déjà s'afficher sans scroll (on montre le maximum) |

## Implémentation

`min-height: calc(100dvh - var(--header-h))` sur `.hero-screen` est retiré du défaut et réintroduit uniquement via `@media (min-width: 768px) and (max-width: 1600px)`. Hors de cette plage, le bloc garde sa hauteur de contenu.

## Vérification (Chrome DevTools MCP)

| Palier | Largeur | `min-height` calculé | Carte visible sans scroll |
|---|---|---|---|
| Smartphone | 500px | **0px** (off) | — (hauteur naturelle) |
| Standard | 1280px | **740px** (100vh) | non (scroll requis) |
| Grand écran | 1920px | **0px** (off) | **oui** |

## Test plan

- [x] `pnpm lint` — 0 erreur (warnings préexistants sans rapport)
- [x] `tsc --noEmit` — 0 erreur
- [x] Vérif navigateur 500 / 1280 / 1920px : min-height actif uniquement en 768–1600px
- [x] Grand écran : hero + catch-phrase + carte chiffres visibles sans scroll
- [x] Standard : comportement 100vh inchangé

## Liens

- #134
