### PR TITLE
fix(deploy): healthchecks frontend + backend pour supprimer les 503 au déploiement

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,6 +27,22 @@ services:
       - NEXT_PUBLIC_PLAUSIBLE_SRC=${NEXT_PUBLIC_PLAUSIBLE_SRC:-}
     expose:
       - "3000"
+    # Without a healthcheck Coolify cannot tell when the new container is ready,
+    # so it stops the old one first and Traefik serves 503 for the whole swap
+    # (#192). `/healthz` is a dedicated route that renders nothing and never
+    # calls the API — probing `/` would mark the frontend unhealthy whenever the
+    # backend is down.
+    #
+    # Address the loopback as 127.0.0.1, never `localhost`: inside the container
+    # `localhost` resolves to ::1 and the server only listens on IPv4, so the
+    # probe would fail every single time and block all deployments.
+    # `curl` is absent from node:22-alpine; `wget` ships with BusyBox.
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     depends_on:
       - backend
     # Persist Next.js' on-the-fly image optimization cache across rebuilds.
@@ -78,6 +94,18 @@ services:
       - SMTP_FROM=${SMTP_FROM:-contact@devfesttoulouse.fr}
       - BILLETWEB_USER=${BILLETWEB_USER:-}
       - BILLETWEB_KEY=${BILLETWEB_KEY:-}
+    # `start_period` is generous because the entrypoint runs `prisma migrate
+    # deploy` and the seed before Fastify ever listens (see scripts/db-boot.sh).
+    # Overshooting costs nothing — the window only suppresses early failures —
+    # whereas undershooting marks the container unhealthy and blocks the deploy.
+    # 127.0.0.1, not `localhost`: the latter resolves to ::1 and Fastify binds
+    # 0.0.0.0 (IPv4 only), so every probe would be refused.
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:4000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     depends_on:
       db:
         condition: service_healthy

--- a/src/frontend/src/app/healthz/route.ts
+++ b/src/frontend/src/app/healthz/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+// Liveness probe for the container healthcheck. Deliberately does not touch the
+// backend: probing `/` would render the home page, which fetches the API, so a
+// backend outage would mark the frontend unhealthy and block deployments even
+// though Next.js is serving fine.
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json({ status: "ok" });
+}


### PR DESCRIPTION
Corrige #192.

## Summary

- Ni le `frontend` ni le `backend` ne déclaraient de **healthcheck**. Coolify ne
  pouvait donc pas savoir quand le nouveau conteneur était prêt : il arrêtait
  l'ancien d'abord, Traefik n'avait plus de backend sain, et le site public
  renvoyait **503 pendant ~1 minute à chaque déploiement**.
- Ajout d'un healthcheck sur les deux services de `docker-compose.prod.yml`
  (utilisé par **prod et beta**).
- Nouvelle route `GET /healthz` côté frontend : réponse `200` sans rendu ni appel
  à l'API.

## Vérifications terrain (avant écriture)

Mesuré sur le conteneur de production, pour ne rien calibrer au jugé :

| Point | Résultat |
|---|---|
| `wget` dans `node:22-alpine` | ✅ présent (front + back) — `curl` **absent** |
| Healthchecks existants | aucun sur `frontend`/`backend` (seul `db` en a un) |
| `http://localhost:4000/api/health` | ❌ **Connection refused** |
| `http://127.0.0.1:4000/api/health` | ✅ `{"status":"ok",…}` |
| Résolution de `localhost` | `::1` (**IPv6**) |
| Écoute du backend | `0.0.0.0:4000` (**IPv4 seulement**) |
| Démarrage Next | `✓ Ready in 348ms` |
| Coût d'un probe sur `/` | 202 ms |

## Trois corrections par rapport à la proposition de l'issue

1. **`127.0.0.1`, jamais `localhost`.** Dans le conteneur, `localhost` résout en
   `::1` alors que les serveurs écoutent sur `0.0.0.0` (IPv4). Un probe sur
   `localhost` aurait **échoué à chaque fois** → conteneur `unhealthy` en
   permanence → **plus aucun déploiement ne passe**. Pire que le 503 actuel.

2. **`/healthz` plutôt que `/`.** Sonder la home la fait rendre, ce qui appelle
   l'API : une panne du backend aurait marqué le frontend `unhealthy` alors que
   Next.js sert parfaitement. Le probe doit tester le service, pas ses dépendances.

3. **`start_period` calibré, pas deviné.** L'issue proposait `40s` en supposant
   « Nuxt SSR, ~60 s à démarrer ». Le projet utilise **Next.js**, qui démarre en
   **348 ms** → `15s` pour le frontend (déjà très large). Le backend garde `60s`
   car son entrypoint joue `prisma migrate deploy` **et** le seed avant que
   Fastify écoute ([`scripts/db-boot.sh`](src/backend/scripts/db-boot.sh)).
   Surdimensionner ne coûte rien (la fenêtre ne fait qu'ignorer les échecs
   précoces) ; sous-dimensionner bloque le déploiement.

## Contenu

| Fichier | Changement |
|---|---|
| `src/frontend/src/app/healthz/route.ts` | Route `GET /healthz` → `200 {"status":"ok"}`, `force-dynamic` |
| `docker-compose.prod.yml` | `healthcheck` sur `frontend` (`/healthz`, 15 s) et `backend` (`/api/health`, 60 s) |

Purement **additif** : 39 insertions, 0 suppression.

## Test plan

**Sur beta d'abord** (elle utilise `docker-compose.prod.yml`) :

- [ ] Déployer, puis vérifier que la route existe :
      `docker exec <frontend-beta> wget -qO- http://127.0.0.1:3000/healthz` → `{"status":"ok"}`
- [ ] Les conteneurs passent `healthy` :
      `docker inspect <c> --format '{{.State.Health.Status}}'` → `healthy` (les deux)
- [ ] `docker inspect <c> --format '{{json .State.Health}}'` → aucun `ExitCode` non nul
- [ ] Attendre 2 min et re-vérifier : les probes ne doivent **pas** flapper
- [ ] `curl https://beta.site.devfesttoulouse.fr/healthz` → `200` (route publique, inoffensive)

**Puis activer « Zero Downtime Deployment »** sur l'application Coolify, et
déclencher un déploiement :

- [ ] Uptime Kuma ne remonte **aucun 503** sur `devfesttoulouse.fr` pendant la bascule
- [ ] `/api/health` reste servi sans interruption pendant le déploiement

## Hors scope

- `docker-compose.dev.yml` n'est pas modifié : il sert les environnements
  `dev-{initiale}` personnels, où une coupure d'une minute est sans conséquence,
  et le frontend y tourne en `next dev` (temps de démarrage différent).
- L'activation du **Zero Downtime Deployment** est un réglage Coolify, pas du code.
  Le healthcheck en est le prérequis, mais il ne suffit pas à lui seul.
- Les **504** mentionnés dans l'issue (saturation de `dockerd` par les builds) et
  l'absence de swap sur le VPS restent traités côté infra.

## Note

L'issue mentionne « Nuxt SSR » : le projet utilise **Next.js**. Cela n'invalide pas
le diagnostic (l'absence de healthcheck est bien la cause racine), mais les valeurs
de calibrage proposées étaient issues d'un autre contexte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
