### PR TITLE
Perf — image hero via next/image : LCP 20,6 s → 3,4 Mo devenus 44 Ko (#197)

### DIFF
--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -133,6 +133,12 @@ await app.register(fastifyStatic, {
   root: "/app/uploads",
   prefix: "/uploads/",
   decorateReply: false,
+  // Uploaded files are content-addressed by name (`${Date.now()}-${random}.ext`,
+  // see routes/admin/files.ts): a given URL never changes content, so it can be
+  // cached hard and forever. Without this, a 3 MB hero image was re-downloaded
+  // on every visit (#197).
+  maxAge: "365d",
+  immutable: true,
 });
 
 // OpenAPI / Swagger — must be registered before routes so it can capture their schemas.

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -350,14 +350,35 @@ body {
 .hero-photo {
   position: relative;
   min-height: clamp(260px, 34vw, 500px);
-  background-size: cover;
-  background-position: center;
+  /* Fallback tint while the image loads, and the whole visual when no hero
+     image is set on the edition. */
+  background-color: rgba(29, 29, 27, 0.28);
   border-radius: var(--hero-radius);
   overflow: hidden;
   display: flex;
   align-items: flex-end;
   justify-content: flex-start;
   padding: clamp(20px, 2vw, 36px);
+}
+/* The photo now goes through next/image (#197); it fills the box the way
+   background-size: cover used to. */
+.hero-photo-img {
+  object-fit: cover;
+  object-position: center;
+}
+/* Reproduces the darkening gradient the CSS background used to carry, so the
+   badge and the year monogram stay readable over any photo. */
+.hero-photo-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(29, 29, 27, 0.28);
+  pointer-events: none;
+}
+/* Keep the monogram above the image and its overlay. The badge already sets
+   position: absolute in its own rule, so it only needs the stacking order. */
+.hero-photo-wordmark {
+  position: relative;
+  z-index: 1;
 }
 .hero-photo-wordmark {
   font-size: clamp(72px, 14vw, 240px);
@@ -371,6 +392,7 @@ body {
 }
 .hero-photo-badge {
   position: absolute;
+  z-index: 1;
   top: clamp(16px, 1.6vw, 28px);
   right: clamp(16px, 1.6vw, 28px);
   background: rgba(255, 255, 255, 0.92);

--- a/src/frontend/src/components/home/HeroSection.tsx
+++ b/src/frontend/src/components/home/HeroSection.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import KeyFiguresSection from "./KeyFiguresSection";
@@ -38,10 +39,6 @@ export default function HeroSection({ edition, cfp, locale, figures = [] }: Hero
 
   // Filigree monogram inside the photo, e.g. "'26" for the 2026 edition.
   const yearMonogram = edition?.year ? `'${String(edition.year).slice(-2)}` : null;
-
-  const photoBackground = heroImageUrl
-    ? `linear-gradient(0deg, rgba(29,29,27,0.28), rgba(29,29,27,0.28)), url('${heroImageUrl}')`
-    : "linear-gradient(0deg, rgba(29,29,27,0.28), rgba(29,29,27,0.28)), url('https://picsum.photos/1600/1000?random=devfest')";
 
   const hasFigures = figures.length > 0;
 
@@ -111,11 +108,26 @@ export default function HeroSection({ edition, cfp, locale, figures = [] }: Hero
           )}
         </div>
 
-        <div
-          className="hero-photo"
-          aria-hidden="true"
-          style={{ backgroundImage: photoBackground }}
-        >
+        {/* The hero image is the LCP element. It used to be a CSS
+            background-image, which never reaches next/image: the raw 3.4 MB
+            upload was served as-is and the browser only discovered it after
+            parsing the CSS, pushing LCP past 20 s on slow 4G (#197). Rendering
+            it through <Image priority> gets it WebP/AVIF conversion, a size
+            matched to the viewport, a preload in the document head and
+            fetchpriority=high. The overlay reproduces the darkening gradient
+            the background used to carry. */}
+        <div className="hero-photo" aria-hidden="true">
+          {heroImageUrl && (
+            <Image
+              src={heroImageUrl}
+              alt=""
+              fill
+              priority
+              sizes="(max-width: 1024px) 100vw, 50vw"
+              className="hero-photo-img"
+            />
+          )}
+          <span className="hero-photo-overlay" />
           {cfpUrl && <span className="hero-photo-badge text-noir">{t("cfpBadge")}</span>}
           {yearMonogram && <span className="hero-photo-wordmark">{yearMonogram}</span>}
         </div>


### PR DESCRIPTION
Ferme #197.

## Résumé

L'image du hero était un **`background-image` CSS**, qui n'atteint jamais `next/image` : l'upload brut de **3,4 Mo** était servi tel quel, et le navigateur ne le découvrait qu'après avoir parsé le CSS. En 4G lente, cela expliquait à lui seul un **LCP de 20,6 s** — huit fois la cible de 2,5 s.

Elle est désormais rendue via **`<Image fill priority>`**.

## Gain mesuré (image de 3,4 Mo, identique à celle du rapport)

| Variante | Poids | Format | Réduction |
|---|---|---|---|
| **Avant (brut)** | **3 414 525 o** | PNG | — |
| Mobile (640w) | **44 931 o** | **AVIF** | **−98,7 %** |
| Tablette (1200w) | 141 899 o | AVIF | −95,8 % |
| Desktop (1920w) | 243 441 o | AVIF | −92,9 % |

**Sur le profil du rapport Lighthouse (mobile 4G lente) : 3,4 Mo → 44 Ko, soit 76× moins lourd.**

## Ce que le correctif apporte

- **Conversion AVIF/WebP + taille adaptée au viewport** (`srcSet` 384w → 1920w).
- **`<link rel="preload" as="image">` dans le `<head>`** : la ressource est découverte immédiatement, plus après le CSS. L'audit « Détection de la requête LCP » est satisfait (`priority` implique `fetchpriority=high`).
- Le dégradé d'assombrissement que portait le background passe dans un **overlay** ; le badge CFP et le monogramme de l'année gardent leur ordre d'empilement au-dessus.
- **`Cache-Control: public, max-age=31536000, immutable` sur `/uploads`** — les noms de fichiers sont uniques (`${Date.now()}-${random}.ext`), donc une URL ne change jamais de contenu. Jusqu'ici, les 3,4 Mo pouvaient être re-téléchargés à **chaque visite**.

## Test plan

- [x] `tsc` backend + `next build` + `eslint` : OK
- [x] Vérifié en local avec **la même image de 3,4 Mo** :
  - l'image passe par `/_next/image` avec un `srcSet` responsive ✅
  - un `<link rel="preload" as="image">` est bien émis ✅
  - poids servi : **44 Ko en AVIF** sur mobile (contre 3 414 525 o bruts) ✅
  - `/uploads` renvoie `Cache-Control: public, max-age=31536000, immutable`, transmis à travers le proxy Next ✅
- [x] **Aucune régression visuelle** (Chrome DevTools MCP) : desktop 1440px et mobile 390px — image, coins arrondis, monogramme et mise en page identiques
- [ ] **Rapport PageSpeed à refaire après mise en prod** pour confirmer LCP < 2,5 s et score ≥ 90 (critères d'acceptation de l'issue)

## Hors périmètre de cette PR

Les tâches **P2** de l'issue (gains marginaux) ne sont pas traitées, pour garder la PR ciblée sur la cause du LCP :
- `preconnect` vers Plausible (~370 ms estimés)
- `browserslist` moderne (14 Ko de polyfills)
- miniature YouTube en `hqdefault` (58 Ko)

À reprendre si le score reste sous 90 une fois celle-ci en prod.
