### PR TITLE
feat(home): supprime le blanc typographique au-dessus des titres (#153)

### DIFF
--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -454,3 +454,14 @@ body {
 .section-title {
   margin-bottom: clamp(24px, 3vw, 40px);
 }
+/* Trim the font's intrinsic leading above caps and below the baseline so the
+   heading box hugs the visible glyphs. Without this the font reserves ~16px of
+   blank space above a 48px title (half-leading + ascender vs cap-height), which
+   adds to the padding and makes the space above a heading read larger than the
+   equal space below the preceding element (#153). text-box has partial browser
+   support (Chromium yes, Firefox/Safari later); where unsupported the heading
+   keeps today's spacing — graceful degradation, no breakage. */
+.hero-screen > .hero-figures-title,
+.section-y h2 {
+  text-box: trim-both cap alphabetic;
+}


### PR DESCRIPTION
## Résumé

Implémente l'**approche 1** votée par @kadorito sur #153 : `text-box-trim` natif.

Les titres de section réservaient ~16px de blanc typographique intrinsèque au-dessus des capitales (demi-leading + écart ascender/cap-height), qui s'ajoutait au padding et faisait paraître l'espace **au-dessus** d'un titre plus grand que l'espace égal en dessous (ex. sous la carte des chiffres). `text-box: trim-both cap alphabetic` rogne ce blanc : la box du titre colle aux glyphes visibles.

## Implémentation

```css
.hero-screen > .hero-figures-title,
.section-y h2 {
  text-box: trim-both cap alphabetic;
}
```

Cible les titres `h2` des sections de la home + la catch-phrase du hero. Support navigateur partiel (Chromium oui, Firefox/Safari plus tardifs) → **dégradation gracieuse** : sans support, le titre garde l'espacement actuel, aucune casse.

## Vérification (Chrome DevTools MCP, 1440px)

| Mesure | Avant | Après |
|---|---|---|
| Hauteur de box du titre 48px | 48px | **34,4px** (≈ cap-height) |
| Espace sous la carte → frontière | 72px | 72px |
| Frontière → haut des lettres du titre | 66px | **72px** |
| Delta perçu | -6px | **0** |

Auto-responsive (vérifié) : box 34,4px pour les titres 48px, 25,8px pour les 36px — aucune compensation en px fixe.

## Test plan

- [x] `pnpm lint` — 0 erreur (warnings préexistants sans rapport)
- [x] `tsc --noEmit` — 0 erreur
- [x] Vérif navigateur : `text-box` appliqué et supporté (Chromium), delta perçu = 0
- [x] Vérif sur titres 48px et 36px : trim proportionnel, pas de px fixe
- [ ] À tester sur Firefox/Safari (dégradation gracieuse attendue) — pour la revue beta

## Liens

- Closes #153
