### PR TITLE
Speakers à la une : rotation automatique quotidienne (#214)

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -29,6 +29,7 @@
     "@prisma/config": "^7.8.0",
     "better-auth": "^1.6.5",
     "fastify": "^5.8.4",
+    "node-cron": "^4.6.0",
     "nodemailer": "^8.0.4",
     "pg": "^8.21.0",
     "prisma": "^7.8.0",

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       fastify:
         specifier: ^5.8.4
         version: 5.8.4
+      node-cron:
+        specifier: ^4.6.0
+        version: 4.6.0
       nodemailer:
         specifier: ^8.0.4
         version: 8.0.4
@@ -1549,6 +1552,10 @@ packages:
   nanostores@1.2.0:
     resolution: {integrity: sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  node-cron@4.6.0:
+    resolution: {integrity: sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==}
+    engines: {node: '>=20'}
 
   node-html-parser@8.0.2:
     resolution: {integrity: sha512-fhG4Ne6moYy00jI3SkBEJzEa/pMX/RLLxnvlvu8x0OvsiegHdw5Q8brbe+AhZHqHFi2PZnSYObQ/x+cQXuNg0Q==}
@@ -3325,6 +3332,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanostores@1.2.0: {}
+
+  node-cron@4.6.0: {}
 
   node-html-parser@8.0.2:
     dependencies:

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -7,6 +7,7 @@ import multipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import { auth } from "./lib/auth.js";
 import { buildAlertPayload, sendAlert } from "./lib/alert-webhook.js";
+import { startScheduledTasks } from "./lib/scheduler.js";
 import { registerSwagger } from "./plugins/swagger.js";
 import { registerCommonSchemas } from "./schemas/common.js";
 import { registerApiKeySchemas } from "./schemas/api-key.js";
@@ -39,6 +40,31 @@ const app = Fastify({
   logger: { level: process.env.LOG_LEVEL || "info" },
   trustProxy: true,
 });
+
+// Fastify rejects `content-type: application/json` with an empty payload
+// (FST_ERR_CTP_EMPTY_JSON_BODY) — yet that is exactly what a plain fetch()
+// with a JSON content-type and no body sends, as our own admin calls do for
+// action-only endpoints (e.g. POST /speakers/rotate-featured). Treat an empty
+// JSON body as `{}` rather than a client error.
+// Fastify already registers a built-in JSON parser, so ours has to replace it.
+app.removeContentTypeParser("application/json");
+app.addContentTypeParser(
+  "application/json",
+  { parseAs: "string" },
+  (_request, body: string, done) => {
+    if (!body || body.trim() === "") return done(null, {});
+    try {
+      done(null, JSON.parse(body));
+    } catch {
+      // Malformed JSON is a client error. Without an explicit statusCode the
+      // default handler would turn it into a 500 — and, since #118, raise a
+      // bogus server-error alert.
+      const err = new Error("Invalid JSON body") as Error & { statusCode?: number };
+      err.statusCode = 400;
+      done(err, undefined);
+    }
+  },
+);
 
 // Per-request decorations attached by auth middleware. Declared without a
 // default so Fastify treats them as optional getters (the typings live in
@@ -249,6 +275,7 @@ await app.register(adminRoutes, { prefix: "/api/admin" });
 
 try {
   await app.listen({ port, host });
+  startScheduledTasks(app.log);
 } catch (err) {
   app.log.error(err);
   process.exit(1);

--- a/src/backend/src/lib/featured-speakers.test.ts
+++ b/src/backend/src/lib/featured-speakers.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { FEATURED_SPEAKERS_COUNT, rotateFeaturedSpeakers } from "./featured-speakers.js";
+import { prisma } from "./prisma.js";
+import { revalidateSpeakers } from "./revalidate.js";
+import { getFeaturedEdition } from "../routes/editions.js";
+
+vi.mock("./prisma.js", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+    $transaction: vi.fn().mockResolvedValue([]),
+    speaker: { updateMany: vi.fn() },
+  },
+}));
+vi.mock("./revalidate.js", () => ({ revalidateSpeakers: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../routes/editions.js", () => ({ getFeaturedEdition: vi.fn() }));
+
+describe("rotateFeaturedSpeakers", () => {
+  beforeEach(() => {
+    vi.mocked(getFeaturedEdition).mockResolvedValue({ id: 1, year: 2026 } as never);
+    vi.mocked(prisma.$queryRaw).mockReset();
+    vi.mocked(prisma.$transaction).mockClear().mockResolvedValue([]);
+    vi.mocked(revalidateSpeakers).mockClear();
+  });
+
+  it("features the speakers drawn at random and reports them", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([
+      { id: 10, name: "Ada Lovelace" },
+      { id: 11, name: "Alan Turing" },
+    ] as never);
+
+    const result = await rotateFeaturedSpeakers();
+
+    expect(result).toEqual({ edition: 2026, featured: ["Ada Lovelace", "Alan Turing"] });
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+  });
+
+  it("purges the home cache, otherwise the new line-up would surface an hour late", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ id: 10, name: "Ada" }] as never);
+
+    await rotateFeaturedSpeakers();
+
+    expect(revalidateSpeakers).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing when there is no featured edition", async () => {
+    vi.mocked(getFeaturedEdition).mockResolvedValue(null as never);
+
+    const result = await rotateFeaturedSpeakers();
+
+    expect(result).toEqual({ edition: null, featured: [] });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(revalidateSpeakers).not.toHaveBeenCalled();
+  });
+
+  it("still clears the previous selection when no speaker can be drawn", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([] as never);
+
+    const result = await rotateFeaturedSpeakers();
+
+    expect(result.featured).toEqual([]);
+    // The transaction runs anyway: yesterday's featured speakers must not stay.
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+  });
+
+  it("targets the number of speakers the home page actually shows", () => {
+    expect(FEATURED_SPEAKERS_COUNT).toBe(8);
+  });
+});

--- a/src/backend/src/lib/featured-speakers.ts
+++ b/src/backend/src/lib/featured-speakers.ts
@@ -1,0 +1,60 @@
+import { prisma } from "./prisma.js";
+import { revalidateSpeakers } from "./revalidate.js";
+import { getFeaturedEdition } from "../routes/editions.js";
+
+// How many speakers the home page highlights. Matches the `take` used by
+// GET /api/speakers/featured, so the rotation fills exactly what is displayed.
+export const FEATURED_SPEAKERS_COUNT = 8;
+
+export interface RotationResult {
+  edition: number | null;
+  featured: string[];
+}
+
+/**
+ * Pick FEATURED_SPEAKERS_COUNT published speakers at random in the current
+ * edition and make them the featured ones, clearing the previous selection
+ * (#214). Fewer speakers than the target simply means all of them are featured.
+ *
+ * This overwrites any manual pick made in the admin — by design: the rotation
+ * is the single source of truth for who is highlighted.
+ */
+export async function rotateFeaturedSpeakers(): Promise<RotationResult> {
+  const edition = await getFeaturedEdition();
+  if (!edition) return { edition: null, featured: [] };
+
+  // Draw in the database rather than loading every speaker into memory.
+  const picked = await prisma.$queryRaw<{ id: number; name: string }[]>`
+    SELECT id, name
+    FROM "Speaker"
+    WHERE "editionId" = ${edition.id}
+      AND "publicationStatus" = 'PUBLISHED'
+    ORDER BY random()
+    LIMIT ${FEATURED_SPEAKERS_COUNT}
+  `;
+
+  const ids = picked.map((s) => s.id);
+
+  // Clear then set, in one transaction: a half-applied rotation would leave the
+  // home page with the wrong line-up.
+  await prisma.$transaction([
+    prisma.speaker.updateMany({
+      where: { editionId: edition.id, isFeatured: true },
+      data: { isFeatured: false },
+    }),
+    ...(ids.length > 0
+      ? [
+          prisma.speaker.updateMany({
+            where: { id: { in: ids } },
+            data: { isFeatured: true },
+          }),
+        ]
+      : []),
+  ]);
+
+  // The home page caches for an hour, so without this the new line-up would
+  // only surface up to an hour later.
+  await revalidateSpeakers();
+
+  return { edition: edition.year, featured: picked.map((s) => s.name) };
+}

--- a/src/backend/src/lib/scheduler.ts
+++ b/src/backend/src/lib/scheduler.ts
@@ -1,0 +1,42 @@
+import type { FastifyBaseLogger } from "fastify";
+import cron from "node-cron";
+
+import { rotateFeaturedSpeakers } from "./featured-speakers.js";
+
+// 1 AM Paris time — the cron expression is evaluated in that timezone, so it
+// holds across DST instead of drifting between 2 AM and 3 AM local (#214).
+const FEATURED_ROTATION_CRON = "0 1 * * *";
+const TIMEZONE = "Europe/Paris";
+
+/**
+ * Register the backend's scheduled tasks. Called once at boot.
+ *
+ * Note: this runs in-process. If the backend is ever scaled to several
+ * replicas, each one would fire the job. The rotation is harmless in that case
+ * (the last write simply wins) but a distributed lock would be needed for tasks
+ * where that is not true.
+ */
+export function startScheduledTasks(log: FastifyBaseLogger): void {
+  cron.schedule(
+    FEATURED_ROTATION_CRON,
+    async () => {
+      try {
+        const result = await rotateFeaturedSpeakers();
+        if (result.edition === null) {
+          log.warn("Featured speakers rotation skipped: no featured edition");
+          return;
+        }
+        log.info(
+          { edition: result.edition, count: result.featured.length, speakers: result.featured },
+          "Featured speakers rotated",
+        );
+      } catch (err) {
+        // A failing cron must never take the server down.
+        log.error({ err }, "Featured speakers rotation failed");
+      }
+    },
+    { name: "featured-speakers-rotation", timezone: TIMEZONE, noOverlap: true },
+  );
+
+  log.info({ cron: FEATURED_ROTATION_CRON, timezone: TIMEZONE }, "Scheduled tasks started");
+}

--- a/src/backend/src/routes/admin/speakers.ts
+++ b/src/backend/src/routes/admin/speakers.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { rotateFeaturedSpeakers } from "../../lib/featured-speakers.js";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateSpeakers } from "../../lib/revalidate.js";
 import { slugify, uniqueSlug } from "../../lib/slug.js";
@@ -133,6 +134,13 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
   });
 
   // POST /api/admin/speakers/bulk — apply one action to several speakers at once.
+  // POST /api/admin/speakers/rotate-featured — run the nightly rotation now.
+  // The scheduled job fires at 1 AM Paris time (#214); this lets an admin
+  // trigger it (or test it) without waiting for the small hours.
+  app.post("/speakers/rotate-featured", async () => {
+    return rotateFeaturedSpeakers();
+  });
+
   app.post<{ Body: SpeakerBulkBody }>("/speakers/bulk", async (request, reply) => {
     const { ids, action, value } = request.body;
     if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => Number.isInteger(id))) {


### PR DESCRIPTION
Ferme #214.

## Résumé

Chaque nuit à **1h du matin (heure de Paris)**, 8 speakers publiés de l'édition en cours sont tirés au sort et mis à la une, remplaçant la sélection précédente.

Le nombre **8** aligne la rotation sur ce que la home affiche déjà (`take: 8` dans `GET /api/speakers/featured`) — décision actée dans l'issue.

## Détails

C'est **la première tâche planifiée du projet** : elle apporte donc le scheduler (`node-cron`, fuseau `Europe/Paris` explicite pour ne pas dériver entre 2h et 3h selon l'heure d'été).

Choix de conception :
- **Transaction** — une rotation à moitié appliquée laisserait la home avec une sélection incohérente.
- **Tirage en SQL** (`ORDER BY random() LIMIT 8`) plutôt que de charger tous les speakers en mémoire.
- **Filtres** : uniquement les speakers `PUBLISHED` de l'édition **en vedette** — un brouillon ou un speaker d'une édition passée ne peut pas se retrouver à la une.
- **`revalidateSpeakers()`** en fin de tâche : la home est cachée 1h, sans ça la nouvelle sélection n'apparaîtrait qu'une heure plus tard.
- **Moins de 8 speakers publiés** → tous sont mis à la une, sans erreur.
- **`POST /api/admin/speakers/rotate-featured`** permet de déclencher la rotation à la demande (indispensable pour tester sans attendre 1h du matin).

⚠️ *Limite assumée* : le cron tourne dans le process. Si le backend passait un jour en plusieurs répliques, chacune déclencherait la tâche — sans conséquence ici (le dernier write gagne), mais à savoir.

## Un bug latent découvert au passage

L'endpoint de déclenchement renvoyait **400** : Fastify refuse `content-type: application/json` avec un corps vide (`FST_ERR_CTP_EMPTY_JSON_BODY`) — or c'est exactement ce qu'envoie un `fetch()` d'action sans payload, comme le ferait un bouton admin.

Le parseur JSON est remplacé pour lire un corps vide comme `{}`. Et en le testant, un second effet est apparu : un **JSON malformé partait en 500** — ce qui, depuis #118, aurait déclenché une **fausse alerte d'erreur serveur**. Il renvoie désormais **400**.

## Test plan

- [x] `tsc` backend : OK
- [x] **5 tests** sur la rotation : sélection remontée, purge du cache, aucune édition en vedette, moins de speakers que la cible (l'ancienne sélection est quand même effacée), nombre aligné sur l'affichage
- [x] Suite backend : **aucune régression** (mêmes 38 échecs préexistants qu'avant — cf. #117 ; réussis 162 → 167)
- [x] Vérifications en conditions réelles :
  - le scheduler démarre au boot : `cron: "0 1 * * *", timezone: "Europe/Paris"` ✅
  - rotation déclenchée → **exactement 8** speakers à la une en base ✅
  - deux rotations successives → **sélections différentes** (l'aléatoire fonctionne) et pas d'accumulation ✅
  - les speakers en **brouillon ne sont jamais** mis à la une ✅
  - `GET /api/speakers/featured` renvoie bien les speakers tirés ✅
  - édition avec seulement 4 publiés → les 4 sont mis à la une, sans erreur ✅
  - non-régression du parseur : login better-auth `200`, JSON malformé `400`, validation bulk `400`, rotation corps vide `200` ✅
