### PR TITLE
SEO — l'image OG custom l'emporte sur le visuel généré (#183)

### DIFF
--- a/src/backend/src/lib/revalidate.ts
+++ b/src/backend/src/lib/revalidate.ts
@@ -35,7 +35,13 @@ function bilingualPaths(template: string): string[] {
 }
 
 export function revalidateHome(): Promise<void> {
-  return revalidatePaths(bilingualPaths(""));
+  return revalidatePaths([
+    ...bilingualPaths(""),
+    // The social preview image is a route of its own: without purging it, an
+    // og:image changed in the admin would keep serving the previous one until
+    // its cache expired (#183).
+    ...bilingualPaths("/opengraph-image"),
+  ]);
 }
 
 export function revalidateArticle(slug: string): Promise<void> {

--- a/src/frontend/src/app/[locale]/opengraph-image.tsx
+++ b/src/frontend/src/app/[locale]/opengraph-image.tsx
@@ -1,7 +1,8 @@
 import { ImageResponse } from "next/og";
 import { getTranslations } from "next-intl/server";
 
-import { getCurrentEdition } from "@/lib/api";
+import { getCurrentEdition, getSeoSettings } from "@/lib/api";
+import { absoluteUrl } from "@/lib/seo";
 
 export const alt = "DevFest Toulouse";
 export const size = { width: 1200, height: 630 };
@@ -13,10 +14,37 @@ export default async function OpengraphImage({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const [t, edition] = await Promise.all([
+  const [t, edition, seoSettings] = await Promise.all([
     getTranslations({ locale, namespace: "site" }),
     getCurrentEdition(),
+    getSeoSettings(),
   ]);
+
+  // This file convention wins over `openGraph.images` from generateMetadata, so
+  // an admin-set og:image was being overridden by the generated visual — while
+  // twitter:image, set explicitly, kept the custom one. The two tags disagreed
+  // (#183). Honour the override here: serve the custom image's bytes when one is
+  // set, and only fall back to the generated card otherwise.
+  //
+  // The bytes are proxied rather than redirected to: the convention expects an
+  // image response, and OG scrapers do not all follow redirects reliably.
+  const customOgImage = seoSettings.seo_og_image;
+  if (customOgImage) {
+    try {
+      const upstream = await fetch(absoluteUrl(customOgImage));
+      if (upstream.ok) {
+        return new Response(upstream.body, {
+          headers: {
+            "Content-Type": upstream.headers.get("content-type") ?? "image/png",
+            "Cache-Control": "public, max-age=3600",
+          },
+        });
+      }
+    } catch {
+      // Unreachable custom image — fall through to the generated card rather
+      // than serving nothing.
+    }
+  }
 
   const year = edition?.year ?? new Date().getFullYear();
   const title = `DevFest Toulouse ${year}`;

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -117,8 +117,11 @@ export async function getSocialLinks(): Promise<SocialLinks> {
   return (await fetchAPI<SocialLinks>("/api/settings/social")) || {};
 }
 
+// Short TTL: the OG image is read both by the layout (twitter:image) and by the
+// opengraph-image route (#183). With the default 1h TTL, changing it in the
+// admin left the old image in the social previews for up to an hour.
 export async function getSeoSettings(): Promise<Record<string, string>> {
-  return (await fetchAPI<Record<string, string>>("/api/settings/seo")) || {};
+  return (await fetchAPI<Record<string, string>>("/api/settings/seo", 60)) || {};
 }
 
 // Brand identity (logo variants + favicons). Layout uses these to wire the


### PR DESCRIPTION
Ferme #183.

## Résumé

Partager le site affichait le **visuel vert généré**, pas l'image configurée dans **Admin → Paramètres → SEO**. Les deux balises sociales se contredisaient :

| Balise | Avant |
|---|---|
| `og:image` | image **générée** ❌ |
| `twitter:image` | image **custom** ✅ |

**Cause** : le fichier-convention `opengraph-image.tsx` l'emporte sur `openGraph.images` de `generateMetadata`. `twitter.images`, défini explicitement, gardait l'override — pas `og:image`.

**Correctif** : lire `seo_og_image` **dans le fichier-convention** et, s'il est défini, **servir les octets de l'image custom** ; sinon, retomber sur le visuel généré.

Les octets sont **proxifiés, pas redirigés** : la convention attend une réponse image, et les scrapers OG ne suivent pas tous les redirections de façon fiable (j'ai d'ailleurs vérifié qu'un `Response.redirect` y est purement ignoré).

Les `opengraph-image` **par page** (speakers, conférences, éditions) ne sont **pas** touchés — leur visuel généré est celui qu'on veut.

## Deux pièges de cache traités

- `getSeoSettings` passe à un **TTL de 60 s** (il était à 1 h) : changer l'image dans l'admin la laissait obsolète jusqu'à une heure dans les aperçus.
- `revalidateHome()` purge désormais **aussi la route `opengraph-image`** — sinon l'ancienne image continuait d'être servie après une sauvegarde admin.

## Test plan

- [x] `tsc` backend + `next build` + `eslint` : OK
- [x] Vérifié en local, en **pesant l'image réellement servie** (custom = 8 230 o, générée = 119 310 o) :
  - **avec `seo_og_image`** → la route sert **8 230 o** = l'image custom ✅
  - **sans** → **119 310 o**, `image/png` valide = le visuel généré ✅
  - `og:image` et `twitter:image` mènent désormais au **même contenu** ✅