### PR TITLE
Import Sessionize : stocker les photos speakers en local pour que les avatars s'affichent (#205)

### DIFF
--- a/src/backend/src/lib/image-store.ts
+++ b/src/backend/src/lib/image-store.ts
@@ -4,8 +4,9 @@ import crypto from "node:crypto";
 import sharp from "sharp";
 
 // Single source of truth for where uploaded media lives. Served publicly at
-// /uploads/ (see index.ts static route).
-export const UPLOADS_DIR = "/app/uploads";
+// /uploads/ (see index.ts static route). The container mounts it at /app/uploads;
+// UPLOADS_DIR overrides the path when running outside Docker.
+export const UPLOADS_DIR = process.env.UPLOADS_DIR || "/app/uploads";
 
 // Raster images larger than this width (px) are downscaled before storage.
 export const COMPRESS_MAX_WIDTH = 2560;

--- a/src/backend/src/lib/image-store.ts
+++ b/src/backend/src/lib/image-store.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import sharp from "sharp";
+
+// Single source of truth for where uploaded media lives. Served publicly at
+// /uploads/ (see index.ts static route).
+export const UPLOADS_DIR = "/app/uploads";
+
+// Raster images larger than this width (px) are downscaled before storage.
+export const COMPRESS_MAX_WIDTH = 2560;
+export const COMPRESS_QUALITY = 85;
+// Mimetypes we run through sharp. SVG (vector) and ICO (multi-res icon
+// container) are intentionally excluded — re-encoding them would lose
+// information or fail outright.
+export const COMPRESSIBLE_MIMES = new Set(["image/jpeg", "image/png", "image/webp"]);
+
+// Remote fetches are bounded: a hostile or broken source must not hang the
+// import nor exhaust memory.
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_REMOTE_IMAGE_SIZE = 10_000_000; // 10 MB
+
+const EXT_BY_MIME: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+};
+
+// Compress a raster image buffer, keeping the original when re-encoding would
+// not save bytes. Returns the buffer to persist.
+function compress(buffer: Buffer, mimetype: string): Promise<Buffer> {
+  if (!COMPRESSIBLE_MIMES.has(mimetype)) return Promise.resolve(buffer);
+
+  return (async () => {
+    try {
+      const pipeline = sharp(buffer, { failOn: "none" }).rotate(); // honor EXIF orientation
+      const meta = await pipeline.metadata();
+
+      const needsResize = (meta.width ?? 0) > COMPRESS_MAX_WIDTH;
+      if (needsResize) {
+        pipeline.resize({ width: COMPRESS_MAX_WIDTH, withoutEnlargement: true });
+      }
+
+      if (mimetype === "image/jpeg") {
+        pipeline.jpeg({ quality: COMPRESS_QUALITY, mozjpeg: true });
+      } else if (mimetype === "image/webp") {
+        pipeline.webp({ quality: COMPRESS_QUALITY });
+      } else {
+        pipeline.png({ compressionLevel: 9 });
+      }
+
+      const processed = await pipeline.toBuffer();
+      return needsResize || processed.length < buffer.length ? processed : buffer;
+    } catch {
+      // Corrupt or unsupported variant — store the original rather than fail.
+      return buffer;
+    }
+  })();
+}
+
+// Persist an image buffer under /uploads/ and return its public URL.
+export async function storeImageBuffer(buffer: Buffer, mimetype: string): Promise<string> {
+  const finalBuffer = await compress(buffer, mimetype);
+  const ext = EXT_BY_MIME[mimetype] ?? ".jpg";
+  const uniqueName = `${Date.now()}-${crypto.randomBytes(4).toString("hex")}${ext}`;
+
+  await fs.promises.mkdir(UPLOADS_DIR, { recursive: true });
+  await fs.promises.writeFile(path.join(UPLOADS_DIR, uniqueName), finalBuffer);
+
+  return `/uploads/${uniqueName}`;
+}
+
+// Download a remote image and store it locally, returning its /uploads/ URL.
+// Throws on any problem (bad status, non-image, oversized, timeout) so callers
+// can decide whether to warn and carry on.
+export async function fetchAndStoreImage(url: string): Promise<string> {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { accept: "image/*" },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const contentType = (res.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+  if (!contentType.startsWith("image/")) {
+    throw new Error(`not an image (content-type: ${contentType || "none"})`);
+  }
+
+  const buffer = Buffer.from(await res.arrayBuffer());
+  if (buffer.length === 0) throw new Error("empty response");
+  if (buffer.length > MAX_REMOTE_IMAGE_SIZE) {
+    throw new Error(`too large (${buffer.length} bytes, max ${MAX_REMOTE_IMAGE_SIZE})`);
+  }
+
+  // Don't trust Content-Type alone: confirm the bytes really are an image and
+  // resolve the true format before storing.
+  const format = (await sharp(buffer, { failOn: "none" }).metadata()).format;
+  if (!format) throw new Error("unreadable image data");
+  const realMime = `image/${format === "jpg" ? "jpeg" : format}`;
+
+  return storeImageBuffer(buffer, realMime);
+}

--- a/src/backend/src/lib/sessionize-import.test.ts
+++ b/src/backend/src/lib/sessionize-import.test.ts
@@ -1,13 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   socialKeyFor,
   buildSocialLinks,
   matchEnum,
   categoryRole,
+  isLocalUpload,
   loadSessionizeData,
+  resolveSpeakerPhoto,
   FORMAT_KEYWORDS,
   LEVEL_KEYWORDS,
+  type ImportReport,
 } from "./sessionize-import.js";
+import { fetchAndStoreImage } from "./image-store.js";
+
+vi.mock("./image-store.js", () => ({ fetchAndStoreImage: vi.fn() }));
 
 describe("socialKeyFor", () => {
   it("maps by linkType", () => {
@@ -76,6 +82,90 @@ describe("categoryRole", () => {
     expect(categoryRole({ id: 1, title: "Session format", items: [] })).toBe("format");
     expect(categoryRole({ id: 2, title: "Niveau", items: [] })).toBe("level");
     expect(categoryRole({ id: 3, title: "Track", items: [] })).toBe("track");
+  });
+});
+
+describe("isLocalUpload", () => {
+  it("recognizes locally stored images only", () => {
+    expect(isLocalUpload("/uploads/123-abc.jpg")).toBe(true);
+    expect(isLocalUpload("https://sessionize.com/image/abc.jpg")).toBe(false);
+    expect(isLocalUpload(null)).toBe(false);
+    expect(isLocalUpload(undefined)).toBe(false);
+  });
+});
+
+describe("resolveSpeakerPhoto", () => {
+  const emptyReport = (): ImportReport => ({
+    speakers: { created: 0, updated: 0 },
+    talks: { created: 0, updated: 0 },
+    categories: { created: 0, reused: 0 },
+    links: 0,
+    warnings: [],
+  });
+
+  beforeEach(() => {
+    vi.mocked(fetchAndStoreImage).mockReset();
+  });
+
+  it("downloads a remote picture and returns its local URL", async () => {
+    vi.mocked(fetchAndStoreImage).mockResolvedValue("/uploads/1-a.jpg");
+    const report = emptyReport();
+
+    const url = await resolveSpeakerPhoto("https://sessionize.com/image/a.jpg", null, "Jane", report);
+
+    expect(url).toBe("/uploads/1-a.jpg");
+    expect(fetchAndStoreImage).toHaveBeenCalledWith("https://sessionize.com/image/a.jpg");
+    expect(report.warnings).toEqual([]);
+  });
+
+  it("keeps an existing local photo without re-downloading (idempotence)", async () => {
+    const report = emptyReport();
+
+    const url = await resolveSpeakerPhoto(
+      "https://sessionize.com/image/a.jpg",
+      "/uploads/existing.jpg",
+      "Jane",
+      report,
+    );
+
+    expect(url).toBe("/uploads/existing.jpg");
+    expect(fetchAndStoreImage).not.toHaveBeenCalled();
+  });
+
+  it("re-downloads when the stored photo is still a remote URL", async () => {
+    vi.mocked(fetchAndStoreImage).mockResolvedValue("/uploads/2-b.jpg");
+    const report = emptyReport();
+
+    const url = await resolveSpeakerPhoto(
+      "https://sessionize.com/image/b.jpg",
+      "https://sessionize.com/image/b.jpg",
+      "Jane",
+      report,
+    );
+
+    expect(url).toBe("/uploads/2-b.jpg");
+    expect(fetchAndStoreImage).toHaveBeenCalled();
+  });
+
+  it("returns null without calling the network when there is no picture", async () => {
+    const report = emptyReport();
+
+    expect(await resolveSpeakerPhoto(null, null, "Jane", report)).toBeNull();
+    expect(await resolveSpeakerPhoto("   ", null, "Jane", report)).toBeNull();
+    expect(fetchAndStoreImage).not.toHaveBeenCalled();
+    expect(report.warnings).toEqual([]);
+  });
+
+  it("warns and keeps importing when the download fails", async () => {
+    vi.mocked(fetchAndStoreImage).mockRejectedValue(new Error("HTTP 404"));
+    const report = emptyReport();
+
+    const url = await resolveSpeakerPhoto("https://sessionize.com/image/gone.jpg", null, "Jane", report);
+
+    expect(url).toBeNull();
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toContain("Jane");
+    expect(report.warnings[0]).toContain("HTTP 404");
   });
 });
 

--- a/src/backend/src/lib/sessionize-import.ts
+++ b/src/backend/src/lib/sessionize-import.ts
@@ -1,3 +1,4 @@
+import { fetchAndStoreImage } from "./image-store.js";
 import { prisma } from "./prisma.js";
 import { slugify, uniqueSlug } from "./slug.js";
 
@@ -118,6 +119,35 @@ export function categoryRole(c: SzCategory): "format" | "level" | "track" {
   return "track";
 }
 
+export function isLocalUpload(url: string | null | undefined): boolean {
+  return !!url && url.startsWith("/uploads/");
+}
+
+// Sessionize serves speaker pictures from its own CDN, which next/image refuses
+// to load (host not in remotePatterns) — so we pull the file into /uploads/ and
+// store a local URL instead (#205). Re-imports keep an existing local photo
+// rather than downloading it again (RG-217 idempotence). A download failure is
+// never fatal: the speaker is imported without a photo and a warning is
+// reported.
+export async function resolveSpeakerPhoto(
+  remoteUrl: string | null | undefined,
+  currentPhotoUrl: string | null,
+  speakerName: string,
+  report: ImportReport,
+): Promise<string | null> {
+  if (isLocalUpload(currentPhotoUrl)) return currentPhotoUrl;
+  if (!remoteUrl?.trim()) return null;
+
+  try {
+    return await fetchAndStoreImage(remoteUrl.trim());
+  } catch (err) {
+    report.warnings.push(
+      `Photo de ${speakerName} non importée : ${(err as Error).message}.`,
+    );
+    return null;
+  }
+}
+
 // Run the idempotent import. Speakers/talks are matched by their slug derived
 // from name/title within the edition (RG-206/RG-214); re-importing the same
 // data updates existing rows instead of duplicating them (RG-217 idempotence).
@@ -174,10 +204,11 @@ export async function importSessionize(
   // 3. Upsert speakers, keyed by slug. Track the resulting db id per Sessionize id.
   const existingSpeakers = await prisma.speaker.findMany({
     where: { editionId },
-    select: { id: true, slug: true },
+    select: { id: true, slug: true, photoUrl: true },
   });
   const takenSpeakerSlugs = new Set(existingSpeakers.map((s) => s.slug));
   const speakerSlugToId = new Map(existingSpeakers.map((s) => [s.slug, s.id]));
+  const photoUrlBySlug = new Map(existingSpeakers.map((s) => [s.slug, s.photoUrl]));
   const dbIdBySzSpeakerId = new Map<string, number>();
 
   for (const sz of data.speakers ?? []) {
@@ -190,6 +221,13 @@ export async function importSessionize(
     const { social, count } = buildSocialLinks(sz.links);
     report.links += count;
 
+    const photoUrl = await resolveSpeakerPhoto(
+      sz.profilePicture,
+      photoUrlBySlug.get(baseSlug) ?? null,
+      name,
+      report,
+    );
+
     const existingId = speakerSlugToId.get(baseSlug);
     if (existingId) {
       const updated = await prisma.speaker.update({
@@ -198,7 +236,7 @@ export async function importSessionize(
           name,
           company: sz.tagLine?.trim() || null,
           bioFr: sz.bio?.trim() || null,
-          photoUrl: sz.profilePicture || null,
+          photoUrl,
           socialLinks: count > 0 ? JSON.stringify(social) : null,
         },
       });
@@ -214,7 +252,7 @@ export async function importSessionize(
           name,
           company: sz.tagLine?.trim() || null,
           bioFr: sz.bio?.trim() || null,
-          photoUrl: sz.profilePicture || null,
+          photoUrl,
           socialLinks: count > 0 ? JSON.stringify(social) : null,
           publicationStatus: "DRAFT",
         },

--- a/src/backend/src/routes/admin/files.ts
+++ b/src/backend/src/routes/admin/files.ts
@@ -5,9 +5,14 @@ import crypto from "node:crypto";
 import sharp from "sharp";
 import { prisma } from "../../lib/prisma.js";
 import { generateAltText } from "../../lib/alt-text.js";
+import {
+  COMPRESSIBLE_MIMES,
+  COMPRESS_MAX_WIDTH,
+  COMPRESS_QUALITY,
+  UPLOADS_DIR,
+} from "../../lib/image-store.js";
 import { TranslationError, QuotaExhaustedError } from "../../lib/translation/errors.js";
 
-const UPLOADS_DIR = "/app/uploads";
 const ALLOWED_MIMES = [
   // Images
   "image/jpeg", "image/png", "image/webp", "image/gif", "image/svg+xml",
@@ -22,17 +27,6 @@ const ALLOWED_MIMES = [
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ];
 const MAX_FILE_SIZE = 20_000_000; // 20 MB
-
-// Raster images larger than this width (px) are downscaled before storage.
-// 2560 fits modern desktop hero images (1920–2560 logical width × 2 DPR
-// covered by Next.js srcset) without keeping multi-megapixel originals
-// that nobody ever displays at full size.
-const COMPRESS_MAX_WIDTH = 2560;
-const COMPRESS_QUALITY = 85;
-// Mimetypes we run through sharp. SVG (vector) and ICO (multi-res icon
-// container) are intentionally excluded — re-encoding them would lose
-// information or fail outright.
-const COMPRESSIBLE_MIMES = new Set(["image/jpeg", "image/png", "image/webp"]);
 
 export default async function adminFileRoutes(app: FastifyInstance) {
   // POST /api/admin/files — upload a single file (image or document)


### PR DESCRIPTION
Ferme #205.

## Résumé

Les avatars des speakers importés depuis Sessionize ne s'affichaient pas : l'import stockait `photoUrl` = l'URL du CDN Sessionize, or [next.config.ts](src/frontend/next.config.ts) n'autorise que `picsum.photos` dans `images.remotePatterns` — `next/image` refusait donc l'hôte, cassant tous les rendus (cartes, fiche speaker, page conférence, grille d'édition, page sponsor).

**Correctif** : télécharger la photo à l'import et la stocker sous `/uploads/`, comme tous les autres médias du site — plutôt que de dépendre d'un CDN tiers.

## Détails

- Nouveau **`lib/image-store.ts`** : le pipeline `sharp` (compression, downscale à 2560px, qualité 85) est extrait du handler d'upload et **partagé** avec [admin/files.ts](src/backend/src/routes/admin/files.ts) — plus de constantes dupliquées.
- `fetchAndStoreImage()` télécharge avec des garde-fous : **timeout 10 s**, **plafond 10 Mo**, et le type réel est **déduit des octets via sharp** (on ne fait pas confiance au seul `Content-Type`).
- `resolveSpeakerPhoto()` encode la politique : photo locale existante **conservée** (idempotence du ré-import, RG-217) ; échec de téléchargement → **avertissement dans le rapport, import poursuivi** (le speaker est créé sans photo).
- `UPLOADS_DIR` devient surchargeable par variable d'environnement (défaut `/app/uploads`) — le conteneur ne change pas de comportement, mais le pipeline devient exerçable hors Docker.

## Test plan

- [x] `tsc --noEmit` backend : OK
- [x] **6 nouveaux tests** sur la politique de photo (téléchargement, idempotence, re-téléchargement si l'URL stockée est encore distante, absence de photo, échec → warning) — `sessionize-import.test.ts` passe à **19 tests verts**
- [x] Suite backend : aucune régression introduite (13 fichiers en échec **avant comme après** — échecs pré-existants liés à l'absence de base locale / tests d'environnement ; réussis 143 → **149**)
- [x] **Vérification réelle du pipeline** (téléchargements effectifs) :
  - JPEG 400×400 → stocké `/uploads/…jpg`, dimensions préservées
  - image 4000px de large → **downscalée à 2560×768**
  - URL 404 → rejet propre (`HTTP 404`)
  - page HTML → rejet (`not an image (content-type: text/html)`)
- [ ] **Reste à faire — validation navigateur de bout en bout** : Docker Desktop est tombé en erreur 500 en fin de session, je n'ai pas pu jouer un import Sessionize complet dans l'admin puis constater l'affichage des avatars sur les pages publiques. À vérifier avant promotion vers `dev`.
