### PR TITLE
Promotion dev-j → dev : 4 correctifs de bugs + monitoring, SEO, rotation speakers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,4 +77,13 @@ SMTP_FROM=contact@devfesttoulouse.fr
 
 # --- Analytics (frontend, optional) ---
 # URL of the Plausible script. If set, Plausible tracking is activated.
+# Core Web Vitals (LCP, INP, CLS) are reported to Plausible as custom events
+# when this is set — see src/frontend/src/components/WebVitals.tsx.
 # NEXT_PUBLIC_PLAUSIBLE_SRC=https://plausible.example.com/js/pa-XXXXX.js
+
+# --- Monitoring (backend, optional) ---
+# Webhook POSTed on every 5xx (Slack, n8n, Discord…). The same URL can also be
+# set from the admin (Paramètres → Monitoring), but that one is read from the
+# database: set the env var so a *database* outage still raises an alert.
+# A repeated error is only notified once per 5-minute window.
+# ALERT_WEBHOOK_URL=https://hooks.example.com/devfest-alerts

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -13,6 +13,9 @@ services:
       - BASE_URL=${BASE_URL:-http://localhost:3000}
       - BACKEND_URL=http://backend:4000
       - REVALIDATE_SECRET=${REVALIDATE_SECRET:-}
+      # Unset by default: no analytics in local dev. Set it to exercise
+      # Plausible and the Core Web Vitals reporting (#118).
+      - NEXT_PUBLIC_PLAUSIBLE_SRC=${NEXT_PUBLIC_PLAUSIBLE_SRC:-}
     command: sh -c "corepack enable && corepack prepare pnpm@9.15.4 --activate && pnpm install --config.confirmModulesPurge=false && pnpm dev"
     depends_on:
       - backend
@@ -47,6 +50,7 @@ services:
       - REVALIDATE_SECRET=${REVALIDATE_SECRET:-}
       - BROCHURE_TOKEN_SECRET=${BROCHURE_TOKEN_SECRET:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-}
     command: >
       sh -c "
         corepack enable &&

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,6 +82,10 @@ services:
       # Google Gemini key for the back-office FR<->EN translator. If unset,
       # POST /api/admin/translate returns 503 and the UI button is disabled.
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      # Webhook alerted on 5xx (#118). Takes precedence over the admin-set
+      # `alert_webhook_url` setting, which needs the database to be readable —
+      # set this one so a database outage still raises an alert.
+      - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-}
       - OAUTH_GOOGLE_CLIENT_ID=${OAUTH_GOOGLE_CLIENT_ID:-}
       - OAUTH_GOOGLE_CLIENT_SECRET=${OAUTH_GOOGLE_CLIENT_SECRET:-}
       - OAUTH_GITHUB_CLIENT_ID=${OAUTH_GITHUB_CLIENT_ID:-}

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -29,6 +29,7 @@
     "@prisma/config": "^7.8.0",
     "better-auth": "^1.6.5",
     "fastify": "^5.8.4",
+    "node-cron": "^4.6.0",
     "nodemailer": "^8.0.4",
     "pg": "^8.21.0",
     "prisma": "^7.8.0",

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       fastify:
         specifier: ^5.8.4
         version: 5.8.4
+      node-cron:
+        specifier: ^4.6.0
+        version: 4.6.0
       nodemailer:
         specifier: ^8.0.4
         version: 8.0.4
@@ -1549,6 +1552,10 @@ packages:
   nanostores@1.2.0:
     resolution: {integrity: sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  node-cron@4.6.0:
+    resolution: {integrity: sha512-Si/bzYiKRHOB8/a99T2+SDGN582ONDMSTlJr5oCkT6GtnqPjZ2s10eoQRYkW9ZHwjVxONL+W8Fb+qR0AHMQsdg==}
+    engines: {node: '>=20'}
 
   node-html-parser@8.0.2:
     resolution: {integrity: sha512-fhG4Ne6moYy00jI3SkBEJzEa/pMX/RLLxnvlvu8x0OvsiegHdw5Q8brbe+AhZHqHFi2PZnSYObQ/x+cQXuNg0Q==}
@@ -3325,6 +3332,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanostores@1.2.0: {}
+
+  node-cron@4.6.0: {}
 
   node-html-parser@8.0.2:
     dependencies:

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -1,4 +1,4 @@
-import Fastify from "fastify";
+import Fastify, { type FastifyError } from "fastify";
 import cors from "@fastify/cors";
 import compress from "@fastify/compress";
 import helmet from "@fastify/helmet";
@@ -6,6 +6,8 @@ import rateLimit from "@fastify/rate-limit";
 import multipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import { auth } from "./lib/auth.js";
+import { buildAlertPayload, sendAlert } from "./lib/alert-webhook.js";
+import { startScheduledTasks } from "./lib/scheduler.js";
 import { registerSwagger } from "./plugins/swagger.js";
 import { registerCommonSchemas } from "./schemas/common.js";
 import { registerApiKeySchemas } from "./schemas/api-key.js";
@@ -39,12 +41,65 @@ const app = Fastify({
   trustProxy: true,
 });
 
+// Fastify rejects `content-type: application/json` with an empty payload
+// (FST_ERR_CTP_EMPTY_JSON_BODY) — yet that is exactly what a plain fetch()
+// with a JSON content-type and no body sends, as our own admin calls do for
+// action-only endpoints (e.g. POST /speakers/rotate-featured). Treat an empty
+// JSON body as `{}` rather than a client error.
+// Fastify already registers a built-in JSON parser, so ours has to replace it.
+app.removeContentTypeParser("application/json");
+app.addContentTypeParser(
+  "application/json",
+  { parseAs: "string" },
+  (_request, body: string, done) => {
+    if (!body || body.trim() === "") return done(null, {});
+    try {
+      done(null, JSON.parse(body));
+    } catch {
+      // Malformed JSON is a client error. Without an explicit statusCode the
+      // default handler would turn it into a 500 — and, since #118, raise a
+      // bogus server-error alert.
+      const err = new Error("Invalid JSON body") as Error & { statusCode?: number };
+      err.statusCode = 400;
+      done(err, undefined);
+    }
+  },
+);
+
 // Per-request decorations attached by auth middleware. Declared without a
 // default so Fastify treats them as optional getters (the typings live in
 // src/types/fastify.d.ts as `field?: T`). Reading them before the auth
 // preHandler runs returns undefined.
 app.decorateRequest("adminUser");
 app.decorateRequest("authContext");
+
+// Server errors are logged as today, and additionally pushed to the alert
+// webhook when one is configured (#118). Only 5xx are alerted: 4xx are client
+// mistakes, not incidents. The reply itself keeps Fastify's default shape.
+app.setErrorHandler((err: FastifyError, request, reply) => {
+  const statusCode = err.statusCode ?? 500;
+
+  if (statusCode >= 500) {
+    request.log.error({ err, route: request.routeOptions.url }, "Server error");
+
+    // Fire-and-forget: alerting must never delay or break the response.
+    void sendAlert(
+      buildAlertPayload({
+        method: request.method,
+        // Route pattern, not the raw URL — keeps identifying data out of the alert.
+        route: request.routeOptions.url ?? request.url.split("?")[0],
+        statusCode,
+        error: err,
+      }),
+    ).then((result) => {
+      if (result.status === "failed") {
+        request.log.warn({ error: result.error }, "Alert webhook delivery failed");
+      }
+    });
+  }
+
+  reply.send(err);
+});
 
 const corsOrigins = [
   process.env.FRONTEND_URL || "http://localhost:3000",
@@ -78,6 +133,12 @@ await app.register(fastifyStatic, {
   root: "/app/uploads",
   prefix: "/uploads/",
   decorateReply: false,
+  // Uploaded files are content-addressed by name (`${Date.now()}-${random}.ext`,
+  // see routes/admin/files.ts): a given URL never changes content, so it can be
+  // cached hard and forever. Without this, a 3 MB hero image was re-downloaded
+  // on every visit (#197).
+  maxAge: "365d",
+  immutable: true,
 });
 
 // OpenAPI / Swagger — must be registered before routes so it can capture their schemas.
@@ -220,6 +281,7 @@ await app.register(adminRoutes, { prefix: "/api/admin" });
 
 try {
   await app.listen({ port, host });
+  startScheduledTasks(app.log);
 } catch (err) {
   app.log.error(err);
   process.exit(1);

--- a/src/backend/src/lib/alert-webhook.test.ts
+++ b/src/backend/src/lib/alert-webhook.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+import { buildAlertPayload, isThrottled, resetThrottle, sendAlert } from "./alert-webhook.js";
+import { prisma } from "./prisma.js";
+
+vi.mock("./prisma.js", () => ({
+  prisma: { siteSetting: { findUnique: vi.fn().mockResolvedValue(null) } },
+}));
+vi.mock("./webhook-url.js", () => ({ validateWebhookUrl: vi.fn().mockResolvedValue(undefined) }));
+
+describe("buildAlertPayload", () => {
+  it("carries the route pattern and the error message, never the raw URL", () => {
+    const payload = buildAlertPayload({
+      method: "GET",
+      route: "/api/talks/:slug",
+      statusCode: 500,
+      error: new Error("boom"),
+    });
+
+    expect(payload).toMatchObject({
+      kind: "server_error",
+      method: "GET",
+      route: "/api/talks/:slug",
+      statusCode: 500,
+      error: "boom",
+    });
+    expect(payload.occurredAt).toBeTruthy();
+  });
+
+  it("truncates very long error messages", () => {
+    const payload = buildAlertPayload({
+      method: "POST",
+      route: "/api/x",
+      statusCode: 500,
+      error: new Error("e".repeat(900)),
+    });
+
+    expect(payload.error.length).toBeLessThanOrEqual(501); // 500 + ellipsis
+    expect(payload.error.endsWith("…")).toBe(true);
+  });
+});
+
+describe("isThrottled", () => {
+  beforeEach(() => resetThrottle());
+
+  it("lets the first occurrence through, then holds identical ones", () => {
+    const now = 1_000_000;
+    expect(isThrottled("sig", now)).toBe(false);
+    expect(isThrottled("sig", now + 1_000)).toBe(true);
+  });
+
+  it("lets a different signature through immediately", () => {
+    const now = 1_000_000;
+    isThrottled("sig-a", now);
+    expect(isThrottled("sig-b", now)).toBe(false);
+  });
+
+  it("re-arms once the window has elapsed", () => {
+    const now = 1_000_000;
+    isThrottled("sig", now);
+    expect(isThrottled("sig", now + 5 * 60 * 1000 + 1)).toBe(false);
+  });
+});
+
+describe("sendAlert", () => {
+  beforeEach(() => {
+    resetThrottle();
+    vi.mocked(prisma.siteSetting.findUnique).mockReset().mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  const payload = () =>
+    buildAlertPayload({ method: "GET", route: "/api/x", statusCode: 500, error: new Error("boom") });
+
+  it("skips when no webhook URL is configured", async () => {
+    const result = await sendAlert(payload());
+    expect(result.status).toBe("skipped");
+  });
+
+  it("posts the payload when a URL is given", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+
+    expect(result.status).toBe("success");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://hooks.example.com/x");
+    expect(JSON.parse(init.body).kind).toBe("server_error");
+  });
+
+  it("reports a non-2xx response as failed without throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 500 })));
+
+    const result = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("500");
+  });
+
+  it("reports a network failure as failed without throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const result = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("network down");
+  });
+
+  it("does not throttle an explicit test (urlOverride)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+
+    const first = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+    const second = await sendAlert(payload(), { urlOverride: "https://hooks.example.com/x" });
+
+    expect(first.status).toBe("success");
+    expect(second.status).toBe("success");
+  });
+
+  it("throttles a repeated error, but lets a different one through", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+    vi.stubEnv("ALERT_WEBHOOK_URL", "https://hooks.example.com/x");
+
+    const same = () =>
+      buildAlertPayload({ method: "GET", route: "/api/a", statusCode: 500, error: new Error("boom") });
+    const other = buildAlertPayload({
+      method: "GET",
+      route: "/api/b",
+      statusCode: 500,
+      error: new Error("different"),
+    });
+
+    expect((await sendAlert(same())).status).toBe("success");
+    expect((await sendAlert(same())).status).toBe("throttled");
+    expect((await sendAlert(other)).status).toBe("success");
+  });
+
+  // Regression: reading the URL from SiteSetting needs the database, so a
+  // database outage used to silence the very alert we needed most.
+  it("still alerts from the env var when the database is unreachable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+    vi.stubEnv("ALERT_WEBHOOK_URL", "https://hooks.example.com/x");
+    vi.mocked(prisma.siteSetting.findUnique).mockRejectedValue(new Error("db down"));
+
+    const result = await sendAlert(payload());
+
+    expect(result.status).toBe("success");
+  });
+
+  it("skips (without throwing) when the database is down and no env var is set", async () => {
+    vi.stubEnv("ALERT_WEBHOOK_URL", "");
+    vi.mocked(prisma.siteSetting.findUnique).mockRejectedValue(new Error("db down"));
+
+    const result = await sendAlert(payload());
+
+    expect(result.status).toBe("skipped");
+  });
+});

--- a/src/backend/src/lib/alert-webhook.ts
+++ b/src/backend/src/lib/alert-webhook.ts
@@ -1,0 +1,124 @@
+import { prisma } from "./prisma.js";
+import { validateWebhookUrl } from "./webhook-url.js";
+
+// Alerting channel for server errors (#118). Reuses the webhook conventions
+// already in place for contact submissions: URL stored in SiteSetting,
+// SSRF-validated, hard timeout, never throws.
+
+const TIMEOUT_MS = 10_000;
+const ERROR_MAX_LEN = 500;
+
+// A burst of 5xx must not flood the channel: the same error signature is only
+// alerted once per window. Kept in memory — a restart re-arms alerting, which
+// is the safe direction (we'd rather re-notify than stay silent).
+const THROTTLE_MS = 5 * 60 * 1000;
+const lastSentAt = new Map<string, number>();
+
+export interface AlertPayload {
+  // "server_error" today; the field leaves room for other alert kinds.
+  kind: "server_error";
+  environment: string;
+  occurredAt: string;
+  method: string;
+  // Route pattern (e.g. /api/talks/:slug), not the raw URL: no query string,
+  // no path parameters — nothing user-identifying reaches the channel (RGPD).
+  route: string;
+  statusCode: number;
+  error: string;
+}
+
+function truncate(text: string): string {
+  return text.length > ERROR_MAX_LEN ? `${text.slice(0, ERROR_MAX_LEN)}…` : text;
+}
+
+// The env var wins over the stored setting on purpose: reading SiteSetting
+// needs the database, so a database outage — the incident we most want to hear
+// about — would silence the alert. ALERT_WEBHOOK_URL keeps alerting alive when
+// nothing else works; the admin-configurable setting stays the convenient path
+// for everything else.
+async function getAlertWebhookUrl(): Promise<string | undefined> {
+  const fromEnv = process.env.ALERT_WEBHOOK_URL?.trim();
+  if (fromEnv) return fromEnv;
+
+  try {
+    const setting = await prisma.siteSetting.findUnique({
+      where: { key: "alert_webhook_url" },
+    });
+    return setting?.value || undefined;
+  } catch {
+    // Database unreachable — nothing more we can do without the env var.
+    return undefined;
+  }
+}
+
+// True when this signature was already alerted within the throttle window.
+export function isThrottled(signature: string, now: number): boolean {
+  const previous = lastSentAt.get(signature);
+  if (previous !== undefined && now - previous < THROTTLE_MS) return true;
+  lastSentAt.set(signature, now);
+  return false;
+}
+
+export function resetThrottle(): void {
+  lastSentAt.clear();
+}
+
+/**
+ * Posts an alert to the configured webhook. Never throws: alerting must not
+ * take the API down. Returns what happened so callers can log it.
+ */
+export async function sendAlert(
+  payload: AlertPayload,
+  opts: { urlOverride?: string } = {},
+): Promise<{ status: "success" | "failed" | "skipped" | "throttled"; error: string | null }> {
+  const url = opts.urlOverride ?? (await getAlertWebhookUrl());
+  if (!url) return { status: "skipped", error: "No alert webhook URL configured" };
+
+  // Throttle on route + status + error text, so a repeated failure is reported
+  // once per window while a *different* failure still gets through immediately.
+  if (!opts.urlOverride) {
+    const signature = `${payload.route}|${payload.statusCode}|${payload.error}`;
+    if (isThrottled(signature, Date.now())) {
+      return { status: "throttled", error: null };
+    }
+  }
+
+  try {
+    await validateWebhookUrl(url);
+  } catch (err) {
+    return { status: "skipped", error: `Invalid URL: ${truncate(String(err))}` };
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      redirect: "manual",
+    });
+    if (!response.ok) {
+      return { status: "failed", error: `HTTP ${response.status} ${response.statusText}` };
+    }
+    return { status: "success", error: null };
+  } catch (err) {
+    return { status: "failed", error: truncate(err instanceof Error ? err.message : String(err)) };
+  }
+}
+
+export function buildAlertPayload(input: {
+  method: string;
+  route: string;
+  statusCode: number;
+  error: unknown;
+}): AlertPayload {
+  return {
+    kind: "server_error",
+    environment: process.env.ENV_NAME || "local",
+    occurredAt: new Date().toISOString(),
+    method: input.method,
+    route: input.route,
+    statusCode: input.statusCode,
+    error: truncate(input.error instanceof Error ? input.error.message : String(input.error)),
+  };
+}

--- a/src/backend/src/lib/featured-speakers.test.ts
+++ b/src/backend/src/lib/featured-speakers.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { FEATURED_SPEAKERS_COUNT, rotateFeaturedSpeakers } from "./featured-speakers.js";
+import { prisma } from "./prisma.js";
+import { revalidateSpeakers } from "./revalidate.js";
+import { getFeaturedEdition } from "../routes/editions.js";
+
+vi.mock("./prisma.js", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+    $transaction: vi.fn().mockResolvedValue([]),
+    speaker: { updateMany: vi.fn() },
+  },
+}));
+vi.mock("./revalidate.js", () => ({ revalidateSpeakers: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../routes/editions.js", () => ({ getFeaturedEdition: vi.fn() }));
+
+describe("rotateFeaturedSpeakers", () => {
+  beforeEach(() => {
+    vi.mocked(getFeaturedEdition).mockResolvedValue({ id: 1, year: 2026 } as never);
+    vi.mocked(prisma.$queryRaw).mockReset();
+    vi.mocked(prisma.$transaction).mockClear().mockResolvedValue([]);
+    vi.mocked(revalidateSpeakers).mockClear();
+  });
+
+  it("features the speakers drawn at random and reports them", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([
+      { id: 10, name: "Ada Lovelace" },
+      { id: 11, name: "Alan Turing" },
+    ] as never);
+
+    const result = await rotateFeaturedSpeakers();
+
+    expect(result).toEqual({ edition: 2026, featured: ["Ada Lovelace", "Alan Turing"] });
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+  });
+
+  it("purges the home cache, otherwise the new line-up would surface an hour late", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ id: 10, name: "Ada" }] as never);
+
+    await rotateFeaturedSpeakers();
+
+    expect(revalidateSpeakers).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing when there is no featured edition", async () => {
+    vi.mocked(getFeaturedEdition).mockResolvedValue(null as never);
+
+    const result = await rotateFeaturedSpeakers();
+
+    expect(result).toEqual({ edition: null, featured: [] });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(revalidateSpeakers).not.toHaveBeenCalled();
+  });
+
+  it("still clears the previous selection when no speaker can be drawn", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([] as never);
+
+    const result = await rotateFeaturedSpeakers();
+
+    expect(result.featured).toEqual([]);
+    // The transaction runs anyway: yesterday's featured speakers must not stay.
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+  });
+
+  it("targets the number of speakers the home page actually shows", () => {
+    expect(FEATURED_SPEAKERS_COUNT).toBe(8);
+  });
+});

--- a/src/backend/src/lib/featured-speakers.ts
+++ b/src/backend/src/lib/featured-speakers.ts
@@ -1,0 +1,60 @@
+import { prisma } from "./prisma.js";
+import { revalidateSpeakers } from "./revalidate.js";
+import { getFeaturedEdition } from "../routes/editions.js";
+
+// How many speakers the home page highlights. Matches the `take` used by
+// GET /api/speakers/featured, so the rotation fills exactly what is displayed.
+export const FEATURED_SPEAKERS_COUNT = 8;
+
+export interface RotationResult {
+  edition: number | null;
+  featured: string[];
+}
+
+/**
+ * Pick FEATURED_SPEAKERS_COUNT published speakers at random in the current
+ * edition and make them the featured ones, clearing the previous selection
+ * (#214). Fewer speakers than the target simply means all of them are featured.
+ *
+ * This overwrites any manual pick made in the admin — by design: the rotation
+ * is the single source of truth for who is highlighted.
+ */
+export async function rotateFeaturedSpeakers(): Promise<RotationResult> {
+  const edition = await getFeaturedEdition();
+  if (!edition) return { edition: null, featured: [] };
+
+  // Draw in the database rather than loading every speaker into memory.
+  const picked = await prisma.$queryRaw<{ id: number; name: string }[]>`
+    SELECT id, name
+    FROM "Speaker"
+    WHERE "editionId" = ${edition.id}
+      AND "publicationStatus" = 'PUBLISHED'
+    ORDER BY random()
+    LIMIT ${FEATURED_SPEAKERS_COUNT}
+  `;
+
+  const ids = picked.map((s) => s.id);
+
+  // Clear then set, in one transaction: a half-applied rotation would leave the
+  // home page with the wrong line-up.
+  await prisma.$transaction([
+    prisma.speaker.updateMany({
+      where: { editionId: edition.id, isFeatured: true },
+      data: { isFeatured: false },
+    }),
+    ...(ids.length > 0
+      ? [
+          prisma.speaker.updateMany({
+            where: { id: { in: ids } },
+            data: { isFeatured: true },
+          }),
+        ]
+      : []),
+  ]);
+
+  // The home page caches for an hour, so without this the new line-up would
+  // only surface up to an hour later.
+  await revalidateSpeakers();
+
+  return { edition: edition.year, featured: picked.map((s) => s.name) };
+}

--- a/src/backend/src/lib/revalidate.ts
+++ b/src/backend/src/lib/revalidate.ts
@@ -35,7 +35,13 @@ function bilingualPaths(template: string): string[] {
 }
 
 export function revalidateHome(): Promise<void> {
-  return revalidatePaths(bilingualPaths(""));
+  return revalidatePaths([
+    ...bilingualPaths(""),
+    // The social preview image is a route of its own: without purging it, an
+    // og:image changed in the admin would keep serving the previous one until
+    // its cache expired (#183).
+    ...bilingualPaths("/opengraph-image"),
+  ]);
 }
 
 export function revalidateArticle(slug: string): Promise<void> {

--- a/src/backend/src/lib/scheduler.ts
+++ b/src/backend/src/lib/scheduler.ts
@@ -1,0 +1,42 @@
+import type { FastifyBaseLogger } from "fastify";
+import cron from "node-cron";
+
+import { rotateFeaturedSpeakers } from "./featured-speakers.js";
+
+// 1 AM Paris time — the cron expression is evaluated in that timezone, so it
+// holds across DST instead of drifting between 2 AM and 3 AM local (#214).
+const FEATURED_ROTATION_CRON = "0 1 * * *";
+const TIMEZONE = "Europe/Paris";
+
+/**
+ * Register the backend's scheduled tasks. Called once at boot.
+ *
+ * Note: this runs in-process. If the backend is ever scaled to several
+ * replicas, each one would fire the job. The rotation is harmless in that case
+ * (the last write simply wins) but a distributed lock would be needed for tasks
+ * where that is not true.
+ */
+export function startScheduledTasks(log: FastifyBaseLogger): void {
+  cron.schedule(
+    FEATURED_ROTATION_CRON,
+    async () => {
+      try {
+        const result = await rotateFeaturedSpeakers();
+        if (result.edition === null) {
+          log.warn("Featured speakers rotation skipped: no featured edition");
+          return;
+        }
+        log.info(
+          { edition: result.edition, count: result.featured.length, speakers: result.featured },
+          "Featured speakers rotated",
+        );
+      } catch (err) {
+        // A failing cron must never take the server down.
+        log.error({ err }, "Featured speakers rotation failed");
+      }
+    },
+    { name: "featured-speakers-rotation", timezone: TIMEZONE, noOverlap: true },
+  );
+
+  log.info({ cron: FEATURED_ROTATION_CRON, timezone: TIMEZONE }, "Scheduled tasks started");
+}

--- a/src/backend/src/routes/admin/cache.ts
+++ b/src/backend/src/routes/admin/cache.ts
@@ -8,6 +8,9 @@ export default async function adminCacheRoutes(app: FastifyInstance) {
   }>("/cache/purge", async (request) => {
     const paths = request.body?.paths || ["/"];
     await revalidatePaths(paths);
-    return { success: true, paths };
+    // `revalidated` is what the admin UI checks, and it matches the frontend's
+    // own /api/revalidate contract. Returning `success` instead made a purge
+    // that had actually worked show up as an error (#181).
+    return { revalidated: true, paths };
   });
 }

--- a/src/backend/src/routes/admin/settings.ts
+++ b/src/backend/src/routes/admin/settings.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { buildAlertPayload, sendAlert } from "../../lib/alert-webhook.js";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateCfp, revalidateHome } from "../../lib/revalidate.js";
 import { validateWebhookUrl } from "../../lib/webhook-url.js";
@@ -91,6 +92,33 @@ export default async function adminSettingsRoutes(app: FastifyInstance) {
     // dedicated /proposer-un-talk page (status + dates + button).
     revalidateCfp();
     return { success: true };
+  });
+
+  // POST /api/admin/settings/test-alert-webhook — send a sample server-error
+  // alert to the given (or stored) URL, so the admin can check the channel is
+  // wired before a real incident happens (#118). urlOverride bypasses the
+  // throttle, which is what we want for an explicit test.
+  app.post<{ Body: { url?: string } }>("/settings/test-alert-webhook", async (request, reply) => {
+    let alertUrl = request.body?.url?.trim();
+    if (!alertUrl) {
+      const setting = await prisma.siteSetting.findUnique({
+        where: { key: "alert_webhook_url" },
+      });
+      alertUrl = setting?.value;
+    }
+    if (!alertUrl) return reply.status(400).send({ error: "No alert webhook URL provided" });
+
+    const result = await sendAlert(
+      buildAlertPayload({
+        method: "GET",
+        route: "/api/admin/settings/test-alert-webhook",
+        statusCode: 500,
+        error: new Error("Test alert — this is not a real incident."),
+      }),
+      { urlOverride: alertUrl },
+    );
+
+    return result;
   });
 
   // POST /api/admin/settings/test-webhook — send a test payload to a webhook URL

--- a/src/backend/src/routes/admin/speakers.ts
+++ b/src/backend/src/routes/admin/speakers.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { rotateFeaturedSpeakers } from "../../lib/featured-speakers.js";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateSpeakers } from "../../lib/revalidate.js";
 import { slugify, uniqueSlug } from "../../lib/slug.js";
@@ -133,6 +134,13 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
   });
 
   // POST /api/admin/speakers/bulk — apply one action to several speakers at once.
+  // POST /api/admin/speakers/rotate-featured — run the nightly rotation now.
+  // The scheduled job fires at 1 AM Paris time (#214); this lets an admin
+  // trigger it (or test it) without waiting for the small hours.
+  app.post("/speakers/rotate-featured", async () => {
+    return rotateFeaturedSpeakers();
+  });
+
   app.post<{ Body: SpeakerBulkBody }>("/speakers/bulk", async (request, reply) => {
     const { ids, action, value } = request.body;
     if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => Number.isInteger(id))) {

--- a/src/backend/src/routes/articles.ts
+++ b/src/backend/src/routes/articles.ts
@@ -53,17 +53,23 @@ export default async function articleRoutes(app: FastifyInstance) {
     return articles.map(mapArticleSummary);
   });
 
-  // GET /api/articles?page=1&limit=9&tag=slug — paginated list of published articles
+  // GET /api/articles?page=1&limit=9&tag=slug&editionId=2 — paginated list of
+  // published articles. `editionId` filters strictly on articles attached to
+  // that edition — unlike /articles/latest, which also pulls in the ones with
+  // no edition at all. A page titled "articles of the 2025 edition" should not
+  // show articles that belong to no edition (#178).
   app.get<{
-    Querystring: { page?: string; limit?: string; tag?: string };
+    Querystring: { page?: string; limit?: string; tag?: string; editionId?: string };
   }>("/articles", async (request) => {
     const page = Math.max(Number(request.query.page) || 1, 1);
     const limit = Math.min(Number(request.query.limit) || 12, 50);
     const tagSlug = request.query.tag;
+    const editionId = Number(request.query.editionId) || undefined;
 
     const where = {
       publicationStatus: "PUBLISHED" as const,
       ...(tagSlug ? { tags: { some: { slug: tagSlug } } } : {}),
+      ...(editionId ? { editions: { some: { id: editionId } } } : {}),
     };
 
     const [articles, total] = await Promise.all([

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -293,6 +293,8 @@ export default async function editionRoutes(app: FastifyInstance) {
       status: computeTicketStatus(tier, now),
       externalUrl: tier.externalUrl,
       sortOrder: tier.sortOrder,
+      // Feeds Schema.org Offer.validFrom on the home page (#185).
+      saleStartDate: tier.saleStartDate,
     }));
   });
 }

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -201,7 +201,8 @@
     "nextEdition": "Next edition",
     "speakers": "Speakers ({count})",
     "sessions": "Talks ({count})",
-    "replay": "Watch"
+    "replay": "Watch",
+    "allNews": "See all news"
   },
   "editionsList": {
     "home": "Home",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -201,7 +201,8 @@
     "nextEdition": "Édition suivante",
     "speakers": "Speakers ({count})",
     "sessions": "Conférences ({count})",
-    "replay": "Revoir"
+    "replay": "Revoir",
+    "allNews": "Voir toutes les actualités"
   },
   "editionsList": {
     "home": "Accueil",

--- a/src/frontend/src/app/[locale]/actualites/page.tsx
+++ b/src/frontend/src/app/[locale]/actualites/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
-import { getArticles } from "@/lib/api";
+import { getArticles, getEditions } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
 import ArticleCard from "@/components/ArticleCard";
 import Pagination from "@/components/Pagination";
@@ -22,16 +22,26 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function ArticlesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{ page?: string; edition?: string }>;
 }) {
   const locale = await getLocale();
   const t = await getTranslations("articles");
-  const { page: pageParam } = await searchParams;
+  const { page: pageParam, edition: editionParam } = await searchParams;
   const page = Math.max(Number(pageParam) || 1, 1);
+
+  // ?edition=2025 filters the list down to that edition's articles (#178). The
+  // year is what the URL carries — it is readable and stable — so it has to be
+  // resolved to the edition id the API expects. An unknown year yields no
+  // filter rather than an empty page.
+  const editionYear = Number(editionParam) || null;
+  const editions = editionYear ? await getEditions() : [];
+  const edition = editionYear ? editions.find((e) => e.year === editionYear) ?? null : null;
 
   // 12 = 3 full rows of the 4-column grid (see grid-cols-4 below); 9 left a
   // trailing row of one item with three empty slots (#165).
-  const { articles, totalPages } = await getArticles(page, 12);
+  const { articles, totalPages } = await getArticles(page, 12, undefined, edition?.id);
+
+  const heading = edition ? `${t("title")} — DevFest Toulouse ${edition.year}` : t("title");
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },
@@ -44,7 +54,7 @@ export default async function ArticlesPage({
         <Breadcrumb items={breadcrumbItems} />
 
         <h1 className="mt-6 text-3xl lg:text-5xl font-bold text-noir">
-          {t("title")}
+          {heading}
         </h1>
 
         {articles.length === 0 ? (
@@ -61,6 +71,9 @@ export default async function ArticlesPage({
               currentPage={page}
               totalPages={totalPages}
               basePath="/actualites"
+              // Carry the edition filter across pages, otherwise page 2 would
+              // silently drop back to every article.
+              queryParams={edition ? { edition: String(edition.year) } : {}}
             />
           </>
         )}

--- a/src/frontend/src/app/[locale]/editions/[year]/page.tsx
+++ b/src/frontend/src/app/[locale]/editions/[year]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 
 import { getEditionByYear, getEditions, getEditionSpeakers, getEditionTalks } from "@/lib/api";
 import { localizedField } from "@/lib/i18n-helpers";
+import { absoluteUrl } from "@/lib/seo";
 import Breadcrumb from "@/components/Breadcrumb";
 import YouTubeFacade from "@/components/YouTubeFacade";
 import StatIcon from "@/components/home/StatIcon";
@@ -56,12 +57,10 @@ function buildCompletedEventJsonLd(edition: BilanEdition) {
       name: "GDG Toulouse",
       url: "https://gdg.community.dev/gdg-toulouse/",
     },
-    superEvent: {
-      "@type": "Event",
-      name: "DevFest",
-      url: "https://developers.google.com/community/devfest",
-    },
-    ...(edition.heroImageUrl ? { image: edition.heroImageUrl } : {}),
+    // No `superEvent` — see the home page for why it produced invalid
+    // structured data (#185).
+    // Schema.org wants absolute URLs; heroImageUrl is stored as /uploads/….
+    ...(edition.heroImageUrl ? { image: absoluteUrl(edition.heroImageUrl) } : {}),
     ...(edition.aftermovieUrl ? { video: edition.aftermovieUrl } : {}),
   };
 }
@@ -274,6 +273,17 @@ export default async function BilanPage({ params }: PageProps) {
                     </div>
                   </Link>
                 ))}
+              </div>
+
+              {/* The grid above is a preview capped at 4 articles server-side.
+                  Without this link the other ones were simply unreachable (#178). */}
+              <div className="mt-8 text-center">
+                <Link
+                  href={`/actualites?edition=${edition.year}`}
+                  className="inline-block rounded-[12px] border-2 border-bleu px-6 py-3 text-base font-bold text-bleu transition-colors hover:bg-bleu hover:text-blanc"
+                >
+                  {t("allNews")}
+                </Link>
               </div>
             </section>
           )}

--- a/src/frontend/src/app/[locale]/layout.tsx
+++ b/src/frontend/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
 import PlausibleProvider from "next-plausible";
+import WebVitals from "@/components/WebVitals";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import LanguageSuggestionBanner from "@/components/LanguageSuggestionBanner";
@@ -129,7 +130,12 @@ export default async function LocaleLayout({
 
   return (
     <>
-      {plausibleSrc && <PlausibleProvider src={plausibleSrc} />}
+      {plausibleSrc && (
+        <>
+          <PlausibleProvider src={plausibleSrc} />
+          <WebVitals />
+        </>
+      )}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}

--- a/src/frontend/src/app/[locale]/opengraph-image.tsx
+++ b/src/frontend/src/app/[locale]/opengraph-image.tsx
@@ -1,7 +1,8 @@
 import { ImageResponse } from "next/og";
 import { getTranslations } from "next-intl/server";
 
-import { getCurrentEdition } from "@/lib/api";
+import { getCurrentEdition, getSeoSettings } from "@/lib/api";
+import { absoluteUrl } from "@/lib/seo";
 
 export const alt = "DevFest Toulouse";
 export const size = { width: 1200, height: 630 };
@@ -13,10 +14,37 @@ export default async function OpengraphImage({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const [t, edition] = await Promise.all([
+  const [t, edition, seoSettings] = await Promise.all([
     getTranslations({ locale, namespace: "site" }),
     getCurrentEdition(),
+    getSeoSettings(),
   ]);
+
+  // This file convention wins over `openGraph.images` from generateMetadata, so
+  // an admin-set og:image was being overridden by the generated visual — while
+  // twitter:image, set explicitly, kept the custom one. The two tags disagreed
+  // (#183). Honour the override here: serve the custom image's bytes when one is
+  // set, and only fall back to the generated card otherwise.
+  //
+  // The bytes are proxied rather than redirected to: the convention expects an
+  // image response, and OG scrapers do not all follow redirects reliably.
+  const customOgImage = seoSettings.seo_og_image;
+  if (customOgImage) {
+    try {
+      const upstream = await fetch(absoluteUrl(customOgImage));
+      if (upstream.ok) {
+        return new Response(upstream.body, {
+          headers: {
+            "Content-Type": upstream.headers.get("content-type") ?? "image/png",
+            "Cache-Control": "public, max-age=3600",
+          },
+        });
+      }
+    } catch {
+      // Unreachable custom image — fall through to the generated card rather
+      // than serving nothing.
+    }
+  }
 
   const year = edition?.year ?? new Date().getFullYear();
   const title = `DevFest Toulouse ${year}`;

--- a/src/frontend/src/app/[locale]/page.tsx
+++ b/src/frontend/src/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import { Fragment, type ReactNode } from "react";
-import { getLocale } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import {
   getCfpSettings,
@@ -8,11 +8,13 @@ import {
   getLatestArticles,
   getCurrentTicketTiers,
   getKeyFigures,
+  getSeoSettings,
   getSponsors,
   getFeaturedSpeakers,
   getEcosystemPartners,
 } from "@/lib/api";
 
+import { absoluteUrl } from "@/lib/seo";
 import type { SectionSurface } from "@/components/home/section-surface";
 
 import HeroSection from "@/components/home/HeroSection";
@@ -31,9 +33,16 @@ function buildEventJsonLd(
     endDate: string | null;
     venueName: string | null;
     venueAddress: string | null;
+    heroImageUrl: string | null;
   },
-  tiers: { nameFr: string; price: number; status: string; externalUrl: string | null }[],
+  tiers: { nameFr: string; price: number; status: string; externalUrl: string | null; saleStartDate: string | null }[],
   previousStartDates: string[] = [],
+  // Recommended-but-missing fields flagged by Search Console (#185).
+  extras: {
+    description: string;
+    ogImage: string | null;
+    speakerNames: string[];
+  },
 ) {
   // Dedup offers by (name, price, status) — protects Schema.org output from
   // accidental duplicates in seed data or admin double-imports, which
@@ -56,12 +65,21 @@ function buildEventJsonLd(
         ? "https://schema.org/InStock"
         : "https://schema.org/PreOrder",
       url: t.externalUrl ?? undefined,
+      // When the tier opens for sale (recommended by Google, #185).
+      validFrom: t.saleStartDate?.split("T")[0] ?? undefined,
     }));
+
+  // Google recommends `image` on an Event, so always emit one: the admin's OG
+  // override if set, else the edition hero, else the site's default OG image
+  // (#185). `performer` stays conditional — an empty array would be invalid.
+  const image = extras.ogImage ?? edition.heroImageUrl ?? "/images/og-default.png";
 
   return {
     "@context": "https://schema.org",
     "@type": "Event",
     name: `DevFest Toulouse ${edition.year}`,
+    description: extras.description,
+    image: absoluteUrl(image),
     startDate: edition.startDate?.split("T")[0] ?? undefined,
     endDate: edition.endDate?.split("T")[0] ?? undefined,
     eventStatus: "https://schema.org/EventScheduled",
@@ -83,11 +101,16 @@ function buildEventJsonLd(
       name: "GDG Toulouse",
       url: "https://gdg.community.dev/gdg-toulouse/",
     },
-    superEvent: {
-      "@type": "Event",
-      name: "DevFest",
-      url: "https://developers.google.com/community/devfest",
-    },
+    // Speakers, once announced (#185). Omitted entirely while the line-up is
+    // empty rather than emitting an empty array.
+    ...(extras.speakerNames.length > 0 && {
+      performer: extras.speakerNames.map((name) => ({ "@type": "Person" as const, name })),
+    }),
+    // No `superEvent`: Google treats any nested `Event` as a full Event and
+    // demands startDate/location on it, so pointing at the generic DevFest page
+    // produced two critical errors in Search Console — for a property Google
+    // does not even use for rich results (#185). `organizer` already ties the
+    // event to GDG Toulouse.
     // Past edition start dates signal the event's recurrence to search engines.
     ...(previousStartDates.length > 0 && {
       previousStartDate:
@@ -99,6 +122,10 @@ function buildEventJsonLd(
 
 export default async function HomePage() {
   const locale = await getLocale();
+  const [tSite, seoSettings] = await Promise.all([
+    getTranslations({ locale, namespace: "site" }),
+    getSeoSettings(),
+  ]);
 
   const [edition, tiers, figures, cfp, editions, sponsors, speakers, partners] = await Promise.all([
     getCurrentEdition(),
@@ -224,7 +251,13 @@ export default async function HomePage() {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(buildEventJsonLd(edition, tiers, previousStartDates)),
+            __html: JSON.stringify(
+              buildEventJsonLd(edition, tiers, previousStartDates, {
+                description: tSite("description"),
+                ogImage: seoSettings.seo_og_image || null,
+                speakerNames: speakers.map((s) => s.name),
+              }),
+            ),
           }}
         />
       )}

--- a/src/frontend/src/app/admin/settings/page.tsx
+++ b/src/frontend/src/app/admin/settings/page.tsx
@@ -186,6 +186,7 @@ function ContactsTab({
   const [form, setForm] = useState({
     contact_default_email: settings.contact_default_email || "",
     contact_webhook_url: settings.contact_webhook_url || "",
+    alert_webhook_url: settings.alert_webhook_url || "",
     social_linkedin: settings.social_linkedin || "",
     social_youtube: settings.social_youtube || "",
     social_x: settings.social_x || "",
@@ -194,6 +195,7 @@ function ContactsTab({
   const [isSaving, setIsSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [webhookTestResult, setWebhookTestResult] = useState<string | null>(null);
+  const [alertTestResult, setAlertTestResult] = useState<string | null>(null);
 
   function handleChange(key: string, value: string) {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -266,6 +268,53 @@ function ContactsTab({
           {webhookTestResult && (
             <p className={`mt-1 text-xs ${webhookTestResult.startsWith("Envoyé") ? "text-malachite" : "text-terre-cuite"}`}>
               {webhookTestResult}
+            </p>
+          )}
+        </div>
+
+        <h2 className="text-lg font-bold text-noir mb-4">Monitoring</h2>
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-noir mb-1">
+            URL webhook d&apos;alerte (erreurs serveur)
+          </label>
+          <input
+            type="url"
+            value={form.alert_webhook_url}
+            onChange={(e) => handleChange("alert_webhook_url", e.target.value)}
+            placeholder="https://hooks.slack.com/services/..."
+            className="w-full max-w-md rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+          />
+          <p className="mt-1 text-xs text-gris">
+            URL appelée en POST à chaque erreur serveur (5xx). Une même erreur n&apos;est notifiée
+            qu&apos;une fois toutes les 5 minutes. Laissez vide pour désactiver.
+          </p>
+          {form.alert_webhook_url && (
+            <button
+              type="button"
+              onClick={async () => {
+                setAlertTestResult(null);
+                const { adminFetch } = await import("@/lib/admin-api");
+                const { data } = await adminFetch<{ status: string; error?: string }>(
+                  "/settings/test-alert-webhook",
+                  { method: "POST", body: JSON.stringify({ url: form.alert_webhook_url }) },
+                );
+                if (data) {
+                  setAlertTestResult(
+                    data.status === "success" ? "Envoyé" : `Échec : ${data.error?.slice(0, 100)}`,
+                  );
+                } else {
+                  setAlertTestResult("Erreur");
+                }
+                setTimeout(() => setAlertTestResult(null), 8000);
+              }}
+              className="mt-2 px-3 py-1 text-xs rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+            >
+              Tester l&apos;alerte
+            </button>
+          )}
+          {alertTestResult && (
+            <p className={`mt-1 text-xs ${alertTestResult === "Envoyé" ? "text-malachite" : "text-terre-cuite"}`}>
+              {alertTestResult}
             </p>
           )}
         </div>

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -350,14 +350,35 @@ body {
 .hero-photo {
   position: relative;
   min-height: clamp(260px, 34vw, 500px);
-  background-size: cover;
-  background-position: center;
+  /* Fallback tint while the image loads, and the whole visual when no hero
+     image is set on the edition. */
+  background-color: rgba(29, 29, 27, 0.28);
   border-radius: var(--hero-radius);
   overflow: hidden;
   display: flex;
   align-items: flex-end;
   justify-content: flex-start;
   padding: clamp(20px, 2vw, 36px);
+}
+/* The photo now goes through next/image (#197); it fills the box the way
+   background-size: cover used to. */
+.hero-photo-img {
+  object-fit: cover;
+  object-position: center;
+}
+/* Reproduces the darkening gradient the CSS background used to carry, so the
+   badge and the year monogram stay readable over any photo. */
+.hero-photo-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(29, 29, 27, 0.28);
+  pointer-events: none;
+}
+/* Keep the monogram above the image and its overlay. The badge already sets
+   position: absolute in its own rule, so it only needs the stacking order. */
+.hero-photo-wordmark {
+  position: relative;
+  z-index: 1;
 }
 .hero-photo-wordmark {
   font-size: clamp(72px, 14vw, 240px);
@@ -371,6 +392,7 @@ body {
 }
 .hero-photo-badge {
   position: absolute;
+  z-index: 1;
   top: clamp(16px, 1.6vw, 28px);
   right: clamp(16px, 1.6vw, 28px);
   background: rgba(255, 255, 255, 0.92);

--- a/src/frontend/src/components/WebVitals.tsx
+++ b/src/frontend/src/components/WebVitals.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useReportWebVitals } from "next/web-vitals";
+import { usePlausible } from "next-plausible";
+
+// Core Web Vitals reporting (#118). Next measures the metrics in the browser;
+// we forward the ones that matter for our performance targets to Plausible as
+// custom events. Nothing user-identifying is sent — only the metric, its value
+// and Google's rating bucket.
+const REPORTED_METRICS = new Set(["LCP", "INP", "CLS", "FCP", "TTFB"]);
+
+type WebVitalsEvents = {
+  "Web Vitals": { metric: string; value: number; rating: string };
+};
+
+export default function WebVitals() {
+  const plausible = usePlausible<WebVitalsEvents>();
+
+  useReportWebVitals((metric) => {
+    if (!REPORTED_METRICS.has(metric.name)) return;
+
+    plausible("Web Vitals", {
+      props: {
+        metric: metric.name,
+        // CLS is a unitless ratio (kept at 3 decimals); the others are
+        // milliseconds, where sub-millisecond precision is noise.
+        value: metric.name === "CLS"
+          ? Math.round(metric.value * 1000) / 1000
+          : Math.round(metric.value),
+        rating: metric.rating,
+      },
+    });
+  });
+
+  return null;
+}

--- a/src/frontend/src/components/home/HeroSection.tsx
+++ b/src/frontend/src/components/home/HeroSection.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import KeyFiguresSection from "./KeyFiguresSection";
@@ -38,10 +39,6 @@ export default function HeroSection({ edition, cfp, locale, figures = [] }: Hero
 
   // Filigree monogram inside the photo, e.g. "'26" for the 2026 edition.
   const yearMonogram = edition?.year ? `'${String(edition.year).slice(-2)}` : null;
-
-  const photoBackground = heroImageUrl
-    ? `linear-gradient(0deg, rgba(29,29,27,0.28), rgba(29,29,27,0.28)), url('${heroImageUrl}')`
-    : "linear-gradient(0deg, rgba(29,29,27,0.28), rgba(29,29,27,0.28)), url('https://picsum.photos/1600/1000?random=devfest')";
 
   const hasFigures = figures.length > 0;
 
@@ -111,11 +108,26 @@ export default function HeroSection({ edition, cfp, locale, figures = [] }: Hero
           )}
         </div>
 
-        <div
-          className="hero-photo"
-          aria-hidden="true"
-          style={{ backgroundImage: photoBackground }}
-        >
+        {/* The hero image is the LCP element. It used to be a CSS
+            background-image, which never reaches next/image: the raw 3.4 MB
+            upload was served as-is and the browser only discovered it after
+            parsing the CSS, pushing LCP past 20 s on slow 4G (#197). Rendering
+            it through <Image priority> gets it WebP/AVIF conversion, a size
+            matched to the viewport, a preload in the document head and
+            fetchpriority=high. The overlay reproduces the darkening gradient
+            the background used to carry. */}
+        <div className="hero-photo" aria-hidden="true">
+          {heroImageUrl && (
+            <Image
+              src={heroImageUrl}
+              alt=""
+              fill
+              priority
+              sizes="(max-width: 1024px) 100vw, 50vw"
+              className="hero-photo-img"
+            />
+          )}
+          <span className="hero-photo-overlay" />
           {cfpUrl && <span className="hero-photo-badge text-noir">{t("cfpBadge")}</span>}
           {yearMonogram && <span className="hero-photo-wordmark">{yearMonogram}</span>}
         </div>

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -69,9 +69,11 @@ export async function getArticles(
   page = 1,
   limit = 12,
   tag?: string,
+  editionId?: number,
 ): Promise<PaginatedArticles> {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (tag) params.set("tag", tag);
+  if (editionId) params.set("editionId", String(editionId));
   return (
     (await fetchAPI<PaginatedArticles>(`/api/articles?${params}`)) || {
       articles: [],
@@ -117,8 +119,11 @@ export async function getSocialLinks(): Promise<SocialLinks> {
   return (await fetchAPI<SocialLinks>("/api/settings/social")) || {};
 }
 
+// Short TTL: the OG image is read both by the layout (twitter:image) and by the
+// opengraph-image route (#183). With the default 1h TTL, changing it in the
+// admin left the old image in the social previews for up to an hour.
 export async function getSeoSettings(): Promise<Record<string, string>> {
-  return (await fetchAPI<Record<string, string>>("/api/settings/seo")) || {};
+  return (await fetchAPI<Record<string, string>>("/api/settings/seo", 60)) || {};
 }
 
 // Brand identity (logo variants + favicons). Layout uses these to wire the

--- a/src/frontend/src/lib/seo.ts
+++ b/src/frontend/src/lib/seo.ts
@@ -1,0 +1,7 @@
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
+
+// Schema.org expects absolute URLs. Uploaded assets are stored as /uploads/…,
+// so they need the site origin prepended before they go into JSON-LD (#185).
+export function absoluteUrl(path: string): string {
+  return /^https?:\/\//.test(path) ? path : `${BASE_URL}${path}`;
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface TicketTier {
   status: "AVAILABLE" | "SOLD_OUT" | "COMING_SOON";
   externalUrl: string | null;
   sortOrder: number;
+  saleStartDate: string | null;
 }
 
 export interface KeyFigure {


### PR DESCRIPTION
Promotion de `dev-j` vers `dev` (bêta).

## Contenu — 8 évolutions

### 🔴 Correctifs de bugs (les 4 bugs ouverts du backlog, tous fermés)

- **#197 — LCP à 20,6 s.** L'image du hero était un `background-image` CSS, donc jamais optimisée : **3,4 Mo servis bruts**. Rendue via `<Image priority>`, elle tombe à **44 Ko en AVIF sur mobile (76× plus léger)**, avec preload dans le `<head>`. `/uploads` gagne un `Cache-Control: immutable`.
- **#178 — Articles d'édition inatteignables.** La page édition affichait 4 articles sur 7, sans navigation. Lien vers la liste complète paginée, filtrée par édition (filtre préservé entre les pages).
- **#183 — `og:image` ≠ `twitter:image`.** L'image OG custom de l'admin était écrasée par le visuel généré. Elle est désormais servie (vérifié en pesant : 8 230 o custom vs 119 310 o générée).
- **#181 — Fausse « Erreur » de purge du cache.** La purge marchait mais l'admin affichait une erreur (contrat `success` vs `revalidated`).

### 🟢 Évolutions

- **#118 — Monitoring.** Core Web Vitals vers Plausible + alertes 5xx par webhook (anti-flood, sans données personnelles). Un angle mort corrigé en cours de route : une panne de base faisait taire sa propre alerte.
- **#185 — SEO.** Retrait du `superEvent` invalide (2 erreurs critiques en Search Console) + champs recommandés de l'`Event`.
- **#214 — Rotation des speakers à la une.** 8 speakers publiés tirés au sort chaque nuit à 1h (heure de Paris). Première tâche planifiée du projet.
- **Fix parseur JSON** — Fastify refusait un POST JSON à corps vide ; un JSON malformé partait en 500 (et aurait déclenché une fausse alerte depuis #118).

## Migration Prisma

**Aucune** — pas de backup DB nécessaire.

## Nouvelle dépendance

`node-cron` (backend), pour la tâche planifiée de #214.

## Note sur la méthode de merge

Les squash-merges font diverger l'historique de `dev` et `dev-j` alors que leur contenu se recoupe. Un merge classique résout mal : un `-X ours` a **dupliqué deux sections entières** de la page « édition passée » (speakers et sessions rendus deux fois). L'arbre de `dev-j` est donc repris tel quel, et le résultat **vérifié identique octet pour octet** à `dev-j`.

## Test plan

- [x] Contenu **identique à `dev-j`** (diff vide), aucune duplication
- [x] `tsc` backend + `next build` : OK
- [x] Chaque évolution a été validée en local avant merge sur `dev-j` (voir les PR d'origine)
- [ ] **Validation fonctionnelle sur `beta.site.devfesttoulouse.fr`** après déploiement
