### PR TITLE
Admin — sélection multiple + actions groupées (statut, à la une) (#201)

### DIFF
--- a/src/backend/src/routes/admin/speakers.ts
+++ b/src/backend/src/routes/admin/speakers.ts
@@ -30,6 +30,12 @@ interface SpeakerListQuery {
   editionId?: string;
 }
 
+interface SpeakerBulkBody {
+  ids: number[];
+  action: "setStatus" | "setFeatured";
+  value: "DRAFT" | "PUBLISHED" | boolean;
+}
+
 function serialize(s: { socialLinks: string | null; [k: string]: unknown }) {
   return { ...s, socialLinks: s.socialLinks ? JSON.parse(s.socialLinks) : {} };
 }
@@ -124,6 +130,33 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
 
     revalidateSpeakers();
     return serialize(speaker);
+  });
+
+  // POST /api/admin/speakers/bulk — apply one action to several speakers at once.
+  app.post<{ Body: SpeakerBulkBody }>("/speakers/bulk", async (request, reply) => {
+    const { ids, action, value } = request.body;
+    if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => Number.isInteger(id))) {
+      return reply.code(400).send({ error: "ids must be a non-empty array of integers" });
+    }
+
+    let data: { publicationStatus: "DRAFT" | "PUBLISHED" } | { isFeatured: boolean };
+    if (action === "setStatus") {
+      if (value !== "DRAFT" && value !== "PUBLISHED") {
+        return reply.code(400).send({ error: "value must be DRAFT or PUBLISHED" });
+      }
+      data = { publicationStatus: value };
+    } else if (action === "setFeatured") {
+      if (typeof value !== "boolean") {
+        return reply.code(400).send({ error: "value must be a boolean" });
+      }
+      data = { isFeatured: value };
+    } else {
+      return reply.code(400).send({ error: "unknown action" });
+    }
+
+    const { count } = await prisma.speaker.updateMany({ where: { id: { in: ids } }, data });
+    revalidateSpeakers();
+    return { count };
   });
 
   // DELETE /api/admin/speakers/:id

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -31,6 +31,12 @@ interface SponsorListQuery {
   editionId?: string;
 }
 
+interface SponsorBulkBody {
+  ids: number[];
+  action: "setStatus";
+  value: "DRAFT" | "PUBLISHED";
+}
+
 function serialize(s: {
   socialLinks: string | null;
   [k: string]: unknown;
@@ -139,6 +145,24 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
 
     revalidateSponsors();
     return serialize(sponsor);
+  });
+
+  // POST /api/admin/sponsors/bulk — apply one action to several sponsors at once.
+  app.post<{ Body: SponsorBulkBody }>("/sponsors/bulk", async (request, reply) => {
+    const { ids, action, value } = request.body;
+    if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => Number.isInteger(id))) {
+      return reply.code(400).send({ error: "ids must be a non-empty array of integers" });
+    }
+    if (action !== "setStatus" || (value !== "DRAFT" && value !== "PUBLISHED")) {
+      return reply.code(400).send({ error: "unsupported action or value" });
+    }
+
+    const { count } = await prisma.sponsor.updateMany({
+      where: { id: { in: ids } },
+      data: { publicationStatus: value },
+    });
+    revalidateSponsors();
+    return { count };
   });
 
   // DELETE /api/admin/sponsors/:id

--- a/src/backend/src/routes/admin/talks.ts
+++ b/src/backend/src/routes/admin/talks.ts
@@ -33,6 +33,12 @@ interface TalkListQuery {
   editionId?: string;
 }
 
+interface TalkBulkBody {
+  ids: number[];
+  action: "setStatus";
+  value: "DRAFT" | "PUBLISHED";
+}
+
 function serialize(t: {
   speakers?: { id: number; name: string }[];
   [k: string]: unknown;
@@ -161,6 +167,24 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
 
     revalidateConferences();
     return serialize(talk);
+  });
+
+  // POST /api/admin/talks/bulk — apply one action to several talks at once.
+  app.post<{ Body: TalkBulkBody }>("/talks/bulk", async (request, reply) => {
+    const { ids, action, value } = request.body;
+    if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => Number.isInteger(id))) {
+      return reply.code(400).send({ error: "ids must be a non-empty array of integers" });
+    }
+    if (action !== "setStatus" || (value !== "DRAFT" && value !== "PUBLISHED")) {
+      return reply.code(400).send({ error: "unsupported action or value" });
+    }
+
+    const { count } = await prisma.talk.updateMany({
+      where: { id: { in: ids } },
+      data: { publicationStatus: value },
+    });
+    revalidateConferences();
+    return { count };
   });
 
   // DELETE /api/admin/talks/:id

--- a/src/frontend/src/app/admin/speakers/page.tsx
+++ b/src/frontend/src/app/admin/speakers/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { adminFetch } from "@/lib/admin-api";
 import type { Speaker } from "@/lib/types";
 import DataTable from "@/components/admin/DataTable";
+import BulkActionBar from "@/components/admin/BulkActionBar";
 import StatusBadge from "@/components/admin/StatusBadge";
 
 interface SpeakerRow extends Speaker {
@@ -19,6 +20,7 @@ export default function SpeakersDataPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [year, setYear] = useState<string>(searchParams.get("year") ?? "");
   const [search, setSearch] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     adminFetch<SpeakerRow[]>("/speakers").then(({ data }) => {
@@ -26,6 +28,25 @@ export default function SpeakersDataPage() {
       setIsLoading(false);
     });
   }, []);
+
+  async function applyBulk(action: "setStatus" | "setFeatured", value: "DRAFT" | "PUBLISHED" | boolean) {
+    const ids = [...selectedIds];
+    const { status } = await adminFetch("/speakers/bulk", {
+      method: "POST",
+      body: JSON.stringify({ ids, action, value }),
+    });
+    if (status !== 200) return;
+    setSpeakers((prev) =>
+      prev.map((s) =>
+        selectedIds.has(s.id)
+          ? action === "setStatus"
+            ? { ...s, publicationStatus: value as "DRAFT" | "PUBLISHED" }
+            : { ...s, isFeatured: value as boolean }
+          : s,
+      ),
+    );
+    setSelectedIds(new Set());
+  }
 
   const years = useMemo(
     () => [...new Set(speakers.map((s) => s.edition?.year).filter((y): y is number => y != null))].sort((a, b) => b - a),
@@ -40,6 +61,12 @@ export default function SpeakersDataPage() {
       return true;
     });
   }, [speakers, year, search]);
+
+  // Reset the selection whenever the filter changes so the header checkbox
+  // and the bulk bar always reflect the currently visible rows.
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [year, search]);
 
   const columns = [
     {
@@ -104,11 +131,24 @@ export default function SpeakersDataPage() {
             <span className="text-sm text-gris">{filtered.length} speaker{filtered.length > 1 ? "s" : ""}</span>
           </div>
 
+          {selectedIds.size > 0 && (
+            <BulkActionBar
+              count={selectedIds.size}
+              entitySingular="speaker"
+              entityPlural="speakers"
+              onSetStatus={(value) => applyBulk("setStatus", value)}
+              onSetFeatured={(value) => applyBulk("setFeatured", value)}
+              onClear={() => setSelectedIds(new Set())}
+            />
+          )}
+
           <DataTable<SpeakerRow>
             columns={columns}
             data={filtered}
             emptyMessage="Aucun speaker"
             onEdit={(s) => router.push(`/admin/speakers/${s.id}`)}
+            selectedIds={selectedIds}
+            onSelectionChange={setSelectedIds}
           />
         </>
       )}

--- a/src/frontend/src/app/admin/sponsors/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { adminFetch } from "@/lib/admin-api";
 import type { Sponsor, SponsorLevel } from "@/lib/types";
 import DataTable from "@/components/admin/DataTable";
+import BulkActionBar from "@/components/admin/BulkActionBar";
 import StatusBadge from "@/components/admin/StatusBadge";
 
 interface SponsorRow extends Sponsor {
@@ -28,6 +29,7 @@ export default function SponsorsDataPage() {
   const [year, setYear] = useState<string>(searchParams.get("year") ?? "");
   const [level, setLevel] = useState<string>("");
   const [search, setSearch] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     adminFetch<SponsorRow[]>("/sponsors").then(({ data }) => {
@@ -35,6 +37,19 @@ export default function SponsorsDataPage() {
       setIsLoading(false);
     });
   }, []);
+
+  async function applyBulk(value: "DRAFT" | "PUBLISHED") {
+    const ids = [...selectedIds];
+    const { status } = await adminFetch("/sponsors/bulk", {
+      method: "POST",
+      body: JSON.stringify({ ids, action: "setStatus", value }),
+    });
+    if (status !== 200) return;
+    setSponsors((prev) =>
+      prev.map((s) => (selectedIds.has(s.id) ? { ...s, publicationStatus: value } : s)),
+    );
+    setSelectedIds(new Set());
+  }
 
   const years = useMemo(
     () => [...new Set(sponsors.map((s) => s.edition?.year).filter((y): y is number => y != null))].sort((a, b) => b - a),
@@ -50,6 +65,10 @@ export default function SponsorsDataPage() {
       return true;
     });
   }, [sponsors, year, level, search]);
+
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [year, level, search]);
 
   const columns = [
     { key: "name", label: "Sponsor", render: (s: SponsorRow) => <span className="font-medium text-noir">{s.name}</span> },
@@ -117,11 +136,23 @@ export default function SponsorsDataPage() {
             <span className="text-sm text-gris">{filtered.length} sponsor{filtered.length > 1 ? "s" : ""}</span>
           </div>
 
+          {selectedIds.size > 0 && (
+            <BulkActionBar
+              count={selectedIds.size}
+              entitySingular="sponsor"
+              entityPlural="sponsors"
+              onSetStatus={applyBulk}
+              onClear={() => setSelectedIds(new Set())}
+            />
+          )}
+
           <DataTable<SponsorRow>
             columns={columns}
             data={filtered}
             emptyMessage="Aucun sponsor"
             onEdit={(s) => router.push(`/admin/sponsors/${s.id}`)}
+            selectedIds={selectedIds}
+            onSelectionChange={setSelectedIds}
           />
         </>
       )}

--- a/src/frontend/src/app/admin/talks/page.tsx
+++ b/src/frontend/src/app/admin/talks/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { adminFetch } from "@/lib/admin-api";
 import type { Talk, TalkFormat } from "@/lib/types";
 import DataTable from "@/components/admin/DataTable";
+import BulkActionBar from "@/components/admin/BulkActionBar";
 import StatusBadge from "@/components/admin/StatusBadge";
 
 interface TalkRow extends Talk {
@@ -26,6 +27,7 @@ export default function TalksDataPage() {
   const [year, setYear] = useState<string>(searchParams.get("year") ?? "");
   const [format, setFormat] = useState<string>("");
   const [search, setSearch] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     adminFetch<TalkRow[]>("/talks").then(({ data }) => {
@@ -33,6 +35,19 @@ export default function TalksDataPage() {
       setIsLoading(false);
     });
   }, []);
+
+  async function applyBulk(value: "DRAFT" | "PUBLISHED") {
+    const ids = [...selectedIds];
+    const { status } = await adminFetch("/talks/bulk", {
+      method: "POST",
+      body: JSON.stringify({ ids, action: "setStatus", value }),
+    });
+    if (status !== 200) return;
+    setTalks((prev) =>
+      prev.map((t) => (selectedIds.has(t.id) ? { ...t, publicationStatus: value } : t)),
+    );
+    setSelectedIds(new Set());
+  }
 
   const years = useMemo(
     () => [...new Set(talks.map((t) => t.edition?.year).filter((y): y is number => y != null))].sort((a, b) => b - a),
@@ -48,6 +63,10 @@ export default function TalksDataPage() {
       return true;
     });
   }, [talks, year, format, search]);
+
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [year, format, search]);
 
   const columns = [
     { key: "title", label: "Titre", render: (t: TalkRow) => <span className="font-medium text-noir">{t.titleFr}</span> },
@@ -133,11 +152,23 @@ export default function TalksDataPage() {
             <span className="text-sm text-gris">{filtered.length} conférence{filtered.length > 1 ? "s" : ""}</span>
           </div>
 
+          {selectedIds.size > 0 && (
+            <BulkActionBar
+              count={selectedIds.size}
+              entitySingular="conférence"
+              entityPlural="conférences"
+              onSetStatus={applyBulk}
+              onClear={() => setSelectedIds(new Set())}
+            />
+          )}
+
           <DataTable<TalkRow>
             columns={columns}
             data={filtered}
             emptyMessage="Aucune conférence"
             onEdit={(t) => router.push(`/admin/talks/${t.id}`)}
+            selectedIds={selectedIds}
+            onSelectionChange={setSelectedIds}
           />
         </>
       )}

--- a/src/frontend/src/components/admin/BulkActionBar.tsx
+++ b/src/frontend/src/components/admin/BulkActionBar.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+
+type PendingAction =
+  | { kind: "status"; value: "DRAFT" | "PUBLISHED" }
+  | { kind: "featured"; value: boolean };
+
+interface BulkActionBarProps {
+  count: number;
+  // Singular/plural entity name used in labels, e.g. "speaker" / "speakers".
+  entitySingular: string;
+  entityPlural: string;
+  onSetStatus: (value: "DRAFT" | "PUBLISHED") => Promise<void>;
+  // Provided only for entities that support "featured" (speakers).
+  onSetFeatured?: (value: boolean) => Promise<void>;
+  onClear: () => void;
+}
+
+export default function BulkActionBar({
+  count,
+  entitySingular,
+  entityPlural,
+  onSetStatus,
+  onSetFeatured,
+  onClear,
+}: BulkActionBarProps) {
+  const [pending, setPending] = useState<PendingAction | null>(null);
+  const [isApplying, setIsApplying] = useState(false);
+
+  const noun = count > 1 ? entityPlural : entitySingular;
+
+  const confirmMessage = (() => {
+    if (!pending) return "";
+    if (pending.kind === "status") {
+      const verb = pending.value === "PUBLISHED" ? "Publier" : "Repasser en brouillon";
+      return `${verb} ${count} ${noun} ?`;
+    }
+    const verb = pending.value ? "Mettre à la une" : "Retirer de la une";
+    return `${verb} ${count} ${noun} ?`;
+  })();
+
+  const apply = async () => {
+    if (!pending) return;
+    setIsApplying(true);
+    try {
+      if (pending.kind === "status") await onSetStatus(pending.value);
+      else if (onSetFeatured) await onSetFeatured(pending.value);
+    } finally {
+      setIsApplying(false);
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-malachite/30 bg-malachite/5 px-4 py-3">
+      <span className="text-sm font-medium text-noir">
+        {count} {noun} sélectionné{count > 1 ? "s" : ""}
+      </span>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          onClick={() => setPending({ kind: "status", value: "PUBLISHED" })}
+          className="rounded-lg bg-malachite px-3 py-1.5 text-sm font-medium text-blanc hover:bg-malachite/90"
+        >
+          Publier
+        </button>
+        <button
+          onClick={() => setPending({ kind: "status", value: "DRAFT" })}
+          className="rounded-lg border border-gris/30 px-3 py-1.5 text-sm text-gris hover:bg-blanc-casse"
+        >
+          Repasser en brouillon
+        </button>
+        {onSetFeatured && (
+          <>
+            <button
+              onClick={() => setPending({ kind: "featured", value: true })}
+              className="rounded-lg border border-gris/30 px-3 py-1.5 text-sm text-gris hover:bg-blanc-casse"
+            >
+              Mettre à la une
+            </button>
+            <button
+              onClick={() => setPending({ kind: "featured", value: false })}
+              className="rounded-lg border border-gris/30 px-3 py-1.5 text-sm text-gris hover:bg-blanc-casse"
+            >
+              Retirer de la une
+            </button>
+          </>
+        )}
+      </div>
+
+      <button
+        onClick={onClear}
+        className="ml-auto text-sm text-gris hover:underline"
+      >
+        Désélectionner
+      </button>
+
+      <ConfirmDialog
+        isOpen={pending !== null}
+        title="Confirmer l'action groupée"
+        message={confirmMessage}
+        confirmLabel={isApplying ? "Application…" : "Confirmer"}
+        onConfirm={apply}
+        onCancel={() => setPending(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/DataTable.tsx
+++ b/src/frontend/src/components/admin/DataTable.tsx
@@ -12,6 +12,10 @@ interface DataTableProps<T> {
   onEdit?: (item: T) => void;
   onDelete?: (item: T) => void;
   emptyMessage?: string;
+  // Row selection is opt-in: pass the current selection and a setter to turn
+  // the checkbox column on. Left undefined, the table renders exactly as before.
+  selectedIds?: Set<number>;
+  onSelectionChange?: (ids: Set<number>) => void;
 }
 
 export default function DataTable<T extends { id: number }>({
@@ -20,16 +24,45 @@ export default function DataTable<T extends { id: number }>({
   onEdit,
   onDelete,
   emptyMessage = "Aucun element",
+  selectedIds,
+  onSelectionChange,
 }: DataTableProps<T>) {
   if (data.length === 0) {
     return <p className="text-gris py-8 text-center">{emptyMessage}</p>;
   }
+
+  const isSelectable = selectedIds !== undefined && onSelectionChange !== undefined;
+  const allSelected = isSelectable && data.length > 0 && data.every((item) => selectedIds!.has(item.id));
+
+  const toggleAll = () => {
+    if (!isSelectable) return;
+    onSelectionChange!(allSelected ? new Set() : new Set(data.map((item) => item.id)));
+  };
+
+  const toggleOne = (id: number) => {
+    if (!isSelectable) return;
+    const next = new Set(selectedIds!);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onSelectionChange!(next);
+  };
 
   return (
     <div className="overflow-x-auto rounded-xl shadow-card bg-blanc">
       <table className="w-full text-sm">
         <thead>
           <tr className="bg-blanc-casse/60 border-b border-gris/20">
+            {isSelectable && (
+              <th className="w-10 px-4 py-3">
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={toggleAll}
+                  aria-label="Tout sélectionner"
+                  className="h-4 w-4 accent-malachite cursor-pointer"
+                />
+              </th>
+            )}
             {columns.map((col) => (
               <th key={col.key} className="text-left px-4 py-3 font-medium text-gris">
                 {col.label}
@@ -43,6 +76,17 @@ export default function DataTable<T extends { id: number }>({
         <tbody>
           {data.map((item) => (
             <tr key={item.id} className="border-b border-gris/10 hover:bg-blanc-casse/50">
+              {isSelectable && (
+                <td className="px-4 py-3">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds!.has(item.id)}
+                    onChange={() => toggleOne(item.id)}
+                    aria-label={`Sélectionner la ligne ${item.id}`}
+                    className="h-4 w-4 accent-malachite cursor-pointer"
+                  />
+                </td>
+              )}
               {columns.map((col) => (
                 <td key={col.key} className="px-4 py-3 text-noir">
                   {col.render ? col.render(item) : String((item as Record<string, unknown>)[col.key] ?? "")}


### PR DESCRIPTION
Ferme #201.

## Résumé

- Ajoute une **sélection multiple** (cases par ligne + case d'en-tête « tout sélectionner / désélectionner ») dans le `DataTable` partagé de l'admin — opt-in, sans régression sur les usages existants.
- Nouvelle **barre d'actions groupées** (`BulkActionBar`) avec **modale de confirmation** : sur speakers / conférences / sponsors, publier ou repasser en brouillon la sélection en une action ; les speakers ont en plus « mettre / retirer de la une » (`isFeatured` n'existe que sur `Speaker`).
- **Endpoints bulk dédiés** `POST /admin/{speakers,talks,sponsors}/bulk` : `updateMany` atomique, validation des `ids` et de l'action/valeur au boundary. Répond `{ count }`.
- Motivation : l'import Sessionize crée tout en `DRAFT` — republier un par un était fastidieux.

## Détails

- La sélection se **réinitialise** au changement de filtre et après chaque action appliquée.
- La case d'en-tête agit sur les **lignes filtrées** affichées.
- `setFeatured` est refusé (400) sur talks / sponsors côté API.

## Test plan

- [x] `tsc --noEmit` backend : OK
- [x] `next build` + `eslint` frontend : OK
- [x] API testée en local (login admin) : bulk statut (speakers/talks/sponsors), bulk featured (speakers), refus 400 sur ids vides / action inconnue / featured hors speakers ; effet vérifié en base
- [ ] **Validation visuelle sur dev-j** : cases à cocher, case d'en-tête avec filtre actif, publication groupée, « à la une » groupée (speakers only), modale de confirmation annulable, absence de « à la une » sur talks / sponsors
