### PR TITLE
Monitoring — Core Web Vitals vers Plausible + alertes 5xx par webhook (#118)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,4 +77,13 @@ SMTP_FROM=contact@devfesttoulouse.fr
 
 # --- Analytics (frontend, optional) ---
 # URL of the Plausible script. If set, Plausible tracking is activated.
+# Core Web Vitals (LCP, INP, CLS) are reported to Plausible as custom events
+# when this is set — see src/frontend/src/components/WebVitals.tsx.
 # NEXT_PUBLIC_PLAUSIBLE_SRC=https://plausible.example.com/js/pa-XXXXX.js
+
+# --- Monitoring (backend, optional) ---
+# Webhook POSTed on every 5xx (Slack, n8n, Discord…). The same URL can also be
+# set from the admin (Paramètres → Monitoring), but that one is read from the
+# database: set the env var so a *database* outage still raises an alert.
+# A repeated error is only notified once per 5-minute window.
+# ALERT_WEBHOOK_URL=https://hooks.example.com/devfest-alerts

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -13,6 +13,9 @@ services:
       - BASE_URL=${BASE_URL:-http://localhost:3000}
       - BACKEND_URL=http://backend:4000
       - REVALIDATE_SECRET=${REVALIDATE_SECRET:-}
+      # Unset by default: no analytics in local dev. Set it to exercise
+      # Plausible and the Core Web Vitals reporting (#118).
+      - NEXT_PUBLIC_PLAUSIBLE_SRC=${NEXT_PUBLIC_PLAUSIBLE_SRC:-}
     command: sh -c "corepack enable && corepack prepare pnpm@9.15.4 --activate && pnpm install --config.confirmModulesPurge=false && pnpm dev"
     depends_on:
       - backend
@@ -47,6 +50,7 @@ services:
       - REVALIDATE_SECRET=${REVALIDATE_SECRET:-}
       - BROCHURE_TOKEN_SECRET=${BROCHURE_TOKEN_SECRET:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-}
     command: >
       sh -c "
         corepack enable &&

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,6 +82,10 @@ services:
       # Google Gemini key for the back-office FR<->EN translator. If unset,
       # POST /api/admin/translate returns 503 and the UI button is disabled.
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      # Webhook alerted on 5xx (#118). Takes precedence over the admin-set
+      # `alert_webhook_url` setting, which needs the database to be readable —
+      # set this one so a database outage still raises an alert.
+      - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-}
       - OAUTH_GOOGLE_CLIENT_ID=${OAUTH_GOOGLE_CLIENT_ID:-}
       - OAUTH_GOOGLE_CLIENT_SECRET=${OAUTH_GOOGLE_CLIENT_SECRET:-}
       - OAUTH_GITHUB_CLIENT_ID=${OAUTH_GITHUB_CLIENT_ID:-}

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -1,4 +1,4 @@
-import Fastify from "fastify";
+import Fastify, { type FastifyError } from "fastify";
 import cors from "@fastify/cors";
 import compress from "@fastify/compress";
 import helmet from "@fastify/helmet";
@@ -6,6 +6,7 @@ import rateLimit from "@fastify/rate-limit";
 import multipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import { auth } from "./lib/auth.js";
+import { buildAlertPayload, sendAlert } from "./lib/alert-webhook.js";
 import { registerSwagger } from "./plugins/swagger.js";
 import { registerCommonSchemas } from "./schemas/common.js";
 import { registerApiKeySchemas } from "./schemas/api-key.js";
@@ -45,6 +46,34 @@ const app = Fastify({
 // preHandler runs returns undefined.
 app.decorateRequest("adminUser");
 app.decorateRequest("authContext");
+
+// Server errors are logged as today, and additionally pushed to the alert
+// webhook when one is configured (#118). Only 5xx are alerted: 4xx are client
+// mistakes, not incidents. The reply itself keeps Fastify's default shape.
+app.setErrorHandler((err: FastifyError, request, reply) => {
+  const statusCode = err.statusCode ?? 500;
+
+  if (statusCode >= 500) {
+    request.log.error({ err, route: request.routeOptions.url }, "Server error");
+
+    // Fire-and-forget: alerting must never delay or break the response.
+    void sendAlert(
+      buildAlertPayload({
+        method: request.method,
+        // Route pattern, not the raw URL — keeps identifying data out of the alert.
+        route: request.routeOptions.url ?? request.url.split("?")[0],
+        statusCode,
+        error: err,
+      }),
+    ).then((result) => {
+      if (result.status === "failed") {
+        request.log.warn({ error: result.error }, "Alert webhook delivery failed");
+      }
+    });
+  }
+
+  reply.send(err);
+});
 
 const corsOrigins = [
   process.env.FRONTEND_URL || "http://localhost:3000",

--- a/src/backend/src/lib/alert-webhook.test.ts
+++ b/src/backend/src/lib/alert-webhook.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 
 import { buildAlertPayload, isThrottled, resetThrottle, sendAlert } from "./alert-webhook.js";
+import { prisma } from "./prisma.js";
 
 vi.mock("./prisma.js", () => ({
   prisma: { siteSetting: { findUnique: vi.fn().mockResolvedValue(null) } },
@@ -64,10 +65,13 @@ describe("isThrottled", () => {
 describe("sendAlert", () => {
   beforeEach(() => {
     resetThrottle();
-    vi.restoreAllMocks();
+    vi.mocked(prisma.siteSetting.findUnique).mockReset().mockResolvedValue(null);
   });
 
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
 
   const payload = () =>
     buildAlertPayload({ method: "GET", route: "/api/x", statusCode: 500, error: new Error("boom") });
@@ -116,5 +120,44 @@ describe("sendAlert", () => {
 
     expect(first.status).toBe("success");
     expect(second.status).toBe("success");
+  });
+
+  it("throttles a repeated error, but lets a different one through", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+    vi.stubEnv("ALERT_WEBHOOK_URL", "https://hooks.example.com/x");
+
+    const same = () =>
+      buildAlertPayload({ method: "GET", route: "/api/a", statusCode: 500, error: new Error("boom") });
+    const other = buildAlertPayload({
+      method: "GET",
+      route: "/api/b",
+      statusCode: 500,
+      error: new Error("different"),
+    });
+
+    expect((await sendAlert(same())).status).toBe("success");
+    expect((await sendAlert(same())).status).toBe("throttled");
+    expect((await sendAlert(other)).status).toBe("success");
+  });
+
+  // Regression: reading the URL from SiteSetting needs the database, so a
+  // database outage used to silence the very alert we needed most.
+  it("still alerts from the env var when the database is unreachable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+    vi.stubEnv("ALERT_WEBHOOK_URL", "https://hooks.example.com/x");
+    vi.mocked(prisma.siteSetting.findUnique).mockRejectedValue(new Error("db down"));
+
+    const result = await sendAlert(payload());
+
+    expect(result.status).toBe("success");
+  });
+
+  it("skips (without throwing) when the database is down and no env var is set", async () => {
+    vi.stubEnv("ALERT_WEBHOOK_URL", "");
+    vi.mocked(prisma.siteSetting.findUnique).mockRejectedValue(new Error("db down"));
+
+    const result = await sendAlert(payload());
+
+    expect(result.status).toBe("skipped");
   });
 });

--- a/src/backend/src/lib/alert-webhook.test.ts
+++ b/src/backend/src/lib/alert-webhook.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+import { buildAlertPayload, isThrottled, resetThrottle, sendAlert } from "./alert-webhook.js";
+
+vi.mock("./prisma.js", () => ({
+  prisma: { siteSetting: { findUnique: vi.fn().mockResolvedValue(null) } },
+}));
+vi.mock("./webhook-url.js", () => ({ validateWebhookUrl: vi.fn().mockResolvedValue(undefined) }));
+
+describe("buildAlertPayload", () => {
+  it("carries the route pattern and the error message, never the raw URL", () => {
+    const payload = buildAlertPayload({
+      method: "GET",
+      route: "/api/talks/:slug",
+      statusCode: 500,
+      error: new Error("boom"),
+    });
+
+    expect(payload).toMatchObject({
+      kind: "server_error",
+      method: "GET",
+      route: "/api/talks/:slug",
+      statusCode: 500,
+      error: "boom",
+    });
+    expect(payload.occurredAt).toBeTruthy();
+  });
+
+  it("truncates very long error messages", () => {
+    const payload = buildAlertPayload({
+      method: "POST",
+      route: "/api/x",
+      statusCode: 500,
+      error: new Error("e".repeat(900)),
+    });
+
+    expect(payload.error.length).toBeLessThanOrEqual(501); // 500 + ellipsis
+    expect(payload.error.endsWith("…")).toBe(true);
+  });
+});
+
+describe("isThrottled", () => {
+  beforeEach(() => resetThrottle());
+
+  it("lets the first occurrence through, then holds identical ones", () => {
+    const now = 1_000_000;
+    expect(isThrottled("sig", now)).toBe(false);
+    expect(isThrottled("sig", now + 1_000)).toBe(true);
+  });
+
+  it("lets a different signature through immediately", () => {
+    const now = 1_000_000;
+    isThrottled("sig-a", now);
+    expect(isThrottled("sig-b", now)).toBe(false);
+  });
+
+  it("re-arms once the window has elapsed", () => {
+    const now = 1_000_000;
+    isThrottled("sig", now);
+    expect(isThrottled("sig", now + 5 * 60 * 1000 + 1)).toBe(false);
+  });
+});
+
+describe("sendAlert", () => {
+  beforeEach(() => {
+    resetThrottle();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  const payload = () =>
+    buildAlertPayload({ method: "GET", route: "/api/x", statusCode: 500, error: new Error("boom") });
+
+  it("skips when no webhook URL is configured", async () => {
+    const result = await sendAlert(payload());
+    expect(result.status).toBe("skipped");
+  });
+
+  it("posts the payload when a URL is given", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+
+    expect(result.status).toBe("success");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://hooks.example.com/x");
+    expect(JSON.parse(init.body).kind).toBe("server_error");
+  });
+
+  it("reports a non-2xx response as failed without throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 500 })));
+
+    const result = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("500");
+  });
+
+  it("reports a network failure as failed without throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const result = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("network down");
+  });
+
+  it("does not throttle an explicit test (urlOverride)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+
+    const first = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+    const second = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+
+    expect(first.status).toBe("success");
+    expect(second.status).toBe("success");
+  });
+});

--- a/src/backend/src/lib/alert-webhook.ts
+++ b/src/backend/src/lib/alert-webhook.ts
@@ -1,0 +1,111 @@
+import { prisma } from "./prisma.js";
+import { validateWebhookUrl } from "./webhook-url.js";
+
+// Alerting channel for server errors (#118). Reuses the webhook conventions
+// already in place for contact submissions: URL stored in SiteSetting,
+// SSRF-validated, hard timeout, never throws.
+
+const TIMEOUT_MS = 10_000;
+const ERROR_MAX_LEN = 500;
+
+// A burst of 5xx must not flood the channel: the same error signature is only
+// alerted once per window. Kept in memory — a restart re-arms alerting, which
+// is the safe direction (we'd rather re-notify than stay silent).
+const THROTTLE_MS = 5 * 60 * 1000;
+const lastSentAt = new Map<string, number>();
+
+export interface AlertPayload {
+  // "server_error" today; the field leaves room for other alert kinds.
+  kind: "server_error";
+  environment: string;
+  occurredAt: string;
+  method: string;
+  // Route pattern (e.g. /api/talks/:slug), not the raw URL: no query string,
+  // no path parameters — nothing user-identifying reaches the channel (RGPD).
+  route: string;
+  statusCode: number;
+  error: string;
+}
+
+function truncate(text: string): string {
+  return text.length > ERROR_MAX_LEN ? `${text.slice(0, ERROR_MAX_LEN)}…` : text;
+}
+
+async function getAlertWebhookUrl(): Promise<string | undefined> {
+  const setting = await prisma.siteSetting.findUnique({
+    where: { key: "alert_webhook_url" },
+  });
+  return setting?.value || undefined;
+}
+
+// True when this signature was already alerted within the throttle window.
+export function isThrottled(signature: string, now: number): boolean {
+  const previous = lastSentAt.get(signature);
+  if (previous !== undefined && now - previous < THROTTLE_MS) return true;
+  lastSentAt.set(signature, now);
+  return false;
+}
+
+export function resetThrottle(): void {
+  lastSentAt.clear();
+}
+
+/**
+ * Posts an alert to the configured webhook. Never throws: alerting must not
+ * take the API down. Returns what happened so callers can log it.
+ */
+export async function sendAlert(
+  payload: AlertPayload,
+  opts: { urlOverride?: string } = {},
+): Promise<{ status: "success" | "failed" | "skipped" | "throttled"; error: string | null }> {
+  const url = opts.urlOverride ?? (await getAlertWebhookUrl());
+  if (!url) return { status: "skipped", error: "No alert webhook URL configured" };
+
+  // Throttle on route + status + error text, so a repeated failure is reported
+  // once per window while a *different* failure still gets through immediately.
+  if (!opts.urlOverride) {
+    const signature = `${payload.route}|${payload.statusCode}|${payload.error}`;
+    if (isThrottled(signature, Date.now())) {
+      return { status: "throttled", error: null };
+    }
+  }
+
+  try {
+    await validateWebhookUrl(url);
+  } catch (err) {
+    return { status: "skipped", error: `Invalid URL: ${truncate(String(err))}` };
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      redirect: "manual",
+    });
+    if (!response.ok) {
+      return { status: "failed", error: `HTTP ${response.status} ${response.statusText}` };
+    }
+    return { status: "success", error: null };
+  } catch (err) {
+    return { status: "failed", error: truncate(err instanceof Error ? err.message : String(err)) };
+  }
+}
+
+export function buildAlertPayload(input: {
+  method: string;
+  route: string;
+  statusCode: number;
+  error: unknown;
+}): AlertPayload {
+  return {
+    kind: "server_error",
+    environment: process.env.ENV_NAME || "local",
+    occurredAt: new Date().toISOString(),
+    method: input.method,
+    route: input.route,
+    statusCode: input.statusCode,
+    error: truncate(input.error instanceof Error ? input.error.message : String(input.error)),
+  };
+}

--- a/src/backend/src/lib/alert-webhook.ts
+++ b/src/backend/src/lib/alert-webhook.ts
@@ -31,11 +31,24 @@ function truncate(text: string): string {
   return text.length > ERROR_MAX_LEN ? `${text.slice(0, ERROR_MAX_LEN)}…` : text;
 }
 
+// The env var wins over the stored setting on purpose: reading SiteSetting
+// needs the database, so a database outage — the incident we most want to hear
+// about — would silence the alert. ALERT_WEBHOOK_URL keeps alerting alive when
+// nothing else works; the admin-configurable setting stays the convenient path
+// for everything else.
 async function getAlertWebhookUrl(): Promise<string | undefined> {
-  const setting = await prisma.siteSetting.findUnique({
-    where: { key: "alert_webhook_url" },
-  });
-  return setting?.value || undefined;
+  const fromEnv = process.env.ALERT_WEBHOOK_URL?.trim();
+  if (fromEnv) return fromEnv;
+
+  try {
+    const setting = await prisma.siteSetting.findUnique({
+      where: { key: "alert_webhook_url" },
+    });
+    return setting?.value || undefined;
+  } catch {
+    // Database unreachable — nothing more we can do without the env var.
+    return undefined;
+  }
 }
 
 // True when this signature was already alerted within the throttle window.

--- a/src/backend/src/routes/admin/settings.ts
+++ b/src/backend/src/routes/admin/settings.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { buildAlertPayload, sendAlert } from "../../lib/alert-webhook.js";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateCfp, revalidateHome } from "../../lib/revalidate.js";
 import { validateWebhookUrl } from "../../lib/webhook-url.js";
@@ -91,6 +92,33 @@ export default async function adminSettingsRoutes(app: FastifyInstance) {
     // dedicated /proposer-un-talk page (status + dates + button).
     revalidateCfp();
     return { success: true };
+  });
+
+  // POST /api/admin/settings/test-alert-webhook — send a sample server-error
+  // alert to the given (or stored) URL, so the admin can check the channel is
+  // wired before a real incident happens (#118). urlOverride bypasses the
+  // throttle, which is what we want for an explicit test.
+  app.post<{ Body: { url?: string } }>("/settings/test-alert-webhook", async (request, reply) => {
+    let alertUrl = request.body?.url?.trim();
+    if (!alertUrl) {
+      const setting = await prisma.siteSetting.findUnique({
+        where: { key: "alert_webhook_url" },
+      });
+      alertUrl = setting?.value;
+    }
+    if (!alertUrl) return reply.status(400).send({ error: "No alert webhook URL provided" });
+
+    const result = await sendAlert(
+      buildAlertPayload({
+        method: "GET",
+        route: "/api/admin/settings/test-alert-webhook",
+        statusCode: 500,
+        error: new Error("Test alert — this is not a real incident."),
+      }),
+      { urlOverride: alertUrl },
+    );
+
+    return result;
   });
 
   // POST /api/admin/settings/test-webhook — send a test payload to a webhook URL

--- a/src/frontend/src/app/[locale]/layout.tsx
+++ b/src/frontend/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
 import PlausibleProvider from "next-plausible";
+import WebVitals from "@/components/WebVitals";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import LanguageSuggestionBanner from "@/components/LanguageSuggestionBanner";
@@ -129,7 +130,12 @@ export default async function LocaleLayout({
 
   return (
     <>
-      {plausibleSrc && <PlausibleProvider src={plausibleSrc} />}
+      {plausibleSrc && (
+        <>
+          <PlausibleProvider src={plausibleSrc} />
+          <WebVitals />
+        </>
+      )}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}

--- a/src/frontend/src/app/admin/settings/page.tsx
+++ b/src/frontend/src/app/admin/settings/page.tsx
@@ -186,6 +186,7 @@ function ContactsTab({
   const [form, setForm] = useState({
     contact_default_email: settings.contact_default_email || "",
     contact_webhook_url: settings.contact_webhook_url || "",
+    alert_webhook_url: settings.alert_webhook_url || "",
     social_linkedin: settings.social_linkedin || "",
     social_youtube: settings.social_youtube || "",
     social_x: settings.social_x || "",
@@ -194,6 +195,7 @@ function ContactsTab({
   const [isSaving, setIsSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [webhookTestResult, setWebhookTestResult] = useState<string | null>(null);
+  const [alertTestResult, setAlertTestResult] = useState<string | null>(null);
 
   function handleChange(key: string, value: string) {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -266,6 +268,53 @@ function ContactsTab({
           {webhookTestResult && (
             <p className={`mt-1 text-xs ${webhookTestResult.startsWith("Envoyé") ? "text-malachite" : "text-terre-cuite"}`}>
               {webhookTestResult}
+            </p>
+          )}
+        </div>
+
+        <h2 className="text-lg font-bold text-noir mb-4">Monitoring</h2>
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-noir mb-1">
+            URL webhook d&apos;alerte (erreurs serveur)
+          </label>
+          <input
+            type="url"
+            value={form.alert_webhook_url}
+            onChange={(e) => handleChange("alert_webhook_url", e.target.value)}
+            placeholder="https://hooks.slack.com/services/..."
+            className="w-full max-w-md rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+          />
+          <p className="mt-1 text-xs text-gris">
+            URL appelée en POST à chaque erreur serveur (5xx). Une même erreur n&apos;est notifiée
+            qu&apos;une fois toutes les 5 minutes. Laissez vide pour désactiver.
+          </p>
+          {form.alert_webhook_url && (
+            <button
+              type="button"
+              onClick={async () => {
+                setAlertTestResult(null);
+                const { adminFetch } = await import("@/lib/admin-api");
+                const { data } = await adminFetch<{ status: string; error?: string }>(
+                  "/settings/test-alert-webhook",
+                  { method: "POST", body: JSON.stringify({ url: form.alert_webhook_url }) },
+                );
+                if (data) {
+                  setAlertTestResult(
+                    data.status === "success" ? "Envoyé" : `Échec : ${data.error?.slice(0, 100)}`,
+                  );
+                } else {
+                  setAlertTestResult("Erreur");
+                }
+                setTimeout(() => setAlertTestResult(null), 8000);
+              }}
+              className="mt-2 px-3 py-1 text-xs rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+            >
+              Tester l&apos;alerte
+            </button>
+          )}
+          {alertTestResult && (
+            <p className={`mt-1 text-xs ${alertTestResult === "Envoyé" ? "text-malachite" : "text-terre-cuite"}`}>
+              {alertTestResult}
             </p>
           )}
         </div>

--- a/src/frontend/src/components/WebVitals.tsx
+++ b/src/frontend/src/components/WebVitals.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useReportWebVitals } from "next/web-vitals";
+import { usePlausible } from "next-plausible";
+
+// Core Web Vitals reporting (#118). Next measures the metrics in the browser;
+// we forward the ones that matter for our performance targets to Plausible as
+// custom events. Nothing user-identifying is sent — only the metric, its value
+// and Google's rating bucket.
+const REPORTED_METRICS = new Set(["LCP", "INP", "CLS", "FCP", "TTFB"]);
+
+type WebVitalsEvents = {
+  "Web Vitals": { metric: string; value: number; rating: string };
+};
+
+export default function WebVitals() {
+  const plausible = usePlausible<WebVitalsEvents>();
+
+  useReportWebVitals((metric) => {
+    if (!REPORTED_METRICS.has(metric.name)) return;
+
+    plausible("Web Vitals", {
+      props: {
+        metric: metric.name,
+        // CLS is a unitless ratio (kept at 3 decimals); the others are
+        // milliseconds, where sub-millisecond precision is noise.
+        value: metric.name === "CLS"
+          ? Math.round(metric.value * 1000) / 1000
+          : Math.round(metric.value),
+        rating: metric.rating,
+      },
+    });
+  });
+
+  return null;
+}


### PR DESCRIPTION
Ferme #118.

## Résumé

Deux manques que les objectifs techniques réclamaient : aucune mesure réelle des Core Web Vitals chez les visiteurs, et aucune alerte quand le backend renvoie une 5xx.

**Core Web Vitals** — `useReportWebVitals` remonte LCP / INP / CLS (+ FCP / TTFB) vers **Plausible** en événements custom. Seuls la métrique, sa valeur et le *rating* Google sont envoyés — **aucune donnée personnelle** (RGPD). Le composant n'est monté que si Plausible est configuré.

**Alertes 5xx** — un gestionnaire d'erreurs global pousse chaque 5xx vers un **webhook** (Slack, n8n, Discord…), en réutilisant les conventions du webhook contact déjà en place : validation anti-SSRF, timeout dur, ne lève jamais d'exception. L'URL est réglable **depuis l'admin** (Paramètres → Monitoring), avec un bouton « Tester l'alerte ».

Points de conception :
- L'alerte porte le **motif de route** (`/api/talks/:slug`), jamais l'URL brute — ni query string ni paramètres de chemin ne sortent.
- **Anti-flood** : une même erreur n'est notifiée qu'une fois par fenêtre de 5 minutes ; une erreur *différente* passe immédiatement.
- L'envoi est *fire-and-forget* : l'alerte ne retarde ni ne casse jamais la réponse HTTP.

## Un angle mort trouvé en testant pour de vrai

En provoquant une **vraie panne de base** (arrêt de Postgres), j'ai constaté que l'alerte ne partait pas : l'URL du webhook était lue dans `SiteSetting`… donc en base. **L'incident le plus grave faisait taire sa propre alerte.**

Corrigé : `ALERT_WEBHOOK_URL` (variable d'environnement) est lue **en priorité** et ne dépend d'aucune requête SQL ; le réglage admin reste le chemin pratique pour le reste. Vérifié en conditions réelles — base coupée, la 5xx atteint bien le webhook (`HTTP 405` de la cible de test), là où **rien** ne sortait auparavant.

## Test plan

- [x] `tsc` backend + `next build` + `eslint` : OK
- [x] **13 tests** sur la lib d'alerte : payload sans donnée identifiante, troncature, anti-flood (répétition bloquée / erreur différente passante), échecs HTTP et réseau gérés sans exception, **alerte encore émise base HS**, skip propre si tout est indisponible
- [x] Vérif en conditions réelles :
  - sauvegarde du réglage depuis l'admin → `200`
  - endpoint « Tester l'alerte » → requête réellement émise, statut remonté
  - **vraie 5xx** (base arrêtée) → handler déclenché, réponse 500 servie normalement, alerte émise
- [ ] ⚠️ **Non vérifié : les Web Vitals dans un vrai navigateur.** En local, le `PlausibleProvider` ne se monte pas (les `NEXT_PUBLIC_*` restent figées par le cache de compilation dev) — un souci d'environnement **antérieur à cette PR**, pas du code livré. À confirmer sur la bêta, où Plausible est réellement configuré : le dashboard doit recevoir des événements « Web Vitals ».

## Configuration

Nouvelle variable, optionnelle (documentée dans `.env.example`, câblée dans les deux compose) :

```
ALERT_WEBHOOK_URL=https://hooks.example.com/devfest-alerts
```

Sans elle ni réglage admin, l'alerting est simplement inactif (aucune erreur).
