### PR TITLE
fix(editor): normalise les liens sans protocole dans l'éditeur (#167)

### DIFF
--- a/src/backend/src/lib/sanitize.test.ts
+++ b/src/backend/src/lib/sanitize.test.ts
@@ -36,4 +36,28 @@ describe("sanitizeRichHtml", () => {
     expect(sanitizeRichHtml(undefined)).toBe("");
     expect(sanitizeRichHtml("")).toBe("");
   });
+
+  // Schemeless links (e.g. from imported WordPress content or hand-typed
+  // domains) must be prefixed with https:// so they don't render as broken
+  // relative links (#167).
+  it("prefixes https:// on a schemeless href", () => {
+    expect(sanitizeRichHtml('<a href="www.devfest.fr">x</a>')).toContain(
+      'href="https://www.devfest.fr"',
+    );
+  });
+
+  it("keeps absolute http(s) hrefs untouched", () => {
+    const output = sanitizeRichHtml('<a href="https://example.com">x</a>');
+    expect(output).toContain('href="https://example.com"');
+    expect(output).not.toContain("https://https://");
+  });
+
+  it("does not touch mailto:, tel:, anchors or root-relative hrefs", () => {
+    expect(sanitizeRichHtml('<a href="mailto:a@b.fr">m</a>')).toContain('href="mailto:a@b.fr"');
+    expect(sanitizeRichHtml('<a href="tel:+33600000000">t</a>')).toContain(
+      'href="tel:+33600000000"',
+    );
+    expect(sanitizeRichHtml('<a href="#section">a</a>')).toContain('href="#section"');
+    expect(sanitizeRichHtml('<a href="/fr/actualites">a</a>')).toContain('href="/fr/actualites"');
+  });
 });

--- a/src/backend/src/lib/sanitize.ts
+++ b/src/backend/src/lib/sanitize.ts
@@ -22,7 +22,7 @@ const OPTIONS: sanitizeHtml.IOptions = {
     "span", "div",
   ],
   allowedAttributes: {
-    a: ["href", "title", "target"],
+    a: ["href", "title", "target", "rel"],
     img: ["src", "alt", "title", "width", "height", "data-align"],
     "*": ["class"],
   },
@@ -33,9 +33,23 @@ const OPTIONS: sanitizeHtml.IOptions = {
     img: ["http", "https"],
   },
   allowedSchemesAppliedToAttributes: ["href", "src"],
-  // Force target=_blank links to carry safe rel attributes.
   transformTags: {
-    a: sanitizeHtml.simpleTransform("a", { rel: "noopener noreferrer" }, false),
+    // Force safe rel on every link, and prefix https:// on schemeless hrefs
+    // (e.g. "www.devfest.fr") so they don't render as broken relative links
+    // (#167). In-page anchors (#…) and root-relative paths (/…) are left as is.
+    a: (tagName, attribs) => {
+      const href = attribs.href;
+      const normalizedHref =
+        href && !/^([a-z][a-z0-9+.-]*:|#|\/)/i.test(href) ? `https://${href}` : href;
+      return {
+        tagName,
+        attribs: {
+          ...attribs,
+          ...(normalizedHref ? { href: normalizedHref } : {}),
+          rel: "noopener noreferrer",
+        },
+      };
+    },
   },
   // Strip entirely (don't keep text content) for clearly malicious tags.
   nonTextTags: ["script", "style", "textarea", "option", "noscript"],

--- a/src/frontend/src/components/admin/RichTextEditor.tsx
+++ b/src/frontend/src/components/admin/RichTextEditor.tsx
@@ -27,6 +27,15 @@ const Image = ImageBase.extend({
   },
 });
 
+// Prefix https:// when the user types a bare domain (e.g. "www.devfest.fr"),
+// otherwise the browser treats it as a relative link and it 404s (#167).
+// Leave absolute URLs and mailto:/tel: links untouched, and don't touch
+// in-page anchors (#...) or root-relative paths (/...).
+function normalizeLinkHref(href: string): string {
+  if (/^([a-z][a-z0-9+.-]*:|#|\/)/i.test(href)) return href;
+  return `https://${href}`;
+}
+
 interface RichTextEditorProps {
   label: string;
   name: string;
@@ -59,7 +68,12 @@ export default function RichTextEditor({
       }),
       Link.configure({
         openOnClick: false,
-        HTMLAttributes: { rel: "noopener noreferrer" },
+        // Prefix https:// when a pasted/autolinked URL has no protocol, so a
+        // bare domain doesn't render as a relative (broken) link (#167).
+        defaultProtocol: "https",
+        // Links open in a new tab; keep rel for security. target is added here
+        // (not lost) because the Link extension adds none by default.
+        HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
       }),
       Image.configure({
         inline: false,
@@ -148,8 +162,9 @@ function Toolbar({
 
   function applyLink() {
     if (!editor) return;
-    if (linkUrl.trim()) {
-      editor.chain().focus().setLink({ href: linkUrl.trim() }).run();
+    const trimmed = linkUrl.trim();
+    if (trimmed) {
+      editor.chain().focus().setLink({ href: normalizeLinkHref(trimmed) }).run();
     } else {
       editor.chain().focus().unsetLink().run();
     }


### PR DESCRIPTION
## Résumé

Un lien saisi sans protocole (ex. `www.devfest.fr`) était stocké tel quel → le navigateur le résolvait en **lien relatif** (`/fr/actualites/<slug>/www.devfest.fr`) → 404. Perçu comme « pas cliquable ».

**Fix** : préfixer `https://` sur les URL sans schéma, à 3 niveaux :

1. **Éditeur `applyLink()`** ([RichTextEditor.tsx](src/frontend/src/components/admin/RichTextEditor.tsx)) : `normalizeLinkHref()` préfixe `https://` avant `setLink`.
2. **Config Link** : `defaultProtocol: "https"` (collage/autolink) + `target="_blank"` restauré (ouverture nouvel onglet) en gardant `rel`.
3. **Sanitizer backend** (défense en profondeur, couvre aussi le contenu WordPress importé) ([sanitize.ts](src/backend/src/lib/sanitize.ts)) : transform custom qui normalise le href schemeless et force `rel`.

`mailto:` / `tel:`, ancres `#…` et chemins racine `/…` sont laissés intacts.

## ⚠️ Bug de sécurité évité (grâce au test)

En remplaçant `simpleTransform` par une transform custom, le `rel="noopener noreferrer"` disparaissait des liens (les attributs retournés sont re-filtrés par l'allowlist, où `rel` était absent). Le test unitaire l'a capté → `rel` ajouté à l'allowlist. Sans le test, régression silencieuse.

## Test plan

- [x] `vitest` `sanitize.test.ts` — **10/10** (3 nouveaux cas #167 + non-régression `rel`/`javascript:`)
- [x] `tsc --noEmit` backend + frontend — 0 erreur
- [x] `eslint` RichTextEditor — 0 erreur
- [ ] Vérif admin : saisir `www.devfest.fr` dans un article → le lien rendu pointe vers `https://www.devfest.fr` en nouvel onglet (pas de 404)

## Liens

- Closes #167
