### PR TITLE
fix(tickets): statut vendu/complet Billetweb + override manuel (#161)

### DIFF
--- a/src/backend/prisma/migrations/20260706120000_ticket_status_override/migration.sql
+++ b/src/backend/prisma/migrations/20260706120000_ticket_status_override/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('AVAILABLE', 'SOLD_OUT', 'COMING_SOON');
+
+-- AlterTable
+ALTER TABLE "TicketTier" ADD COLUMN     "isSoldOut" BOOLEAN,
+ADD COLUMN     "manualStatus" "TicketStatus";

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -184,6 +184,12 @@ model SponsorPlan {
 
 // --- Ticketing ---
 
+enum TicketStatus {
+  AVAILABLE
+  SOLD_OUT
+  COMING_SOON
+}
+
 model TicketTier {
   id               Int              @id @default(autoincrement())
   nameFr           String
@@ -194,6 +200,12 @@ model TicketTier {
   saleEndDate      DateTime?
   externalUrl      String?
   sortOrder        Int              @default(0)
+  // Admin override: when set, it wins over both the BilletWeb sync and the
+  // date-based computation. Null means "Auto" (fall back to isSoldOut/dates).
+  manualStatus     TicketStatus?
+  // Sold-out flag synced from BilletWeb (/event/:id/avail). Null means the
+  // tier was never synced from BilletWeb (created manually or legacy import).
+  isSoldOut        Boolean?
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
 

--- a/src/backend/src/routes/admin/tickets.test.ts
+++ b/src/backend/src/routes/admin/tickets.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { availToIsSoldOut } from "./tickets.js";
+
+describe("availToIsSoldOut", () => {
+  it("treats -1 (unlimited) as not sold out", () => {
+    expect(availToIsSoldOut("-1")).toBe(false);
+  });
+
+  it("treats a positive remaining quantity as not sold out", () => {
+    expect(availToIsSoldOut("5")).toBe(false);
+  });
+
+  it("treats 0 remaining as sold out", () => {
+    expect(availToIsSoldOut("0")).toBe(true);
+  });
+
+  it("treats a negative-but-not-unlimited value as unlimited (not sold out)", () => {
+    // Any negative value is BilletWeb's "no limit" sentinel.
+    expect(availToIsSoldOut("-4")).toBe(false);
+  });
+
+  it("returns null (unknown) for empty, null, undefined or unparseable input", () => {
+    expect(availToIsSoldOut("")).toBeNull();
+    expect(availToIsSoldOut(null)).toBeNull();
+    expect(availToIsSoldOut(undefined)).toBeNull();
+    expect(availToIsSoldOut("abc")).toBeNull();
+  });
+});

--- a/src/backend/src/routes/admin/tickets.ts
+++ b/src/backend/src/routes/admin/tickets.ts
@@ -3,6 +3,9 @@ import { prisma } from "../../lib/prisma.js";
 import { computeTicketStatus } from "../editions.js";
 import { revalidateBilletterie } from "../../lib/revalidate.js";
 
+type TicketStatus = "AVAILABLE" | "SOLD_OUT" | "COMING_SOON";
+const TICKET_STATUSES: TicketStatus[] = ["AVAILABLE", "SOLD_OUT", "COMING_SOON"];
+
 interface TicketTierBody {
   nameFr: string;
   nameEn: string;
@@ -12,10 +15,50 @@ interface TicketTierBody {
   saleEndDate?: string | null;
   externalUrl?: string;
   sortOrder?: number;
+  // Admin status override. "AUTO" (or null) clears it → falls back to
+  // the BilletWeb sync / date-based computation.
+  manualStatus?: TicketStatus | "AUTO" | null;
   editionId: number;
 }
 
 const BILLETWEB_API = "https://www.billetweb.fr/api";
+
+// Maps BilletWeb's /event/:id/avail "avail" field to a sold-out flag.
+// "-1" (or a negative number) means unlimited → not sold out. A remaining
+// quantity of 0 or less means sold out. Anything unparseable → unknown (null).
+export function availToIsSoldOut(avail: unknown): boolean | null {
+  if (avail === undefined || avail === null || avail === "") return null;
+  const n = Number(avail);
+  if (isNaN(n)) return null;
+  if (n < 0) return false;
+  return n <= 0;
+}
+
+// Fetches per-ticket sold-out flags from /event/:id/avail, keyed by ticket id.
+// Returns an empty map on any failure — the import must not break if BilletWeb's
+// availability endpoint is unavailable.
+async function fetchBilletwebSoldOut(
+  billetwebEventId: string,
+  params: URLSearchParams,
+): Promise<Map<string, boolean | null>> {
+  const map = new Map<string, boolean | null>();
+  try {
+    const res = await fetch(
+      `${BILLETWEB_API}/event/${encodeURIComponent(billetwebEventId)}/avail?${params}`,
+    );
+    if (!res.ok) return map;
+    const rows = (await res.json()) as Array<Record<string, unknown>>;
+    for (const row of rows) {
+      if (row.type !== "ticket") continue;
+      const id = String(row.id ?? "");
+      if (!id) continue;
+      map.set(id, availToIsSoldOut(row.avail));
+    }
+  } catch {
+    // Availability is best-effort; leave the map empty on network errors.
+  }
+  return map;
+}
 
 function getBilletwebParams(): URLSearchParams | null {
   const user = process.env.BILLETWEB_USER;
@@ -101,6 +144,9 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
 
     const tickets = (await ticketsRes.json()) as Array<Record<string, unknown>>;
 
+    // Fetch per-ticket availability (sold-out) to seed isSoldOut (best-effort).
+    const soldOutByTicket = await fetchBilletwebSoldOut(billetwebEventId, params);
+
     // Delete existing tiers for this edition
     await prisma.ticketTier.deleteMany({ where: { editionId } });
 
@@ -121,6 +167,7 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
           saleStartDate: unixToDate(t.start_time),
           saleEndDate: unixToDate(t.end_time),
           externalUrl: shopUrl || null,
+          isSoldOut: soldOutByTicket.get(String(t.id ?? "")) ?? null,
           sortOrder: i,
           editionId,
         },
@@ -154,7 +201,9 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
       isVisible: t.isVisible,
       saleStartDate: t.saleStartDate,
       saleEndDate: t.saleEndDate,
-      status: computeTicketStatus(t.saleStartDate, t.saleEndDate, now),
+      status: computeTicketStatus(t, now),
+      manualStatus: t.manualStatus,
+      isSoldOut: t.isSoldOut,
       externalUrl: t.externalUrl,
       sortOrder: t.sortOrder,
       editionId: t.editionId,
@@ -201,6 +250,18 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
 
     const body = request.body;
 
+    // manualStatus: "AUTO" or null clears the override; a valid enum sets it.
+    let manualStatus = existing.manualStatus;
+    if (body.manualStatus !== undefined) {
+      if (body.manualStatus === null || body.manualStatus === "AUTO") {
+        manualStatus = null;
+      } else if (TICKET_STATUSES.includes(body.manualStatus)) {
+        manualStatus = body.manualStatus;
+      } else {
+        return reply.status(400).send({ error: "Invalid manualStatus" });
+      }
+    }
+
     const tier = await prisma.ticketTier.update({
       where: { id },
       data: {
@@ -211,6 +272,7 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
         saleStartDate: body.saleStartDate !== undefined ? toDateOrNull(body.saleStartDate) : existing.saleStartDate,
         saleEndDate: body.saleEndDate !== undefined ? toDateOrNull(body.saleEndDate) : existing.saleEndDate,
         externalUrl: body.externalUrl !== undefined ? (body.externalUrl?.trim() || null) : existing.externalUrl,
+        manualStatus,
         sortOrder: body.sortOrder ?? existing.sortOrder,
       },
     });

--- a/src/backend/src/routes/editions.test.ts
+++ b/src/backend/src/routes/editions.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { computeTicketStatus } from "./editions.js";
+
+const NOW = new Date("2026-06-01T12:00:00Z");
+const PAST = new Date("2026-05-01T00:00:00Z");
+const FUTURE = new Date("2026-07-01T00:00:00Z");
+
+describe("computeTicketStatus", () => {
+  it("returns AVAILABLE when the sale window is open and nothing overrides", () => {
+    expect(
+      computeTicketStatus(
+        { saleStartDate: PAST, saleEndDate: FUTURE, isSoldOut: false, manualStatus: null },
+        NOW,
+      ),
+    ).toBe("AVAILABLE");
+  });
+
+  it("returns SOLD_OUT when the sale end date has passed", () => {
+    expect(
+      computeTicketStatus({ saleStartDate: PAST, saleEndDate: PAST }, NOW),
+    ).toBe("SOLD_OUT");
+  });
+
+  it("returns COMING_SOON when the sale start date is in the future", () => {
+    expect(
+      computeTicketStatus({ saleStartDate: FUTURE, saleEndDate: null }, NOW),
+    ).toBe("COMING_SOON");
+  });
+
+  it("uses the BilletWeb isSoldOut flag over the date window", () => {
+    expect(
+      computeTicketStatus(
+        { saleStartDate: PAST, saleEndDate: FUTURE, isSoldOut: true },
+        NOW,
+      ),
+    ).toBe("SOLD_OUT");
+  });
+
+  it("lets manualStatus win over both isSoldOut and the dates", () => {
+    expect(
+      computeTicketStatus(
+        {
+          saleStartDate: PAST,
+          saleEndDate: PAST,
+          isSoldOut: true,
+          manualStatus: "AVAILABLE",
+        },
+        NOW,
+      ),
+    ).toBe("AVAILABLE");
+  });
+
+  it("ignores a null manualStatus (auto mode)", () => {
+    expect(
+      computeTicketStatus(
+        { saleStartDate: PAST, saleEndDate: FUTURE, isSoldOut: false, manualStatus: null },
+        NOW,
+      ),
+    ).toBe("AVAILABLE");
+  });
+});

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -1,13 +1,22 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 
-export function computeTicketStatus(
-  saleStartDate: Date | null,
-  saleEndDate: Date | null,
-  now: Date,
-): "AVAILABLE" | "SOLD_OUT" | "COMING_SOON" {
-  if (saleEndDate && saleEndDate < now) return "SOLD_OUT";
-  if (saleStartDate && saleStartDate > now) return "COMING_SOON";
+type TicketStatus = "AVAILABLE" | "SOLD_OUT" | "COMING_SOON";
+
+// Resolves the effective ticket status by priority:
+//   1. manualStatus — admin override, always wins when set
+//   2. isSoldOut    — synced from BilletWeb (/event/:id/avail)
+//   3. dates        — sale window fallback
+export function computeTicketStatus(tier: {
+  manualStatus?: TicketStatus | null;
+  isSoldOut?: boolean | null;
+  saleStartDate: Date | null;
+  saleEndDate: Date | null;
+}, now: Date): TicketStatus {
+  if (tier.manualStatus) return tier.manualStatus;
+  if (tier.isSoldOut) return "SOLD_OUT";
+  if (tier.saleEndDate && tier.saleEndDate < now) return "SOLD_OUT";
+  if (tier.saleStartDate && tier.saleStartDate > now) return "COMING_SOON";
   return "AVAILABLE";
 }
 
@@ -201,7 +210,7 @@ export default async function editionRoutes(app: FastifyInstance) {
       nameFr: tier.nameFr,
       nameEn: tier.nameEn,
       price: Number(tier.price),
-      status: computeTicketStatus(tier.saleStartDate, tier.saleEndDate, now),
+      status: computeTicketStatus(tier, now),
       externalUrl: tier.externalUrl,
       sortOrder: tier.sortOrder,
     }));

--- a/src/frontend/src/components/admin/edition-detail/TicketingTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/TicketingTab.tsx
@@ -16,6 +16,8 @@ interface TicketTier {
   saleStartDate: string | null;
   saleEndDate: string | null;
   status: string;
+  manualStatus: string | null;
+  isSoldOut: boolean | null;
   externalUrl: string | null;
   sortOrder: number;
 }
@@ -33,6 +35,15 @@ const TICKET_STATUS = [
   { value: "SOLD_OUT", label: "Complet", variant: "orange" as const },
 ];
 
+// Admin override choices. "AUTO" clears the override → status is derived from
+// the BilletWeb sync and sale dates.
+const MANUAL_STATUS_OPTIONS = [
+  { value: "AUTO", label: "Auto (dates / Billetweb)" },
+  { value: "AVAILABLE", label: "Disponible" },
+  { value: "SOLD_OUT", label: "Complet" },
+  { value: "COMING_SOON", label: "Bientôt disponible" },
+];
+
 function toInputDate(isoDate: string | null): string {
   if (!isoDate) return "";
   return isoDate.substring(0, 10);
@@ -47,6 +58,7 @@ const emptyTier = {
   saleEndDate: "",
   externalUrl: "",
   sortOrder: "0",
+  manualStatus: "AUTO",
 };
 
 function TierTable({
@@ -92,7 +104,10 @@ function TierTable({
                   <td className="px-4 py-3 text-noir font-medium">{tier.nameFr}</td>
                   <td className="px-4 py-3 text-noir">{tier.price} EUR</td>
                   <td className="px-4 py-3">
-                    <StatusBadge status={TICKET_STATUS.find((s) => s.value === tier.status)?.label || tier.status} variant={TICKET_STATUS.find((s) => s.value === tier.status)?.variant || "gray"} />
+                    <div className="flex items-center gap-2">
+                      <StatusBadge status={TICKET_STATUS.find((s) => s.value === tier.status)?.label || tier.status} variant={TICKET_STATUS.find((s) => s.value === tier.status)?.variant || "gray"} />
+                      {tier.manualStatus && <span className="text-xs text-gris" title="Statut forcé manuellement">forcé</span>}
+                    </div>
                   </td>
                   <td className="px-4 py-3 text-right space-x-2">
                     <button onClick={() => onEdit(tier)} className="text-bleu hover:underline text-sm">Modifier</button>
@@ -151,6 +166,7 @@ export default function TicketingTab({ editionId }: TicketingTabProps) {
       saleEndDate: toInputDate(tier.saleEndDate),
       externalUrl: tier.externalUrl || "",
       sortOrder: String(tier.sortOrder),
+      manualStatus: tier.manualStatus || "AUTO",
     });
     setShowForm(true);
   }
@@ -172,6 +188,7 @@ export default function TicketingTab({ editionId }: TicketingTabProps) {
       saleEndDate: form.saleEndDate || null,
       externalUrl: form.externalUrl || undefined,
       sortOrder: Number(form.sortOrder) || 0,
+      manualStatus: form.manualStatus,
       editionId,
     };
 
@@ -265,17 +282,33 @@ export default function TicketingTab({ editionId }: TicketingTabProps) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <FormField label="Ordre" name="sortOrder" type="number" value={form.sortOrder} onChange={(v) => setForm({ ...form, sortOrder: v })} />
             <FormField label="URL externe" name="externalUrl" type="url" value={form.externalUrl} onChange={(v) => setForm({ ...form, externalUrl: v })} />
-            <div className="flex items-center pt-6">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={form.isVisible}
-                  onChange={(e) => setForm({ ...form, isVisible: e.target.checked })}
-                  className="rounded border-gris/30 text-malachite focus:ring-malachite"
-                />
-                <span className="text-sm text-noir">Visible sur le site</span>
-              </label>
+            <div>
+              <label className="block text-sm font-medium text-noir mb-1">Statut</label>
+              <select
+                value={form.manualStatus}
+                onChange={(e) => setForm({ ...form, manualStatus: e.target.value })}
+                className="w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              >
+                {MANUAL_STATUS_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              <p className="text-xs text-gris mt-1">
+                « Auto » calcule le statut selon les dates de vente et l&apos;épuisement Billetweb.
+              </p>
             </div>
+          </div>
+
+          <div className="flex items-center">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={form.isVisible}
+                onChange={(e) => setForm({ ...form, isVisible: e.target.checked })}
+                className="rounded border-gris/30 text-malachite focus:ring-malachite"
+              />
+              <span className="text-sm text-noir">Visible sur le site</span>
+            </label>
           </div>
 
           <div className="flex gap-3 justify-end">


### PR DESCRIPTION
## Summary

Corrige #161 : le statut d'un billet était calculé **uniquement** à partir des dates de vente. Un tarif marqué « complet » par Billetweb dans sa fenêtre de vente restait « Disponible », et l'admin ne pouvait pas le corriger à la main.

- **Auto-sync Billetweb** : l'import lit `GET /event/:id/avail` et alimente `isSoldOut` depuis le champ `avail` (`-1` = illimité, `<= 0` = épuisé). Best-effort : si `/avail` échoue, l'import ne casse pas.
- **Override manuel** : `manualStatus` éditable dans l'admin, prioritaire. Un mode « Auto » remet le calcul automatique.
- **Priorité** : `manualStatus ?? isSoldOut (Billetweb) ?? dates`.

## Détails techniques

- Schéma : `enum TicketStatus`, `TicketTier.manualStatus`, `TicketTier.isSoldOut` + migration.
- `computeTicketStatus` prend le tier complet et résout par priorité.
- `PUT /tickets/:id` accepte `manualStatus` (`"AUTO"`/`null` efface l'override, valeur validée par allowlist).
- Admin `TicketingTab` : sélecteur de statut + marqueur « forcé » dans le tableau.

## Test plan

- [x] Backend typecheck clean (`tsc --noEmit`)
- [x] Frontend lint clean (0 erreur) + `tsc` sans erreur dans le code applicatif
- [x] Tests unitaires : `computeTicketStatus` (priorité) + `availToIsSoldOut` (mapping) — 11/11 ✅
- [x] Migration appliquée en local, `prisma migrate status` : « up to date » (pas de drift)
- [x] Navigateur (Chrome DevTools MCP) sur `/admin/editions/1` → Billetterie :
  - forcer un tarif « Disponible » → « Complet » → statut effectif + « forcé » ✅
  - valeur rechargée correctement à la réouverture ✅
  - retour « Auto » → statut recalculé, marqueur retiré ✅
- [x] Rendu public `/fr/billetterie` : statuts Disponible / Épuisé / Bientôt corrects, boutons « Acheter » conditionnels ✅

Qualification technique complète : voir les commentaires de #161.
