### PR TITLE
fix(build): passer BACKEND_URL et BASE_URL en build args du frontend

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,13 @@ services:
     build:
       context: .
       dockerfile: src/frontend/Dockerfile
+      # `next build` reads these to generate the rewrites, so they have to reach
+      # the image at build time — the runtime `environment:` block below comes
+      # too late and the Dockerfile's ARG defaults get baked into
+      # routes-manifest.json instead (see #189).
+      args:
+        - BACKEND_URL=http://devfest-${ENV_NAME:-local}-backend:4000
+        - BASE_URL=${BASE_URL}
     environment:
       - BASE_URL=${BASE_URL}
       # Pinned to the env-scoped backend container name. Resolving the bare

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,15 @@ services:
     build:
       context: .
       dockerfile: src/frontend/Dockerfile
+      # `next build` reads these to generate the rewrites, the CSP and the
+      # NEXT_PUBLIC_* bundle, so they have to reach the image at build time —
+      # the runtime `environment:` block below comes too late. Without them the
+      # Dockerfile's ARG defaults get baked into routes-manifest.json, pinning
+      # the rewrites to the bare `backend` hostname (see #189).
+      args:
+        - BACKEND_URL=http://devfest-${ENV_NAME:-local}-backend:4000
+        - BASE_URL=${BASE_URL}
+        - NEXT_PUBLIC_PLAUSIBLE_SRC=${NEXT_PUBLIC_PLAUSIBLE_SRC:-}
     environment:
       - NODE_ENV=production
       - BASE_URL=${BASE_URL}


### PR DESCRIPTION
Corrige #189.

## Summary

- `next build` lit `BACKEND_URL` pour générer les `rewrites` et **grave la valeur
  dans `routes-manifest.json`**. Aucun des composes ne passait de `build args`, donc
  le défaut du Dockerfile (`ARG BACKEND_URL=http://backend:4000`) était figé à la
  place de l'alias env-scopé.
- Invisible tant qu'aucun backend n'était sur le réseau partagé `coolify`. Depuis
  v1.1.1 (#188), les deux backends y sont : ils répondent tous deux au nom nu
  `backend` → **la prod servait une requête sur deux depuis le backend beta**,
  donc depuis la **base de données beta**.
- On passe désormais l'alias env-scopé au build. `BASE_URL` et
  `NEXT_PUBLIC_PLAUSIBLE_SRC` sont également figés par `next build` : ils sont
  passés en args plutôt que de dépendre du toggle « Available at Buildtime » de
  Coolify (qui n'existe pas pour `BACKEND_URL`, construite dans le compose).

## Contenu

| Fichier | Changement |
|---|---|
| `docker-compose.prod.yml` | `build.args` : `BACKEND_URL`, `BASE_URL`, `NEXT_PUBLIC_PLAUSIBLE_SRC` |
| `docker-compose.dev.yml` | `build.args` : `BACKEND_URL`, `BASE_URL` |

`docker-compose.local.yml` n'est pas concerné (pas de `build:`, image node directe).
Purement **additif** : 16 insertions, 0 suppression.

## Validation (`docker compose config`)

| Contexte | `build.args.BACKEND_URL` résolu |
|---|---|
| prod, `ENV_NAME=prod` | `http://devfest-prod-backend:4000` ✅ |
| dev, `ENV_NAME=beta` | `http://devfest-beta-backend:4000` ✅ |
| fallback, `ENV_NAME` absent | `http://devfest-local-backend:4000` ✅ |

Build et runtime portent désormais la **même** valeur.

## Test plan

⚠️ **Un `Redeploy WITHOUT CACHE` est impératif** : sans purge, `routes-manifest.json`
n'est pas régénéré et le correctif reste sans effet.

**Sur beta** (dont le backend est actuellement détaché de `coolify`) :
- [ ] Redeploy **without cache**
- [ ] `docker exec <frontend-beta> cat /app/.next/routes-manifest.json | grep -o 'http://[^"]*:4000'`
      → `http://devfest-beta-backend:4000` (plus de `http://backend:4000`)
- [ ] Rattacher le backend beta à `coolify` (`docker network connect --alias devfest-beta-backend coolify <backend-beta>`)
      ou redeploy — les deux backends cohabitent alors sur le réseau partagé
- [ ] **Le test décisif** : 5× `curl https://devfesttoulouse.fr/api/health`
      → 5× `"environment":"prod"` (aucun `beta`)
- [ ] 5× `curl https://beta.site.devfesttoulouse.fr/api/health` → 5× `"environment":"beta"`
- [ ] `docker exec <backend-beta> getent hosts postfix` → résout (emails beta rétablis)
- [ ] Formulaire de contact beta → email reçu

**Après promotion en prod** : mêmes vérifications sur `devfesttoulouse.fr`.

## Contexte

Incident du 2026-07-09, découvert pendant le déploiement de v1.1.1. La prod a été
stabilisée en sortant le backend beta du réseau `coolify` — au prix de casser les
**emails beta**, qui resteront cassés jusqu'au déploiement de cette PR.

Voir #189 pour le diagnostic complet, #184 (fermée) pour le correctif réseau initial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
