### PR TITLE
feat(edit): speakers can edit their talk content from the edit link

### DIFF
--- a/src/backend/src/__tests__/edit-talk-update.test.ts
+++ b/src/backend/src/__tests__/edit-talk-update.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+// The talk-edit endpoint notifies the CFP address on success; stub SMTP so the
+// tests don't depend on a mail server. Must be hoisted above the app import.
+const { sendMailMock } = vi.hoisted(() => ({ sendMailMock: vi.fn().mockResolvedValue({}) }));
+vi.mock("nodemailer", () => ({
+  default: { createTransport: () => ({ sendMail: sendMailMock }) },
+}));
+
+import { buildEditApp } from "./test-edit-app.js";
+import { prisma } from "../lib/prisma.js";
+
+// PUT /api/edit/:token/talks/:talkId — a speaker edits the descriptive content
+// of one of their published sessions (#260).
+
+const TOKEN = "test-talk-update-token-fedcba9876543210aa";
+const OTHER_TOKEN = "test-talk-update-other-token-0011223344556677";
+
+let editionId: number;
+let speakerId: number;
+let otherSpeakerId: number;
+let ownedTalkId: number;
+let draftTalkId: number;
+let foreignTalkId: number;
+
+describe("PUT /api/edit/:token/talks/:talkId — speaker edits a session (#260)", () => {
+  beforeAll(async () => {
+    const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
+    if (!edition) throw new Error("seed missing an edition");
+    editionId = edition.id;
+
+    const speaker = await prisma.speaker.create({
+      data: {
+        name: "Talk Update Speaker",
+        slug: "talk-update-speaker",
+        editionId,
+        editToken: TOKEN,
+        editTokenSentAt: new Date(),
+        publicationStatus: "PUBLISHED",
+      },
+    });
+    speakerId = speaker.id;
+
+    const other = await prisma.speaker.create({
+      data: {
+        name: "Other Speaker",
+        slug: "talk-update-other-speaker",
+        editionId,
+        editToken: OTHER_TOKEN,
+        editTokenSentAt: new Date(),
+        publicationStatus: "PUBLISHED",
+      },
+    });
+    otherSpeakerId = other.id;
+
+    const owned = await prisma.talk.create({
+      data: {
+        editionId, slug: "talk-update-owned", titleFr: "Titre initial", titleEn: "Initial title",
+        descriptionFr: "desc fr", descriptionEn: "desc en", format: "CONFERENCE", level: "DEBUTANT",
+        language: "fr", publicationStatus: "PUBLISHED", speakers: { connect: { id: speakerId } },
+      },
+    });
+    ownedTalkId = owned.id;
+
+    const draft = await prisma.talk.create({
+      data: {
+        editionId, slug: "talk-update-draft", titleFr: "Brouillon", titleEn: "Draft",
+        descriptionFr: "", descriptionEn: "", format: "CONFERENCE", language: "fr",
+        publicationStatus: "DRAFT", speakers: { connect: { id: speakerId } },
+      },
+    });
+    draftTalkId = draft.id;
+
+    const foreign = await prisma.talk.create({
+      data: {
+        editionId, slug: "talk-update-foreign", titleFr: "Talk d'un autre", titleEn: "Someone else's",
+        descriptionFr: "", descriptionEn: "", format: "CONFERENCE", language: "fr",
+        publicationStatus: "PUBLISHED", speakers: { connect: { id: otherSpeakerId } },
+      },
+    });
+    foreignTalkId = foreign.id;
+  });
+
+  afterAll(async () => {
+    await prisma.talk.deleteMany({ where: { id: { in: [ownedTalkId, draftTalkId, foreignTalkId] } } });
+    await prisma.speaker.deleteMany({ where: { id: { in: [speakerId, otherSpeakerId] } } });
+  });
+
+  beforeEach(() => sendMailMock.mockClear());
+
+  it("updates the descriptive fields and notifies the CFP address", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}/talks/${ownedTalkId}`,
+      payload: { titleFr: "Nouveau titre", descriptionFr: "Nouveau résumé", format: "WORKSHOP", level: "" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ saved: true });
+
+    const talk = await prisma.talk.findUnique({ where: { id: ownedTalkId } });
+    expect(talk?.titleFr).toBe("Nouveau titre");
+    expect(talk?.descriptionFr).toBe("Nouveau résumé");
+    expect(talk?.format).toBe("WORKSHOP");
+    // Empty level clears back to "all levels".
+    expect(talk?.level).toBeNull();
+    // Untouched fields stay put.
+    expect(talk?.titleEn).toBe("Initial title");
+
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    await app.close();
+  });
+
+  it("rejects a talk the token does not present (404), without touching it", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}/talks/${foreignTalkId}`,
+      payload: { titleFr: "Piratage" },
+    });
+    expect(res.statusCode).toBe(404);
+
+    const talk = await prisma.talk.findUnique({ where: { id: foreignTalkId } });
+    expect(talk?.titleFr).toBe("Talk d'un autre");
+    expect(sendMailMock).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("does not expose an unpublished talk for editing (404)", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}/talks/${draftTalkId}`,
+      payload: { titleFr: "Nope" },
+    });
+    expect(res.statusCode).toBe(404);
+    await app.close();
+  });
+
+  it("rejects an unknown field (400) instead of silently dropping it", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}/talks/${ownedTalkId}`,
+      payload: { titleFr: "OK", publicationStatus: "DRAFT" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("forbidden_field");
+    await app.close();
+  });
+
+  it("rejects an invalid enum value (400)", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}/talks/${ownedTalkId}`,
+      payload: { format: "LIGHTNING" },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("rejects a blank title (400)", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}/talks/${ownedTalkId}`,
+      payload: { titleFr: "   " },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("empty_title");
+    await app.close();
+  });
+
+  it("rejects a sponsor token (404 — no session to edit)", async () => {
+    const sponsorToken = "test-talk-update-sponsor-token-8899aabbccddeeff";
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Talk Update Sponsor", slug: "talk-update-sponsor", editionId,
+        editToken: sponsorToken, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
+      },
+    });
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${sponsorToken}/talks/${ownedTalkId}`,
+      payload: { titleFr: "Nope" },
+    });
+    expect(res.statusCode).toBe(404);
+    await app.close();
+    await prisma.sponsor.deleteMany({ where: { id: sponsor.id } });
+  });
+});

--- a/src/backend/src/__tests__/edit-talk-update.test.ts
+++ b/src/backend/src/__tests__/edit-talk-update.test.ts
@@ -176,7 +176,7 @@ describe("PUT /api/edit/:token/talks/:talkId — speaker edits a session (#260)"
     const sponsorToken = "test-talk-update-sponsor-token-8899aabbccddeeff";
     const sponsor = await prisma.sponsor.create({
       data: {
-        name: "Talk Update Sponsor", slug: "talk-update-sponsor", editionId,
+        name: "Talk Update Sponsor", slug: "talk-update-sponsor", editionId, level: "GOLD",
         editToken: sponsorToken, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
       },
     });

--- a/src/backend/src/lib/cfp-settings.test.ts
+++ b/src/backend/src/lib/cfp-settings.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { prisma } from "./prisma.js";
+import { getCfpNotificationEmail, DEFAULT_CFP_NOTIFICATION_EMAIL } from "./cfp-settings.js";
+
+// The CFP notification address falls back to a default when the setting is
+// missing or blank, so talk-edit notifications (#260) never land nowhere.
+
+describe("getCfpNotificationEmail (#260)", () => {
+  afterEach(async () => {
+    await prisma.siteSetting.deleteMany({ where: { key: "cfp_notification_email" } });
+  });
+
+  it("returns the default when the setting is absent", async () => {
+    expect(await getCfpNotificationEmail()).toBe(DEFAULT_CFP_NOTIFICATION_EMAIL);
+  });
+
+  it("returns the default when the setting is blank", async () => {
+    await prisma.siteSetting.create({ data: { key: "cfp_notification_email", value: "   " } });
+    expect(await getCfpNotificationEmail()).toBe(DEFAULT_CFP_NOTIFICATION_EMAIL);
+  });
+
+  it("returns the configured address when set", async () => {
+    await prisma.siteSetting.create({ data: { key: "cfp_notification_email", value: "team@example.org" } });
+    expect(await getCfpNotificationEmail()).toBe("team@example.org");
+  });
+});

--- a/src/backend/src/lib/cfp-settings.ts
+++ b/src/backend/src/lib/cfp-settings.ts
@@ -1,0 +1,14 @@
+import { prisma } from "./prisma.js";
+
+// Where talk-edit notifications go when a speaker updates their session from
+// the edit link (#260). Configurable in the admin CFP settings
+// (cfp_notification_email); this default keeps notifications flowing even if
+// the setting is never filled in.
+export const DEFAULT_CFP_NOTIFICATION_EMAIL = "cfp@devfesttoulouse.fr";
+
+export async function getCfpNotificationEmail(): Promise<string> {
+  const setting = await prisma.siteSetting.findUnique({
+    where: { key: "cfp_notification_email" },
+  });
+  return setting?.value?.trim() || DEFAULT_CFP_NOTIFICATION_EMAIL;
+}

--- a/src/backend/src/routes/admin/settings.ts
+++ b/src/backend/src/routes/admin/settings.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { buildAlertPayload, sendAlert } from "../../lib/alert-webhook.js";
 import { prisma } from "../../lib/prisma.js";
+import { DEFAULT_CFP_NOTIFICATION_EMAIL } from "../../lib/cfp-settings.js";
 import { revalidateCfp, revalidateHome } from "../../lib/revalidate.js";
 import { validateWebhookUrl } from "../../lib/webhook-url.js";
 
@@ -9,6 +10,7 @@ interface CfpBody {
   sessionizeUrl?: string;
   openDate?: string;
   closeDate?: string;
+  notificationEmail?: string;
 }
 
 const GENERAL_PREFIXES = ["contact_", "social_", "seo_", "identity_", "ecosystem_", "about_"];
@@ -66,6 +68,7 @@ export default async function adminSettingsRoutes(app: FastifyInstance) {
       sessionizeUrl: map.get("cfp_sessionize_url") || null,
       openDate: map.get("cfp_open_date") || null,
       closeDate: map.get("cfp_close_date") || null,
+      notificationEmail: map.get("cfp_notification_email") || DEFAULT_CFP_NOTIFICATION_EMAIL,
     };
   });
 
@@ -78,6 +81,7 @@ export default async function adminSettingsRoutes(app: FastifyInstance) {
       { key: "cfp_sessionize_url", value: body.sessionizeUrl || "" },
       { key: "cfp_open_date", value: body.openDate || "" },
       { key: "cfp_close_date", value: body.closeDate || "" },
+      { key: "cfp_notification_email", value: body.notificationEmail?.trim() || "" },
     ];
 
     for (const entry of entries) {

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -3,8 +3,14 @@ import { prisma } from "../lib/prisma.js";
 import { isEditingFrozen, isEditTokenExpired } from "../lib/edit-token.js";
 import { normalizeLocale } from "../lib/edit-link-email.js";
 import { isSafeUrl } from "../lib/sanitize.js";
-import { revalidateSpeakers, revalidateSponsors } from "../lib/revalidate.js";
+import {
+  revalidateConferences,
+  revalidateSpeakers,
+  revalidateSponsors,
+} from "../lib/revalidate.js";
 import { storeImageBuffer } from "../lib/image-store.js";
+import { sendEmail } from "../lib/email.js";
+import { getCfpNotificationEmail } from "../lib/cfp-settings.js";
 
 // This is the only unauthenticated endpoint that writes to the database and
 // whose content is rendered on public pages, so everything below is an
@@ -66,6 +72,57 @@ const editBodySchema = {
 
 const ALLOWED_FIELDS = Object.keys(editBodySchema.properties);
 
+// Talk fields a speaker may edit from the link (#260): descriptive content
+// only. Programming (room, slot, publication status), slug and the speaker
+// list stay with the organizers. Titles are single-line, descriptions long.
+const TITLE_MAX = 300;
+const TALK_FORMATS = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"] as const;
+const TALK_LEVELS = ["DEBUTANT", "INTERMEDIAIRE", "CONFIRME"] as const;
+const TALK_LANGUAGES = ["fr", "en"] as const;
+
+const talkBodySchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    titleFr: { type: "string", maxLength: TITLE_MAX },
+    titleEn: { type: "string", maxLength: TITLE_MAX },
+    descriptionFr: { type: "string", maxLength: TEXT_MAX },
+    descriptionEn: { type: "string", maxLength: TEXT_MAX },
+    format: { type: "string", enum: [...TALK_FORMATS] },
+    // level may be cleared ("" -> "Tous niveaux"), so an empty string is valid.
+    level: { type: "string", enum: ["", ...TALK_LEVELS] },
+    language: { type: "string", enum: [...TALK_LANGUAGES] },
+  },
+};
+
+const TALK_ALLOWED_FIELDS = Object.keys(talkBodySchema.properties);
+
+interface TalkEditBody {
+  titleFr?: string;
+  titleEn?: string;
+  descriptionFr?: string;
+  descriptionEn?: string;
+  format?: (typeof TALK_FORMATS)[number];
+  level?: "" | (typeof TALK_LEVELS)[number];
+  language?: (typeof TALK_LANGUAGES)[number];
+}
+
+// A title is the only field that cannot be blank: it's rendered as the session
+// heading and used to derive the slug. Descriptions and level may be cleared.
+function findBlankTitle(body: TalkEditBody): string | null {
+  for (const field of ["titleFr", "titleEn"] as const) {
+    if (body[field] !== undefined && !body[field]!.trim()) return field;
+  }
+  return null;
+}
+
+function findForbiddenTalkKey(body: Record<string, unknown>): string | null {
+  for (const key of Object.keys(body)) {
+    if (!TALK_ALLOWED_FIELDS.includes(key)) return key;
+  }
+  return null;
+}
+
 // Fastify's Ajv runs with `removeAdditional: true`, so `additionalProperties:
 // false` silently STRIPS an unknown key instead of rejecting it: a PUT carrying
 // `name` or `publicationStatus` answered 200 while quietly ignoring them.
@@ -115,11 +172,22 @@ async function resolveToken(token: string) {
     where: { editToken: token },
     include: {
       edition: { select: { startDate: true } },
-      // Read-only list shown on the edit page (#229). Sessions themselves are
-      // not editable here (RG-247); only published ones are surfaced.
+      // Sessions the speaker can edit from the link (#260). Only published ones
+      // are surfaced; the descriptive content is editable, the programming
+      // (room/slot/status) and the speaker list are not.
       talks: {
         where: { publicationStatus: "PUBLISHED" },
-        select: { slug: true, titleFr: true, titleEn: true, format: true },
+        select: {
+          id: true,
+          slug: true,
+          titleFr: true,
+          titleEn: true,
+          descriptionFr: true,
+          descriptionEn: true,
+          format: true,
+          level: true,
+          language: true,
+        },
         orderBy: { titleFr: "asc" },
       },
     },
@@ -175,6 +243,44 @@ interface SponsorEditBody {
   socialLinks?: Record<string, string>;
 }
 
+// Notify the organizers that a speaker changed a session. Sent to the
+// configurable CFP address (#260); the link points to the admin talk page so
+// they can review the change in one click.
+async function notifyTalkEdited(
+  speakerName: string,
+  talk: { id: number; titleFr: string },
+): Promise<void> {
+  const to = await getCfpNotificationEmail();
+  const baseUrl = (process.env.BASE_URL || "http://localhost:3000").replace(/\/$/, "");
+  const adminUrl = `${baseUrl}/admin/talks/${talk.id}`;
+
+  const subject = `Conférence modifiée par un·e speaker — ${talk.titleFr}`;
+  const text = [
+    `${speakerName} a mis à jour sa conférence « ${talk.titleFr} ».`,
+    "",
+    `Les modifications sont déjà en ligne (publication directe).`,
+    `Fiche admin : ${adminUrl}`,
+  ].join("\n");
+  const html = `
+    <h3>Conférence modifiée par un·e speaker</h3>
+    <p><strong>${escapeHtml(speakerName)}</strong> a mis à jour sa conférence
+    « ${escapeHtml(talk.titleFr)} ».</p>
+    <p>Les modifications sont déjà en ligne (publication directe).</p>
+    <p><a href="${adminUrl}">Voir la fiche dans l'admin</a></p>
+  `;
+
+  await sendEmail({ to: [to], subject, text, html });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export default async function editRoutes(app: FastifyInstance) {
   // GET /api/edit/:token — load the editable fields of the entity behind the token.
   app.get<{ Params: { token: string } }>("/edit/:token", {
@@ -205,7 +311,10 @@ export default async function editRoutes(app: FastifyInstance) {
           photoUrl: entity.photoUrl,
           socialLinks: parseSocial(entity.socialLinks),
         },
-        // Read-only (RG-247): shown so the speaker can confirm their sessions.
+        // Editable sessions (#260). The numeric id is required so the client
+        // can target PUT /edit/:token/talks/:id; ownership is re-checked
+        // server-side on every write, so exposing it opens no door the token
+        // didn't already open.
         talks: entity.talks,
       };
     }
@@ -287,6 +396,85 @@ export default async function editRoutes(app: FastifyInstance) {
 
     return { saved: true };
   });
+
+  // PUT /api/edit/:token/talks/:talkId — a speaker edits the descriptive
+  // content of one of their sessions (#260). Programming, status and the
+  // speaker list are NOT editable here. Changes publish immediately (direct
+  // publication) and notify the CFP address.
+  app.put<{ Params: { token: string; talkId: string }; Body: TalkEditBody }>(
+    "/edit/:token/talks/:talkId",
+    {
+      config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+      schema: {
+        params: {
+          type: "object",
+          required: ["token", "talkId"],
+          properties: { token: { type: "string" }, talkId: { type: "string", pattern: "^[0-9]+$" } },
+        },
+        body: talkBodySchema,
+      },
+      // Runs before Ajv strips unknown keys, so a client sending `room` or
+      // `publicationStatus` is refused, not silently ignored (#223 pattern).
+      preValidation: async (request, reply) => {
+        const body = request.body;
+        if (!body || typeof body !== "object") return;
+        const forbidden = findForbiddenTalkKey(body as Record<string, unknown>);
+        if (forbidden) {
+          return reply.code(400).send({ error: "forbidden_field", field: forbidden });
+        }
+      },
+    },
+    async (request, reply) => {
+      const resolved = await resolveToken(request.params.token);
+      if (!resolved) return reply.code(404).send({ error: "invalid_token" });
+
+      // Only a speaker token carries talks; a sponsor token has no session to edit.
+      if (resolved.kind !== "speaker") return reply.code(404).send({ error: "invalid_token" });
+
+      const { entity } = resolved;
+      const blocked = editingBlockedReason(entity);
+      if (blocked) return reply.code(403).send({ error: blocked });
+
+      // Ownership: the token may only edit a talk it actually presents. The
+      // talks list already comes filtered to this speaker's published sessions,
+      // so a talkId absent from it is either someone else's or not editable.
+      const talkId = Number(request.params.talkId);
+      const talk = entity.talks.find((t) => t.id === talkId);
+      if (!talk) return reply.code(404).send({ error: "talk_not_found" });
+
+      const body = request.body;
+      const blankTitle = findBlankTitle(body);
+      if (blankTitle) return reply.code(400).send({ error: "empty_title", field: blankTitle });
+
+      // A field absent from the body is left untouched; level accepts "" to
+      // clear it back to "Tous niveaux".
+      await prisma.talk.update({
+        where: { id: talk.id },
+        data: {
+          ...(body.titleFr !== undefined && { titleFr: body.titleFr.trim() }),
+          ...(body.titleEn !== undefined && { titleEn: body.titleEn.trim() }),
+          ...(body.descriptionFr !== undefined && { descriptionFr: body.descriptionFr }),
+          ...(body.descriptionEn !== undefined && { descriptionEn: body.descriptionEn }),
+          ...(body.format !== undefined && { format: body.format }),
+          ...(body.level !== undefined && { level: body.level || null }),
+          ...(body.language !== undefined && { language: body.language }),
+        },
+      });
+
+      // Direct publication: the change is public right away.
+      revalidateConferences();
+
+      // Notify the organizers (best-effort: a mail failure must not fail the
+      // save the speaker just made).
+      try {
+        await notifyTalkEdited(entity.name, { id: talk.id, titleFr: body.titleFr?.trim() || talk.titleFr });
+      } catch (err) {
+        request.log.error("Failed to send talk-edit notification: %s", String(err));
+      }
+
+      return { saved: true };
+    },
+  );
 
   // POST /api/edit/:token/upload — upload a logo (sponsor) or photo (speaker)
   // straight from the recipient's device (#241). Gated exactly like the edit

--- a/src/frontend/src/app/edit/[token]/page.tsx
+++ b/src/frontend/src/app/edit/[token]/page.tsx
@@ -6,11 +6,20 @@ import BilingualTabs from "@/components/admin/BilingualTabs";
 
 type Locale = "fr" | "en";
 
+type TalkFormat = "CONFERENCE" | "QUICKIE" | "KEYNOTE" | "WORKSHOP";
+type TalkLevel = "" | "DEBUTANT" | "INTERMEDIAIRE" | "CONFIRME";
+type TalkLanguage = "fr" | "en";
+
 interface EditTalk {
+  id: number;
   slug: string;
   titleFr: string;
   titleEn: string;
-  format: "CONFERENCE" | "QUICKIE" | "KEYNOTE" | "WORKSHOP";
+  descriptionFr: string;
+  descriptionEn: string;
+  format: TalkFormat;
+  level: TalkLevel | null;
+  language: TalkLanguage;
 }
 
 interface EditData {
@@ -48,8 +57,19 @@ const T = {
     websiteUrl: "Site web",
     logo: "Logo",
     mySessions: "Mes sessions",
-    mySessionsHint: "Vos sessions retenues. Pour toute correction, contactez l'organisation.",
+    mySessionsHint:
+      "Modifiez le contenu de vos conférences retenues. Les changements sont publiés aussitôt sur le programme.",
+    talkTitle: "Titre",
+    talkDescription: "Résumé",
+    talkFormat: "Format",
+    talkLevel: "Niveau",
+    talkLanguage: "Langue de présentation",
+    levelAll: "Tous niveaux",
     format: { CONFERENCE: "Conférence", QUICKIE: "Quickie", KEYNOTE: "Keynote", WORKSHOP: "Workshop" },
+    level: { DEBUTANT: "Débutant", INTERMEDIAIRE: "Intermédiaire", CONFIRME: "Confirmé" },
+    language: { fr: "Français", en: "Anglais" },
+    talkSaved: "Conférence enregistrée !",
+    talkRejected: "Le titre est obligatoire et le résumé doit rester sous 5 000 caractères.",
     social: { linkedin: "LinkedIn", twitter: "X (Twitter)", github: "GitHub", website: "Autre site" },
     upload: "Choisir une image…",
     uploading: "Envoi…",
@@ -89,8 +109,19 @@ const T = {
     websiteUrl: "Website",
     logo: "Logo",
     mySessions: "My sessions",
-    mySessionsHint: "Your accepted sessions. For any correction, please contact the organisers.",
+    mySessionsHint:
+      "Edit the content of your accepted talks. Changes are published to the programme right away.",
+    talkTitle: "Title",
+    talkDescription: "Abstract",
+    talkFormat: "Format",
+    talkLevel: "Level",
+    talkLanguage: "Talk language",
+    levelAll: "All levels",
     format: { CONFERENCE: "Conference", QUICKIE: "Quickie", KEYNOTE: "Keynote", WORKSHOP: "Workshop" },
+    level: { DEBUTANT: "Beginner", INTERMEDIAIRE: "Intermediate", CONFIRME: "Advanced" },
+    language: { fr: "French", en: "English" },
+    talkSaved: "Talk saved!",
+    talkRejected: "A title is required and the abstract must stay under 5,000 characters.",
     social: { linkedin: "LinkedIn", twitter: "X (Twitter)", github: "GitHub", website: "Other website" },
     upload: "Choose an image…",
     uploading: "Uploading…",
@@ -304,27 +335,18 @@ export default function EditByTokenPage({ params }: { params: Promise<{ token: s
             </div>
           </div>
 
-          {/* Read-only list of the speaker's accepted sessions (#229, RG-247):
-              informational only, not editable from this page. */}
+          {/* Editable list of the speaker's accepted sessions (#260). Each talk
+              is its own form with its own save button — the API updates one talk
+              at a time and publishes it immediately. */}
           {isSpeaker && data!.talks && data!.talks.length > 0 && (
-            <div>
+            <div className="border-t border-gris/15 pt-6">
               <p className="mb-1 text-sm font-semibold text-noir">{t.mySessions}</p>
-              <p className="mb-3 text-sm text-gris">{t.mySessionsHint}</p>
-              <ul className="space-y-2">
+              <p className="mb-4 text-sm text-gris">{t.mySessionsHint}</p>
+              <div className="space-y-6">
                 {data!.talks.map((talk) => (
-                  <li
-                    key={talk.slug}
-                    className="flex flex-wrap items-center gap-3 rounded-lg border border-gris/15 bg-blanc-casse px-4 py-3"
-                  >
-                    <span className="rounded-full bg-bleu/10 px-3 py-1 text-xs font-bold text-bleu">
-                      {t.format[talk.format]}
-                    </span>
-                    <span className="font-medium text-noir">
-                      {(data!.locale ?? "fr") === "en" ? talk.titleEn : talk.titleFr}
-                    </span>
-                  </li>
+                  <TalkEditor key={talk.id} talk={talk} token={token} t={t} />
                 ))}
-              </ul>
+              </div>
             </div>
           )}
 
@@ -475,6 +497,140 @@ function ImageField({
             <p role="alert" className="text-sm font-medium text-terre-cuite">
               {t.uploadError}
             </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const TALK_FORMATS = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"] as const;
+const TALK_LEVELS = ["DEBUTANT", "INTERMEDIAIRE", "CONFIRME"] as const;
+const TALK_LANGUAGES = ["fr", "en"] as const;
+
+// One editable session (#260). Self-contained: holds its own draft state and
+// saves itself, since the API updates one talk at a time and publishes it
+// immediately. Titles/abstract are bilingual; format/level/language are selects.
+function TalkEditor({
+  talk,
+  token,
+  t,
+}: {
+  talk: EditTalk;
+  token: string;
+  t: (typeof T)[Locale];
+}) {
+  const [titleFr, setTitleFr] = useState(talk.titleFr);
+  const [titleEn, setTitleEn] = useState(talk.titleEn);
+  const [descriptionFr, setDescriptionFr] = useState(talk.descriptionFr);
+  const [descriptionEn, setDescriptionEn] = useState(talk.descriptionEn);
+  const [format, setFormat] = useState<TalkFormat>(talk.format);
+  const [level, setLevel] = useState<TalkLevel>(talk.level ?? "");
+  const [language, setLanguage] = useState<TalkLanguage>(talk.language);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState("");
+
+  async function save() {
+    setSaving(true);
+    setSaved(false);
+    setError("");
+    const res = await fetch(`/api/edit/${token}/talks/${talk.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ titleFr, titleEn, descriptionFr, descriptionEn, format, level, language }),
+    });
+    setSaving(false);
+    if (res.ok) {
+      setSaved(true);
+      return;
+    }
+    setError(t.talkRejected);
+  }
+
+  return (
+    <div className="rounded-lg border border-gris/15 bg-blanc-casse p-4 sm:p-5">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <span className="rounded-full bg-bleu/10 px-3 py-1 text-xs font-bold text-bleu">
+          {t.format[format]}
+        </span>
+      </div>
+
+      <div className="space-y-5">
+        <BilingualTabs
+          label={t.talkTitle}
+          labels={{ fr: t.langFr, en: t.langEn }}
+          isEmpty={(lang) => !(lang === "fr" ? titleFr : titleEn)?.trim()}
+          renderPanel={(lang) => (
+            <input
+              value={lang === "fr" ? titleFr : titleEn}
+              onChange={(e) => (lang === "fr" ? setTitleFr : setTitleEn)(e.target.value)}
+              className={inputClass}
+            />
+          )}
+        />
+
+        <BilingualTabs
+          label={t.talkDescription}
+          labels={{ fr: t.langFr, en: t.langEn }}
+          isEmpty={(lang) => !(lang === "fr" ? descriptionFr : descriptionEn)?.trim()}
+          renderPanel={(lang) => (
+            <textarea
+              value={lang === "fr" ? descriptionFr : descriptionEn}
+              onChange={(e) => (lang === "fr" ? setDescriptionFr : setDescriptionEn)(e.target.value)}
+              rows={5}
+              className={inputClass}
+            />
+          )}
+        />
+
+        <div className="grid gap-5 md:grid-cols-3">
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-noir">{t.talkFormat}</span>
+            <select value={format} onChange={(e) => setFormat(e.target.value as TalkFormat)} className={inputClass}>
+              {TALK_FORMATS.map((f) => (
+                <option key={f} value={f}>
+                  {t.format[f]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-noir">{t.talkLevel}</span>
+            <select value={level} onChange={(e) => setLevel(e.target.value as TalkLevel)} className={inputClass}>
+              <option value="">{t.levelAll}</option>
+              {TALK_LEVELS.map((l) => (
+                <option key={l} value={l}>
+                  {t.level[l]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-noir">{t.talkLanguage}</span>
+            <select value={language} onChange={(e) => setLanguage(e.target.value as TalkLanguage)} className={inputClass}>
+              {TALK_LANGUAGES.map((l) => (
+                <option key={l} value={l}>
+                  {t.language[l]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <button
+            onClick={save}
+            disabled={saving}
+            className="rounded-[12px] bg-malachite px-5 py-2.5 text-sm font-bold text-blanc hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {saving ? t.saving : t.save}
+          </button>
+          {saved && <span className="text-sm font-medium text-malachite">{t.talkSaved}</span>}
+          {error && (
+            <span role="alert" className="text-sm font-medium text-terre-cuite">
+              {error}
+            </span>
           )}
         </div>
       </div>

--- a/src/frontend/src/components/admin/edition-detail/CfpTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/CfpTab.tsx
@@ -9,10 +9,17 @@ interface CfpData {
   sessionizeUrl: string | null;
   openDate: string | null;
   closeDate: string | null;
+  notificationEmail: string | null;
 }
 
 export default function CfpTab() {
-  const [cfp, setCfp] = useState<CfpData>({ isOpen: false, sessionizeUrl: null, openDate: null, closeDate: null });
+  const [cfp, setCfp] = useState<CfpData>({
+    isOpen: false,
+    sessionizeUrl: null,
+    openDate: null,
+    closeDate: null,
+    notificationEmail: null,
+  });
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [saved, setSaved] = useState(false);
@@ -65,6 +72,16 @@ export default function CfpTab() {
         <FormField label="Date d'ouverture" name="openDate" type="date" value={cfp.openDate || ""} onChange={(v) => setCfp({ ...cfp, openDate: v || null })} />
         <FormField label="Date de fermeture" name="closeDate" type="date" value={cfp.closeDate || ""} onChange={(v) => setCfp({ ...cfp, closeDate: v || null })} />
       </div>
+
+      <FormField
+        label="Email de notification CFP"
+        name="notificationEmail"
+        type="email"
+        value={cfp.notificationEmail || ""}
+        onChange={(v) => setCfp({ ...cfp, notificationEmail: v || null })}
+        placeholder="cfp@devfesttoulouse.fr"
+        helpText="Adresse prévenue quand un·e speaker modifie sa conférence depuis son lien."
+      />
 
       <div className="flex items-center gap-4">
         <button onClick={handleSave} disabled={isSaving} className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50">


### PR DESCRIPTION
## Summary

- Les speakers peuvent désormais **modifier le contenu descriptif de leurs conférences** (titre, résumé FR/EN, format, niveau, langue) depuis leur lien de modification, en plus de leur profil.
- La programmation (salle, créneau, statut de publication) et la liste des speakers restent réservées à l'organisation.
- **Publication directe** : les modifications sont visibles immédiatement sur le programme public.
- **Notification** envoyée à l'adresse CFP à chaque enregistrement, adresse **configurable en admin** (`cfp_notification_email`, défaut `cfp@devfesttoulouse.fr`).

## Détails techniques

- Backend : `PUT /api/edit/:token/talks/:talkId` — allowlist stricte, contrôle d'appartenance (un token ne modifie que ses talks → 404 sinon), validation des enums, mêmes garde-fous locked/frozen/expired que le profil.
- Nouveau helper `getCfpNotificationEmail()` (lib) + champ « Email de notification CFP » dans l'onglet CFP admin.
- Front : le bloc lecture seule « Mes sessions » devient un formulaire éditable par talk (onglets bilingues + selects).

## Test plan

- [x] `pnpm typecheck` backend + frontend
- [x] `pnpm lint` frontend
- [x] Tests backend : **10/10** nouveaux (appartenance, champ interdit, enum, titre vide, talk non publié, token sponsor, fallback email) — suite complète **258/258**
- [x] Vérif fonctionnelle API réelle (Docker local) : GET champs éditables, PUT + publication immédiate sur `/fr/conferences`, notification MailHog vers l'adresse par défaut **et** configurée, tous les cas d'erreur (400/404)
- [ ] Vérif visuelle du formulaire dans le navigateur (Chrome DevTools MCP déconnecté pendant l'implémentation)

Refs #260
