### PR TITLE
fix(prod): rattacher le backend au réseau coolify (emails cassés)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -75,14 +75,25 @@ services:
     # The backend itself is NOT exposed via Traefik (the frontend proxies
     # /api/* to it through the Next.js rewrites). It joins the shared
     # `coolify` network only to reach the standalone `postfix` service
-    # deployed at the Coolify level. Inbound resolution from other projects
-    # is mitigated by the env-scoped network alias on `default` —
-    # `BACKEND_URL` points at that alias, never at the bare `backend` name.
+    # deployed at the Coolify level.
+    #
+    # The env-scoped alias must sit on `coolify`, not on `default`: `default` is
+    # private to this stack, so an alias there protects nothing. On the shared
+    # network the service would otherwise answer to the bare `backend` name and
+    # collide with every other project's backend (see
+    # docs/coolify-pieges-multi-environnements.md).
+    #
+    # Both networks are declared as mappings with content. A bare `coolify:`
+    # key serialises to `coolify: null`, and Compose then silently skips the
+    # attachment — the container comes up without the shared network and
+    # `postfix` stops resolving, breaking every outgoing email.
     networks:
       default:
         aliases:
           - devfest-${ENV_NAME:-local}-backend
       coolify:
+        aliases:
+          - devfest-${ENV_NAME:-local}-backend
 
   db:
     image: postgres:16-alpine


### PR DESCRIPTION
Corrige #184.

## Summary

- Le backend n'était **pas** rattaché au réseau partagé `coolify`, donc `postfix`
  ne résolvait pas et **tout envoi d'email échouait** (formulaire de contact,
  reset de mot de passe, magic links) — en **prod et en beta**.
- Cause : une clé `coolify:` nue sous le `networks:` d'un service se sérialise en
  `coolify: null`, et Compose **ignore silencieusement le rattachement**. Le
  `frontend` n'était pas touché parce qu'il déclare ses réseaux en **forme liste**.
- On donne un alias à l'entrée `coolify` (le mapping porte donc du contenu) et on
  déplace l'alias env-scopé sur le **réseau partagé**, là où la collision existe
  réellement.

## Diagnostic

Reproduit sur les **deux** stacks, de façon systématique (pas une race condition) :

| Service | Forme `networks` | Rattaché à `coolify` ? |
|---|---|---|
| `frontend` | liste (`- coolify`) | ✅ oui |
| `backend` | mapping (`coolify:` → `null`) | ❌ **non** |

Pistes écartées en cours d'investigation :
- Coolify ne *strippe* pas la déclaration : le « Show Deployable Compose » contient
  bien `coolify: null` sous `backend`.
- Ce n'est pas un problème de nom de réseau : `docker network ls` renvoie
  exactement `coolify`, donc pas de `name:` à forcer.
- La spec Compose considère `coolify:` (null) équivalent à `- coolify` — mais en
  pratique, dans cette chaîne (Coolify → Compose v5.1.4), le rattachement est perdu.

## Correction de l'alias

Le commentaire affirmait que l'alias sur `default` protégeait de la résolution
inter-projets. C'est inexact : `default` est **privé au stack**, un alias y
protège de rien. Sur le réseau partagé, le backend répondait au nom nu `backend`
et **entrait en collision avec le backend de tout autre projet** — exactement le
piège décrit dans [`docs/coolify-pieges-multi-environnements.md`](docs/coolify-pieges-multi-environnements.md).
L'alias est donc désormais posé sur `coolify`.

## Hors scope

Le `frontend` est rattaché à `coolify` **sans alias** : il expose le nom nu
`frontend` sur le réseau partagé et court le même risque de collision. Il n'est
pas modifié ici : sa forme liste fonctionne, et la convertir en mapping pour y
ajouter un alias risquerait de déclencher le bug corrigé par cette PR. À traiter
séparément.

## Test plan

- [x] `docker compose config` résout `backend.networks.coolify.aliases = [devfest-prod-backend]`
      (plus de `null`), interpolation `${ENV_NAME}` correcte
- [x] YAML valide, un seul fichier touché
- [ ] Déployer sur **beta**, puis vérifier :
  - `docker inspect <backend-beta> --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}'`
    → `coolify` présent
  - `docker exec <backend-beta> getent hosts postfix` → résout
  - `docker exec <frontend-beta> getent hosts devfest-beta-backend` → résout (non-régression)
  - Envoi d'un message via le formulaire de contact beta → email reçu
- [ ] Après promotion en prod : mêmes vérifications, et **retirer le
      `docker network connect` manuel** posé pendant l'incident (il redevient inutile)

## Note

En prod, le rattachement a été rétabli **manuellement** pendant l'incident
(`docker network connect`), ce qui **ne survit pas à un redeploy** — c'est
d'ailleurs notre redeploy de 10h50 (coupure de `site.`) qui l'avait effacé une
première fois. Cette PR rend le rattachement persistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
