### PR TITLE
Conférences — grille responsive pour la liste des sessions

### DIFF
--- a/src/frontend/src/app/[locale]/conferences/page.tsx
+++ b/src/frontend/src/app/[locale]/conferences/page.tsx
@@ -39,7 +39,7 @@ export default async function ConferencesPage() {
 
   return (
     <div className="px-6 py-8 lg:py-12">
-      <div className="mx-auto max-w-4xl">
+      <div className="mx-auto max-w-6xl">
         <Breadcrumb items={breadcrumbItems} />
 
         <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">

--- a/src/frontend/src/components/conferences/ConferencesList.tsx
+++ b/src/frontend/src/components/conferences/ConferencesList.tsx
@@ -15,17 +15,19 @@ interface ConferencesListProps {
 // to its detail page; badges mirror the ones used there.
 export default function ConferencesList({ talks, locale, formatLabels }: ConferencesListProps) {
   return (
-    <ul className="space-y-4">
+    <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {talks.map((talk) => {
         const title = localizedField(talk, "title", locale);
         const categoryName = talk.category ? localizedField(talk.category, "name", locale) : null;
         const speakerNames = talk.speakers.map((s) => s.name).join(", ");
 
         return (
-          <li key={talk.slug}>
+          <li key={talk.slug} className="h-full">
+            {/* Cards stretch to the tallest in their row, so the speaker line
+                stays pinned to the bottom whatever the title length. */}
             <Link
               href={`/conferences/${talk.slug}`}
-              className="block rounded-2xl bg-blanc shadow-card p-5 transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              className="flex h-full flex-col rounded-2xl bg-blanc shadow-card p-5 transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
             >
               <div className="flex flex-wrap items-center gap-2">
                 <span className="rounded-full bg-bleu/10 px-3 py-1 text-sm font-bold text-bleu">
@@ -41,9 +43,9 @@ export default function ConferencesList({ talks, locale, formatLabels }: Confere
                 )}
               </div>
 
-              <h2 className="mt-3 text-xl font-bold text-noir">{title}</h2>
+              <h2 className="mt-3 text-lg font-bold text-noir">{title}</h2>
 
-              {speakerNames && <p className="mt-1 text-sm text-gris">{speakerNames}</p>}
+              {speakerNames && <p className="mt-auto pt-3 text-sm text-gris">{speakerNames}</p>}
             </Link>
           </li>
         );


### PR DESCRIPTION
Suite de #207 / #208.

## Résumé

La liste s'affichait sur une seule colonne pleine largeur, laissant beaucoup de vide sur desktop.

- Passage en **grille responsive** : 1 colonne (mobile) → 2 (tablette) → 3 (desktop).
- Conteneur élargi de `max-w-4xl` à **`max-w-6xl`**, comme la page speakers.
- Les cartes s'étirent à la hauteur de leur ligne : la ligne des speakers reste alignée en bas quelle que soit la longueur du titre.

## Test plan

- [x] `eslint` + `next build` : OK
- [x] Vérif navigateur aux trois paliers :
  - **1440px** → 3 colonnes, largeur exploitée
  - **768px** → 2 colonnes
  - **390px** → 1 colonne