### PR TITLE
fix(articles): pagination /actualites par 12 pour remplir la grille 4 colonnes (#165)

### DIFF
--- a/src/backend/src/routes/articles.ts
+++ b/src/backend/src/routes/articles.ts
@@ -58,7 +58,7 @@ export default async function articleRoutes(app: FastifyInstance) {
     Querystring: { page?: string; limit?: string; tag?: string };
   }>("/articles", async (request) => {
     const page = Math.max(Number(request.query.page) || 1, 1);
-    const limit = Math.min(Number(request.query.limit) || 9, 50);
+    const limit = Math.min(Number(request.query.limit) || 12, 50);
     const tagSlug = request.query.tag;
 
     const where = {

--- a/src/frontend/src/app/[locale]/actualites/page.tsx
+++ b/src/frontend/src/app/[locale]/actualites/page.tsx
@@ -29,7 +29,9 @@ export default async function ArticlesPage({
   const { page: pageParam } = await searchParams;
   const page = Math.max(Number(pageParam) || 1, 1);
 
-  const { articles, totalPages } = await getArticles(page, 9);
+  // 12 = 3 full rows of the 4-column grid (see grid-cols-4 below); 9 left a
+  // trailing row of one item with three empty slots (#165).
+  const { articles, totalPages } = await getArticles(page, 12);
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -64,7 +64,7 @@ export async function getKeyFigures(): Promise<KeyFigure[]> {
 
 export async function getArticles(
   page = 1,
-  limit = 9,
+  limit = 12,
   tag?: string,
 ): Promise<PaginatedArticles> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });


### PR DESCRIPTION
## Résumé

La page `/actualites` paginait par **9** articles alors que la grille est en **4 colonnes** → la dernière rangée n'affichait qu'1 article avec 3 emplacements vides.

Correctif : passer à **12** (= 3 rangées pleines de 4).

## Détail

- [actualites/page.tsx](src/frontend/src/app/[locale]/actualites/page.tsx) : `getArticles(page, 12)` (ligne déterminante) + commentaire.
- Alignement des défauts pour cohérence :
  - [api.ts](src/frontend/src/lib/api.ts) : `getArticles(page = 1, limit = 12)`
  - [articles.ts](src/backend/src/routes/articles.ts) : défaut `12` (toujours plafonné à 50).

## Test plan

- [x] `tsc --noEmit` backend — 0 erreur
- [x] `tsc --noEmit` frontend — 0 erreur
- [ ] Vérif navigateur `/actualites` : 12 articles / page, grille pleine sur desktop (4×3)

## Liens

- Closes #165
