### PR TITLE
Articles — accéder à tous les articles d'une édition passée (#178)

### DIFF
--- a/src/backend/src/routes/articles.ts
+++ b/src/backend/src/routes/articles.ts
@@ -53,17 +53,23 @@ export default async function articleRoutes(app: FastifyInstance) {
     return articles.map(mapArticleSummary);
   });
 
-  // GET /api/articles?page=1&limit=9&tag=slug — paginated list of published articles
+  // GET /api/articles?page=1&limit=9&tag=slug&editionId=2 — paginated list of
+  // published articles. `editionId` filters strictly on articles attached to
+  // that edition — unlike /articles/latest, which also pulls in the ones with
+  // no edition at all. A page titled "articles of the 2025 edition" should not
+  // show articles that belong to no edition (#178).
   app.get<{
-    Querystring: { page?: string; limit?: string; tag?: string };
+    Querystring: { page?: string; limit?: string; tag?: string; editionId?: string };
   }>("/articles", async (request) => {
     const page = Math.max(Number(request.query.page) || 1, 1);
     const limit = Math.min(Number(request.query.limit) || 12, 50);
     const tagSlug = request.query.tag;
+    const editionId = Number(request.query.editionId) || undefined;
 
     const where = {
       publicationStatus: "PUBLISHED" as const,
       ...(tagSlug ? { tags: { some: { slug: tagSlug } } } : {}),
+      ...(editionId ? { editions: { some: { id: editionId } } } : {}),
     };
 
     const [articles, total] = await Promise.all([

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -201,7 +201,8 @@
     "nextEdition": "Next edition",
     "speakers": "Speakers ({count})",
     "sessions": "Talks ({count})",
-    "replay": "Watch"
+    "replay": "Watch",
+    "allNews": "See all news"
   },
   "editionsList": {
     "home": "Home",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -201,7 +201,8 @@
     "nextEdition": "Édition suivante",
     "speakers": "Speakers ({count})",
     "sessions": "Conférences ({count})",
-    "replay": "Revoir"
+    "replay": "Revoir",
+    "allNews": "Voir toutes les actualités"
   },
   "editionsList": {
     "home": "Accueil",

--- a/src/frontend/src/app/[locale]/actualites/page.tsx
+++ b/src/frontend/src/app/[locale]/actualites/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
-import { getArticles } from "@/lib/api";
+import { getArticles, getEditions } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleCard from "@/components/ArticleCard";
 import Pagination from "@/components/Pagination";
@@ -22,16 +22,26 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function ArticlesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{ page?: string; edition?: string }>;
 }) {
   const locale = await getLocale();
   const t = await getTranslations("articles");
-  const { page: pageParam } = await searchParams;
+  const { page: pageParam, edition: editionParam } = await searchParams;
   const page = Math.max(Number(pageParam) || 1, 1);
+
+  // ?edition=2025 filters the list down to that edition's articles (#178). The
+  // year is what the URL carries — it is readable and stable — so it has to be
+  // resolved to the edition id the API expects. An unknown year yields no
+  // filter rather than an empty page.
+  const editionYear = Number(editionParam) || null;
+  const editions = editionYear ? await getEditions() : [];
+  const edition = editionYear ? editions.find((e) => e.year === editionYear) ?? null : null;
 
   // 12 = 3 full rows of the 4-column grid (see grid-cols-4 below); 9 left a
   // trailing row of one item with three empty slots (#165).
-  const { articles, totalPages } = await getArticles(page, 12);
+  const { articles, totalPages } = await getArticles(page, 12, undefined, edition?.id);
+
+  const heading = edition ? `${t("title")} — DevFest Toulouse ${edition.year}` : t("title");
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },
@@ -44,7 +54,7 @@ export default async function ArticlesPage({
         <Breadcrumb items={breadcrumbItems} />
 
         <h1 className="mt-6 text-3xl lg:text-5xl font-bold text-noir">
-          {t("title")}
+          {heading}
         </h1>
 
         {articles.length === 0 ? (
@@ -61,6 +71,9 @@ export default async function ArticlesPage({
               currentPage={page}
               totalPages={totalPages}
               basePath="/actualites"
+              // Carry the edition filter across pages, otherwise page 2 would
+              // silently drop back to every article.
+              queryParams={edition ? { edition: String(edition.year) } : {}}
             />
           </>
         )}

--- a/src/frontend/src/app/[locale]/editions/[year]/page.tsx
+++ b/src/frontend/src/app/[locale]/editions/[year]/page.tsx
@@ -274,6 +274,17 @@ export default async function BilanPage({ params }: PageProps) {
                   </Link>
                 ))}
               </div>
+
+              {/* The grid above is a preview capped at 4 articles server-side.
+                  Without this link the other ones were simply unreachable (#178). */}
+              <div className="mt-8 text-center">
+                <Link
+                  href={`/actualites?edition=${edition.year}`}
+                  className="inline-block rounded-[12px] border-2 border-bleu px-6 py-3 text-base font-bold text-bleu transition-colors hover:bg-bleu hover:text-blanc"
+                >
+                  {t("allNews")}
+                </Link>
+              </div>
             </section>
           )}
 

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -69,9 +69,11 @@ export async function getArticles(
   page = 1,
   limit = 12,
   tag?: string,
+  editionId?: number,
 ): Promise<PaginatedArticles> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (tag) params.set("tag", tag);
+  if (editionId) params.set("editionId", String(editionId));
   return (
     (await fetchAPI<PaginatedArticles>(`/api/articles?${params}`)) || {
       articles: [],


### PR DESCRIPTION
Ferme #178.

## Résumé

La page d'une édition passée n'affichait que **4 articles** et n'offrait **aucune navigation** vers les autres : l'API plafonne l'aperçu à `take: 4` et la page se contente d'afficher ce qu'elle reçoit. L'édition 2025 a 7 articles publiés — 3 étaient donc inatteignables.

**Correctif** (celui retenu dans la qualification de l'issue) : garder l'aperçu de 4 articles, et ajouter un lien vers la **liste complète paginée, filtrée par édition**.

## Détails

- **Backend** : `GET /api/articles` accepte désormais `editionId`. Le filtre est **strict** (`editions: { some: { id } }`), contrairement à `/articles/latest` qui ramène aussi les articles sans édition — une page intitulée « articles de l'édition 2023 » ne doit pas lister ceux qui n'appartiennent à aucune édition.
- **Front `/actualites`** : lit un `?edition=<année>`, la résout en édition, et adapte son titre (« Actualités — DevFest Toulouse 2023 »). L'année dans l'URL est plus lisible et stable qu'un id.
- **Pagination** : le filtre est propagé dans les liens de pages — sans quoi la page 2 serait silencieusement retombée sur *tous* les articles.
- **Page édition** : lien « Voir toutes les actualités » sous la grille (FR/EN).

## Test plan

- [x] `tsc` backend + `next build` : OK
- [x] Vérifié en local sur une édition à **8 articles publiés** (le bug s'y reproduit) :
  - API sans filtre : 32 articles · avec `editionId` : **exactement 8** ✅
  - API filtre + pagination : page 2 renvoie les 3 restants ✅
  - Page édition : lien `/fr/actualites?edition=2023` présent, aperçu toujours à 4 ✅
  - Page filtrée : **8 articles**, titre « Actualités — DevFest Toulouse 2023 » ✅
  - `/actualites` **sans paramètre : comportement inchangé** (12 articles, titre « Actualités ») ✅
  - Avec >12 articles : liens de pagination `?edition=2023&page=2` et `&page=3` — **le filtre survit à la pagination** ✅