### PR TITLE
Seed dev — mur de sponsors complet (4 platinum, 16 gold, 8 soutien)

### DIFF
--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -304,29 +304,176 @@ async function seedDev() {
   });
   console.log("Categories created: 2");
 
-  const sponsorOvh = await prisma.sponsor.create({
-    data: {
-      slug: "ovhcloud", name: "OVHcloud", level: "PLATINUM",
-      websiteUrl: "https://www.ovhcloud.com",
-      descriptionFr: "Leader européen du cloud.", descriptionEn: "European cloud leader.",
-      logoUrl: null, publicationStatus: "PUBLISHED", editionId: edition.id,
-    },
+  // A realistic sponsor wall: 4 Platinum, 16 Gold, 8 Soutien. Every field is
+  // filled (logo, both descriptions, website, socials, contact email) so the
+  // public pages and the admin forms can be exercised for real. Logos are
+  // placeholder SVGs under public/images/sponsors/ — see the slugs below.
+  const DEMO_SPONSORS: Array<{
+    slug: string;
+    name: string;
+    level: "PLATINUM" | "GOLD" | "SOUTIEN";
+    descriptionFr: string;
+    descriptionEn: string;
+    websiteUrl: string;
+  }> = [
+    { slug: "airbus-tech", name: "Airbus Tech", level: "PLATINUM",
+      descriptionFr: "Pôle logiciel embarqué et cloud souverain de l'avionneur toulousain. Nos équipes conçoivent les systèmes critiques qui volent chaque jour.",
+      descriptionEn: "Embedded software and sovereign cloud division of the Toulouse aircraft manufacturer. Our teams build the critical systems that fly every day.",
+      websiteUrl: "https://example.com/airbus-tech" },
+    { slug: "capgemini-sud", name: "Capgemini Sud", level: "PLATINUM",
+      descriptionFr: "Conseil et ingénierie logicielle en Occitanie. Nous accompagnons la transformation numérique des grands comptes régionaux.",
+      descriptionEn: "Consulting and software engineering in Occitanie. We drive the digital transformation of major regional accounts.",
+      websiteUrl: "https://example.com/capgemini-sud" },
+    { slug: "orange-business", name: "Orange Business", level: "PLATINUM",
+      descriptionFr: "Opérateur et intégrateur de services numériques. Réseaux, cybersécurité et plateformes de données pour les entreprises.",
+      descriptionEn: "Carrier and digital services integrator. Networks, cybersecurity and data platforms for businesses.",
+      websiteUrl: "https://example.com/orange-business" },
+    { slug: "thales-digital", name: "Thales Digital", level: "PLATINUM",
+      descriptionFr: "Technologies de confiance pour l'aérospatial, la défense et le transport. R&D logicielle basée à Toulouse.",
+      descriptionEn: "Trusted technologies for aerospace, defence and transport. Software R&D based in Toulouse.",
+      websiteUrl: "https://example.com/thales-digital" },
+
+    { slug: "sopra-steria", name: "Sopra Steria", level: "GOLD",
+      descriptionFr: "ESN européenne, forte présence à Toulouse sur les projets aéronautiques et bancaires.",
+      descriptionEn: "European IT services firm with a strong Toulouse presence in aerospace and banking projects.",
+      websiteUrl: "https://example.com/sopra-steria" },
+    { slug: "atos-occitanie", name: "Atos Occitanie", level: "GOLD",
+      descriptionFr: "Cloud, cybersécurité et calcul haute performance au service des acteurs régionaux.",
+      descriptionEn: "Cloud, cybersecurity and high-performance computing for regional players.",
+      websiteUrl: "https://example.com/atos-occitanie" },
+    { slug: "cgi-toulouse", name: "CGI Toulouse", level: "GOLD",
+      descriptionFr: "Conseil en management et intégration de systèmes, avec une practice Data & IA locale.",
+      descriptionEn: "Management consulting and systems integration, with a local Data & AI practice.",
+      websiteUrl: "https://example.com/cgi-toulouse" },
+    { slug: "akka-tech", name: "Akka Technologies", level: "GOLD",
+      descriptionFr: "Ingénierie et conseil en technologies, spécialiste des systèmes embarqués.",
+      descriptionEn: "Engineering and technology consulting, specialised in embedded systems.",
+      websiteUrl: "https://example.com/akka-tech" },
+    { slug: "altran-sud", name: "Altran Sud", level: "GOLD",
+      descriptionFr: "Ingénierie de la R&D externalisée pour l'industrie aéronautique et spatiale.",
+      descriptionEn: "Outsourced R&D engineering for the aerospace industry.",
+      websiteUrl: "https://example.com/altran-sud" },
+    { slug: "scalian-labs", name: "Scalian Labs", level: "GOLD",
+      descriptionFr: "Systèmes numériques critiques, qualité et performance opérationnelle.",
+      descriptionEn: "Critical digital systems, quality and operational performance.",
+      websiteUrl: "https://example.com/scalian-labs" },
+    { slug: "expleo-group", name: "Expleo Group", level: "GOLD",
+      descriptionFr: "Ingénierie, qualité et conseil en transformation, du prototype à la série.",
+      descriptionEn: "Engineering, quality and transformation consulting, from prototype to production.",
+      websiteUrl: "https://example.com/expleo-group" },
+    { slug: "niji-toulouse", name: "Niji Toulouse", level: "GOLD",
+      descriptionFr: "Cabinet de conseil et agence digitale : produit, design et développement.",
+      descriptionEn: "Consulting firm and digital agency: product, design and development.",
+      websiteUrl: "https://example.com/niji-toulouse" },
+    { slug: "onepoint-occ", name: "Onepoint Occitanie", level: "GOLD",
+      descriptionFr: "Architecte des grandes transformations, du conseil à la mise en œuvre.",
+      descriptionEn: "Architect of large-scale transformations, from advice to delivery.",
+      websiteUrl: "https://example.com/onepoint-occ" },
+    { slug: "devoteam-sud", name: "Devoteam Sud", level: "GOLD",
+      descriptionFr: "Cloud, data et cybersécurité. Partenaire des principaux hyperscalers.",
+      descriptionEn: "Cloud, data and cybersecurity. Partner of the major hyperscalers.",
+      websiteUrl: "https://example.com/devoteam-sud" },
+    { slug: "ippon-tech", name: "Ippon Technologies", level: "GOLD",
+      descriptionFr: "Cabinet de conseil et de développement : craft, cloud et data engineering.",
+      descriptionEn: "Consulting and development firm: software craft, cloud and data engineering.",
+      websiteUrl: "https://example.com/ippon-tech" },
+    { slug: "zenika-toulouse", name: "Zenika Toulouse", level: "GOLD",
+      descriptionFr: "Conseil, réalisation et formation autour des technologies open source.",
+      descriptionEn: "Consulting, delivery and training around open source technologies.",
+      websiteUrl: "https://example.com/zenika-toulouse" },
+    { slug: "octo-tech", name: "OCTO Technology", level: "GOLD",
+      descriptionFr: "There is a better way. Architecture, agilité et culture produit.",
+      descriptionEn: "There is a better way. Architecture, agility and product culture.",
+      websiteUrl: "https://example.com/octo-tech" },
+    { slug: "theodo-cloud", name: "Theodo Cloud", level: "GOLD",
+      descriptionFr: "Experts serverless et plateformes cloud natives, du POC à la production.",
+      descriptionEn: "Serverless and cloud-native platform experts, from PoC to production.",
+      websiteUrl: "https://example.com/theodo-cloud" },
+    { slug: "shodo-occitanie", name: "Shodo Occitanie", level: "GOLD",
+      descriptionFr: "Collectif d'artisans du logiciel, attaché à la qualité et à l'humain.",
+      descriptionEn: "A collective of software craftspeople, committed to quality and to people.",
+      websiteUrl: "https://example.com/shodo-occitanie" },
+    { slug: "kaizen-solutions", name: "Kaizen Solutions", level: "GOLD",
+      descriptionFr: "Amélioration continue appliquée aux systèmes d'information.",
+      descriptionEn: "Continuous improvement applied to information systems.",
+      websiteUrl: "https://example.com/kaizen-solutions" },
+
+    { slug: "la-melee", name: "La Mêlée Numérique", level: "SOUTIEN",
+      descriptionFr: "Association qui fédère l'écosystème numérique d'Occitanie depuis plus de vingt ans.",
+      descriptionEn: "The association bringing together Occitanie's digital ecosystem for over twenty years.",
+      websiteUrl: "https://example.com/la-melee" },
+    { slug: "toulouse-tech-hub", name: "Toulouse Tech Hub", level: "SOUTIEN",
+      descriptionFr: "Point de rencontre des startups et des talents tech du bassin toulousain.",
+      descriptionEn: "Meeting point for the startups and tech talent of the Toulouse area.",
+      websiteUrl: "https://example.com/toulouse-tech-hub" },
+    { slug: "digital-113", name: "Digital 113", level: "SOUTIEN",
+      descriptionFr: "Cluster des entreprises du numérique en Occitanie.",
+      descriptionEn: "Cluster of digital companies in Occitanie.",
+      websiteUrl: "https://example.com/digital-113" },
+    { slug: "at-home-coworking", name: "At Home Coworking", level: "SOUTIEN",
+      descriptionFr: "Espaces de coworking au cœur de Toulouse, ouverts aux communautés tech.",
+      descriptionEn: "Coworking spaces in the heart of Toulouse, open to tech communities.",
+      websiteUrl: "https://example.com/at-home-coworking" },
+    { slug: "harry-cover", name: "Harry Cover Studio", level: "SOUTIEN",
+      descriptionFr: "Studio de création graphique et d'illustration, partenaire visuel de l'événement.",
+      descriptionEn: "Graphic design and illustration studio, the event's visual partner.",
+      websiteUrl: "https://example.com/harry-cover" },
+    { slug: "le-connecteur", name: "Le Connecteur", level: "SOUTIEN",
+      descriptionFr: "Tiers-lieu dédié à l'innovation et à l'entrepreneuriat.",
+      descriptionEn: "A third place dedicated to innovation and entrepreneurship.",
+      websiteUrl: "https://example.com/le-connecteur" },
+    { slug: "cafe-et-code", name: "Café & Code", level: "SOUTIEN",
+      descriptionFr: "Torréfacteur local qui réveille les développeurs depuis 2016.",
+      descriptionEn: "The local coffee roaster that has been waking developers up since 2016.",
+      websiteUrl: "https://example.com/cafe-et-code" },
+    { slug: "pink-lab", name: "Pink Innovation Lab", level: "SOUTIEN",
+      descriptionFr: "Laboratoire d'innovation ouverte, incubateur de projets communautaires.",
+      descriptionEn: "Open innovation lab, incubator of community projects.",
+      websiteUrl: "https://example.com/pink-lab" },
+  ];
+
+  for (const s of DEMO_SPONSORS) {
+    await prisma.sponsor.create({
+      data: {
+        slug: s.slug,
+        name: s.name,
+        level: s.level,
+        logoUrl: `/images/sponsors/${s.slug}.svg`,
+        websiteUrl: s.websiteUrl,
+        descriptionFr: s.descriptionFr,
+        descriptionEn: s.descriptionEn,
+        socialLinks: JSON.stringify({
+          linkedin: `https://www.linkedin.com/company/${s.slug}`,
+          twitter: `https://x.com/${s.slug.replace(/-/g, "")}`,
+          github: `https://github.com/${s.slug}`,
+        }),
+        contactEmail: `contact@${s.slug}.example.com`,
+        publicationStatus: "PUBLISHED",
+        editionId: edition.id,
+      },
+    });
+  }
+
+  const counts = DEMO_SPONSORS.reduce<Record<string, number>>((acc, s) => {
+    acc[s.level] = (acc[s.level] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log(
+    `Sponsors created: ${DEMO_SPONSORS.length} ` +
+      `(${counts.PLATINUM} platinum, ${counts.GOLD} gold, ${counts.SOUTIEN} soutien)`,
+  );
+
+  // The featured speaker below works for a sponsor, which exercises the
+  // speaker↔sponsor link (RG-204/RG-226) — her company must match its name.
+  const sponsorOfMarie = await prisma.sponsor.findFirstOrThrow({
+    where: { editionId: edition.id, slug: "capgemini-sud" },
   });
-  await prisma.sponsor.create({
-    data: {
-      slug: "google", name: "Google", level: "GOLD",
-      websiteUrl: "https://developers.google.com",
-      descriptionFr: "Partenaire historique du DevFest.", descriptionEn: "Long-time DevFest partner.",
-      publicationStatus: "PUBLISHED", editionId: edition.id,
-    },
-  });
-  console.log("Sponsors created: 2");
 
   const speakerMarie = await prisma.speaker.create({
     data: {
-      slug: "marie-dupont", name: "Marie Dupont", company: "OVHcloud", city: "Toulouse",
+      slug: "marie-dupont", name: "Marie Dupont", company: sponsorOfMarie.name, city: "Toulouse",
       bioFr: "Ingénieure cloud passionnée de Kubernetes.", bioEn: "Cloud engineer passionate about Kubernetes.",
-      isFeatured: true, publicationStatus: "PUBLISHED", editionId: edition.id, sponsorId: sponsorOvh.id,
+      isFeatured: true, publicationStatus: "PUBLISHED", editionId: edition.id, sponsorId: sponsorOfMarie.id,
       socialLinks: JSON.stringify({ github: "https://github.com/example", linkedin: "https://linkedin.com/in/example" }),
     },
   });

--- a/src/frontend/public/images/sponsors/airbus-tech.svg
+++ b/src/frontend/public/images/sponsors/airbus-tech.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Airbus Tech">
+  <rect width="320" height="120" rx="16" fill="#0B7350"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">AT</text>
+</svg>

--- a/src/frontend/public/images/sponsors/akka-tech.svg
+++ b/src/frontend/public/images/sponsors/akka-tech.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Akka Technologies">
+  <rect width="320" height="120" rx="16" fill="#B3437D"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">AT</text>
+</svg>

--- a/src/frontend/public/images/sponsors/altran-sud.svg
+++ b/src/frontend/public/images/sponsors/altran-sud.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Altran Sud">
+  <rect width="320" height="120" rx="16" fill="#B57700"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">AS</text>
+</svg>

--- a/src/frontend/public/images/sponsors/at-home-coworking.svg
+++ b/src/frontend/public/images/sponsors/at-home-coworking.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="At Home Coworking">
+  <rect width="320" height="120" rx="16" fill="#B3437D"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">AHC</text>
+</svg>

--- a/src/frontend/public/images/sponsors/atos-occitanie.svg
+++ b/src/frontend/public/images/sponsors/atos-occitanie.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Atos Occitanie">
+  <rect width="320" height="120" rx="16" fill="#2E8F6B"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">AO</text>
+</svg>

--- a/src/frontend/public/images/sponsors/cafe-et-code.svg
+++ b/src/frontend/public/images/sponsors/cafe-et-code.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Café &amp; Code">
+  <rect width="320" height="120" rx="16" fill="#B94420"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">CC</text>
+</svg>

--- a/src/frontend/public/images/sponsors/capgemini-sud.svg
+++ b/src/frontend/public/images/sponsors/capgemini-sud.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Capgemini Sud">
+  <rect width="320" height="120" rx="16" fill="#3B6BB0"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">CS</text>
+</svg>

--- a/src/frontend/public/images/sponsors/cgi-toulouse.svg
+++ b/src/frontend/public/images/sponsors/cgi-toulouse.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="CGI Toulouse">
+  <rect width="320" height="120" rx="16" fill="#1C7D3C"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">CT</text>
+</svg>

--- a/src/frontend/public/images/sponsors/devoteam-sud.svg
+++ b/src/frontend/public/images/sponsors/devoteam-sud.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Devoteam Sud">
+  <rect width="320" height="120" rx="16" fill="#C24A1F"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">DS</text>
+</svg>

--- a/src/frontend/public/images/sponsors/digital-113.svg
+++ b/src/frontend/public/images/sponsors/digital-113.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Digital 113">
+  <rect width="320" height="120" rx="16" fill="#C24A1F"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">D</text>
+</svg>

--- a/src/frontend/public/images/sponsors/expleo-group.svg
+++ b/src/frontend/public/images/sponsors/expleo-group.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Expleo Group">
+  <rect width="320" height="120" rx="16" fill="#C53226"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">EG</text>
+</svg>

--- a/src/frontend/public/images/sponsors/harry-cover.svg
+++ b/src/frontend/public/images/sponsors/harry-cover.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Harry Cover Studio">
+  <rect width="320" height="120" rx="16" fill="#1E7FB8"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">HCS</text>
+</svg>

--- a/src/frontend/public/images/sponsors/ippon-tech.svg
+++ b/src/frontend/public/images/sponsors/ippon-tech.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Ippon Technologies">
+  <rect width="320" height="120" rx="16" fill="#1E7FB8"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">IT</text>
+</svg>

--- a/src/frontend/public/images/sponsors/kaizen-solutions.svg
+++ b/src/frontend/public/images/sponsors/kaizen-solutions.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Kaizen Solutions">
+  <rect width="320" height="120" rx="16" fill="#B57700"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">KS</text>
+</svg>

--- a/src/frontend/public/images/sponsors/la-melee.svg
+++ b/src/frontend/public/images/sponsors/la-melee.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="La Mêlée Numérique">
+  <rect width="320" height="120" rx="16" fill="#3B6BB0"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">LMN</text>
+</svg>

--- a/src/frontend/public/images/sponsors/le-connecteur.svg
+++ b/src/frontend/public/images/sponsors/le-connecteur.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Le Connecteur">
+  <rect width="320" height="120" rx="16" fill="#2E8F6B"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">LC</text>
+</svg>

--- a/src/frontend/public/images/sponsors/niji-toulouse.svg
+++ b/src/frontend/public/images/sponsors/niji-toulouse.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Niji Toulouse">
+  <rect width="320" height="120" rx="16" fill="#0B7350"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">NT</text>
+</svg>

--- a/src/frontend/public/images/sponsors/octo-tech.svg
+++ b/src/frontend/public/images/sponsors/octo-tech.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="OCTO Technology">
+  <rect width="320" height="120" rx="16" fill="#2E8F6B"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">OT</text>
+</svg>

--- a/src/frontend/public/images/sponsors/onepoint-occ.svg
+++ b/src/frontend/public/images/sponsors/onepoint-occ.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Onepoint Occitanie">
+  <rect width="320" height="120" rx="16" fill="#4A8A42"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">OO</text>
+</svg>

--- a/src/frontend/public/images/sponsors/orange-business.svg
+++ b/src/frontend/public/images/sponsors/orange-business.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Orange Business">
+  <rect width="320" height="120" rx="16" fill="#C24A1F"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">OB</text>
+</svg>

--- a/src/frontend/public/images/sponsors/pink-lab.svg
+++ b/src/frontend/public/images/sponsors/pink-lab.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Pink Innovation Lab">
+  <rect width="320" height="120" rx="16" fill="#C53226"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">PIL</text>
+</svg>

--- a/src/frontend/public/images/sponsors/scalian-labs.svg
+++ b/src/frontend/public/images/sponsors/scalian-labs.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Scalian Labs">
+  <rect width="320" height="120" rx="16" fill="#3B6BB0"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">SL</text>
+</svg>

--- a/src/frontend/public/images/sponsors/shodo-occitanie.svg
+++ b/src/frontend/public/images/sponsors/shodo-occitanie.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Shodo Occitanie">
+  <rect width="320" height="120" rx="16" fill="#1C7D3C"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">SO</text>
+</svg>

--- a/src/frontend/public/images/sponsors/sopra-steria.svg
+++ b/src/frontend/public/images/sponsors/sopra-steria.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Sopra Steria">
+  <rect width="320" height="120" rx="16" fill="#B94420"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">SS</text>
+</svg>

--- a/src/frontend/public/images/sponsors/thales-digital.svg
+++ b/src/frontend/public/images/sponsors/thales-digital.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Thales Digital">
+  <rect width="320" height="120" rx="16" fill="#1E7FB8"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">TD</text>
+</svg>

--- a/src/frontend/public/images/sponsors/theodo-cloud.svg
+++ b/src/frontend/public/images/sponsors/theodo-cloud.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Theodo Cloud">
+  <rect width="320" height="120" rx="16" fill="#B3437D"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">TC</text>
+</svg>

--- a/src/frontend/public/images/sponsors/toulouse-tech-hub.svg
+++ b/src/frontend/public/images/sponsors/toulouse-tech-hub.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Toulouse Tech Hub">
+  <rect width="320" height="120" rx="16" fill="#0B7350"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">TTH</text>
+</svg>

--- a/src/frontend/public/images/sponsors/zenika-toulouse.svg
+++ b/src/frontend/public/images/sponsors/zenika-toulouse.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="Zenika Toulouse">
+  <rect width="320" height="120" rx="16" fill="#B94420"/>
+  <text x="160" y="60" text-anchor="middle" dominant-baseline="central" font-family="system-ui, -apple-system, sans-serif" font-size="56" font-weight="700" letter-spacing="2" fill="#FFFFFF">ZT</text>
+</svg>


### PR DESCRIPTION
## Résumé

Le seed ne créait que **2 sponsors sans logo** — impossible de juger le rendu des pages sponsors.

Il crée désormais un mur réaliste : **4 Platinum, 16 Gold, 8 Soutien** (28 au total), avec **tous les champs remplis** — logo, description FR **et** EN, site web, liens sociaux (LinkedIn/Twitter/GitHub), email de contact — pour exercer réellement les pages publiques et les formulaires admin.

## Détails

- **Logos** : 28 SVG placeholder (monogrammes colorés) sous `public/images/sponsors/`, un par slug. Légers, versionnables, pas de binaire.
- **Cohérence speaker↔sponsor** : la `company` de la speaker à la une correspond maintenant au sponsor auquel elle est rattachée — c'est sur ce champ que repose l'association (RG-204/RG-226). Elle était incohérente ("OVHcloud" pour un sponsor qui n'existait plus).

## Test plan

- [x] `tsc` backend : OK
- [x] Seed exécuté : `Sponsors created: 28 (4 platinum, 16 gold, 8 soutien)`
- [x] **Complétude vérifiée en base** : les 28 sponsors ont logo, site, description FR, description EN, liens sociaux et email — **aucun champ vide**
- [x] Vérif navigateur :
  - `/fr/sponsors` : les 28 s'affichent, groupés par niveau, bandeaux colorés, cartes Platinum plus grandes ✅
  - page détail : logo, description, bouton « Visiter le site », liens sociaux ✅
  - home : les 28 apparaissent aussi ✅
  - aucune erreur console ✅
- [x] Lien speaker↔sponsor cohérent (`company` == sponsor rattaché)

## Note

Un logo ("Café & Code") était cassé au premier essai : le `&` non échappé rendait le SVG invalide en XML. Corrigé, et les 28 fichiers sont validés.