### PR TITLE
fix(seo): beta partageable sur les réseaux sans indexation Google (#169)

### DIFF
--- a/docs/mise-en-production.md
+++ b/docs/mise-en-production.md
@@ -183,8 +183,11 @@ sudo docker exec <db-prod> psql -U devfest -d devfest -c \
 ## 6. Basculer le DNS sur le domaine final (SEO)
 
 Tant que `BASE_URL` ≠ `https://devfesttoulouse.fr`, le site est **volontairement
-non indexé** (`robots.txt` = `Disallow: /`, `robots: noindex`). C'est un test
-d'égalité stricte dans [`robots.ts`](../src/frontend/src/app/robots.ts) et
+non indexé par Google mais reste partageable sur les réseaux sociaux**
+(`robots.txt` = `Disallow: /` + une meta `noindex` ciblée **uniquement sur
+Googlebot** — pas de `noindex` global, sinon `facebookexternalhit` refuse
+l'aperçu Open Graph, cf. #169). C'est un test d'égalité stricte dans
+[`robots.ts`](../src/frontend/src/app/robots.ts) et
 [`layout.tsx`](../src/frontend/src/app/[locale]/layout.tsx).
 
 Le jour du basculement DNS, **sans modifier le code** :

--- a/src/frontend/src/app/[locale]/layout.tsx
+++ b/src/frontend/src/app/[locale]/layout.tsx
@@ -71,8 +71,14 @@ export async function generateMetadata({
         "x-default": "/fr",
       },
     },
+    // On non-production hosts (beta), keep the site out of Google without
+    // killing social sharing: emit noindex *only for Googlebot* rather than a
+    // global `robots` meta. facebookexternalhit / LinkedInBot respect the
+    // global `robots` noindex and refuse to render an OG preview, so a global
+    // noindex made the beta unshareable (#169). Scoping it to googleBot leaves
+    // the page shareable while robots.txt (Disallow: /) still gates crawlers.
     ...(!isProduction && {
-      robots: { index: false, follow: false },
+      robots: { googleBot: { index: false, follow: false } },
     }),
   };
 }


### PR DESCRIPTION
## Summary

Corrige #169 : la beta n'affichait pas d'aperçu Open Graph sur Facebook/LinkedIn.

- **Cause** : la beta émettait `<meta name="robots" content="noindex, nofollow">` globalement. `facebookexternalhit` respecte ce signal et refuse de générer un aperçu (Twitter l'ignore → carte OK, d'où « marche sur Twitter, pas sur Facebook »). Les balises OG elles-mêmes étaient correctes.
- **Fix** : `noindex` ciblé **uniquement sur Googlebot** (`robots: { googleBot: {...} }`) → `<meta name="googlebot" content="noindex, nofollow">`. Google reste bloqué, les crawlers sociaux voient une page partageable.
- **Filet** : `robots.txt` (`Disallow: /`) inchangé.
- **Prod** : comportement préservé — quand `BASE_URL` = apex, aucune directive noindex n'est émise.

## Test plan

- [x] Lint frontend clean (0 erreur)
- [x] HTML rendu en local (`BASE_URL=localhost` → non-prod) :
  - `<meta name="googlebot" content="noindex, nofollow">` présent ✅
  - **plus** de `<meta name="robots" content="noindex...">` global ✅
  - `og:image`, `og:title`, `twitter:card` corrects ✅
  - `robots.txt` = `Disallow: /` conservé ✅
- [ ] **Après déploiement beta** : valider l'aperçu via le [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) ou opengraph.xyz sur une URL `site.devfesttoulouse.fr` (nécessite le déploiement — non testable en local).

Qualification technique complète : voir les commentaires de #169.
