### PR TITLE
fix(auth): utilise SESSION_SECRET comme secret Better Auth

### DIFF
--- a/src/backend/src/lib/auth.ts
+++ b/src/backend/src/lib/auth.ts
@@ -37,6 +37,10 @@ const trustedOrigins = [baseUrl, frontendUrl, ...(wildcardOrigin ? [wildcardOrig
 );
 
 export const auth = betterAuth({
+  // Reuse SESSION_SECRET so we keep a single secret to manage. Better Auth
+  // otherwise reads BETTER_AUTH_SECRET and, in production, throws at startup
+  // when it falls back to its built-in default secret.
+  secret: process.env.SESSION_SECRET || process.env.BETTER_AUTH_SECRET,
   database: prismaAdapter(prisma, {
     provider: "postgresql",
   }),


### PR DESCRIPTION
## Résumé

Le backend prod crashait en boucle au seed avec :
```
[BetterAuthError: You are using the default secret. Please set `BETTER_AUTH_SECRET`...]
```

**Cause** : `betterAuth({...})` ne passait aucun `secret`. Better Auth lit alors `BETTER_AUTH_SECRET` et, **uniquement quand `NODE_ENV=production`**, jette une erreur fatale s'il tombe sur son secret par défaut (cf. `validateSecret` : `isDefaultSecret && isProduction`). Comme on vient d'ajouter `NODE_ENV=production` au compose prod (#156), cet enforcement s'est activé — ce qui explique aussi pourquoi beta (mode dev) ne crashait pas.

**Fix** : passer `secret: process.env.SESSION_SECRET` (fallback `BETTER_AUTH_SECRET`) → on réutilise le secret déjà provisionné, pas de nouvelle variable à gérer.

## Détail

- [auth.ts](src/backend/src/lib/auth.ts) : ajout de `secret:` dans la config Better Auth.
- Fallback sur `BETTER_AUTH_SECRET` pour rester compatible si quelqu'un a déjà défini cette variable (ex. déblocage prod immédiat).

## Test plan

- [x] `tsc --noEmit` backend — 0 erreur
- [ ] Prod : après merge + deploy, le backend démarre sans BetterAuthError et le seed passe
- [ ] Sign-in admin fonctionne

## Liens

Débloque le déploiement prod (crash-loop backend).
