### PR TITLE
docs: versioning + releases dans la procédure de prod + skill deploy-to-prod (#171)

### DIFF
--- a/.claude/skills/deploy-to-prod/SKILL.md
+++ b/.claude/skills/deploy-to-prod/SKILL.md
@@ -35,10 +35,23 @@ git tag -l 'v*' --sort=-v:refname | head -1
 
 # Version actuelle dans le code
 git show origin/dev:src/backend/src/lib/version.ts | grep APP_VERSION
+
+# MIGRATIONS Prisma qui s'exécuteraient en prod (au boot) — les LIRE
+git diff origin/main..origin/dev -- src/backend/prisma/migrations/
 ```
 
 - **Aucun commit** `origin/main..origin/dev` → rien à promouvoir, s'arrêter.
-- Noter le **dernier tag** et la **version code** : ils doivent être cohérents avant de commencer (sinon signaler l'écart).
+- Noter le **dernier tag** et la **version code** : cohérents avant de commencer (sinon signaler l'écart).
+- **Migrations** : si le diff en contient, repérer les opérations **destructives**
+  (`DROP`, `ALTER … DROP COLUMN`, `TRUNCATE`, renommages) → backup DB obligatoire (étape 4),
+  et le signaler à l'utilisateur.
+- **Secrets** : vérifier qu'aucun secret n'est dans le diff promu (chercher `SECRET`/`KEY`/`PASSWORD`/`TOKEN`).
+
+### Fenêtre de déploiement
+
+Rappeler à l'utilisateur : **ne pas déployer à J-1 du DevFest** ni pendant un pic
+(ouverture billetterie, annonce), **prévenir l'équipe**, préférer un créneau où
+quelqu'un peut réagir. Si le timing est sensible, demander confirmation explicite.
 
 ---
 
@@ -65,6 +78,10 @@ Le bump se fait **sur la branche de promotion**, avant le merge. Mettre à jour 
 1. `APP_VERSION` dans [`src/backend/src/lib/version.ts`](../../../src/backend/src/lib/version.ts)
 2. `version` dans [`src/backend/package.json`](../../../src/backend/package.json)
 3. `version` dans [`src/frontend/package.json`](../../../src/frontend/package.json)
+
+Dans la même PR, mettre à jour [`CHANGELOG.md`](../../../CHANGELOG.md) : déplacer les
+entrées de `## [Non publié]` vers une nouvelle section `## [X.Y.Z] - AAAA-MM-JJ`
+(Ajouté / Corrigé / Modifié). Ce texte sert aussi de notes de release.
 
 > ⚠️ Oublier ce bump = la prod affiche l'ancien numéro. C'est l'erreur la plus fréquente.
 
@@ -95,7 +112,18 @@ gh pr create --base main --head promote/vX.Y.Z-to-main \
 
 ---
 
-## Étape 4 — Déployer + vérifier
+## Étape 4 — Sauvegarder la base prod (si migration)
+
+**Si le pre-flight a détecté une migration Prisma**, faire un `pg_dump` horodaté
+de la prod **avant** de déployer (le backend joue les migrations au boot ; sans
+dump, une migration destructrice est irrécupérable). Commandes : voir
+[`docs/mise-en-production.md`](../../../docs/mise-en-production.md) §4.
+
+Sans migration, cette étape est facultative.
+
+---
+
+## Étape 5 — Déployer + vérifier
 
 Le déploiement Coolify se déclenche sur le push `main`. Rappeler la config prod
 critique (détails : [`docs/mise-en-production.md`](../../../docs/mise-en-production.md) §3) :
@@ -112,14 +140,22 @@ curl -s https://site.devfesttoulouse.fr/api/health
 
 Si la version ne correspond pas : bump oublié ou build non régénéré (Redeploy without cache).
 
+**Smoke tests** — tester les parcours critiques (idéalement dans un navigateur) :
+home, **login admin**, **billetterie** (tarifs + statut), **article**, **contact**
+(envoi), chargement des **images** `/uploads/`. Détail : [`docs/mise-en-production.md`](../../../docs/mise-en-production.md) §6.
+
 ---
 
-## Étape 5 — Taguer + publier la release
+## Étape 6 — Taguer + publier la release
 
 **Seulement après déploiement vérifié.** Le tag pointe sur le `main` en prod.
 
 ```bash
 git checkout main && git pull origin main
+
+# GARDE-FOU : vérifier AVANT de taguer que main porte bien le numéro
+git show main:src/backend/src/lib/version.ts | grep APP_VERSION   # == X.Y.Z
+
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 gh release create vX.Y.Z \
@@ -128,41 +164,61 @@ gh release create vX.Y.Z \
 ```
 
 Garde-fous :
-- Le tag **doit** être identique à `APP_VERSION`. Vérifier :
-  `git show vX.Y.Z:src/backend/src/lib/version.ts | grep APP_VERSION`
+- Le tag **doit** être identique à `APP_VERSION` — vérifié **avant** le push.
 - **Un seul tag par version**, jamais déplacé une fois poussé.
 - `--generate-notes` compile les PR mergées depuis le tag précédent.
 
 ---
 
-## Étape 6 — Migrer les données (si nécessaire)
+## Étape 7 — Migrer les données — **à la demande UNIQUEMENT**
 
-Uniquement si le contenu prod doit être synchronisé depuis la beta. C'est un
-**écrasement complet** (`pg_dump --clean`) + copie des uploads (`docker cp`).
-Voir [`docs/mise-en-production.md`](../../../docs/mise-en-production.md) §7 pour les commandes exactes.
+> 🚫 **N'est PAS une étape systématique.** Un déploiement de prod ne migre **jamais**
+> les données par défaut — on ne déploie que du **code**. Ne proposer cette étape que
+> si l'utilisateur la **demande explicitement** (ex. première mise en prod, sync ponctuelle).
+
+C'est un **écrasement complet** (`pg_dump --clean`) de la base prod par celle de la
+beta + copie des uploads (`docker cp`). Voir
+[`docs/mise-en-production.md`](../../../docs/mise-en-production.md) §8 pour les commandes.
 
 ⚠️ **Confirmer explicitement** avant : identifier le BON conteneur source (vérifier
-le `BASE_URL`, pas le hash — beta ≠ dev-j), l'opération remplace toute la base prod.
+le `BASE_URL`, pas le hash — beta ≠ dev-j), l'opération **détruit** la base prod actuelle.
+
+---
+
+## En cas de problème — Rollback
+
+Ne pas improviser. Voir [`docs/mise-en-production.md`](../../../docs/mise-en-production.md) (section « Rollback ») :
+- **Sans migration** : redéployer le tag précédent (Coolify), vérifier `/api/health`.
+- **Avec migration** : redéployer l'ancien code **ne suffit pas** — restaurer le
+  dump pris à l'étape 4, puis redéployer. Sans dump, pas de rollback propre.
+- Ne **jamais** supprimer/déplacer le tag fautif : créer un correctif `vX.Y.Z+1`.
 
 ---
 
 ## Checklist finale
 
-- [ ] Diff réel `main..dev` revu, bump SemVer choisi et **confirmé**
-- [ ] `APP_VERSION` + 2× `package.json` bumpés dans la PR de promotion
+- [ ] Fenêtre de déploiement OK (pas J-1 DevFest / pic), équipe prévenue
+- [ ] Diff réel `main..dev` revu, **migrations Prisma lues** (destructives repérées)
+- [ ] Bump SemVer choisi et **confirmé**
+- [ ] `APP_VERSION` + 2× `package.json` + `CHANGELOG.md` mis à jour dans la PR de promotion
 - [ ] PR `dev → main` squashée, approuvée, mergée (faux conflit géré si besoin)
+- [ ] (si migration) **Backup DB prod** effectué avant déploiement
 - [ ] Déploiement Coolify OK, `/api/health` renvoie la **nouvelle** version
-- [ ] Tag `vX.Y.Z` poussé + release GitHub publiée
-- [ ] (si besoin) Données migrées beta → prod, uploads compris
+- [ ] **Smoke tests** passés (home, login, billetterie, article, contact, images)
+- [ ] Tag `vX.Y.Z` poussé (après vérif tag==APP_VERSION) + release GitHub publiée
+- [ ] (à la demande seulement) Données migrées beta → prod, uploads compris
 
 ## What NOT to do
 
 - **Ne jamais** push direct / force-push sur `main`.
 - **Ne jamais** taguer/release **avant** d'avoir vérifié le déploiement.
 - **Ne jamais** déplacer un tag déjà poussé (créer un nouveau numéro à la place).
-- **Ne pas** merger la PR de promotion sans que le bump de version y soit inclus.
-- **Ne pas** lancer la migration de données sans confirmation + vérification du conteneur source.
-- **Ne pas** exécuter les gestes irréversibles (merge main, push tag, migration) sans montrer la commande et faire valider.
+- **Ne jamais** jouer une migration en prod sans **backup DB** préalable.
+- **Ne pas** merger la PR de promotion sans le bump de version + CHANGELOG.
+- **Ne pas** migrer les données par défaut : c'est **opt-in**, sur demande explicite,
+  avec confirmation + vérification du conteneur source (écrase la base prod).
+- **Ne pas** exécuter les gestes irréversibles (merge main, push tag, backup/restore,
+  migration) sans montrer la commande et faire valider.
 
 ## Quand cette skill s'applique
 

--- a/.claude/skills/deploy-to-prod/SKILL.md
+++ b/.claude/skills/deploy-to-prod/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: deploy-to-prod
+description: Guide la mise en production du site DevFest Toulouse — promotion dev→main, versioning SemVer, tag git + release GitHub, et rappel des garde-fous (branches protégées, faux conflit squash, config Coolify, migration données). Trigger phrases — « pousse en prod », « mise en prod », « déployer en production », « promouvoir dev vers main », « publier une release », « taguer la version », « bumper la version ». Ne PAS trigger pour un simple push vers dev/beta.
+---
+
+# Mise en production — site DevFest Toulouse 2026
+
+Objectif : orchestrer une mise en prod **complète et sûre**, en garantissant les règles du repo : promotion `dev → main` par PR squashée, **versioning SemVer** (bump + tag + release), et les garde-fous appris lors des mises en prod précédentes.
+
+Repo cible : `GDGToulouse/Site-Devfest-Toulouse-2026`. CLI : `gh` + `git` (authentifiés). Langue : **français**.
+
+> **Source de vérité** : [`docs/mise-en-production.md`](../../../docs/mise-en-production.md). Cette skill **applique** et **guide** cette procédure — en cas de doute ou de divergence, la doc fait foi. Lire la doc si un cas n'est pas couvert ici.
+
+## Règles absolues (non négociables)
+
+1. **`main` est protégée** : jamais de push direct, jamais de force-push. Toute arrivée en prod passe par une **PR `dev → main` squashée et approuvée**.
+2. **Une mise en prod = une version** : bump SemVer + tag git + release GitHub. Pas de déploiement prod sans nouveau numéro.
+3. **La version affichée = la version déployée** : le bump de `APP_VERSION` fait partie de la **PR de promotion**, jamais après.
+4. **Confirmer avant tout geste irréversible** : merge vers main, tag poussé, migration de données (écrasement). Montrer la commande, faire valider.
+
+---
+
+## Pre-flight — état des lieux
+
+Avant de proposer quoi que ce soit, établir l'état réel :
+
+```bash
+# Qu'est-ce qui partirait en prod ? (diff réel dev vs main)
+git fetch origin main dev
+git log --oneline origin/main..origin/dev
+git diff --stat origin/main..origin/dev
+
+# Dernière version taguée
+git tag -l 'v*' --sort=-v:refname | head -1
+
+# Version actuelle dans le code
+git show origin/dev:src/backend/src/lib/version.ts | grep APP_VERSION
+```
+
+- **Aucun commit** `origin/main..origin/dev` → rien à promouvoir, s'arrêter.
+- Noter le **dernier tag** et la **version code** : ils doivent être cohérents avant de commencer (sinon signaler l'écart).
+
+---
+
+## Étape 1 — Choisir le bump SemVer
+
+Analyser les commits promus et proposer un bump, en s'appuyant sur les préfixes Conventional Commits :
+
+| Bump | Déclencheur | Préfixes |
+|------|-------------|----------|
+| **MAJOR** | Changement cassant, refonte, migration lourde | `feat!`, `BREAKING CHANGE`, refonte modèle |
+| **MINOR** | Nouvelle fonctionnalité sans casse | `feat:` |
+| **PATCH** | Correctif, doc, chore | `fix:`, `docs:`, `chore:`, `refactor:` |
+
+**Le plus haut l'emporte** (un `feat:` parmi des `fix:` → MINOR).
+
+Utiliser `AskUserQuestion` pour **confirmer le numéro proposé** (l'humain valide toujours le bump) : proposer le calcul en option recommandée + les alternatives.
+
+---
+
+## Étape 2 — Bumper la source de vérité (dans la PR de promotion)
+
+Le bump se fait **sur la branche de promotion**, avant le merge. Mettre à jour les **3** emplacements :
+
+1. `APP_VERSION` dans [`src/backend/src/lib/version.ts`](../../../src/backend/src/lib/version.ts)
+2. `version` dans [`src/backend/package.json`](../../../src/backend/package.json)
+3. `version` dans [`src/frontend/package.json`](../../../src/frontend/package.json)
+
+> ⚠️ Oublier ce bump = la prod affiche l'ancien numéro. C'est l'erreur la plus fréquente.
+
+---
+
+## Étape 3 — Promouvoir (PR dev → main)
+
+La stratégie de merge vers `main` est **squash**.
+
+### ⚠️ Faux conflit `add/add` après squash
+
+Comme les PR vers `dev` sont squashées, les SHA divergent et une PR `dev → main`
+directe peut afficher un conflit `add/add` **factice**. Procédure de contournement :
+
+```bash
+git checkout dev && git pull origin dev
+git checkout -b promote/vX.Y.Z-to-main
+git merge origin/main            # résoudre en gardant TOUJOURS la version de dev
+# (le bump de version de l'étape 2 se fait ici si pas déjà commité)
+git push -u origin promote/vX.Y.Z-to-main
+gh pr create --base main --head promote/vX.Y.Z-to-main \
+  --repo GDGToulouse/Site-Devfest-Toulouse-2026 \
+  --title "Release vX.Y.Z" --body-file -
+```
+
+- Vérifier le **diff réel** avant merge : `git diff --stat origin/main..HEAD`.
+- Merge **après approbation** (main protégée). Confirmer avec l'utilisateur.
+
+---
+
+## Étape 4 — Déployer + vérifier
+
+Le déploiement Coolify se déclenche sur le push `main`. Rappeler la config prod
+critique (détails : [`docs/mise-en-production.md`](../../../docs/mise-en-production.md) §3) :
+
+- `ENV_NAME=prod`, `BASE_URL`, `BACKEND_URL`, `NEXT_PUBLIC_PLAUSIBLE_SRC` → **Available at Buildtime** cochés.
+- `SESSION_SECRET` runtime **obligatoire** en prod (sinon Better Auth crashe au boot).
+
+Vérifier la **version réellement déployée** (garde-fou #171) :
+
+```bash
+curl -s https://site.devfesttoulouse.fr/api/health
+# → doit renvoyer "version":"X.Y.Z" == le bump de l'étape 2
+```
+
+Si la version ne correspond pas : bump oublié ou build non régénéré (Redeploy without cache).
+
+---
+
+## Étape 5 — Taguer + publier la release
+
+**Seulement après déploiement vérifié.** Le tag pointe sur le `main` en prod.
+
+```bash
+git checkout main && git pull origin main
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+gh release create vX.Y.Z \
+  --repo GDGToulouse/Site-Devfest-Toulouse-2026 \
+  --title "vX.Y.Z" --generate-notes
+```
+
+Garde-fous :
+- Le tag **doit** être identique à `APP_VERSION`. Vérifier :
+  `git show vX.Y.Z:src/backend/src/lib/version.ts | grep APP_VERSION`
+- **Un seul tag par version**, jamais déplacé une fois poussé.
+- `--generate-notes` compile les PR mergées depuis le tag précédent.
+
+---
+
+## Étape 6 — Migrer les données (si nécessaire)
+
+Uniquement si le contenu prod doit être synchronisé depuis la beta. C'est un
+**écrasement complet** (`pg_dump --clean`) + copie des uploads (`docker cp`).
+Voir [`docs/mise-en-production.md`](../../../docs/mise-en-production.md) §7 pour les commandes exactes.
+
+⚠️ **Confirmer explicitement** avant : identifier le BON conteneur source (vérifier
+le `BASE_URL`, pas le hash — beta ≠ dev-j), l'opération remplace toute la base prod.
+
+---
+
+## Checklist finale
+
+- [ ] Diff réel `main..dev` revu, bump SemVer choisi et **confirmé**
+- [ ] `APP_VERSION` + 2× `package.json` bumpés dans la PR de promotion
+- [ ] PR `dev → main` squashée, approuvée, mergée (faux conflit géré si besoin)
+- [ ] Déploiement Coolify OK, `/api/health` renvoie la **nouvelle** version
+- [ ] Tag `vX.Y.Z` poussé + release GitHub publiée
+- [ ] (si besoin) Données migrées beta → prod, uploads compris
+
+## What NOT to do
+
+- **Ne jamais** push direct / force-push sur `main`.
+- **Ne jamais** taguer/release **avant** d'avoir vérifié le déploiement.
+- **Ne jamais** déplacer un tag déjà poussé (créer un nouveau numéro à la place).
+- **Ne pas** merger la PR de promotion sans que le bump de version y soit inclus.
+- **Ne pas** lancer la migration de données sans confirmation + vérification du conteneur source.
+- **Ne pas** exécuter les gestes irréversibles (merge main, push tag, migration) sans montrer la commande et faire valider.
+
+## Quand cette skill s'applique
+
+Trigger : « pousse en prod », « mise en prod », « déployer en production »,
+« promouvoir dev vers main », « publier une release », « taguer la version ».
+
+**Ne pas** trigger pour un simple merge/push vers `dev` (beta) : ça, c'est le flux
+normal de développement, pas une mise en prod.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+Toutes les évolutions notables de ce projet sont documentées ici.
+
+Le format s'inspire de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/),
+et le projet suit le [versionnement sémantique](https://semver.org/lang/fr/).
+
+Chaque version correspond à une **mise en production** (tag `vX.Y.Z` + release
+GitHub). Voir [`docs/mise-en-production.md`](docs/mise-en-production.md).
+
+## [Non publié]
+
+_Changements mergés sur `dev` (beta), pas encore en production._
+
+## [1.0.0] - 2026-07-06
+
+Première mise en production du site DevFest Toulouse 2026, en remplacement de
+l'ancien site WordPress.
+
+### Ajouté
+
+- Site public bilingue (FR/EN) : accueil, actualités, billetterie, sponsors,
+  éditions passées, contact, pages de contenu.
+- Back-office admin complet : éditions, articles, pages, billetterie, messages
+  de contact, utilisateurs, clés API, paramètres.
+- SSR + cache HTTP, SEO (Schema.org, Open Graph), accessibilité (WCAG 2.1 AA).
+- Authentification admin (better-auth : email/password + Google + GitHub).
+
+[Non publié]: https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/compare/v1.0.0...dev
+[1.0.0]: https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/releases/tag/v1.0.0

--- a/docs/mise-en-production.md
+++ b/docs/mise-en-production.md
@@ -14,17 +14,54 @@ et migrer le contenu depuis la beta.
 ## Vue d'ensemble
 
 ```
-1. Promouvoir le code sur main (PR dev → main)
-2. Créer / configurer la ressource Coolify prod
-3. Déployer
-4. Vérifier (checklist)
-5. Migrer les données depuis la beta
-6. (plus tard) Basculer le DNS sur le domaine final → active le SEO
+1. Choisir le numéro de version + bumper (dans la PR de promotion)
+2. Promouvoir le code sur main (PR dev → main)
+3. Créer / configurer la ressource Coolify prod
+4. Déployer
+5. Vérifier (checklist)
+6. Taguer + publier la release GitHub
+7. Migrer les données depuis la beta
+8. (plus tard) Basculer le DNS sur le domaine final → active le SEO
 ```
 
 ---
 
-## 1. Promouvoir le code sur `main`
+## 1. Choisir le numéro de version et le bumper
+
+**Règle : une mise en prod = une nouvelle version.** Chaque déploiement sur
+`main` porte un numéro **SemVer** (`MAJOR.MINOR.PATCH`) tagué et publié en release.
+
+### Choisir le bump (SemVer)
+
+Regarder les commits promus (`git log --oneline origin/main..origin/dev`) et
+appliquer les préfixes Conventional Commits déjà en place :
+
+| Bump | Quand | Exemple |
+|------|-------|---------|
+| **MAJOR** (`2.0.0`) | Changement cassant, refonte, migration lourde du modèle | Refonte du modèle Speaker (#123) |
+| **MINOR** (`1.1.0`) | Nouvelle fonctionnalité (`feat:`), sans casse | Badge version admin (#171) |
+| **PATCH** (`1.0.1`) | Correctif de bug (`fix:`), doc, chore | Fix pagination articles (#165) |
+
+En cas de mix, le plus haut l'emporte (un `feat:` parmi des `fix:` → MINOR).
+
+### Bumper la source de vérité (dans la PR de promotion)
+
+La version affichée dans l'admin vient de [`APP_VERSION`](../src/backend/src/lib/version.ts)
+(exposée par `GET /api/health`, cf. #171). Elle **doit** être incrémentée
+**dans la PR `dev → main`**, sinon la prod afficherait l'ancien numéro.
+
+Mettre à jour, dans la même PR :
+
+1. `APP_VERSION` dans [`src/backend/src/lib/version.ts`](../src/backend/src/lib/version.ts)
+2. `version` dans [`src/backend/package.json`](../src/backend/package.json)
+3. `version` dans [`src/frontend/package.json`](../src/frontend/package.json) (cohérence)
+
+> Le tag git (`v1.2.3`) et la release GitHub, eux, se posent **après** le
+> déploiement vérifié (étape 6) — pas maintenant.
+
+---
+
+## 2. Promouvoir le code sur `main`
 
 La prod tourne sur `main`. Toute correction doit y arriver via une PR `dev → main`.
 
@@ -38,7 +75,7 @@ La prod tourne sur `main`. Toute correction doit y arriver via une PR `dev → m
 
 ---
 
-## 2. Créer / configurer la ressource Coolify prod
+## 3. Créer / configurer la ressource Coolify prod
 
 Suivre [`deployer-nouvel-environnement.md`](deployer-nouvel-environnement.md), avec
 pour la prod :
@@ -76,14 +113,14 @@ complète. Spécifique prod :
 
 ---
 
-## 3. Déployer
+## 4. Déployer
 
 Lancer **Deploy** dans Coolify. Le build compile frontend + backend puis le
 backend joue les migrations Prisma et le seed idempotent au démarrage.
 
 ---
 
-## 4. Vérifications obligatoires
+## 5. Vérifications obligatoires
 
 En plus de la checklist de [`deployer-nouvel-environnement.md`](deployer-nouvel-environnement.md)
 (BACKEND_URL runtime + build, alias DNS, sign-in) :
@@ -103,9 +140,50 @@ sudo docker exec "$FRONT" wget -qO- http://localhost:3000/fr | head -c 200
 Résultats attendus : `dig` renvoie l'IP du VPS ; `curl` renvoie 200/redirection ;
 le frontend interne renvoie du HTML.
 
+**Vérifier la version déployée** (cf. #171) : le badge `v{version} · prod` dans
+la sidebar admin doit afficher le **nouveau** numéro. Sinon, `APP_VERSION` n'a pas
+été bumpé (étape 1) ou le build n'a pas été régénéré.
+
+```bash
+curl -s https://site.devfesttoulouse.fr/api/health
+# → {"status":"ok","version":"1.2.3","environment":"prod", ...}
+```
+
 ---
 
-## 5. Migrer les données depuis la beta
+## 6. Taguer + publier la release GitHub
+
+Une fois le déploiement **vérifié**, figer l'état avec un tag git et une release.
+Le tag pointe sur le commit de `main` réellement en prod.
+
+```bash
+# Se placer sur le main à jour
+git checkout main
+git pull origin main
+
+# Taguer (annotated) — le numéro DOIT correspondre à APP_VERSION bumpé à l'étape 1
+git tag -a v1.2.3 -m "Release v1.2.3"
+git push origin v1.2.3
+
+# Publier la release avec des notes auto-générées depuis les PR mergées
+gh release create v1.2.3 \
+  --repo GDGToulouse/Site-Devfest-Toulouse-2026 \
+  --title "v1.2.3" \
+  --generate-notes
+```
+
+- `--generate-notes` compile les PR mergées depuis le tag précédent.
+- Le tag doit être **identique** à `APP_VERSION` (sinon l'admin et la release
+  divergent). Vérifier : `git show v1.2.3:src/backend/src/lib/version.ts | grep APP_VERSION`.
+- **Un seul tag par version.** Ne jamais déplacer un tag déjà poussé.
+
+> ℹ️ La skill **`deploy-to-prod`** (`.claude/skills/deploy-to-prod`) automatise
+> le choix du bump, le rappel de tous ces garde-fous et la génération de ces
+> commandes.
+
+---
+
+## 7. Migrer les données depuis la beta
 
 La base prod démarre avec un seed minimal. Pour l'alimenter avec le contenu réel,
 copier depuis la **beta** (base + fichiers uploadés).
@@ -180,7 +258,7 @@ sudo docker exec <db-prod> psql -U devfest -d devfest -c \
 
 ---
 
-## 6. Basculer le DNS sur le domaine final (SEO)
+## 8. Basculer le DNS sur le domaine final (SEO)
 
 Tant que `BASE_URL` ≠ `https://devfesttoulouse.fr`, le site est **volontairement
 non indexé par Google mais reste partageable sur les réseaux sociaux**

--- a/docs/mise-en-production.md
+++ b/docs/mise-en-production.md
@@ -14,15 +14,61 @@ et migrer le contenu depuis la beta.
 ## Vue d'ensemble
 
 ```
+0. Pré-vol : fenêtre de déploiement + revue des migrations Prisma
 1. Choisir le numéro de version + bumper (dans la PR de promotion)
 2. Promouvoir le code sur main (PR dev → main)
 3. Créer / configurer la ressource Coolify prod
-4. Déployer
-5. Vérifier (checklist)
-6. Taguer + publier la release GitHub
-7. Migrer les données depuis la beta
-8. (plus tard) Basculer le DNS sur le domaine final → active le SEO
+4. Sauvegarder la base prod (si la release contient une migration)
+5. Déployer
+6. Vérifier (checklist + smoke tests)
+7. Taguer + publier la release GitHub
+8. (à la demande) Migrer les données depuis la beta
+9. (plus tard) Basculer le DNS sur le domaine final → active le SEO
+
+En cas de problème → Rollback (voir la section dédiée en fin de document).
 ```
+
+---
+
+## 0. Pré-vol
+
+Avant de lancer quoi que ce soit :
+
+### Fenêtre de déploiement
+
+- **Ne pas déployer à J-1 du DevFest** ni pendant un pic connu (ouverture de
+  billetterie, campagne d'annonce). Un bug en prod à ce moment est très coûteux.
+- **Prévenir l'équipe** avant de pousser en prod (canal habituel).
+- Privilégier un créneau où quelqu'un peut réagir en cas de souci (pas un vendredi soir).
+
+### Revue des migrations Prisma
+
+Le backend joue les migrations **automatiquement au boot**. Il faut donc savoir
+**ce qui va s'exécuter sur la base prod** avant de déployer :
+
+```bash
+# Migrations qui partiraient en prod
+git diff --stat origin/main..origin/dev -- src/backend/prisma/migrations/
+
+# Lire le SQL — repérer les opérations DESTRUCTIVES (DROP, ALTER … DROP COLUMN,
+# TRUNCATE, renommages) qui peuvent perdre des données
+git diff origin/main..origin/dev -- src/backend/prisma/migrations/
+```
+
+- **Aucune migration** → déploiement à faible risque, backup DB facultatif.
+- **Migration présente** → backup obligatoire (étape 4). Toute opération destructive
+  doit être **consciente et assumée** (une colonne `DROP` ne se rollback pas en
+  redéployant l'ancien code — la donnée est déjà partie).
+
+### Hygiène des secrets
+
+- **Aucun secret dans le diff promu** : vérifier qu'aucune clé/mot de passe/token
+  n'a été committé (`git diff origin/main..origin/dev` — chercher `SECRET`, `KEY`,
+  `PASSWORD`, `TOKEN`). Les secrets vivent **uniquement** côté Coolify (runtime).
+- **Ne jamais logger un secret** : ni en clair dans les logs, ni dans un message
+  d'erreur renvoyé au client.
+- **Rotation** : après tout doute de fuite (secret affiché en clair, poussé par
+  erreur), le régénérer (`openssl rand -hex 32`) et le remplacer dans Coolify.
 
 ---
 
@@ -113,14 +159,36 @@ complète. Spécifique prod :
 
 ---
 
-## 4. Déployer
+## 4. Sauvegarder la base prod (si la release contient une migration)
+
+**Obligatoire dès qu'une migration Prisma est présente** (étape 0). Le déploiement
+joue les migrations au boot ; sans dump préalable, une migration qui corrompt ou
+supprime des données est **irrécupérable**.
+
+```bash
+PROD_DB=<db-prod>   # le conteneur db dont le BASE_URL est site.devfesttoulouse.fr
+STAMP=$(date +%Y%m%d-%H%M%S)
+
+sudo docker exec "$PROD_DB" pg_dump -U devfest -d devfest \
+  --no-owner --no-privileges > "/root/backups/prod-$STAMP.sql"
+
+# Vérifier que le dump n'est pas vide
+ls -lh "/root/backups/prod-$STAMP.sql"
+```
+
+Garder au moins le dernier dump avant chaque déploiement à migration. En cas de
+problème, il sert au rollback (voir section dédiée).
+
+---
+
+## 5. Déployer
 
 Lancer **Deploy** dans Coolify. Le build compile frontend + backend puis le
 backend joue les migrations Prisma et le seed idempotent au démarrage.
 
 ---
 
-## 5. Vérifications obligatoires
+## 6. Vérifications obligatoires
 
 En plus de la checklist de [`deployer-nouvel-environnement.md`](deployer-nouvel-environnement.md)
 (BACKEND_URL runtime + build, alias DNS, sign-in) :
@@ -149,9 +217,21 @@ curl -s https://site.devfesttoulouse.fr/api/health
 # → {"status":"ok","version":"1.2.3","environment":"prod", ...}
 ```
 
+### Smoke tests — parcours critiques
+
+Au-delà des sondes techniques, tester **manuellement** les parcours qui cassent le
+plus souvent après un déploiement (idéalement dans un navigateur, sur le domaine prod) :
+
+- [ ] **Home** `/fr` : rendu correct, pas d'erreur console.
+- [ ] **Login admin** `/admin` : connexion OK, dashboard s'affiche.
+- [ ] **Billetterie** `/fr/billetterie` : les tarifs s'affichent avec le bon statut.
+- [ ] **Article** : une page d'actualité s'ouvre et affiche son contenu.
+- [ ] **Contact** `/fr/contact` : le formulaire s'envoie (email reçu côté MailHog/Postfix).
+- [ ] **Images** : logos et images d'articles se chargent (pas de 404 sur `/uploads/`).
+
 ---
 
-## 6. Taguer + publier la release GitHub
+## 7. Taguer + publier la release GitHub
 
 Une fois le déploiement **vérifié**, figer l'état avec un tag git et une release.
 Le tag pointe sur le commit de `main` réellement en prod.
@@ -161,7 +241,12 @@ Le tag pointe sur le commit de `main` réellement en prod.
 git checkout main
 git pull origin main
 
-# Taguer (annotated) — le numéro DOIT correspondre à APP_VERSION bumpé à l'étape 1
+# GARDE-FOU : vérifier AVANT de taguer que le code de main porte bien le numéro
+git show main:src/backend/src/lib/version.ts | grep APP_VERSION
+# → doit afficher APP_VERSION = "1.2.3". Si ce n'est pas le cas, le bump de
+#   l'étape 1 n'a pas été promu : NE PAS taguer, corriger d'abord.
+
+# Taguer (annotated) — numéro identique à APP_VERSION
 git tag -a v1.2.3 -m "Release v1.2.3"
 git push origin v1.2.3
 
@@ -174,8 +259,16 @@ gh release create v1.2.3 \
 
 - `--generate-notes` compile les PR mergées depuis le tag précédent.
 - Le tag doit être **identique** à `APP_VERSION` (sinon l'admin et la release
-  divergent). Vérifier : `git show v1.2.3:src/backend/src/lib/version.ts | grep APP_VERSION`.
+  divergent) — vérifié **avant** le push ci-dessus.
 - **Un seul tag par version.** Ne jamais déplacer un tag déjà poussé.
+
+### Mettre à jour le CHANGELOG
+
+Reporter la release dans [`CHANGELOG.md`](../CHANGELOG.md) (format
+[Keep a Changelog](https://keepachangelog.com/fr/)) — donne un historique lisible
+hors GitHub, versionné avec le code. En pratique, l'ajouter dans la **PR de
+promotion** (étape 1) : une section `## [1.2.3] - AAAA-MM-JJ` listant les
+changements (Ajouté / Corrigé / Modifié). La release GitHub peut réutiliser ce texte.
 
 > ℹ️ La skill **`deploy-to-prod`** (`.claude/skills/deploy-to-prod`) automatise
 > le choix du bump, le rappel de tous ces garde-fous et la génération de ces
@@ -183,7 +276,17 @@ gh release create v1.2.3 \
 
 ---
 
-## 7. Migrer les données depuis la beta
+## 8. Migrer les données depuis la beta — **à la demande uniquement**
+
+> 🚫 **Cette étape n'est PAS systématique.** Un déploiement de prod **ne migre
+> jamais** les données par défaut. La migration beta → prod est un geste **explicite**,
+> déclenché **à la demande du développeur** dans un cas précis (ex. première mise en
+> prod, ou synchronisation ponctuelle décidée). En routine, la prod garde ses
+> propres données ; on ne déploie que du **code**.
+
+> ⚠️ **C'est un écrasement complet** (`pg_dump --clean`) : elle **détruit** le
+> contenu prod actuel pour le remplacer par celui de la beta. Ne jamais la lancer
+> « par acquit de conscience ».
 
 La base prod démarre avec un seed minimal. Pour l'alimenter avec le contenu réel,
 copier depuis la **beta** (base + fichiers uploadés).
@@ -258,7 +361,7 @@ sudo docker exec <db-prod> psql -U devfest -d devfest -c \
 
 ---
 
-## 8. Basculer le DNS sur le domaine final (SEO)
+## 9. Basculer le DNS sur le domaine final (SEO)
 
 Tant que `BASE_URL` ≠ `https://devfesttoulouse.fr`, le site est **volontairement
 non indexé par Google mais reste partageable sur les réseaux sociaux**
@@ -275,6 +378,41 @@ Le jour du basculement DNS, **sans modifier le code** :
 3. **Redeploy without cache** (pour régénérer le bundle Next figé au build)
 
 → l'indexation SEO s'active automatiquement.
+
+---
+
+## Rollback — revenir en arrière
+
+Si la prod est cassée après un déploiement, **ne pas improviser**. Deux cas.
+
+### Cas 1 — la release ne contenait PAS de migration (code seul)
+
+Le rollback est simple : **redéployer le tag précédent**.
+
+1. Dans Coolify, pointer la ressource sur le commit/tag précédent (`vX.Y.(Z-1)`)
+   ou revert la PR de promotion, puis **Redeploy without cache**.
+2. Vérifier `/api/health` → la version doit redescendre au numéro précédent.
+
+> Ne **jamais** supprimer/déplacer le tag fautif. Créer plutôt un correctif
+> (`vX.Y.Z+1`) ou assumer le retour au tag précédent.
+
+### Cas 2 — la release contenait une migration Prisma
+
+Redéployer l'ancien code **ne suffit pas** : la base a déjà changé (une colonne
+`DROP` est perdue). Il faut **restaurer le dump** pris à l'étape 4.
+
+```bash
+PROD_DB=<db-prod>
+DUMP=/root/backups/prod-<STAMP>.sql     # le dump d'avant CE déploiement
+
+# Restauration COMPLÈTE (écrase l'état courant)
+cat "$DUMP" | sudo docker exec -i "$PROD_DB" psql -U devfest -d devfest
+
+# Puis redéployer le code de la version précédente (cas 1)
+```
+
+- **Sans dump préalable, pas de rollback propre possible** → d'où l'étape 4 obligatoire.
+- Après restauration, revérifier les smoke tests (étape 6).
 
 ---
 


### PR DESCRIPTION
## Summary

Comble la lacune identifiée : la procédure de mise en prod ne gérait ni les **numéros de version** ni les **releases GitHub**, et aucun tag/release n'existait. #171 avait introduit `APP_VERSION` mais rien ne le reliait à une vraie release.

- **`docs/mise-en-production.md`** : deux nouvelles étapes dans le flux —
  1. « Choisir le numéro de version » (règles de bump SemVer + où bumper `APP_VERSION` : `version.ts` + les 2 `package.json`, **dans la PR de promotion**).
  2. « Taguer + publier la release » (`git tag` + `gh release create`, après déploiement vérifié).
  - Ajout d'un contrôle de la version déployée via `/api/health`.
- **Nouvelle skill `.claude/skills/deploy-to-prod`** : guide tout le flux prod (choix du bump, PR de promotion, gestion du faux conflit squash, rappels config Coolify, tag/release, migration données) avec les garde-fous non négociables.

## Déjà fait (hors PR)

- **Tag `v1.0.0`** posé sur l'état de prod actuel (HEAD de `main`, `4a1312c`).
- **Release GitHub `v1.0.0`** publiée : https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/releases/tag/v1.0.0

## Convention retenue (validée)

- **Bump** : une mise en prod = une version.
- **Règle** : SemVer classique (major = cassant, minor = `feat:`, patch = `fix:`).
- **Création** : manuelle, guidée par la skill (pas de CI).

## Test plan

- [x] Doc relue : flux renuméroté cohérent (8 étapes), liens valides.
- [x] Skill : structure conforme à `qualify-issue` (frontmatter, triggers, garde-fous).
- [x] Tag `v1.0.0` visible (`git tag -l`) et release publiée sur GitHub.
- [ ] Prochaine mise en prod : dérouler la skill de bout en bout (validation réelle du process).

Note : purement doc + skill, aucun code applicatif touché.
