### PR TITLE
Conférences — liste publique des sessions de l'édition en cours (#207)

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -53,6 +53,74 @@ feature/us-xxx-description
 - Les branches feature sont supprimées après merge.
 - Stratégie de merge : **squash merge** pour les PRs vers `dev` et `main` (un commit propre par feature). Merge classique autorisé de feature vers `dev-{initiale}`.
 
+## Issues, milestones et versions
+
+Trois outils, trois questions distinctes — ne pas les mélanger.
+
+| Outil | Répond à | Se ferme quand |
+|-------|----------|----------------|
+| **Milestone « Lot N »** | Le périmètre initial est-il couvert ? | Toutes ses issues sont faites |
+| **Release `vX.Y.Z`** | Qu'est-ce qui est parti en prod, et quand ? | Le tag est poussé |
+| **Label** (`bug`, `enhancement`…) | De quoi s'agit-il ? | — (filtre, pas compteur) |
+
+### Fermeture des issues
+
+`main` est la branche par défaut : GitHub n'honore les mots-clés de fermeture
+(`Closes`, `Fixes`) que sur une PR mergée **dans `main`**. Une PR feature mergée
+dans `dev-{initiale}` ne ferme donc **rien**.
+
+- **PR feature → `dev-{initiale}`** : écrire `Refs #123` (lie sans fermer).
+- **PR de promotion `dev → main`** : écrire `Closes #123` pour **chaque** issue
+  embarquée. Les issues se ferment ainsi au moment exact de la mise en prod.
+
+Les PRs vers `dev` et `main` étant **squashées**, les SHA d'origine disparaissent :
+la PR de promotion est le **seul** endroit fiable pour porter les `Closes`. La skill
+`deploy-to-prod` collecte les `Refs #` du diff `main..dev` pour construire ce bloc.
+
+### Label `corrigé` — suivi entre le merge et la prod
+
+Une issue corrigée reste **ouverte** jusqu'à la mise en prod (cf. ci-dessus). Sans marqueur,
+elle apparaît comme « à faire » alors que le travail est fait. D'où le label `corrigé`.
+
+**Au merge d'une PR feature vers `dev-{initiale}`**, pour chaque issue traitée :
+
+1. Poser le label `corrigé` sur l'issue.
+2. **Commenter l'issue** en citant le ou les commits qui la corrigent (SHA court + sujet).
+   Le commentaire porte le *quand* et le *quoi* ; le label ne sert qu'à filtrer.
+
+```bash
+gh issue edit <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --add-label "corrigé"
+gh issue comment <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --body-file - <<'EOF'
+**Corrigé** — mergé dans `dev` (beta), en attente de mise en production.
+
+- `<sha>` — `<sujet du commit>`
+
+L'issue sera fermée automatiquement lors de la promotion `dev → main` (release).
+EOF
+```
+
+Filtres GitHub correspondants :
+
+| Recherche | Donne |
+|---|---|
+| `is:issue is:open -label:corrigé` | **Ce qu'il reste à corriger** |
+| `is:issue is:open label:corrigé` | Corrigé, en attente de mise en prod |
+
+Le label **n'est jamais retiré** : il décrit l'état de l'issue (`corrigé`), pas un
+environnement. À la release, l'issue se ferme via `Closes` et le label reste vrai.
+
+### Rattachement au milestone
+
+- Une issue va dans un milestone **seulement si elle appartient au périmètre du Lot** —
+  y compris un bug qui empêche de déclarer le Lot terminé.
+- Un **bug ou une amélioration découverts après la livraison du Lot** n'ont **pas**
+  de milestone : ils portent un label (`bug`, `enhancement`) et apparaissent dans les
+  notes de la release qui les embarque.
+- Test : « peut-on déclarer le Lot terminé en laissant cette issue ouverte ? »
+  Oui → pas de milestone. Non → milestone.
+- Ne **jamais** créer de milestone fourre-tout permanent (`Backlog`, `v1.x`,
+  `Maintenance`) : sans fin, la barre de progression ne veut rien dire. Utiliser un label.
+
 ## Remote Operations
 - Remote git commands are allowed (`git push`, `git pull`, `git fetch`, `gh pr create`, etc.)
 - SSH is configured via PuTTY/Pageant — no special handling needed

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -82,7 +82,8 @@ la PR de promotion est le **seul** endroit fiable pour porter les `Closes`. La s
 Une issue corrigée reste **ouverte** jusqu'à la mise en prod (cf. ci-dessus). Sans marqueur,
 elle apparaît comme « à faire » alors que le travail est fait. D'où le label `corrigé`.
 
-**Au merge d'une PR feature vers `dev-{initiale}`**, pour chaque issue traitée :
+**Dès l'arrivée du correctif sur `dev-{initiale}`** (merge de la branche feature, ou commit
+direct), pour chaque issue traitée :
 
 1. Poser le label `corrigé` sur l'issue.
 2. **Commenter l'issue** en citant le ou les commits qui la corrigent (SHA court + sujet).
@@ -91,13 +92,17 @@ elle apparaît comme « à faire » alors que le travail est fait. D'où le labe
 ```bash
 gh issue edit <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --add-label "corrigé"
 gh issue comment <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --body-file - <<'EOF'
-**Corrigé** — mergé dans `dev` (beta), en attente de mise en production.
+**Corrigé** — mergé sur `dev-j`, en attente de mise en production.
 
 - `<sha>` — `<sujet du commit>`
 
 L'issue sera fermée automatiquement lors de la promotion `dev → main` (release).
 EOF
 ```
+
+> Le label dit que **le correctif est écrit et mergé sur la branche de dev** — pas qu'il est
+> déployé en beta ni en prod. C'est voulu : il décrit l'état de l'issue, qui ne change plus.
+> L'environnement, lui, se lit dans les branches (`main..dev`) et les releases.
 
 Filtres GitHub correspondants :
 

--- a/.claude/skills/deploy-to-prod/SKILL.md
+++ b/.claude/skills/deploy-to-prod/SKILL.md
@@ -49,8 +49,9 @@ git diff origin/main..origin/dev -- src/backend/prisma/migrations/
 
 ### Cohérence du label `corrigé`
 
-Les issues traitées portent le label `corrigé` (posé au merge vers `dev` — cf.
-[`.claude/rules/git-workflow.md`](../../rules/git-workflow.md)). Vérifier qu'aucune n'a été oubliée :
+Les issues traitées portent le label `corrigé` (posé dès l'arrivée du correctif sur
+`dev-{initiale}` — cf. [`.claude/rules/git-workflow.md`](../../rules/git-workflow.md)).
+Vérifier qu'aucune de celles qui **partent en prod** n'a été oubliée :
 
 ```bash
 # Issues ouvertes référencées par les commits promus
@@ -63,6 +64,10 @@ comm -12 /tmp/refs.txt /tmp/open.txt
 ⚠️ Un `#NN` peut être un **numéro de PR**, pas d'issue — **vérifier chaque candidat**
 (`gh issue view <NN>`) avant de conclure. Celles qui sont de vraies issues corrigées et
 qui n'ont pas le label : le poser + commenter les commits (voir la règle).
+
+> L'inverse n'est **pas** une anomalie : une issue `corrigé` absente de `main..dev` est
+> simplement restée sur une branche `dev-{initiale}` non encore promue vers `dev`. Elle
+> partira à la release suivante — ne pas la faire figurer dans les `Closes` de cette PR.
 
 ### Fenêtre de déploiement
 

--- a/.claude/skills/deploy-to-prod/SKILL.md
+++ b/.claude/skills/deploy-to-prod/SKILL.md
@@ -47,6 +47,23 @@ git diff origin/main..origin/dev -- src/backend/prisma/migrations/
   et le signaler à l'utilisateur.
 - **Secrets** : vérifier qu'aucun secret n'est dans le diff promu (chercher `SECRET`/`KEY`/`PASSWORD`/`TOKEN`).
 
+### Cohérence du label `corrigé`
+
+Les issues traitées portent le label `corrigé` (posé au merge vers `dev` — cf.
+[`.claude/rules/git-workflow.md`](../../rules/git-workflow.md)). Vérifier qu'aucune n'a été oubliée :
+
+```bash
+# Issues ouvertes référencées par les commits promus
+git log origin/main..origin/dev --pretty=%s | grep -oE '#[0-9]+' | tr -d '#' | sort -u > /tmp/refs.txt
+gh issue list --repo GDGToulouse/Site-Devfest-Toulouse-2026 --state open --limit 200 \
+  --json number --jq '.[].number' | sort -u > /tmp/open.txt
+comm -12 /tmp/refs.txt /tmp/open.txt
+```
+
+⚠️ Un `#NN` peut être un **numéro de PR**, pas d'issue — **vérifier chaque candidat**
+(`gh issue view <NN>`) avant de conclure. Celles qui sont de vraies issues corrigées et
+qui n'ont pas le label : le poser + commenter les commits (voir la règle).
+
 ### Fenêtre de déploiement
 
 Rappeler à l'utilisateur : **ne pas déployer à J-1 du DevFest** ni pendant un pic
@@ -90,6 +107,27 @@ entrées de `## [Non publié]` vers une nouvelle section `## [X.Y.Z] - AAAA-MM-J
 ## Étape 3 — Promouvoir (PR dev → main)
 
 La stratégie de merge vers `main` est **squash**.
+
+### Collecter les issues à fermer
+
+`main` étant la branche par défaut, **seule** cette PR peut fermer les issues (les PR
+feature vers `dev-{initiale}` écrivent `Refs #`, qui ne ferme rien). Le squash ayant
+effacé les SHA d'origine, le bloc `Closes` de cette PR est le **seul** mécanisme fiable.
+
+```bash
+# Issues référencées par les commits promus
+git log origin/main..origin/dev --pretty=%B | grep -oE '#[0-9]+' | sort -u
+```
+
+Croiser avec les entrées du CHANGELOG (étape 2) — même périmètre. **Montrer la liste à
+l'utilisateur pour validation** (un `#123` peut être une simple mention, pas une issue
+à fermer), puis ajouter dans le body de la PR :
+
+```markdown
+## Issues fermées
+Closes #123
+Closes #145
+```
 
 ### ⚠️ Faux conflit `add/add` après squash
 
@@ -168,6 +206,15 @@ Garde-fous :
 - **Un seul tag par version**, jamais déplacé une fois poussé.
 - `--generate-notes` compile les PR mergées depuis le tag précédent.
 
+Vérifier que les `Closes` de l'étape 3 ont bien fermé les issues (le merge dans `main`
+les ferme automatiquement — si l'une est encore ouverte, le mot-clé était mal écrit) :
+
+```bash
+gh issue view <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --json number,state
+```
+
+Fermer à la main celles qui seraient restées ouvertes.
+
 ---
 
 ## Étape 7 — Migrer les données — **à la demande UNIQUEMENT**
@@ -201,6 +248,7 @@ Ne pas improviser. Voir [`docs/mise-en-production.md`](../../../docs/mise-en-pro
 - [ ] Diff réel `main..dev` revu, **migrations Prisma lues** (destructives repérées)
 - [ ] Bump SemVer choisi et **confirmé**
 - [ ] `APP_VERSION` + 2× `package.json` + `CHANGELOG.md` mis à jour dans la PR de promotion
+- [ ] Issues embarquées listées en `Closes #NN` dans le body de la PR de promotion (validées par l'utilisateur)
 - [ ] PR `dev → main` squashée, approuvée, mergée (faux conflit géré si besoin)
 - [ ] (si migration) **Backup DB prod** effectué avant déploiement
 - [ ] Déploiement Coolify OK, `/api/health` renvoie la **nouvelle** version

--- a/.claude/skills/github-issue/SKILL.md
+++ b/.claude/skills/github-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-issue
-description: Rédige une issue GitHub cohérente pour le repo GDGToulouse/Site-Devfest-Toulouse-2026 — création d'une nouvelle issue OU enrichissement d'une issue existante via commentaire (sans écraser le body). Interview l'utilisateur sur les détails manquants, applique les conventions du repo (labels bug/enhancement/documentation/question, rattachement à un milestone « Lot N »), cite de vrais fichiers/lignes du repo et des specs docs/. Trigger phrases — création « crée une issue pour… », « ouvre un ticket… », « ajoute une issue sur… », « ouvre une issue GitHub pour… ». Refine « rédige l'issue #X », « clean up issue #X », « commente l'issue #X », « enrichis l'issue #X », « transforme cette issue ».
+description: Rédige une issue GitHub cohérente pour le repo GDGToulouse/Site-Devfest-Toulouse-2026 — création d'une nouvelle issue OU enrichissement d'une issue existante via commentaire (sans écraser le body). Interview l'utilisateur sur les détails manquants, applique les conventions du repo (labels bug/enhancement/documentation/question, milestone « Lot N » uniquement si l'issue relève du périmètre du lot), cite de vrais fichiers/lignes du repo et des specs docs/. Trigger phrases — création « crée une issue pour… », « ouvre un ticket… », « ajoute une issue sur… », « ouvre une issue GitHub pour… ». Refine « rédige l'issue #X », « clean up issue #X », « commente l'issue #X », « enrichis l'issue #X », « transforme cette issue ».
 ---
 
 # Rédaction d'issue GitHub — site DevFest Toulouse
@@ -11,7 +11,9 @@ Skill bi-mode :
 
 Repo cible : `GDGToulouse/Site-Devfest-Toulouse-2026` sur `github.com`. CLI : `gh` (authentifiée). Langue : **français**.
 
-> **Contexte projet** : site Next.js (`src/frontend/`) + API Fastify/Prisma (`src/backend/`), bilingue FR/EN. Le travail est découpé en **milestones « Lot 1 → Lot 5 »** — rattacher chaque issue au bon Lot est une convention forte du repo. Voir [CLAUDE.md](../../../CLAUDE.md) et les specs `docs/`.
+> **Contexte projet** : site Next.js (`src/frontend/`) + API Fastify/Prisma (`src/backend/`), bilingue FR/EN. Voir [CLAUDE.md](../../../CLAUDE.md) et les specs `docs/`.
+>
+> **Milestones « Lot 1 → Lot 5 »** : ils mesurent la couverture du **périmètre initial**, pas les versions. Une issue n'y est rattachée que si elle appartient à ce périmètre. Un **bug ou une amélioration découverts après la livraison du Lot n'ont pas de milestone** — juste un label. Règle complète : [`.claude/rules/git-workflow.md`](../../rules/git-workflow.md) § « Issues, milestones et versions ».
 
 ## Pre-flight — éviter le travail dupliqué
 
@@ -51,7 +53,9 @@ Ne jamais lancer `gh issue create` sans avoir fait cette recherche.
 À partir du brief utilisateur :
 - Identifier la **nature** → label de type (`bug`, `enhancement`, `documentation`, `question`)
 - Déterminer si c'est une **User Story** → la structurer comme telle dans le body (le repo n'a pas de label `user-story` ; le format suffit)
-- Identifier le **milestone** (« Lot N ») le plus pertinent → voir [references/milestones.md](references/milestones.md). Demander si ambigu.
+- Décider s'il y a un **milestone**. Test : *« peut-on déclarer le Lot terminé en laissant cette issue ouverte ? »*
+  - **Non** (l'issue fait partie du périmètre du Lot, y compris un bug qui l'empêche d'être « done ») → rattacher au Lot → voir [references/milestones.md](references/milestones.md). Demander si ambigu.
+  - **Oui** (bug / amélioration découverts **après** la livraison du Lot) → **pas de milestone**, le label suffit.
 - Identifier les **specs concernées** dans `docs/` → à citer dans le body (`docs/fonctionnalites-2026.md`, `docs/modele-donnees-metier.md`, etc.)
 
 Voir [references/labels.md](references/labels.md) pour les labels disponibles.
@@ -176,7 +180,7 @@ gh issue list --repo GDGToulouse/Site-Devfest-Toulouse-2026 --milestone "Lot 3 �
 - **Pas de secrets** : pas de tokens, mots de passe, clés, `DATABASE_URL`, secrets OAuth/SMTP. Hostnames publics (`*.site.devfesttoulouse.fr`), noms de modèles, versions OK.
 - **Liens** : `[AboutSection.tsx](src/frontend/src/components/home/AboutSection.tsx)` ou `[editions.ts:36](src/backend/src/routes/editions.ts#L36)` (relatif au repo) ; `#NN` pour issues liées ; specs `docs/fonctionnalites-2026.md` ; URL pleine pour ressources externes.
 - **Label obligatoire min.** : 1 label de type (`bug` / `enhancement` / `documentation` / `question`).
-- **Milestone** : rattacher au Lot pertinent dès que possible — c'est la structuration principale du repo.
+- **Milestone** : optionnel, et réservé au **périmètre d'un Lot**. Un bug ou une amélioration post-livraison n'en ont pas. Jamais de milestone fourre-tout (`Backlog`, `v1.x`, `Maintenance`).
 - **Validation utilisateur** : toujours afficher l'issue / commentaire complet AVANT exécution.
 
 ## What NOT to do
@@ -187,7 +191,8 @@ gh issue list --repo GDGToulouse/Site-Devfest-Toulouse-2026 --milestone "Lot 3 �
 - **Ne pas inventer de fichiers / lignes** — vérifier avec `Read`/`Grep` d'abord
 - **Ne pas assumer la nature (bug vs feature)** — demander si flou
 - **Ne pas chaîner les `gh issue edit`** : un seul call pour titre + labels + milestone
-- **Ne pas inventer un milestone** — utiliser un Lot existant ou demander
+- **Ne pas inventer un milestone** — utiliser un Lot existant, ou aucun
+- **Ne pas rattacher un bug post-livraison à un Lot** juste pour lui donner un milestone (ça fausse la mesure du périmètre) — le label suffit
 - **Ne pas ajouter d'assignee / project** tant que l'utilisateur n'en a pas convenu
 - **Ne pas inclure de signature « Generated with Claude Code »** ou équivalent dans le body / commentaire
 

--- a/.claude/skills/github-issue/references/labels.md
+++ b/.claude/skills/github-issue/references/labels.md
@@ -29,10 +29,10 @@ Cumulables (ex. `bug` + `backend` + `admin`).
 
 | Label | Sens | Couleur |
 |---|---|---|
-| `corrigé` | Correction mergée, en attente de mise en production | `#1a7f37` |
+| `corrigé` | Correctif mergé sur `dev-{initiale}`, en attente de mise en production | `#1a7f37` |
 
-**Ne jamais poser `corrigé` à la création d'une issue.** Il est posé au **merge vers
-`dev-{initiale}`**, avec un commentaire citant les commits — voir
+**Ne jamais poser `corrigé` à la création d'une issue.** Il est posé **dès l'arrivée du
+correctif sur `dev-{initiale}`**, avec un commentaire citant les commits — voir
 [`.claude/rules/git-workflow.md`](../../../rules/git-workflow.md) § « Label `corrigé` ».
 
 Filtre associé : `is:issue is:open -label:corrigé` = ce qu'il reste à corriger.

--- a/.claude/skills/github-issue/references/labels.md
+++ b/.claude/skills/github-issue/references/labels.md
@@ -1,6 +1,6 @@
 # Labels — repo `GDGToulouse/Site-Devfest-Toulouse-2026`
 
-Chaque issue **doit** avoir au minimum 1 label de **type**. Le repo n'utilise pas de labels de domaine custom : la **structuration fonctionnelle passe par les milestones « Lot N »** (voir [milestones.md](milestones.md)), pas par des labels.
+Chaque issue **doit** avoir au minimum 1 label de **type**. Trois familles : **type** (obligatoire), **domaine** (optionnel), **état** (posé au fil de l'eau, jamais à la création).
 
 ## Famille type — nature du ticket
 
@@ -13,6 +13,30 @@ Chaque issue **doit** avoir au minimum 1 label de **type**. Le repo n'utilise pa
 
 > `bug` et `enhancement` sont **mutuellement exclusifs**. `documentation` / `question` peuvent se combiner avec un autre type si besoin.
 
+## Famille domaine — où ça se passe
+
+| Label | Périmètre |
+|---|---|
+| `frontend` | Application Next.js (UI publique) |
+| `backend` | API Fastify / Prisma / base de données |
+| `admin` | Back-office d'administration |
+| `seo` | SEO, métadonnées, Open Graph, sitemap |
+| `infra` | Docker Compose, Coolify, réseau, déploiement, SMTP |
+
+Cumulables (ex. `bug` + `backend` + `admin`).
+
+## Famille état
+
+| Label | Sens | Couleur |
+|---|---|---|
+| `corrigé` | Correction mergée, en attente de mise en production | `#1a7f37` |
+
+**Ne jamais poser `corrigé` à la création d'une issue.** Il est posé au **merge vers
+`dev-{initiale}`**, avec un commentaire citant les commits — voir
+[`.claude/rules/git-workflow.md`](../../../rules/git-workflow.md) § « Label `corrigé` ».
+
+Filtre associé : `is:issue is:open -label:corrigé` = ce qu'il reste à corriger.
+
 ## User Story
 
 Le repo **n'a pas de label `user-story`**. Une US se reconnaît à son **format de body** (« En tant que… je veux… afin que… ») ; le label reste `enhancement`. Ne pas créer de label `user-story` sauf demande explicite de l'utilisateur.
@@ -23,7 +47,7 @@ Présents dans le repo, utilisables ponctuellement : `duplicate`, `invalid`, `wo
 
 ## Création de labels
 
-Le repo se contente volontairement des labels par défaut. **Ne pas créer de nouveaux labels** (domaine, priorité…) sans accord explicite de l'utilisateur — la granularité fonctionnelle est portée par les milestones.
+Les trois familles ci-dessus couvrent les besoins. **Ne pas créer de nouveau label** (priorité, statut supplémentaire…) sans accord explicite de l'utilisateur.
 
 Si l'utilisateur valide la création d'un label :
 

--- a/.claude/skills/github-issue/references/milestones.md
+++ b/.claude/skills/github-issue/references/milestones.md
@@ -1,6 +1,20 @@
 # Milestones « Lot N » — repo `GDGToulouse/Site-Devfest-Toulouse-2026`
 
-Le travail est découpé en **5 lots** = 5 milestones GitHub. **Rattacher chaque issue au bon Lot** est une convention forte de ce repo. En cas d'ambiguïté, demander à l'utilisateur.
+Le périmètre initial du site est découpé en **5 lots** = 5 milestones GitHub. Un milestone mesure **la couverture du périmètre d'un lot** — pas une version, pas le flux de maintenance.
+
+## D'abord : cette issue a-t-elle un milestone ?
+
+> **Test** : *« peut-on déclarer le Lot terminé en laissant cette issue ouverte ? »*
+>
+> - **Non** → l'issue relève du périmètre du Lot → la rattacher (tableau ci-dessous).
+>   Vaut aussi pour un **bug qui empêche la feature d'être « done »** (ex. #205, import
+>   Sessionize incomplet → reste dans le Lot 2).
+> - **Oui** → **pas de milestone**. C'est le cas des bugs et améliorations **découverts
+>   après la livraison du Lot** (ex. #197 perf LCP, #133 césure — détachés du Lot 1).
+>   Le label (`bug`, `enhancement`) suffit ; l'issue apparaîtra dans les notes de la
+>   release qui l'embarque.
+
+Ne **jamais** créer de milestone fourre-tout (`Backlog`, `v1.x`, `Maintenance`) : sans fin, la progression ne veut rien dire. Règle complète : [`.claude/rules/git-workflow.md`](../../../rules/git-workflow.md) § « Issues, milestones et versions ».
 
 Vérifier les intitulés exacts (ils peuvent évoluer) avant de poser un milestone :
 
@@ -30,4 +44,6 @@ gh api repos/GDGToulouse/Site-Devfest-Toulouse-2026/milestones --jq '.[].title'
 
 ## Note
 
-Les Lots 1, 2 et 4 ont déjà des issues livrées ; les Lots 3 et 5 sont encore vides (à décomposer le moment venu). Quand on crée la première issue d'un lot vide, c'est normal — pas besoin de demander confirmation du milestone pour autant, mais signaler que le lot démarre.
+Les 5 lots ont désormais des issues. Les Lots 1 et 2 sont largement livrés — d'où la vigilance sur le test ci-dessus : les issues qui arrivent maintenant sur leur périmètre sont le plus souvent des **bugs post-livraison**, donc **sans milestone**.
+
+Une fois un lot livré, son milestone se ferme et **ne se rouvre pas**. Ne pas y ranger de nouvelles issues pour « garder l'outil vivant ».

--- a/src/frontend/src/app/[locale]/conferences/page.tsx
+++ b/src/frontend/src/app/[locale]/conferences/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
-import { getCurrentEdition } from "@/lib/api";
+import { getCurrentEdition, getEditionTalks } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
+import ConferencesList from "@/components/conferences/ConferencesList";
+import type { TalkFormat } from "@/lib/types";
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
@@ -17,16 +19,23 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+const TALK_FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE"];
+
 export default async function ConferencesPage() {
   const locale = await getLocale();
   const t = await getTranslations("conferences");
   const edition = await getCurrentEdition();
   const year = edition?.year ?? new Date().getFullYear();
+  const talks = edition ? await getEditionTalks(edition.year) : [];
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },
     { label: t("title"), href: `/${locale}/conferences` },
   ];
+
+  const formatLabels = Object.fromEntries(
+    TALK_FORMATS.map((format) => [format, t(`format.${format}`)]),
+  );
 
   return (
     <div className="px-6 py-8 lg:py-12">
@@ -37,14 +46,20 @@ export default async function ConferencesPage() {
           {t("heading", { year })}
         </h1>
 
-        <div className="mt-8 p-8 rounded-3xl bg-blanc shadow-card">
-          <h2 className="text-2xl lg:text-3xl font-bold text-noir">
-            {t("comingSoonTitle")}
-          </h2>
-          <p className="mt-4 text-lg text-gris leading-relaxed">
-            {t("comingSoonBody", { year })}
-          </p>
-        </div>
+        {talks.length > 0 ? (
+          <div className="mt-8">
+            <ConferencesList talks={talks} locale={locale} formatLabels={formatLabels} />
+          </div>
+        ) : (
+          <div className="mt-8 p-8 rounded-3xl bg-blanc shadow-card">
+            <h2 className="text-2xl lg:text-3xl font-bold text-noir">
+              {t("comingSoonTitle")}
+            </h2>
+            <p className="mt-4 text-lg text-gris leading-relaxed">
+              {t("comingSoonBody", { year })}
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/frontend/src/components/conferences/ConferencesList.tsx
+++ b/src/frontend/src/components/conferences/ConferencesList.tsx
@@ -1,0 +1,53 @@
+import { Link } from "@/i18n/navigation";
+
+import type { EditionTalk } from "@/lib/types";
+import { localizedField } from "@/lib/i18n-helpers";
+
+interface ConferencesListProps {
+  talks: EditionTalk[];
+  locale: string;
+  // Pre-resolved labels: the parent owns the `conferences` translation
+  // namespace, so this component stays a plain server component.
+  formatLabels: Record<string, string>;
+}
+
+// Public list of the current edition's published talks (#207). Each entry links
+// to its detail page; badges mirror the ones used there.
+export default function ConferencesList({ talks, locale, formatLabels }: ConferencesListProps) {
+  return (
+    <ul className="space-y-4">
+      {talks.map((talk) => {
+        const title = localizedField(talk, "title", locale);
+        const categoryName = talk.category ? localizedField(talk.category, "name", locale) : null;
+        const speakerNames = talk.speakers.map((s) => s.name).join(", ");
+
+        return (
+          <li key={talk.slug}>
+            <Link
+              href={`/conferences/${talk.slug}`}
+              className="block rounded-2xl bg-blanc shadow-card p-5 transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full bg-bleu/10 px-3 py-1 text-sm font-bold text-bleu">
+                  {formatLabels[talk.format]}
+                </span>
+                {categoryName && (
+                  <span
+                    className="rounded-full px-3 py-1 text-sm font-bold"
+                    style={{ backgroundColor: `${talk.category!.color}20`, color: talk.category!.color }}
+                  >
+                    {categoryName}
+                  </span>
+                )}
+              </div>
+
+              <h2 className="mt-3 text-xl font-bold text-noir">{title}</h2>
+
+              {speakerNames && <p className="mt-1 text-sm text-gris">{speakerNames}</p>}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}


### PR DESCRIPTION
Ferme #207.

## Résumé

`/conferences` n'affichait qu'un bloc « bientôt disponible » statique : la page ne récupérait **aucune** conférence, si bien que les sessions publiées n'apparaissaient nulle part sur le site public — alors même que leurs pages de détail existaient.

La page liste désormais les conférences **publiées** de l'édition en cours.

## Détails

- **Aucune nouvelle route backend** : réutilisation de `GET /api/editions/:year/talks` ([editions.ts:135](src/backend/src/routes/editions.ts#L135)), qui renvoie déjà les talks publiés d'une année avec leurs speakers et leur catégorie, via le helper existant `getEditionTalks()`.
- Nouveau composant [ConferencesList.tsx](src/frontend/src/components/conferences/ConferencesList.tsx) : une carte par conférence — badge **format**, badge **catégorie** (couleur de la catégorie), **titre**, **speakers** — cliquable vers la page de détail. Les badges reprennent le vocabulaire visuel de la page détail.
- Le bloc « bientôt disponible » est **conservé comme état vide**.
- Bilingue FR/EN (`localizedField`).

## Hors scope (conforme à l'issue)

Pas de filtres/recherche (→ #107), pas de grille horaire par salle/créneau (→ #106). Cette PR ne fait que **lister**.

## Test plan

- [x] `eslint` + `next build` : OK
- [x] Vérif navigateur (Chrome DevTools MCP), en local :
  - 2 conférences publiées / 2 en brouillon → **seules les publiées sont listées**
  - clic sur une conférence → page de détail correcte
  - **état vide** : dépublication via l'admin → la liste disparaît, le bloc « Le programme arrive bientôt » réapparaît
  - republication → les 4 conférences (dont celles importées de Sessionize) s'affichent
  - rendu **FR + EN** (liens `/fr/...` et `/en/...`)
  - aucune erreur console
