### PR TITLE
fix(admin): permet de vider les champs optionnels d'une édition (#166)

### DIFF
--- a/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
@@ -58,17 +58,22 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
     setSaved(false);
     await adminFetch(`/editions/${edition.id}`, {
       method: "PUT",
+      // Optional text/URL fields are sent as "" (not undefined) when cleared, so
+      // the key stays in the payload and the backend applies its "" → null
+      // branch; `|| undefined` dropped the key and left the old value (#166).
+      // Dates keep `|| undefined`: the backend has no clear branch for them
+      // (falsy → keep existing), so clearing a date is a no-op either way.
       body: JSON.stringify({
         status: form.status,
         startDate: form.startDate || undefined,
         endDate: form.endDate || undefined,
-        venueName: form.venueName || undefined,
-        venueAddress: form.venueAddress || undefined,
-        heroImageUrl: form.heroImageUrl || undefined,
-        sponsorFormUrl: form.sponsorFormUrl || undefined,
-        aftermovieUrl: form.aftermovieUrl || undefined,
-        galleryUrl: form.galleryUrl || undefined,
-        archivedSiteUrl: form.archivedSiteUrl || undefined,
+        venueName: form.venueName,
+        venueAddress: form.venueAddress,
+        heroImageUrl: form.heroImageUrl,
+        sponsorFormUrl: form.sponsorFormUrl,
+        aftermovieUrl: form.aftermovieUrl,
+        galleryUrl: form.galleryUrl,
+        archivedSiteUrl: form.archivedSiteUrl,
       }),
     });
     setIsSaving(false);


### PR DESCRIPTION
## Résumé

Dans l'admin d'édition, **vider** un champ optionnel (lieu, image hero, formulaire sponsor, aftermovie, galerie, site archivé) ne se sauvegardait pas : l'ancienne valeur revenait.

**Cause** : `form.field || undefined` transformait la chaîne vide en `undefined` → `JSON.stringify` retirait la clé du payload → le backend interprétait la clé absente comme « ne pas modifier » et réécrivait l'ancienne valeur.

**Fix** : envoyer la valeur brute (toujours une `string`, `form` étant initialisé avec `|| ""`) au lieu de `|| undefined`. La clé reste présente → le backend applique sa branche `"" → null`.

## Détail

- [GeneralTab.tsx](src/frontend/src/components/admin/edition-detail/GeneralTab.tsx) : 7 champs texte/URL corrigés.
- **Dates** (`startDate`/`endDate`) : gardent `|| undefined` — le backend n'a **pas** de branche d'effacement pour elles (`falsy → garde l'existant`), donc vider une date est un no-op quel que soit le cas ; on ne change pas ce comportement.
- Backend ([editions.ts](src/backend/src/routes/admin/editions.ts)) et schéma Prisma : **déjà corrects**, aucun changement.

## Test plan

- [x] `tsc --noEmit` frontend — 0 erreur
- [x] `eslint` — 0 erreur (warning `<img>` préexistant sans rapport)
- [ ] Vérif admin : vider chaque champ optionnel d'une édition → sauvegarde → le champ reste vide après reload, et le bouton public associé (ex. site archivé) disparaît

## Liens

- Closes #166
