### PR TITLE
feat(admin): badge version + environnement dans la sidebar (#171)

### DIFF
--- a/docs/variables-environnement.md
+++ b/docs/variables-environnement.md
@@ -28,6 +28,8 @@ Un fichier `.env.example` est fourni à la racine du projet avec des valeurs fic
 | `REVALIDATE_SECRET` | oui en prod | Secret partagé entre backend et frontend pour invalider le cache Next via `POST /api/revalidate`. Si absent, la revalidation est désactivée (le cache reste statique jusqu'au TTL `s-maxage`). | (32+ caractères aléatoires) |
 | `BROCHURE_TOKEN_SECRET` | oui en prod | Secret HMAC utilisé pour signer les liens de téléchargement de la plaquette envoyés par email. Si absent, le mail de confirmation tombe sur l'URL brute (sans tracking). | (32+ caractères aléatoires) |
 | `GEMINI_API_KEY` | non (mais requise pour la traduction IA) | Clé API Google Gemini utilisée par la fonctionnalité de traduction FR⇄EN du back-office. Si absente, l'endpoint `/api/admin/translate` répond `503 not_configured` et le bouton « Traduire » est désactivé côté UI. **Free tier** : données potentiellement utilisées pour l'entraînement — ne pas activer sur du contenu confidentiel. Migrer vers Tier 1 payant si besoin. Obtenir une clé : https://aistudio.google.com/apikey | `AIzaSy...` |
+| `ENV_NAME` | non | Nom de l'environnement de déploiement. Sert à l'aliasing réseau Docker **et** est exposé dans l'admin via `GET /api/health` → badge `v{version} · {environment}` dans la sidebar (#171). Défaut `local`. | `beta`, `prod` |
+| `APP_VERSION` | non | Surcharge le numéro de version applicatif (semver) exposé par `GET /api/health`. Par défaut, la constante `APP_VERSION` du code (`1.0.0`), incrémentée à la main à chaque release et taguée sur `main`. | `1.0.0` |
 
 ## Base de données (backend uniquement)
 

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devfest-toulouse-backend",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "DevFest Toulouse 2026 — REST API backend",
   "type": "module",
   "scripts": {

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -9,6 +9,7 @@ import { auth } from "./lib/auth.js";
 import { registerSwagger } from "./plugins/swagger.js";
 import { registerCommonSchemas } from "./schemas/common.js";
 import { registerApiKeySchemas } from "./schemas/api-key.js";
+import { APP_VERSION, APP_ENVIRONMENT } from "./lib/version.js";
 import editionRoutes from "./routes/editions.js";
 import articleRoutes from "./routes/articles.js";
 import settingsRoutes from "./routes/settings.js";
@@ -106,13 +107,20 @@ app.get("/api/health", {
         properties: {
           status: { type: "string", enum: ["ok"] },
           timestamp: { type: "string", format: "date-time" },
+          version: { type: "string" },
+          environment: { type: "string" },
         },
-        required: ["status", "timestamp"],
+        required: ["status", "timestamp", "version", "environment"],
       },
     },
   },
 }, async () => {
-  return { status: "ok", timestamp: new Date().toISOString() };
+  return {
+    status: "ok",
+    timestamp: new Date().toISOString(),
+    version: APP_VERSION,
+    environment: APP_ENVIRONMENT,
+  };
 });
 
 // Auth providers availability

--- a/src/backend/src/lib/version.test.ts
+++ b/src/backend/src/lib/version.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+describe("version module", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("defaults to 1.0.0 / local when no env is set", async () => {
+    vi.stubEnv("APP_VERSION", "");
+    vi.stubEnv("ENV_NAME", "");
+    const { APP_VERSION, APP_ENVIRONMENT } = await import("./version.js");
+    expect(APP_VERSION).toBe("1.0.0");
+    expect(APP_ENVIRONMENT).toBe("local");
+  });
+
+  it("reads APP_VERSION and ENV_NAME from the environment when set", async () => {
+    vi.stubEnv("APP_VERSION", "2.3.4");
+    vi.stubEnv("ENV_NAME", "beta");
+    const { APP_VERSION, APP_ENVIRONMENT } = await import("./version.js");
+    expect(APP_VERSION).toBe("2.3.4");
+    expect(APP_ENVIRONMENT).toBe("beta");
+  });
+});

--- a/src/backend/src/lib/version.ts
+++ b/src/backend/src/lib/version.ts
@@ -1,0 +1,10 @@
+// Application semver — bumped by hand on each release and tagged on `main`
+// (see #171). Kept as a code constant rather than read from package.json:
+// package.json lives outside tsconfig's rootDir ("src"), so importing it would
+// break the build. An APP_VERSION env var can still override at runtime.
+export const APP_VERSION = process.env.APP_VERSION || "1.0.0";
+
+// Deployment environment name (local / beta / prod). ENV_NAME already exists
+// for Docker network aliasing; here we surface it so the admin knows which
+// deployment is running. Defaults to "local" for dev.
+export const APP_ENVIRONMENT = process.env.ENV_NAME || "local";

--- a/src/frontend/next.config.ts
+++ b/src/frontend/next.config.ts
@@ -57,6 +57,10 @@ const nextConfig: NextConfig = {
         destination: `${backendUrl}/api/me/:path*`,
       },
       {
+        source: "/api/health",
+        destination: `${backendUrl}/api/health`,
+      },
+      {
         source: "/api/docs",
         destination: `${backendUrl}/api/docs/`,
       },

--- a/src/frontend/src/components/admin/AdminSidebar.tsx
+++ b/src/frontend/src/components/admin/AdminSidebar.tsx
@@ -110,6 +110,12 @@ export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSideba
         })}
       </nav>
 
+      {health && (
+        <p className="px-4 pb-2 text-xs text-blanc/40">
+          v{health.version} · {health.environment}
+        </p>
+      )}
+
       <div className="p-4 border-t border-blanc/10">
         <Link href="/admin/profile" onClick={onNavigate} className="block hover:bg-blanc/5 -mx-2 px-2 py-1 rounded transition-colors">
           {user.name && <p className="text-sm text-blanc truncate">{user.name}</p>}
@@ -122,11 +128,6 @@ export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSideba
         >
           Déconnexion
         </button>
-        {health && (
-          <p className="mt-3 text-xs text-blanc/30">
-            v{health.version} · {health.environment}
-          </p>
-        )}
       </div>
     </aside>
   );

--- a/src/frontend/src/components/admin/AdminSidebar.tsx
+++ b/src/frontend/src/components/admin/AdminSidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -42,11 +43,33 @@ const iconMap: Record<string, IconDefinition> = {
   key: faKey,
 };
 
+interface HealthInfo {
+  version: string;
+  environment: string;
+}
+
 export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSidebarProps) {
   const pathname = usePathname();
   const visibleItems = adminNavItems
     .filter((item) => item.roles.includes(user.role))
     .map((item) => ({ ...item, href: item.path }));
+
+  // Surface the running backend's version + environment so admins know which
+  // deployment they're on (#171). Best-effort: a failed fetch just hides the
+  // badge, it never blocks the sidebar.
+  const [health, setHealth] = useState<HealthInfo | null>(null);
+  useEffect(() => {
+    fetch("/api/health")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.version && data?.environment) {
+          setHealth({ version: data.version, environment: data.environment });
+        }
+      })
+      .catch(() => {
+        // Silently ignore — the version badge is non-essential.
+      });
+  }, []);
 
   return (
     <aside className="w-64 bg-noir text-blanc flex flex-col h-full">
@@ -99,6 +122,11 @@ export default function AdminSidebar({ user, onLogout, onNavigate }: AdminSideba
         >
           Déconnexion
         </button>
+        {health && (
+          <p className="mt-3 text-xs text-blanc/30">
+            v{health.version} · {health.environment}
+          </p>
+        )}
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary

Implémente #171 : un admin ne pouvait pas savoir quel déploiement tournait. On affiche un badge `v{version} · {environment}` dans le pied de la sidebar admin, sourcé depuis le backend réellement en cours d'exécution.

- **Backend** : nouveau `lib/version.ts` (constante `APP_VERSION` + environnement via `ENV_NAME`). `GET /api/health` renvoie désormais `{ status, timestamp, version, environment }` (schéma Swagger mis à jour). `package.json` backend porté à `1.0.0`.
- **Frontend** : rewrite proxy `/api/health` (l'allow-list ne le proxifiait pas) ; `AdminSidebar` fetch best-effort et affiche le badge (échec = badge masqué, rien ne casse).
- **Docs** : `ENV_NAME` (désormais exposé dans l'admin) + `APP_VERSION` documentés.
- **Test** : test unitaire du module version (défauts + override par env).

## Source de vérité du semver

`APP_VERSION` est une **constante de code** (`1.0.0`), incrémentée à la main à chaque release. Elle n'est pas lue depuis `package.json` car celui-ci est hors du `rootDir` (`src`) du tsconfig backend — l'importer casserait le build. Une var d'env `APP_VERSION` peut surcharger au runtime.

## Test plan

- [x] Backend typecheck clean
- [x] Frontend lint clean (0 erreur)
- [x] Test unitaire `version.ts` (2/2 ✅)
- [x] `GET /api/health` via le proxy frontend renvoie `{"status":"ok","version":"1.0.0","environment":"local"}` ✅
- [x] Navigateur (Chrome DevTools MCP) : badge `v1.0.0 · local` visible dans la sidebar admin (desktop), sur les pages admin ✅
- [x] Aucune erreur console ✅

## Hors scope (noté dans la qualification)

- Volet **process GitHub** : introduction des milestones/releases + tag `v1.0.0` sur la prod, convention de bump semver. À traiter séparément (hors code).
- SHA git court, badge public, automatisation du bump en CI.

Qualification technique complète : voir les commentaires de #171.
