### PR TITLE
feat(sponsors): add Bluesky to social links (sponsors + speakers)

### DIFF
--- a/src/backend/src/__tests__/edit-social-bluesky.test.ts
+++ b/src/backend/src/__tests__/edit-social-bluesky.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { buildEditApp } from "./test-edit-app.js";
+import { prisma } from "../lib/prisma.js";
+
+// Bluesky is part of the shared socialLinks allowlist (#253). A sponsor (and a
+// speaker) can save it via their edit link; an unknown social key stays rejected.
+
+const TOKEN = "test-edit-bluesky-sponsor-token-a1b2c3d4e5f6a7b8";
+let editionId: number;
+let sponsorId: number;
+
+describe("PUT /api/edit/:token — bluesky social link (#253)", () => {
+  beforeAll(async () => {
+    const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
+    if (!edition) throw new Error("seed missing an edition");
+    editionId = edition.id;
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Bluesky Test Sponsor", slug: "bluesky-test-sponsor", editionId, level: "GOLD",
+        editToken: TOKEN, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
+      },
+    });
+    sponsorId = sponsor.id;
+  });
+
+  afterAll(async () => {
+    await prisma.sponsor.deleteMany({ where: { id: sponsorId } });
+  });
+
+  it("accepts and persists a bluesky link", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}`,
+      payload: { socialLinks: { bluesky: "https://bsky.app/profile/devfest.example" } },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
+    const social = JSON.parse(sponsor?.socialLinks ?? "{}");
+    expect(social.bluesky).toBe("https://bsky.app/profile/devfest.example");
+    await app.close();
+  });
+
+  it("still rejects an unknown social key", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}`,
+      payload: { socialLinks: { mastodon: "https://example.social/@x" } },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("forbidden_field");
+    await app.close();
+  });
+});

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -27,7 +27,7 @@ const URL_MAX = 2_048;
 const UPLOAD_MAX_SIZE = 5_000_000; // 5 MB
 const UPLOAD_MIMES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif"]);
 
-const SOCIAL_KEYS = ["linkedin", "twitter", "github", "website"] as const;
+const SOCIAL_KEYS = ["linkedin", "twitter", "bluesky", "github", "website"] as const;
 
 const socialLinksSchema = {
   type: "object",

--- a/src/frontend/src/app/admin/speakers/[id]/page.tsx
+++ b/src/frontend/src/app/admin/speakers/[id]/page.tsx
@@ -56,6 +56,7 @@ export default function SpeakerEditorPage() {
           bioEn: data.bioEn || "",
           linkedin: data.socialLinks?.linkedin || "",
           twitter: data.socialLinks?.twitter || "",
+          bluesky: data.socialLinks?.bluesky || "",
           github: data.socialLinks?.github || "",
           website: data.socialLinks?.website || "",
           locale: data.locale === "en" ? "en" : "fr",
@@ -86,6 +87,7 @@ export default function SpeakerEditorPage() {
     const socialLinks: Record<string, string> = {};
     if (form.linkedin.trim()) socialLinks.linkedin = form.linkedin.trim();
     if (form.twitter.trim()) socialLinks.twitter = form.twitter.trim();
+    if (form.bluesky.trim()) socialLinks.bluesky = form.bluesky.trim();
     if (form.github.trim()) socialLinks.github = form.github.trim();
     if (form.website.trim()) socialLinks.website = form.website.trim();
 

--- a/src/frontend/src/app/admin/sponsors/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/[id]/page.tsx
@@ -54,6 +54,7 @@ export default function SponsorEditorPage() {
           descriptionEn: data.descriptionEn || "",
           linkedin: data.socialLinks?.linkedin || "",
           twitter: data.socialLinks?.twitter || "",
+          bluesky: data.socialLinks?.bluesky || "",
           locale: data.locale === "en" ? "en" : "fr",
           publicationStatus: data.publicationStatus,
         });
@@ -72,6 +73,7 @@ export default function SponsorEditorPage() {
     const socialLinks: Record<string, string> = {};
     if (form.linkedin.trim()) socialLinks.linkedin = form.linkedin.trim();
     if (form.twitter.trim()) socialLinks.twitter = form.twitter.trim();
+    if (form.bluesky.trim()) socialLinks.bluesky = form.bluesky.trim();
 
     const payload = {
       editionId,

--- a/src/frontend/src/app/edit/[token]/page.tsx
+++ b/src/frontend/src/app/edit/[token]/page.tsx
@@ -70,7 +70,7 @@ const T = {
     language: { fr: "Français", en: "Anglais" },
     talkSaved: "Conférence enregistrée !",
     talkRejected: "Le titre est obligatoire et le résumé doit rester sous 5 000 caractères.",
-    social: { linkedin: "LinkedIn", twitter: "X (Twitter)", github: "GitHub", website: "Autre site" },
+    social: { linkedin: "LinkedIn", twitter: "X (Twitter)", bluesky: "Bluesky", github: "GitHub", website: "Autre site" },
     upload: "Choisir une image…",
     uploading: "Envoi…",
     uploadHint: "JPEG, PNG, WebP ou GIF — 5 Mo max.",
@@ -122,7 +122,7 @@ const T = {
     language: { fr: "French", en: "English" },
     talkSaved: "Talk saved!",
     talkRejected: "A title is required and the abstract must stay under 5,000 characters.",
-    social: { linkedin: "LinkedIn", twitter: "X (Twitter)", github: "GitHub", website: "Other website" },
+    social: { linkedin: "LinkedIn", twitter: "X (Twitter)", bluesky: "Bluesky", github: "GitHub", website: "Other website" },
     upload: "Choose an image…",
     uploading: "Uploading…",
     uploadHint: "JPEG, PNG, WebP or GIF — 5 MB max.",
@@ -324,7 +324,7 @@ export default function EditByTokenPage({ params }: { params: Promise<{ token: s
           <div>
             <p className="mb-3 text-sm font-semibold text-noir">{t.socialLinks}</p>
             <div className="grid gap-5 md:grid-cols-2">
-              {(["linkedin", "twitter", "github", "website"] as const).map((key) => (
+              {(["linkedin", "twitter", "bluesky", "github", "website"] as const).map((key) => (
                 <Field
                   key={key}
                   label={t.social[key as SocialKey]}

--- a/src/frontend/src/components/admin/speakers/SpeakerForm.tsx
+++ b/src/frontend/src/components/admin/speakers/SpeakerForm.tsx
@@ -15,6 +15,7 @@ export interface SpeakerFormValue {
   bioEn: string;
   linkedin: string;
   twitter: string;
+  bluesky: string;
   github: string;
   website: string;
   locale: "fr" | "en";
@@ -32,6 +33,7 @@ export const emptySpeakerForm: SpeakerFormValue = {
   bioEn: "",
   linkedin: "",
   twitter: "",
+  bluesky: "",
   github: "",
   website: "",
   locale: "fr",
@@ -131,6 +133,10 @@ export default function SpeakerForm({ value, onChange, sponsors }: SpeakerFormPr
         <label className="block">
           <span className="block text-sm font-medium text-noir mb-1">X / Twitter</span>
           <input type="url" value={value.twitter} onChange={(e) => onChange({ ...value, twitter: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Bluesky</span>
+          <input type="url" value={value.bluesky} onChange={(e) => onChange({ ...value, bluesky: e.target.value })} className={inputClass} />
         </label>
         <label className="block">
           <span className="block text-sm font-medium text-noir mb-1">Site web</span>

--- a/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
+++ b/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
@@ -23,6 +23,7 @@ export interface SponsorFormValue {
   descriptionEn: string;
   linkedin: string;
   twitter: string;
+  bluesky: string;
   locale: "fr" | "en";
   publicationStatus: "DRAFT" | "PUBLISHED";
 }
@@ -36,6 +37,7 @@ export const emptySponsorForm: SponsorFormValue = {
   descriptionEn: "",
   linkedin: "",
   twitter: "",
+  bluesky: "",
   locale: "fr",
   publicationStatus: "DRAFT",
 };
@@ -119,6 +121,10 @@ export default function SponsorForm({ value, onChange }: SponsorFormProps) {
         <label className="block">
           <span className="block text-sm font-medium text-noir mb-1">X / Twitter</span>
           <input type="url" value={value.twitter} onChange={(e) => onChange({ ...value, twitter: e.target.value })} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="block text-sm font-medium text-noir mb-1">Bluesky</span>
+          <input type="url" value={value.bluesky} onChange={(e) => onChange({ ...value, bluesky: e.target.value })} className={inputClass} />
         </label>
       </div>
 


### PR DESCRIPTION
## Summary

- Ajoute **Bluesky** à la liste des liens sociaux, **pour les sponsors ET les speakers** (le JSON `socialLinks` est partagé).
- Éditable depuis les formulaires admin **et** depuis la page de modification par magic link.
- Affichage public automatique sur les fiches sponsor/speaker (rendu générique de `socialLinks`).

## Détails

- Backend : `bluesky` ajouté à `SOCIAL_KEYS` ([edit.ts](src/backend/src/routes/edit.ts)) — le schéma et la validation d'URL http/https en découlent automatiquement.
- Admin : champ Bluesky dans `SponsorForm` et `SpeakerForm`, câblé dans les mappings load/save des pages admin.
- Magic link : Bluesky dans la liste sociale + libellés FR/EN.

## Test plan

- [x] `pnpm typecheck` backend + frontend, `pnpm lint` frontend
- [x] Test backend : bluesky accepté + persisté, clé sociale inconnue toujours rejetée (400) — suite complète **260/260**
- [x] Vérif fonctionnelle (Docker local) : PUT bluesky via magic link → persisté en DB → **affiché sur `/fr/sponsors/{slug}`** ; clé inconnue rejetée
- [ ] Vérif visuelle admin (Chrome DevTools MCP indisponible)

Refs #253
