### PR TITLE
Admin — la purge du cache réussie n'affiche plus « Erreur » (#181)

### DIFF
--- a/src/backend/src/routes/admin/cache.ts
+++ b/src/backend/src/routes/admin/cache.ts
@@ -8,6 +8,9 @@ export default async function adminCacheRoutes(app: FastifyInstance) {
   }>("/cache/purge", async (request) => {
     const paths = request.body?.paths || ["/"];
     await revalidatePaths(paths);
-    return { success: true, paths };
+    // `revalidated` is what the admin UI checks, and it matches the frontend's
+    // own /api/revalidate contract. Returning `success` instead made a purge
+    // that had actually worked show up as an error (#181).
+    return { revalidated: true, paths };
   });
 }


### PR DESCRIPTION
Ferme #181.

## Résumé

La purge du cache **fonctionnait**, mais l'admin affichait « Erreur lors du purge ».

**Cause** : décalage de contrat. Le front teste `data.revalidated` ([settings/page.tsx:62](src/frontend/src/app/admin/settings/page.tsx#L62)), alors que la route renvoyait `{ success: true }` — le champ était donc toujours `undefined`, et **toute purge passait pour un échec**.

**Correctif** : la route renvoie `revalidated`, qui est aussi le nom employé par le contrat `/api/revalidate` du frontend. La page admin est le seul consommateur (vérifié).

## Test plan

- [x] `tsc` backend : OK
- [x] Vérifié en local : `POST /api/admin/cache/purge` renvoie `{"revalidated": true, "paths": ["/fr"]}` — le test `data?.revalidated` du front passe désormais, l'UI affiche un succès ✅