### PR TITLE
fix(prod): câble les variables d'env lues par le code mais absentes du compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,11 +4,18 @@ services:
       context: .
       dockerfile: src/frontend/Dockerfile
     environment:
+      - NODE_ENV=production
       - BASE_URL=${BASE_URL}
       # Pinned to the env-scoped backend container name. Resolving the bare
       # `backend` hostname picks up other Coolify projects' backends via the
       # shared `coolify` network (IPv6 priority), causing cross-env requests.
       - BACKEND_URL=http://devfest-${ENV_NAME:-local}-backend:4000
+      # Shared with the backend to authorise POST /api/revalidate (on-demand
+      # cache invalidation when the admin edits content). If unset, revalidation
+      # is disabled and public pages stay cached until the s-maxage TTL.
+      - REVALIDATE_SECRET=${REVALIDATE_SECRET:-}
+      # Plausible analytics script URL. If unset, analytics stays off.
+      - NEXT_PUBLIC_PLAUSIBLE_SRC=${NEXT_PUBLIC_PLAUSIBLE_SRC:-}
     expose:
       - "3000"
     depends_on:
@@ -32,12 +39,21 @@ services:
     volumes:
       - uploads:/app/uploads
     environment:
+      - NODE_ENV=production
       - BASE_URL=${BASE_URL}
       - FRONTEND_URL=http://frontend:3000
       - PORT=4000
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       - SESSION_SECRET=${SESSION_SECRET}
       - MAGIC_LINK_SECRET=${MAGIC_LINK_SECRET:-}
+      # Shared with the frontend to sign POST /api/revalidate (see frontend).
+      - REVALIDATE_SECRET=${REVALIDATE_SECRET:-}
+      # HMAC secret to sign per-message brochure download links sent by email.
+      # If unset, confirmation emails fall back to the raw URL (no tracking).
+      - BROCHURE_TOKEN_SECRET=${BROCHURE_TOKEN_SECRET:-}
+      # Google Gemini key for the back-office FR<->EN translator. If unset,
+      # POST /api/admin/translate returns 503 and the UI button is disabled.
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - OAUTH_GOOGLE_CLIENT_ID=${OAUTH_GOOGLE_CLIENT_ID:-}
       - OAUTH_GOOGLE_CLIENT_SECRET=${OAUTH_GOOGLE_CLIENT_SECRET:-}
       - OAUTH_GITHUB_CLIENT_ID=${OAUTH_GITHUB_CLIENT_ID:-}


### PR DESCRIPTION
## Résumé

`docker-compose.prod.yml` ne transmettait pas aux conteneurs 5 variables pourtant **lues par le code** et **documentées dans `.env.example`**. Les renseigner dans le `.env` Coolify n'avait donc aucun effet (le pont `- VAR=${VAR}` manquait dans les blocs `environment:`).

| Variable | Service | Impact si absente |
|---|---|---|
| `REVALIDATE_SECRET` | frontend + backend | ⚠️ invalidation du cache admin **désactivée** (pages figées jusqu'au TTL `s-maxage`) |
| `BROCHURE_TOKEN_SECRET` | backend | liens plaquette non signés |
| `GEMINI_API_KEY` | backend | traduction IA admin désactivée (503) |
| `NEXT_PUBLIC_PLAUSIBLE_SRC` | frontend | analytics off |
| `NODE_ENV` | front + back | pas forcé à `production` |

Toutes câblées en **optionnel** (`${VAR:-}`) sauf `NODE_ENV=production` (fixé) → rien ne casse si une variable est laissée vide.

## Détail

- Référence : [.env.example](.env.example) documente ces variables ; [revalidate.ts](src/backend/src/lib/revalidate.ts), [brochure-token.ts](src/backend/src/lib/brochure-token.ts), [gemini-client.ts](src/backend/src/lib/translation/gemini-client.ts), [layout.tsx](src/frontend/src/app/[locale]/layout.tsx) les lisent.
- `REVALIDATE_SECRET` doit être **identique** côté frontend et backend (secret partagé).

## Test plan

- [x] `docker compose -f docker-compose.prod.yml config` valide
- [x] Les 5 variables apparaissent dans la config résolue quand définies, absentes/vides sinon
- [ ] En prod : après config du `.env` Coolify, vérifier qu'une modif admin invalide bien le cache public (POST /api/revalidate 200)

## Note déploiement

Sur Coolify, cocher **« Available at Buildtime »** pour `NEXT_PUBLIC_PLAUSIBLE_SRC` (lue au build par Next). `REVALIDATE_SECRET` / `BROCHURE_TOKEN_SECRET` / `GEMINI_API_KEY` sont des secrets runtime → **ne pas** cocher Buildtime.
