### PR TITLE
feat(sponsors): private editable section (booth contacts + com kit) #249

### DIFF
--- a/src/backend/prisma/migrations/20260718150408_add_sponsor_private_fields/migration.sql
+++ b/src/backend/prisma/migrations/20260718150408_add_sponsor_private_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Sponsor" ADD COLUMN     "comKitCharterUrl" TEXT,
+ADD COLUMN     "comKitLogoPrintUrl" TEXT,
+ADD COLUMN     "comKitLogoWebUrl" TEXT,
+ADD COLUMN     "comKitNotes" TEXT,
+ADD COLUMN     "comKitReceived" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "standContacts" TEXT;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -547,6 +547,18 @@ model Sponsor {
   socialLinks      String?
   // Contact email used to send the modification link (RG-243). Optional.
   contactEmail     String?
+
+  // --- Private fields (#249) — organizers only, NEVER exposed publicly ---
+  // Social handles of the people staffing the booth, for day-of relaying.
+  // JSON array of { name, linkedin, twitter, bluesky }.
+  standContacts    String?
+  // Communication kit: whether the sponsor confirmed receiving it, plus the
+  // assets they can drop as links (web/print logo, brand charter) and free notes.
+  comKitReceived   Boolean           @default(false)
+  comKitLogoWebUrl   String?
+  comKitLogoPrintUrl String?
+  comKitCharterUrl   String?
+  comKitNotes      String?
   // Language we write to this sponsor in — "fr" | "en" (#224). Same rule as
   // Speaker.locale: set in the admin, defaults to French.
   locale           String            @default("fr")

--- a/src/backend/src/__tests__/edit-sponsor-private.test.ts
+++ b/src/backend/src/__tests__/edit-sponsor-private.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+// The com-kit email endpoint sends mail; stub SMTP. Must be hoisted above imports.
+const { sendMailMock } = vi.hoisted(() => ({ sendMailMock: vi.fn().mockResolvedValue({}) }));
+vi.mock("nodemailer", () => ({
+  default: { createTransport: () => ({ sendMail: sendMailMock }) },
+}));
+
+import { buildEditApp } from "./test-edit-app.js";
+import { buildPublicApp } from "./test-public-app.js";
+import { prisma } from "../lib/prisma.js";
+
+// Sponsor private fields (#249): editable via the magic link, visible in the
+// admin, but NEVER exposed on any public route.
+
+const TOKEN = "test-sponsor-private-token-0f1e2d3c4b5a6978";
+let editionId: number;
+let sponsorId: number;
+let slug: string;
+
+describe("Sponsor private section (#249)", () => {
+  beforeAll(async () => {
+    const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
+    if (!edition) throw new Error("seed missing an edition");
+    editionId = edition.id;
+    slug = `private-test-sponsor-${Date.now()}`;
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Private Test Sponsor", slug, editionId, level: "GOLD",
+        editToken: TOKEN, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
+        contactEmail: "sponsor@example.org",
+      },
+    });
+    sponsorId = sponsor.id;
+  });
+
+  afterAll(async () => {
+    await prisma.sponsor.deleteMany({ where: { id: sponsorId } });
+  });
+
+  beforeEach(() => sendMailMock.mockClear());
+
+  it("accepts and persists private fields via the magic link", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}`,
+      payload: {
+        standContacts: [{ name: "Alice", linkedin: "https://linkedin.com/in/alice" }, {}],
+        comKitReceived: true,
+        comKitLogoWebUrl: "https://example.org/logo-web.png",
+        comKitNotes: "Charte à venir",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
+    expect(sponsor?.comKitReceived).toBe(true);
+    expect(sponsor?.comKitLogoWebUrl).toBe("https://example.org/logo-web.png");
+    // The empty contact row is dropped; only Alice remains.
+    const stand = JSON.parse(sponsor?.standContacts ?? "[]");
+    expect(stand).toHaveLength(1);
+    expect(stand[0].name).toBe("Alice");
+    await app.close();
+  });
+
+  it("returns the private block to the token holder (GET)", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({ method: "GET", url: `/api/edit/${TOKEN}` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.private).toBeDefined();
+    expect(body.private.comKitReceived).toBe(true);
+    expect(body.private.level).toBe("GOLD");
+    await app.close();
+  });
+
+  it("rejects an unsafe URL in a stand contact", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}`,
+      payload: { standContacts: [{ name: "Bob", linkedin: "javascript:alert(1)" }] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_url");
+    await app.close();
+  });
+
+  it("NEVER exposes private fields on the public sponsor route", async () => {
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: `/api/sponsors/${slug}` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // The public payload is an explicit allowlist — private keys must be absent.
+    expect(body).not.toHaveProperty("standContacts");
+    expect(body).not.toHaveProperty("comKitReceived");
+    expect(body).not.toHaveProperty("comKitNotes");
+    expect(body).not.toHaveProperty("private");
+    expect(body).not.toHaveProperty("contactEmail");
+    await app.close();
+  });
+
+  it("sends a com-kit complement email to the sponsoring team", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/edit/${TOKEN}/com-kit-email`,
+      payload: { message: "J'ai un PDF de charte à envoyer." },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ sent: true });
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    // Reply-To points back to the sponsor so the orga can ask for the files.
+    expect(sendMailMock.mock.calls[0][0].replyTo).toBe("sponsor@example.org");
+    await app.close();
+  });
+});

--- a/src/backend/src/__tests__/test-public-app.ts
+++ b/src/backend/src/__tests__/test-public-app.ts
@@ -1,0 +1,10 @@
+import Fastify from "fastify";
+import sponsorRoutes from "../routes/sponsors.js";
+
+// Minimal app exposing the public sponsor routes, used to assert that private
+// sponsor fields (#249) never leak on the public API.
+export async function buildPublicApp() {
+  const app = Fastify({ logger: false });
+  await app.register(sponsorRoutes, { prefix: "/api" });
+  return app;
+}

--- a/src/backend/src/lib/sponsor-contact.ts
+++ b/src/backend/src/lib/sponsor-contact.ts
@@ -1,0 +1,20 @@
+import { prisma } from "./prisma.js";
+
+// Where sponsor-related notifications go (e.g. a sponsor sending com-kit
+// complements, #249). Reuses the "sponsoring" contact category recipients so
+// the address stays configurable in the admin, with a safe fallback.
+export async function getSponsorContactRecipients(): Promise<string[]> {
+  const category = await prisma.contactCategory.findUnique({
+    where: { slug: "sponsoring" },
+  });
+  const recipients = category?.emailRecipients
+    ?.split(",")
+    .map((e) => e.trim())
+    .filter(Boolean);
+  if (recipients?.length) return recipients;
+
+  const fallback = await prisma.siteSetting.findUnique({
+    where: { key: "contact_default_email" },
+  });
+  return [fallback?.value || "contact@devfesttoulouse.fr"];
+}

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -8,6 +8,13 @@ import { sendEditLinkEmail, normalizeLocale } from "../../lib/edit-link-email.js
 const SPONSOR_LEVELS = ["PLATINUM", "GOLD", "SILVER", "SOUTIEN", "COMMUNAUTE"] as const;
 type SponsorLevel = (typeof SPONSOR_LEVELS)[number];
 
+interface StandContact {
+  name?: string;
+  linkedin?: string;
+  twitter?: string;
+  bluesky?: string;
+}
+
 interface SponsorCreateBody {
   editionId: number;
   name: string;
@@ -20,6 +27,13 @@ interface SponsorCreateBody {
   contactEmail?: string;
   locale?: string;
   publicationStatus?: "DRAFT" | "PUBLISHED";
+  // Private fields (#249) — organizers only.
+  standContacts?: StandContact[];
+  comKitReceived?: boolean;
+  comKitLogoWebUrl?: string;
+  comKitLogoPrintUrl?: string;
+  comKitCharterUrl?: string;
+  comKitNotes?: string;
 }
 
 type SponsorUpdateBody = Partial<Omit<SponsorCreateBody, "editionId">>;
@@ -40,9 +54,14 @@ interface SponsorBulkBody {
 
 function serialize(s: {
   socialLinks: string | null;
+  standContacts?: string | null;
   [k: string]: unknown;
 }) {
-  return { ...s, socialLinks: s.socialLinks ? JSON.parse(s.socialLinks) : {} };
+  return {
+    ...s,
+    socialLinks: s.socialLinks ? JSON.parse(s.socialLinks) : {},
+    standContacts: s.standContacts ? JSON.parse(s.standContacts) : [],
+  };
 }
 
 export default async function adminSponsorRoutes(app: FastifyInstance) {
@@ -108,6 +127,13 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         contactEmail: body.contactEmail || null,
         locale: normalizeLocale(body.locale),
         publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
+        // Private fields (#249).
+        standContacts: body.standContacts?.length ? JSON.stringify(body.standContacts) : null,
+        comKitReceived: body.comKitReceived ?? false,
+        comKitLogoWebUrl: body.comKitLogoWebUrl || null,
+        comKitLogoPrintUrl: body.comKitLogoPrintUrl || null,
+        comKitCharterUrl: body.comKitCharterUrl || null,
+        comKitNotes: body.comKitNotes || null,
       },
     });
 
@@ -143,6 +169,15 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         ...(body.contactEmail !== undefined && { contactEmail: body.contactEmail || null }),
         ...(body.locale !== undefined && { locale: normalizeLocale(body.locale) }),
         ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
+        // Private fields (#249).
+        ...(body.standContacts !== undefined && {
+          standContacts: body.standContacts?.length ? JSON.stringify(body.standContacts) : null,
+        }),
+        ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
+        ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
+        ...(body.comKitLogoPrintUrl !== undefined && { comKitLogoPrintUrl: body.comKitLogoPrintUrl || null }),
+        ...(body.comKitCharterUrl !== undefined && { comKitCharterUrl: body.comKitCharterUrl || null }),
+        ...(body.comKitNotes !== undefined && { comKitNotes: body.comKitNotes || null }),
       },
     });
 

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -11,6 +11,7 @@ import {
 import { storeImageBuffer } from "../lib/image-store.js";
 import { sendEmail } from "../lib/email.js";
 import { getCfpNotificationEmail } from "../lib/cfp-settings.js";
+import { getSponsorContactRecipients } from "../lib/sponsor-contact.js";
 
 // This is the only unauthenticated endpoint that writes to the database and
 // whose content is rendered on public pages, so everything below is an
@@ -50,6 +51,24 @@ const speakerBodySchema = {
   },
 };
 
+// Booth staff whose social handles the organizers relay on the day (#249).
+// Private: never rendered publicly. A bounded list of bounded strings.
+const STAND_CONTACTS_MAX = 20;
+const standContactsSchema = {
+  type: "array",
+  maxItems: STAND_CONTACTS_MAX,
+  items: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      name: { type: "string", maxLength: SHORT_MAX },
+      linkedin: { type: "string", maxLength: URL_MAX },
+      twitter: { type: "string", maxLength: URL_MAX },
+      bluesky: { type: "string", maxLength: URL_MAX },
+    },
+  },
+};
+
 const sponsorBodySchema = {
   type: "object",
   additionalProperties: false,
@@ -59,6 +78,13 @@ const sponsorBodySchema = {
     websiteUrl: { type: "string", maxLength: URL_MAX },
     logoUrl: { type: "string", maxLength: URL_MAX },
     socialLinks: socialLinksSchema,
+    // Private fields (#249) — organizers only, never exposed on public pages.
+    standContacts: standContactsSchema,
+    comKitReceived: { type: "boolean" },
+    comKitLogoWebUrl: { type: "string", maxLength: URL_MAX },
+    comKitLogoPrintUrl: { type: "string", maxLength: URL_MAX },
+    comKitCharterUrl: { type: "string", maxLength: URL_MAX },
+    comKitNotes: { type: "string", maxLength: TEXT_MAX },
   },
 };
 
@@ -145,7 +171,15 @@ function findForbiddenKey(body: Record<string, unknown>): string | null {
 // An empty string clears the field; anything else must be a safe URL. Returns
 // the offending field name, or null when every URL is acceptable.
 function findUnsafeUrl(body: Record<string, unknown>): string | null {
-  for (const field of ["photoUrl", "logoUrl", "websiteUrl"]) {
+  for (const field of [
+    "photoUrl",
+    "logoUrl",
+    "websiteUrl",
+    // Private com-kit links (#249) — same http(s) allowlist as public URLs.
+    "comKitLogoWebUrl",
+    "comKitLogoPrintUrl",
+    "comKitCharterUrl",
+  ]) {
     const value = body[field];
     if (typeof value === "string" && value.trim() && !isSafeUrl(value)) return field;
   }
@@ -153,6 +187,19 @@ function findUnsafeUrl(body: Record<string, unknown>): string | null {
   if (social && typeof social === "object") {
     for (const [key, value] of Object.entries(social as Record<string, unknown>)) {
       if (typeof value === "string" && value.trim() && !isSafeUrl(value)) return `socialLinks.${key}`;
+    }
+  }
+  // Booth contacts carry their own social URLs (#249).
+  const stand = body.standContacts;
+  if (Array.isArray(stand)) {
+    for (const [i, contact] of stand.entries()) {
+      if (!contact || typeof contact !== "object") continue;
+      for (const key of ["linkedin", "twitter", "bluesky"]) {
+        const value = (contact as Record<string, unknown>)[key];
+        if (typeof value === "string" && value.trim() && !isSafeUrl(value)) {
+          return `standContacts[${i}].${key}`;
+        }
+      }
     }
   }
   return null;
@@ -163,6 +210,40 @@ function cleanSocial(social: Record<string, string> | undefined): string | null 
   if (!social) return null;
   const kept = Object.entries(social).filter(([, v]) => typeof v === "string" && v.trim());
   return kept.length ? JSON.stringify(Object.fromEntries(kept)) : null;
+}
+
+interface StandContact {
+  name?: string;
+  linkedin?: string;
+  twitter?: string;
+  bluesky?: string;
+}
+
+// Trim entries and drop those with no content at all, so an empty row the
+// sponsor left behind isn't persisted (#249). Returns null when nothing remains.
+function cleanStandContacts(contacts: StandContact[] | undefined): string | null {
+  if (!contacts) return null;
+  const kept = contacts
+    .map((c) => {
+      const entry: StandContact = {};
+      for (const key of ["name", "linkedin", "twitter", "bluesky"] as const) {
+        const v = c[key];
+        if (typeof v === "string" && v.trim()) entry[key] = v.trim();
+      }
+      return entry;
+    })
+    .filter((c) => Object.keys(c).length > 0);
+  return kept.length ? JSON.stringify(kept) : null;
+}
+
+function parseStandContacts(raw: string | null): StandContact[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as StandContact[]) : [];
+  } catch {
+    return [];
+  }
 }
 
 // Resolve a modification token to either a speaker or a sponsor. Returns null
@@ -241,6 +322,13 @@ interface SponsorEditBody {
   websiteUrl?: string;
   logoUrl?: string;
   socialLinks?: Record<string, string>;
+  // Private fields (#249).
+  standContacts?: StandContact[];
+  comKitReceived?: boolean;
+  comKitLogoWebUrl?: string;
+  comKitLogoPrintUrl?: string;
+  comKitCharterUrl?: string;
+  comKitNotes?: string;
 }
 
 // Notify the organizers that a speaker changed a session. Sent to the
@@ -329,6 +417,18 @@ export default async function editRoutes(app: FastifyInstance) {
         logoUrl: entity.logoUrl,
         socialLinks: parseSocial(entity.socialLinks),
       },
+      // Private fields (#249) — served to the token holder so they can edit
+      // them, kept in a separate block so the UI can render them apart. The
+      // public sponsor route never returns these.
+      private: {
+        level: entity.level,
+        standContacts: parseStandContacts(entity.standContacts),
+        comKitReceived: entity.comKitReceived,
+        comKitLogoWebUrl: entity.comKitLogoWebUrl,
+        comKitLogoPrintUrl: entity.comKitLogoPrintUrl,
+        comKitCharterUrl: entity.comKitCharterUrl,
+        comKitNotes: entity.comKitNotes,
+      },
     };
   });
 
@@ -389,9 +489,24 @@ export default async function editRoutes(app: FastifyInstance) {
           ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
           ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
           ...(body.socialLinks !== undefined && { socialLinks: cleanSocial(body.socialLinks) }),
+          // Private fields (#249).
+          ...(body.standContacts !== undefined && { standContacts: cleanStandContacts(body.standContacts) }),
+          ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
+          ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
+          ...(body.comKitLogoPrintUrl !== undefined && { comKitLogoPrintUrl: body.comKitLogoPrintUrl || null }),
+          ...(body.comKitCharterUrl !== undefined && { comKitCharterUrl: body.comKitCharterUrl || null }),
+          ...(body.comKitNotes !== undefined && { comKitNotes: body.comKitNotes || null }),
         },
       });
-      revalidateSponsors();
+      // Only public-facing changes need cache revalidation; a private-only
+      // save (com kit, stand contacts) changes nothing on the public pages.
+      const touchesPublic =
+        body.descriptionFr !== undefined ||
+        body.descriptionEn !== undefined ||
+        body.websiteUrl !== undefined ||
+        body.logoUrl !== undefined ||
+        body.socialLinks !== undefined;
+      if (touchesPublic) revalidateSponsors();
     }
 
     return { saved: true };
@@ -473,6 +588,68 @@ export default async function editRoutes(app: FastifyInstance) {
       }
 
       return { saved: true };
+    },
+  );
+
+  // POST /api/edit/:token/com-kit-email — a sponsor asks the organizers to
+  // collect com-kit complements that don't fit as links (#249). We don't accept
+  // attachments here (the token is unauthenticated); instead we email the
+  // sponsoring team with Reply-To set to the sponsor, so they can reply and the
+  // sponsor answers with the files attached.
+  app.post<{ Params: { token: string }; Body: { message?: string } }>(
+    "/edit/:token/com-kit-email",
+    {
+      config: { rateLimit: { max: 5, timeWindow: "1 minute" } },
+      schema: {
+        params: { type: "object", required: ["token"], properties: { token: { type: "string" } } },
+        body: {
+          type: "object",
+          additionalProperties: false,
+          properties: { message: { type: "string", maxLength: TEXT_MAX } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const resolved = await resolveToken(request.params.token);
+      if (!resolved || resolved.kind !== "sponsor") return reply.code(404).send({ error: "invalid_token" });
+
+      const { entity } = resolved;
+      const blocked = editingBlockedReason(entity);
+      if (blocked) return reply.code(403).send({ error: blocked });
+
+      const recipients = await getSponsorContactRecipients();
+      const message = request.body?.message?.trim();
+
+      const subject = `Compléments kit de com — ${entity.name}`;
+      const text = [
+        `${entity.name} souhaite transmettre des compléments pour son kit de communication.`,
+        message ? `\nMessage :\n${message}` : "",
+        entity.contactEmail
+          ? `\nRépondez à cet email pour demander les pièces jointes (Reply-To : ${entity.contactEmail}).`
+          : "\nRépondez à cet email pour demander les pièces jointes.",
+      ].join("\n");
+      const html = `
+        <h3>Compléments kit de com — ${escapeHtml(entity.name)}</h3>
+        <p><strong>${escapeHtml(entity.name)}</strong> souhaite transmettre des compléments
+        pour son kit de communication.</p>
+        ${message ? `<p><strong>Message :</strong><br>${escapeHtml(message).replace(/\n/g, "<br>")}</p>` : ""}
+        <p>Répondez à cet email pour demander les pièces jointes.</p>
+      `;
+
+      try {
+        await sendEmail({
+          to: recipients,
+          subject,
+          text,
+          html,
+          ...(entity.contactEmail ? { replyTo: entity.contactEmail } : {}),
+        });
+      } catch (err) {
+        request.log.error("Failed to send com-kit email: %s", String(err));
+        return reply.code(502).send({ error: "email_failed" });
+      }
+
+      return { sent: true };
     },
   );
 

--- a/src/frontend/src/app/admin/sponsors/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/[id]/page.tsx
@@ -57,6 +57,11 @@ export default function SponsorEditorPage() {
           bluesky: data.socialLinks?.bluesky || "",
           locale: data.locale === "en" ? "en" : "fr",
           publicationStatus: data.publicationStatus,
+          comKitReceived: data.comKitReceived ?? false,
+          comKitLogoWebUrl: data.comKitLogoWebUrl || "",
+          comKitLogoPrintUrl: data.comKitLogoPrintUrl || "",
+          comKitCharterUrl: data.comKitCharterUrl || "",
+          comKitNotes: data.comKitNotes || "",
         });
         setEditionId(data.editionId);
         setEditionYear(data.edition?.year ?? null);
@@ -86,6 +91,11 @@ export default function SponsorEditorPage() {
       socialLinks,
       locale: form.locale,
       publicationStatus: form.publicationStatus,
+      comKitReceived: form.comKitReceived,
+      comKitLogoWebUrl: form.comKitLogoWebUrl || undefined,
+      comKitLogoPrintUrl: form.comKitLogoPrintUrl || undefined,
+      comKitCharterUrl: form.comKitCharterUrl || undefined,
+      comKitNotes: form.comKitNotes || undefined,
     };
 
     if (isNew) {

--- a/src/frontend/src/app/edit/[token]/SponsorPrivateSection.tsx
+++ b/src/frontend/src/app/edit/[token]/SponsorPrivateSection.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState } from "react";
+
+type SponsorLevel = "PLATINUM" | "GOLD" | "SILVER" | "SOUTIEN" | "COMMUNAUTE";
+
+interface StandContact {
+  name?: string;
+  linkedin?: string;
+  twitter?: string;
+  bluesky?: string;
+}
+
+export interface SponsorPrivate {
+  level: SponsorLevel;
+  standContacts: StandContact[];
+  comKitReceived: boolean;
+  comKitLogoWebUrl: string | null;
+  comKitLogoPrintUrl: string | null;
+  comKitCharterUrl: string | null;
+  comKitNotes: string | null;
+}
+
+// Only the string labels this section needs. The parent passes its whole dict
+// (which also holds nested objects like `format`); this interface picks the
+// flat keys we use, so the wider dict is assignable to it.
+interface Labels {
+  save: string;
+  saving: string;
+  saved: string;
+  rejected: string;
+  privateSection: string;
+  privateHint: string;
+  standContacts: string;
+  standContactsHint: string;
+  standName: string;
+  addStandContact: string;
+  removeContact: string;
+  comKit: string;
+  comKitReceived: string;
+  comKitLogoWeb: string;
+  comKitLogoPrint: string;
+  comKitCharter: string;
+  comKitNotes: string;
+  comKitEmailIntro: string;
+  comKitEmailButton: string;
+  comKitEmailMessage: string;
+  comKitEmailSending: string;
+  comKitEmailSent: string;
+  comKitEmailError: string;
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+// Sponsor private information (#249): booth contacts + com kit. Organizers
+// only — never rendered on public pages. Self-contained: own draft state and
+// own save (PUT sends only the private fields; the profile save is separate).
+export default function SponsorPrivateSection({
+  token,
+  initial,
+  t,
+}: {
+  token: string;
+  initial: SponsorPrivate;
+  t: Labels;
+}) {
+  const [standContacts, setStandContacts] = useState<StandContact[]>(
+    initial.standContacts.length ? initial.standContacts : [],
+  );
+  const [comKitReceived, setComKitReceived] = useState(initial.comKitReceived);
+  const [comKitLogoWebUrl, setComKitLogoWebUrl] = useState(initial.comKitLogoWebUrl ?? "");
+  const [comKitLogoPrintUrl, setComKitLogoPrintUrl] = useState(initial.comKitLogoPrintUrl ?? "");
+  const [comKitCharterUrl, setComKitCharterUrl] = useState(initial.comKitCharterUrl ?? "");
+  const [comKitNotes, setComKitNotes] = useState(initial.comKitNotes ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState("");
+
+  function updateContact(index: number, patch: Partial<StandContact>) {
+    setStandContacts((prev) => prev.map((c, i) => (i === index ? { ...c, ...patch } : c)));
+  }
+  function addContact() {
+    setStandContacts((prev) => [...prev, {}]);
+  }
+  function removeContact(index: number) {
+    setStandContacts((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  async function save() {
+    setSaving(true);
+    setSaved(false);
+    setError("");
+    const res = await fetch(`/api/edit/${token}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        standContacts,
+        comKitReceived,
+        comKitLogoWebUrl,
+        comKitLogoPrintUrl,
+        comKitCharterUrl,
+        comKitNotes,
+      }),
+    });
+    setSaving(false);
+    if (res.ok) {
+      setSaved(true);
+      return;
+    }
+    setError(t.rejected);
+  }
+
+  return (
+    <section className="rounded-2xl border-2 border-dashed border-gris/25 bg-blanc-casse/60 p-5 sm:p-6">
+      <div className="mb-1 flex items-center gap-2">
+        <span aria-hidden className="text-lg">🔒</span>
+        <h2 className="text-lg font-bold text-noir">{t.privateSection}</h2>
+      </div>
+      <p className="mb-6 text-sm text-gris">{t.privateHint}</p>
+
+      {/* Booth staff social handles */}
+      <div className="mb-8">
+        <p className="text-sm font-semibold text-noir">{t.standContacts}</p>
+        <p className="mb-3 text-sm text-gris">{t.standContactsHint}</p>
+        <div className="space-y-4">
+          {standContacts.map((contact, i) => (
+            <div key={i} className="rounded-lg border border-gris/15 bg-blanc p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-xs font-semibold text-gris">#{i + 1}</span>
+                <button
+                  type="button"
+                  onClick={() => removeContact(i)}
+                  className="text-xs font-medium text-terre-cuite hover:underline"
+                >
+                  {t.removeContact}
+                </button>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                <Field label={t.standName} value={contact.name ?? ""} onChange={(v) => updateContact(i, { name: v })} />
+                <Field label="LinkedIn" value={contact.linkedin ?? ""} onChange={(v) => updateContact(i, { linkedin: v })} />
+                <Field label="X (Twitter)" value={contact.twitter ?? ""} onChange={(v) => updateContact(i, { twitter: v })} />
+                <Field label="Bluesky" value={contact.bluesky ?? ""} onChange={(v) => updateContact(i, { bluesky: v })} />
+              </div>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={addContact}
+          className="mt-3 rounded-lg border border-gris/30 bg-blanc px-4 py-2 text-sm font-medium text-noir hover:bg-blanc-casse"
+        >
+          + {t.addStandContact}
+        </button>
+      </div>
+
+      {/* Communication kit */}
+      <div className="mb-6">
+        <p className="mb-3 text-sm font-semibold text-noir">{t.comKit}</p>
+        <label className="mb-4 flex items-center gap-3">
+          <input
+            type="checkbox"
+            checked={comKitReceived}
+            onChange={(e) => setComKitReceived(e.target.checked)}
+            className="h-4 w-4 rounded border-gris/40 text-malachite focus:ring-malachite/50"
+          />
+          <span className="text-sm text-noir">{t.comKitReceived}</span>
+        </label>
+        <div className="grid gap-4 md:grid-cols-2">
+          <Field label={t.comKitLogoWeb} value={comKitLogoWebUrl} onChange={setComKitLogoWebUrl} />
+          <Field label={t.comKitLogoPrint} value={comKitLogoPrintUrl} onChange={setComKitLogoPrintUrl} />
+          <Field label={t.comKitCharter} value={comKitCharterUrl} onChange={setComKitCharterUrl} />
+        </div>
+        <label className="mt-4 block">
+          <span className="mb-1 block text-sm font-medium text-noir">{t.comKitNotes}</span>
+          <textarea value={comKitNotes} onChange={(e) => setComKitNotes(e.target.value)} rows={3} className={inputClass} />
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 border-t border-gris/15 pt-5">
+        <button
+          onClick={save}
+          disabled={saving}
+          className="rounded-[12px] bg-malachite px-5 py-2.5 text-sm font-bold text-blanc hover:bg-malachite/90 disabled:opacity-50"
+        >
+          {saving ? t.saving : t.save}
+        </button>
+        {saved && <span className="text-sm font-medium text-malachite">{t.saved}</span>}
+        {error && (
+          <span role="alert" className="text-sm font-medium text-terre-cuite">
+            {error}
+          </span>
+        )}
+      </div>
+
+      {/* Send com-kit complements by email */}
+      <ComKitEmail token={token} t={t} />
+    </section>
+  );
+}
+
+// Lets the sponsor ask the organizers to collect files that don't fit as links
+// (#249). Posts to a dedicated endpoint that emails the sponsoring team with
+// Reply-To set to the sponsor.
+function ComKitEmail({ token, t }: { token: string; t: Labels }) {
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState(false);
+
+  async function send() {
+    setSending(true);
+    setSent(false);
+    setError(false);
+    const res = await fetch(`/api/edit/${token}/com-kit-email`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message }),
+    });
+    setSending(false);
+    if (res.ok) {
+      setSent(true);
+      setMessage("");
+      return;
+    }
+    setError(true);
+  }
+
+  return (
+    <div className="mt-6 rounded-lg bg-blanc p-4">
+      <p className="mb-2 text-sm text-noir">{t.comKitEmailIntro}</p>
+      <label className="mb-3 block">
+        <span className="mb-1 block text-xs text-gris">{t.comKitEmailMessage}</span>
+        <textarea value={message} onChange={(e) => setMessage(e.target.value)} rows={2} className={inputClass} />
+      </label>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={send}
+          disabled={sending}
+          className="rounded-lg border border-gris/30 bg-blanc px-4 py-2 text-sm font-medium text-noir hover:bg-blanc-casse disabled:opacity-50"
+        >
+          {sending ? t.comKitEmailSending : t.comKitEmailButton}
+        </button>
+        {sent && <span className="text-sm font-medium text-malachite">{t.comKitEmailSent}</span>}
+        {error && (
+          <span role="alert" className="text-sm font-medium text-terre-cuite">
+            {t.comKitEmailError}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-sm font-medium text-noir">{label}</span>
+      <input value={value} onChange={(e) => onChange(e.target.value)} className={inputClass} />
+    </label>
+  );
+}

--- a/src/frontend/src/app/edit/[token]/page.tsx
+++ b/src/frontend/src/app/edit/[token]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useEffect, useRef, useState } from "react";
 
 import BilingualTabs from "@/components/admin/BilingualTabs";
+import SponsorPrivateSection, { type SponsorPrivate } from "./SponsorPrivateSection";
 
 type Locale = "fr" | "en";
 
@@ -29,6 +30,8 @@ interface EditData {
   fields: Record<string, unknown>;
   // Speaker only, read-only (#229).
   talks?: EditTalk[];
+  // Sponsor only, private section (#249).
+  private?: SponsorPrivate;
 }
 
 type SocialLinks = Record<string, string>;
@@ -71,6 +74,25 @@ const T = {
     talkSaved: "Conférence enregistrée !",
     talkRejected: "Le titre est obligatoire et le résumé doit rester sous 5 000 caractères.",
     social: { linkedin: "LinkedIn", twitter: "X (Twitter)", bluesky: "Bluesky", github: "GitHub", website: "Autre site" },
+    privateSection: "Informations privées",
+    privateHint: "Réservé à l'organisation — ces informations ne sont jamais affichées publiquement.",
+    standContacts: "Personnes présentes sur le stand",
+    standContactsHint: "Leurs réseaux sociaux, pour un relais le jour J.",
+    standName: "Nom",
+    addStandContact: "Ajouter une personne",
+    removeContact: "Retirer",
+    comKit: "Kit de communication",
+    comKitReceived: "Kit de com reçu",
+    comKitLogoWeb: "Logo (version Web)",
+    comKitLogoPrint: "Logo (version Print)",
+    comKitCharter: "Charte graphique",
+    comKitNotes: "Notes / autres supports",
+    comKitEmailIntro: "Des fichiers à transmettre qui ne tiennent pas en lien ?",
+    comKitEmailButton: "Envoyer les compléments par email",
+    comKitEmailMessage: "Message (optionnel)",
+    comKitEmailSending: "Envoi…",
+    comKitEmailSent: "Demande envoyée ! L'organisation vous recontactera pour les pièces jointes.",
+    comKitEmailError: "Envoi impossible. Réessayez plus tard.",
     upload: "Choisir une image…",
     uploading: "Envoi…",
     uploadHint: "JPEG, PNG, WebP ou GIF — 5 Mo max.",
@@ -123,6 +145,25 @@ const T = {
     talkSaved: "Talk saved!",
     talkRejected: "A title is required and the abstract must stay under 5,000 characters.",
     social: { linkedin: "LinkedIn", twitter: "X (Twitter)", bluesky: "Bluesky", github: "GitHub", website: "Other website" },
+    privateSection: "Private information",
+    privateHint: "Organizers only — this information is never shown publicly.",
+    standContacts: "People staffing the booth",
+    standContactsHint: "Their social handles, for relaying on the day.",
+    standName: "Name",
+    addStandContact: "Add a person",
+    removeContact: "Remove",
+    comKit: "Communication kit",
+    comKitReceived: "Com kit received",
+    comKitLogoWeb: "Logo (web version)",
+    comKitLogoPrint: "Logo (print version)",
+    comKitCharter: "Brand guidelines",
+    comKitNotes: "Notes / other assets",
+    comKitEmailIntro: "Files to send that don't fit as a link?",
+    comKitEmailButton: "Send complements by email",
+    comKitEmailMessage: "Message (optional)",
+    comKitEmailSending: "Sending…",
+    comKitEmailSent: "Request sent! The organisers will get back to you for the attachments.",
+    comKitEmailError: "Sending failed. Please try again later.",
     upload: "Choose an image…",
     uploading: "Uploading…",
     uploadHint: "JPEG, PNG, WebP or GIF — 5 MB max.",
@@ -360,6 +401,13 @@ export default function EditByTokenPage({ params }: { params: Promise<{ token: s
             </button>
             {saved && <span className="font-medium text-malachite">{t.saved}</span>}
           </div>
+
+          {/* Sponsor private section (#249) — organizers only, own save button.
+              Rendered after the public save so the public/private boundary is
+              visually explicit. */}
+          {!isSpeaker && data!.private && (
+            <SponsorPrivateSection token={token} initial={data!.private} t={t} />
+          )}
           {saveError && (
             <p role="alert" className="font-medium text-terre-cuite">
               {saveError}

--- a/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
+++ b/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
@@ -26,6 +26,12 @@ export interface SponsorFormValue {
   bluesky: string;
   locale: "fr" | "en";
   publicationStatus: "DRAFT" | "PUBLISHED";
+  // Private fields (#249) — organizers only, never public.
+  comKitReceived: boolean;
+  comKitLogoWebUrl: string;
+  comKitLogoPrintUrl: string;
+  comKitCharterUrl: string;
+  comKitNotes: string;
 }
 
 export const emptySponsorForm: SponsorFormValue = {
@@ -40,6 +46,11 @@ export const emptySponsorForm: SponsorFormValue = {
   bluesky: "",
   locale: "fr",
   publicationStatus: "DRAFT",
+  comKitReceived: false,
+  comKitLogoWebUrl: "",
+  comKitLogoPrintUrl: "",
+  comKitCharterUrl: "",
+  comKitNotes: "",
 };
 
 const inputClass =
@@ -152,6 +163,40 @@ export default function SponsorForm({ value, onChange }: SponsorFormProps) {
         />
         <span className="text-sm text-noir">Publié (visible sur le site)</span>
       </label>
+
+      {/* Private fields (#249) — organizers only, never shown publicly. The
+          booth contacts are edited by the sponsor via their magic link; here we
+          expose the com-kit tracking, which the orga fills in. */}
+      <fieldset className="rounded-lg border-2 border-dashed border-gris/25 bg-blanc-casse/50 p-4">
+        <legend className="px-2 text-sm font-semibold text-noir">🔒 Informations privées (kit de com)</legend>
+        <label className="flex items-center gap-2 cursor-pointer mb-4">
+          <input
+            type="checkbox"
+            checked={value.comKitReceived}
+            onChange={(e) => onChange({ ...value, comKitReceived: e.target.checked })}
+            className="rounded border-gris/30 text-malachite focus:ring-malachite"
+          />
+          <span className="text-sm text-noir">Kit de com reçu</span>
+        </label>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <label className="block">
+            <span className="block text-sm font-medium text-noir mb-1">Logo (version Web)</span>
+            <input type="url" value={value.comKitLogoWebUrl} onChange={(e) => onChange({ ...value, comKitLogoWebUrl: e.target.value })} className={inputClass} />
+          </label>
+          <label className="block">
+            <span className="block text-sm font-medium text-noir mb-1">Logo (version Print)</span>
+            <input type="url" value={value.comKitLogoPrintUrl} onChange={(e) => onChange({ ...value, comKitLogoPrintUrl: e.target.value })} className={inputClass} />
+          </label>
+          <label className="block">
+            <span className="block text-sm font-medium text-noir mb-1">Charte graphique</span>
+            <input type="url" value={value.comKitCharterUrl} onChange={(e) => onChange({ ...value, comKitCharterUrl: e.target.value })} className={inputClass} />
+          </label>
+        </div>
+        <label className="block mt-4">
+          <span className="block text-sm font-medium text-noir mb-1">Notes / autres supports</span>
+          <textarea value={value.comKitNotes} onChange={(e) => onChange({ ...value, comKitNotes: e.target.value })} rows={3} className={inputClass} />
+        </label>
+      </fieldset>
 
       <ImagePickerDialog
         open={isImagePickerOpen}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -143,6 +143,13 @@ export interface Sponsor {
   editLinkLocked: boolean;
   publicationStatus: "DRAFT" | "PUBLISHED";
   editionId: number;
+  // Private fields (#249) — organizers only, never on public pages.
+  standContacts?: { name?: string; linkedin?: string; twitter?: string; bluesky?: string }[];
+  comKitReceived?: boolean;
+  comKitLogoWebUrl?: string | null;
+  comKitLogoPrintUrl?: string | null;
+  comKitCharterUrl?: string | null;
+  comKitNotes?: string | null;
 }
 
 // Public list item (lighter than the admin Sponsor).


### PR DESCRIPTION
## Summary

- Section **« Informations privées (réservées à l'organisation) »** dans la page de modification du sponsor (magic link), **jamais** affichée publiquement.
- **Personnes au stand** : liste répétable (nom + LinkedIn / X / Bluesky) pour relais le jour J.
- **Kit de com** : case « Kit reçu », liens logo Web/Print + charte, notes, et **bouton d'envoi email** des compléments à l'équipe sponsoring (Reply-To = sponsor).

## Détails techniques

- **Prisma** : migration additive (`standContacts` JSON, `comKitReceived`, `comKitLogoWebUrl/PrintUrl/CharterUrl`, `comKitNotes`) — non destructive.
- **edit** : GET renvoie un bloc `private` séparé ; PUT allowliste les champs privés (URL validées, entrées vides supprimées) et ne revalide le cache que si un champ **public** change. Nouvel endpoint `POST /edit/:token/com-kit-email`.
- **Garde public/privé** : la route publique sponsor garde son allowlist explicite → aucun champ privé ne fuite (test dédié qui l'assert).
- **Admin** : champs kit de com dans `SponsorForm` + câblage.

## Test plan

- [x] `pnpm typecheck` backend + frontend, `pnpm lint` frontend
- [x] Tests backend : allowlist privé, rejet URL non sûre, **garde anti-fuite publique**, com-kit email — suite **265/265**
- [x] Vérif fonctionnelle (Docker local) : PUT privé (drop des entrées vides), GET bloc `private`, **API + HTML publics sans aucune donnée privée**, com-kit email → MailHog avec Reply-To sponsor
- [ ] Vérif visuelle du formulaire (Chrome DevTools MCP indisponible)

Refs #249
