### PR TITLE
Nav — « Conférences » niveau 1, puis sous « Programme » quand planning prêt (#203)

### DIFF
--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -186,13 +186,19 @@ export default async function editionRoutes(app: FastifyInstance) {
       select: { year: true, aftermovieUrl: true, galleryUrl: true },
     });
 
-    // Drive the Programme / Speakers / Sponsors nav links (Header/Footer):
+    // Drive the Conférences / Speakers / Sponsors nav links (Header/Footer):
     // a link is shown only when the edition has at least one PUBLISHED record
     // of that kind — matching what the public pages actually display.
-    const [publishedTalkCount, publishedSpeakerCount, publishedSponsorCount] =
+    // scheduledTalkCount additionally tells whether the schedule (planning) is
+    // ready: at least one published talk has been given a time slot (startsAt),
+    // which promotes the flat "Conférences" link to a "Programme" menu (#203).
+    const [publishedTalkCount, scheduledTalkCount, publishedSpeakerCount, publishedSponsorCount] =
       await Promise.all([
         prisma.talk.count({
           where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+        }),
+        prisma.talk.count({
+          where: { editionId: edition.id, publicationStatus: "PUBLISHED", startsAt: { not: null } },
         }),
         prisma.speaker.count({
           where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
@@ -223,6 +229,7 @@ export default async function editionRoutes(app: FastifyInstance) {
       sponsorPageStatus: edition.sponsorPageStatus,
       sponsorTemporaryFormUrl: edition.sponsorTemporaryFormUrl,
       isProgramPublished: publishedTalkCount > 0,
+      isScheduleReady: scheduledTalkCount > 0,
       hasSpeakers: publishedSpeakerCount > 0,
       hasSponsors: publishedSponsorCount > 0,
     };

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -10,6 +10,7 @@
   },
   "nav": {
     "home": "Home",
+    "conferences": "Talks",
     "program": "Schedule",
     "speakers": "Speakers",
     "sponsors": "Sponsors",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -10,6 +10,7 @@
   },
   "nav": {
     "home": "Accueil",
+    "conferences": "Conférences",
     "program": "Programme",
     "speakers": "Speakers",
     "sponsors": "Sponsors",

--- a/src/frontend/src/components/Footer.tsx
+++ b/src/frontend/src/components/Footer.tsx
@@ -10,14 +10,8 @@ import {
   getSocialLinks,
 } from "@/lib/api";
 import { getLogoUrl } from "@/lib/identity";
+import { getPublicNavEntries } from "@/lib/nav";
 import SocialIcons from "./SocialIcons";
-
-const NAV_LINKS = [
-  { key: "program", href: "/conferences" },
-  { key: "speakers", href: "/speakers" },
-  { key: "sponsors", href: "/sponsors" },
-  { key: "blog", href: "/actualites" },
-] as const;
 
 export default async function Footer() {
   const [tNav, tFooter, tCta, edition, editions, socialLinks, identity, ecosystemPartners] =
@@ -76,26 +70,26 @@ export default async function Footer() {
             {/* Navigation — always shown; links appear as their content goes
                 live (Actus is always available). */}
             {(() => {
-              const footerLinks = NAV_LINKS.filter((link) => {
-                if (link.key === "program" && !edition?.isProgramPublished) return false;
-                if (link.key === "speakers" && !edition?.hasSpeakers) return false;
-                if (link.key === "sponsors" && !edition?.hasSponsors) return false;
-                return true;
-              });
-              if (footerLinks.length === 0) return null;
+              // Flatten parent + children into one list (the footer has no
+              // dropdowns); children render indented under their parent (#203).
+              const footerEntries = getPublicNavEntries(edition).flatMap((entry) => [
+                { ...entry, indented: false },
+                ...(entry.children ?? []).map((child) => ({ ...child, indented: true })),
+              ]);
+              if (footerEntries.length === 0) return null;
               return (
                 <div>
                   <p className="text-blanc text-xl font-bold mb-2 leading-snug">
                     {tFooter("navigation")}
                   </p>
                   <ul className="flex flex-col gap-1">
-                    {footerLinks.map((link) => (
-                      <li key={link.key}>
+                    {footerEntries.map((entry) => (
+                      <li key={entry.key}>
                         <Link
-                          href={link.href}
-                          className="text-blanc text-base hover:opacity-70 transition-opacity"
+                          href={entry.href}
+                          className={`text-blanc text-base hover:opacity-70 transition-opacity ${entry.indented ? "pl-4" : ""}`}
                         >
-                          {tNav(link.key)}
+                          {tNav(entry.labelKey)}
                         </Link>
                       </li>
                     ))}

--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -9,13 +9,7 @@ import LanguageSwitcher from "./LanguageSwitcher";
 import { useCfpSettings, useEdition, useIdentitySettings, useSocialLinks } from "@/contexts/EditionContext";
 import { getCfpCtaUrl } from "@/lib/cfp";
 import { getLogoUrl } from "@/lib/identity";
-
-const ALL_NAV_LINKS = [
-  { key: "program", href: "/conferences" },
-  { key: "speakers", href: "/speakers" },
-  { key: "sponsors", href: "/sponsors" },
-  { key: "blog", href: "/actualites" },
-] as const;
+import { getPublicNavEntries } from "@/lib/nav";
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -34,12 +28,7 @@ export default function Header() {
   const showSponsorCta = edition && edition.sponsorPageStatus !== "SOLD_OUT";
   const cfpUrl = getCfpCtaUrl(cfp);
 
-  const navLinks = ALL_NAV_LINKS.filter((link) => {
-    if (link.key === "program" && !edition?.isProgramPublished) return false;
-    if (link.key === "speakers" && !edition?.hasSpeakers) return false;
-    if (link.key === "sponsors" && !edition?.hasSponsors) return false;
-    return true;
-  });
+  const navEntries = getPublicNavEntries(edition);
 
   return (
     <header
@@ -61,15 +50,41 @@ export default function Header() {
 
           {/* Desktop nav — right of logo */}
           <nav className="hidden lg:flex items-center gap-6" aria-label="Main navigation">
-            {navLinks.map((link) => (
-              <Link
-                key={link.key}
-                href={link.href}
-                className="text-gris text-base hover:text-noir transition-colors"
-              >
-                {t(link.key)}
-              </Link>
-            ))}
+            {navEntries.map((entry) =>
+              entry.children ? (
+                <div key={entry.key} className="group relative">
+                  <Link
+                    href={entry.href}
+                    className="flex items-center gap-1 text-gris text-base hover:text-noir transition-colors"
+                    aria-haspopup="true"
+                  >
+                    {t(entry.labelKey)}
+                    <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </Link>
+                  <div className="absolute left-0 top-full hidden min-w-[180px] flex-col rounded-[12px] bg-blanc py-2 shadow-card group-hover:flex group-focus-within:flex">
+                    {entry.children.map((child) => (
+                      <Link
+                        key={child.key}
+                        href={child.href}
+                        className="px-4 py-2 text-gris text-base hover:text-noir hover:bg-blanc-casse transition-colors"
+                      >
+                        {t(child.labelKey)}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <Link
+                  key={entry.key}
+                  href={entry.href}
+                  className="text-gris text-base hover:text-noir transition-colors"
+                >
+                  {t(entry.labelKey)}
+                </Link>
+              ),
+            )}
           </nav>
         </div>
 
@@ -126,15 +141,26 @@ export default function Header() {
           aria-label="Mobile navigation"
         >
           <div className="flex flex-col gap-4">
-            {navLinks.map((link) => (
-              <Link
-                key={link.key}
-                href={link.href}
-                className="text-gris text-base hover:text-noir transition-colors"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                {t(link.key)}
-              </Link>
+            {navEntries.map((entry) => (
+              <div key={entry.key} className="flex flex-col gap-4">
+                <Link
+                  href={entry.href}
+                  className="text-gris text-base hover:text-noir transition-colors"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  {t(entry.labelKey)}
+                </Link>
+                {entry.children?.map((child) => (
+                  <Link
+                    key={child.key}
+                    href={child.href}
+                    className="pl-4 text-gris text-base hover:text-noir transition-colors"
+                    onClick={() => setIsMenuOpen(false)}
+                  >
+                    {t(child.labelKey)}
+                  </Link>
+                ))}
+              </div>
             ))}
             {(showSponsorCta || cfpUrl) && <hr className="border-gray-100" />}
             {showSponsorCta && (

--- a/src/frontend/src/lib/nav.ts
+++ b/src/frontend/src/lib/nav.ts
@@ -1,0 +1,50 @@
+import type { Edition } from "@/lib/types";
+
+// A public navigation entry. `labelKey` is a key under the `nav` i18n
+// namespace. An entry may carry `children` — currently only "Programme",
+// which nests "Conférences" once the schedule (planning) is ready (#203).
+export interface NavEntry {
+  key: string;
+  labelKey: string;
+  href: string;
+  children?: NavEntry[];
+}
+
+const CONFERENCES_ENTRY: NavEntry = {
+  key: "conferences",
+  labelKey: "conferences",
+  href: "/conferences",
+};
+
+const SPEAKERS_ENTRY: NavEntry = { key: "speakers", labelKey: "speakers", href: "/speakers" };
+const SPONSORS_ENTRY: NavEntry = { key: "sponsors", labelKey: "sponsors", href: "/sponsors" };
+const BLOG_ENTRY: NavEntry = { key: "blog", labelKey: "blog", href: "/actualites" };
+
+// Build the ordered public nav entries for the given edition. Conference-,
+// speaker- and sponsor-related links only appear once their content is live.
+// While there are published talks but no schedule yet, "Conférences" is a
+// top-level link; once the schedule is ready it becomes a "Programme" menu
+// with "Conférences" nested underneath (#203).
+export function getPublicNavEntries(edition: Edition | null): NavEntry[] {
+  const entries: NavEntry[] = [];
+
+  if (edition?.isScheduleReady) {
+    // The schedule (planning) page lives at /programme and is built in Lot 3.
+    // Until it exists, the parent points to /conferences so the menu never
+    // leads to a 404; flip this href to /programme when the page ships.
+    entries.push({
+      key: "program",
+      labelKey: "program",
+      href: "/conferences",
+      children: [CONFERENCES_ENTRY],
+    });
+  } else if (edition?.isProgramPublished) {
+    entries.push(CONFERENCES_ENTRY);
+  }
+
+  if (edition?.hasSpeakers) entries.push(SPEAKERS_ENTRY);
+  if (edition?.hasSponsors) entries.push(SPONSORS_ENTRY);
+  entries.push(BLOG_ENTRY);
+
+  return entries;
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface Edition {
   sponsorPageStatus: SponsorPageStatus;
   sponsorTemporaryFormUrl: string | null;
   isProgramPublished: boolean;
+  isScheduleReady: boolean;
   hasSpeakers: boolean;
   hasSponsors: boolean;
 }


### PR DESCRIPTION
Ferme #203.

## Résumé

- Un lien **« Conférences »** de niveau 1 apparaît dès qu'il y a des conférences **publiées**.
- Dès que le **planning est prêt** (une conférence publiée a un créneau `startsAt`), le lien devient un menu **« Programme »** avec **« Conférences »** en sous-entrée.
- Corrige le bug observé après #201 : le lien « Programme » (qui pointait vers `/conferences` et n'apparaissait que si des talks étaient publiés) mélangeait liste des conférences et planning.

## Détails techniques

- Backend : nouveau flag **`isScheduleReady`** sur `/api/editions/current` (une conférence publiée avec `startsAt` non nul), à côté de `isProgramPublished` (au moins une conférence publiée).
- Construction de la nav centralisée dans **`lib/nav.ts`**, partagée par le Header (dropdown au survol, `haspopup`) et le Footer (liste indentée), en FR et EN.
- i18n : ajout de `nav.conferences` (« Conférences » / « Talks »).
- Le menu parent « Programme » pointe pour l'instant vers `/conferences` (la page planning `/programme` est du Lot 3, hors scope) — un commentaire indique de basculer le href quand la page existera.

## Test plan

- [x] `tsc` backend + `next build` + `eslint` : OK
- [x] Vérif navigateur (Chrome DevTools MCP) en local :
  - conférences publiées, aucun créneau → **« Conférences »** niveau 1 (header + footer)
  - une conférence avec créneau → **« Programme »** niveau 1, **« Conférences »** en sous-menu (dropdown header + indenté footer)
  - API : `isProgramPublished` / `isScheduleReady` corrects dans les deux états
  - aucune erreur console
- [ ] Re-vérif sur dev-j après déploiement
