### PR TITLE
SEO — retirer le superEvent invalide + compléter l'Event Schema.org (#185)

### DIFF
--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -293,6 +293,8 @@ export default async function editionRoutes(app: FastifyInstance) {
       status: computeTicketStatus(tier, now),
       externalUrl: tier.externalUrl,
       sortOrder: tier.sortOrder,
+      // Feeds Schema.org Offer.validFrom on the home page (#185).
+      saleStartDate: tier.saleStartDate,
     }));
   });
 }

--- a/src/frontend/src/app/[locale]/editions/[year]/page.tsx
+++ b/src/frontend/src/app/[locale]/editions/[year]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 
 import { getEditionByYear, getEditions, getEditionSpeakers, getEditionTalks } from "@/lib/api";
 import { localizedField } from "@/lib/i18n-helpers";
+import { absoluteUrl } from "@/lib/seo";
 import Breadcrumb from "@/components/Breadcrumb";
 import YouTubeFacade from "@/components/YouTubeFacade";
 import StatIcon from "@/components/home/StatIcon";
@@ -56,12 +57,10 @@ function buildCompletedEventJsonLd(edition: BilanEdition) {
       name: "GDG Toulouse",
       url: "https://gdg.community.dev/gdg-toulouse/",
     },
-    superEvent: {
-      "@type": "Event",
-      name: "DevFest",
-      url: "https://developers.google.com/community/devfest",
-    },
-    ...(edition.heroImageUrl ? { image: edition.heroImageUrl } : {}),
+    // No `superEvent` — see the home page for why it produced invalid
+    // structured data (#185).
+    // Schema.org wants absolute URLs; heroImageUrl is stored as /uploads/….
+    ...(edition.heroImageUrl ? { image: absoluteUrl(edition.heroImageUrl) } : {}),
     ...(edition.aftermovieUrl ? { video: edition.aftermovieUrl } : {}),
   };
 }

--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import { Fragment, type ReactNode } from "react";
-import { getLocale } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import {
   getCfpSettings,
@@ -8,11 +8,13 @@ import {
   getLatestArticles,
   getCurrentTicketTiers,
   getKeyFigures,
+  getSeoSettings,
   getSponsors,
   getFeaturedSpeakers,
   getEcosystemPartners,
 } from "@/lib/api";
 
+import { absoluteUrl } from "@/lib/seo";
 import type { SectionSurface } from "@/components/home/section-surface";
 
 import HeroSection from "@/components/home/HeroSection";
@@ -31,9 +33,16 @@ function buildEventJsonLd(
     endDate: string | null;
     venueName: string | null;
     venueAddress: string | null;
+    heroImageUrl: string | null;
   },
-  tiers: { nameFr: string; price: number; status: string; externalUrl: string | null }[],
+  tiers: { nameFr: string; price: number; status: string; externalUrl: string | null; saleStartDate: string | null }[],
   previousStartDates: string[] = [],
+  // Recommended-but-missing fields flagged by Search Console (#185).
+  extras: {
+    description: string;
+    ogImage: string | null;
+    speakerNames: string[];
+  },
 ) {
   // Dedup offers by (name, price, status) — protects Schema.org output from
   // accidental duplicates in seed data or admin double-imports, which
@@ -56,12 +65,21 @@ function buildEventJsonLd(
         ? "https://schema.org/InStock"
         : "https://schema.org/PreOrder",
       url: t.externalUrl ?? undefined,
+      // When the tier opens for sale (recommended by Google, #185).
+      validFrom: t.saleStartDate?.split("T")[0] ?? undefined,
     }));
+
+  // Google recommends `image` on an Event, so always emit one: the admin's OG
+  // override if set, else the edition hero, else the site's default OG image
+  // (#185). `performer` stays conditional — an empty array would be invalid.
+  const image = extras.ogImage ?? edition.heroImageUrl ?? "/images/og-default.png";
 
   return {
     "@context": "https://schema.org",
     "@type": "Event",
     name: `DevFest Toulouse ${edition.year}`,
+    description: extras.description,
+    image: absoluteUrl(image),
     startDate: edition.startDate?.split("T")[0] ?? undefined,
     endDate: edition.endDate?.split("T")[0] ?? undefined,
     eventStatus: "https://schema.org/EventScheduled",
@@ -83,11 +101,16 @@ function buildEventJsonLd(
       name: "GDG Toulouse",
       url: "https://gdg.community.dev/gdg-toulouse/",
     },
-    superEvent: {
-      "@type": "Event",
-      name: "DevFest",
-      url: "https://developers.google.com/community/devfest",
-    },
+    // Speakers, once announced (#185). Omitted entirely while the line-up is
+    // empty rather than emitting an empty array.
+    ...(extras.speakerNames.length > 0 && {
+      performer: extras.speakerNames.map((name) => ({ "@type": "Person" as const, name })),
+    }),
+    // No `superEvent`: Google treats any nested `Event` as a full Event and
+    // demands startDate/location on it, so pointing at the generic DevFest page
+    // produced two critical errors in Search Console — for a property Google
+    // does not even use for rich results (#185). `organizer` already ties the
+    // event to GDG Toulouse.
     // Past edition start dates signal the event's recurrence to search engines.
     ...(previousStartDates.length > 0 && {
       previousStartDate:
@@ -99,6 +122,10 @@ function buildEventJsonLd(
 
 export default async function HomePage() {
   const locale = await getLocale();
+  const [tSite, seoSettings] = await Promise.all([
+    getTranslations({ locale, namespace: "site" }),
+    getSeoSettings(),
+  ]);
 
   const [edition, tiers, figures, cfp, editions, sponsors, speakers, partners] = await Promise.all([
     getCurrentEdition(),
@@ -224,7 +251,13 @@ export default async function HomePage() {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(buildEventJsonLd(edition, tiers, previousStartDates)),
+            __html: JSON.stringify(
+              buildEventJsonLd(edition, tiers, previousStartDates, {
+                description: tSite("description"),
+                ogImage: seoSettings.seo_og_image || null,
+                speakerNames: speakers.map((s) => s.name),
+              }),
+            ),
           }}
         />
       )}

--- a/src/frontend/src/lib/seo.ts
+++ b/src/frontend/src/lib/seo.ts
@@ -1,0 +1,7 @@
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
+
+// Schema.org expects absolute URLs. Uploaded assets are stored as /uploads/…,
+// so they need the site origin prepended before they go into JSON-LD (#185).
+export function absoluteUrl(path: string): string {
+  return /^https?:\/\//.test(path) ? path : `${BASE_URL}${path}`;
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface TicketTier {
   status: "AVAILABLE" | "SOLD_OUT" | "COMING_SOON";
   externalUrl: string | null;
   sortOrder: number;
+  saleStartDate: string | null;
 }
 
 export interface KeyFigure {


### PR DESCRIPTION
Ferme #185.

## Résumé

Search Console remontait **2 erreurs critiques** sur les données structurées `Event` — les éléments non valides ne peuvent pas apparaître dans les résultats enrichis.

**Cause** : le bloc `superEvent` pointait vers la page générique DevFest de Google. Or Google traite tout objet typé `Event` comme un Event à part entière et exige alors `startDate` et `location` dessus → 2 erreurs. La propriété n'est de toute façon **pas exploitée** par Google pour les résultats enrichis Event, et `organizer` relie déjà l'événement à GDG Toulouse.

**Correctif** : `superEvent` retiré — de la home **et** de la page édition passée, qui portait le même bloc.

## Champs recommandés ajoutés

Search Console signalait aussi des manques sur l'Event principal :

- **`description`** — réutilise la description SEO du site (même source que les métadonnées).
- **`image`** — chaîne de repli : override OG de l'admin → hero de l'édition → `og-default.png`. Une image est donc **toujours** émise (Google la recommande), en URL absolue.
- **`performer`** — les speakers annoncés, en `Person`. Omis tant que le line-up est vide (un tableau vide serait invalide).
- **`validFrom`** sur chaque `Offer` — la date d'ouverture des ventes du tarif (`saleStartDate`, désormais exposée par l'endpoint billetterie).

La conversion en URL absolue passe dans un helper partagé `lib/seo.ts` : Schema.org rejette les chemins relatifs `/uploads/…` stockés en base.

## Test plan

- [x] `tsc` backend + `next build` + `eslint` : OK
- [x] **JSON-LD réellement servi**, inspecté sur la home :
  - `superEvent` → **absent** ✅
  - `description` → présente ✅
  - `image` → `…/images/og-default.png` (URL absolue) ✅
  - `performer` → 2 speakers ✅
  - `offers` → 4, chacune avec son `validFrom` ✅
  - `startDate` / `location` → toujours valides ✅
- [x] `superEvent` absent des deux pages (vérifié dans tout le frontend)
- [ ] **Rich Results Test** sur la prod après déploiement — critère d'acceptation de l'issue, à faire une fois en ligne.

## Note

L'issue mentionne un faux positif sur `eventStatus` (`http://` vs `https://`) : rien à corriger, le HTML servi contient bien `https://`. Confirmé — inchangé par cette PR.
