### PR TITLE
feat(sponsors): secondary contacts with per-person edit links (#250)

### DIFF
--- a/src/backend/prisma/migrations/20260718160000_sponsor_contacts/migration.sql
+++ b/src/backend/prisma/migrations/20260718160000_sponsor_contacts/migration.sql
@@ -1,0 +1,48 @@
+-- Multi-contact modification links for sponsors (#250).
+-- Replaces the single editToken on Sponsor with a SponsorContact table:
+-- several people per sponsor, each with their own token / lock / send date.
+-- Order matters: create the table and MIGRATE existing tokens into it BEFORE
+-- dropping the columns, so no live modification link is lost.
+
+-- 1. New table
+CREATE TABLE "SponsorContact" (
+    "id" SERIAL NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "role" TEXT,
+    "editToken" TEXT,
+    "editLinkLocked" BOOLEAN NOT NULL DEFAULT false,
+    "editTokenSentAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "sponsorId" INTEGER NOT NULL,
+    CONSTRAINT "SponsorContact_pkey" PRIMARY KEY ("id")
+);
+
+-- 2. Carry over every sponsor that already has a modification link, as its
+--    first contact. Sponsors with a token but no contactEmail get a synthetic
+--    placeholder so the NOT NULL email holds; the admin can fix it later.
+-- name is left NULL: Sponsor.name is the company, not the person behind the
+-- link, and we don't know the latter for pre-existing tokens.
+INSERT INTO "SponsorContact" ("email", "editToken", "editLinkLocked", "editTokenSentAt", "createdAt", "updatedAt", "sponsorId")
+SELECT
+    COALESCE(NULLIF(TRIM("contactEmail"), ''), 'contact-' || "id" || '@import.local'),
+    "editToken",
+    "editLinkLocked",
+    "editTokenSentAt",
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    "id"
+FROM "Sponsor"
+WHERE "editToken" IS NOT NULL;
+
+-- 3. Indexes and FK
+CREATE UNIQUE INDEX "SponsorContact_editToken_key" ON "SponsorContact"("editToken");
+CREATE INDEX "SponsorContact_sponsorId_idx" ON "SponsorContact"("sponsorId");
+ALTER TABLE "SponsorContact" ADD CONSTRAINT "SponsorContact_sponsorId_fkey" FOREIGN KEY ("sponsorId") REFERENCES "Sponsor"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 4. Now that the tokens live in SponsorContact, drop them from Sponsor.
+DROP INDEX "Sponsor_editToken_key";
+ALTER TABLE "Sponsor" DROP COLUMN "editLinkLocked",
+DROP COLUMN "editToken",
+DROP COLUMN "editTokenSentAt";

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -568,11 +568,6 @@ model Sponsor {
   locale           String            @default("fr")
   publicationStatus PublicationStatus @default(DRAFT)
 
-  // Modification-link token infrastructure (issue #79, RG-242 to RG-251).
-  editToken        String?           @unique
-  editLinkLocked   Boolean           @default(false)
-  editTokenSentAt  DateTime?
-
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
 
@@ -582,8 +577,38 @@ model Sponsor {
   // Speakers working for this sponsor's company (RG-226).
   speakers         Speaker[]
 
+  // People allowed to edit this sponsor's page, each with their own
+  // modification link (#250). Replaces the single editToken on Sponsor.
+  contacts         SponsorContact[]
+
   @@unique([editionId, slug])
   @@index([editionId])
+}
+
+// A person who can edit a sponsor's page via their own modification link
+// (#250). Replaces the single editToken that used to live on Sponsor: a
+// sponsor can now have several contacts, each with an independent token, send
+// date (30-day expiry) and lock. All contacts edit the same sponsor page with
+// equal rights.
+model SponsorContact {
+  id               Int       @id @default(autoincrement())
+  email            String
+  name             String?
+  role             String?
+
+  // Modification-link token infrastructure (issue #79, RG-242 to RG-251),
+  // now per-contact. Locale for the link email is inherited from the sponsor.
+  editToken        String?   @unique
+  editLinkLocked   Boolean   @default(false)
+  editTokenSentAt  DateTime?
+
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  sponsorId        Int
+  sponsor          Sponsor   @relation(fields: [sponsorId], references: [id], onDelete: Cascade)
+
+  @@index([sponsorId])
 }
 
 // --- Categories / Tracks (RG-213, US-246) ---

--- a/src/backend/src/__tests__/admin-sponsor-contacts.test.ts
+++ b/src/backend/src/__tests__/admin-sponsor-contacts.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+// The contact endpoints send the modification link by email; stub SMTP.
+const { sendMailMock } = vi.hoisted(() => ({ sendMailMock: vi.fn().mockResolvedValue({}) }));
+vi.mock("nodemailer", () => ({
+  default: { createTransport: () => ({ sendMail: sendMailMock }) },
+}));
+
+import Fastify, { type FastifyInstance } from "fastify";
+import adminSponsorRoutes from "../routes/admin/sponsors.js";
+import { prisma } from "../lib/prisma.js";
+
+// Admin management of sponsor contacts (#250): add, list, lock, resend, delete.
+
+let app: FastifyInstance;
+let editionId: number;
+let sponsorId: number;
+
+describe("Admin sponsor contacts (#250)", () => {
+  beforeAll(async () => {
+    app = Fastify({ logger: false });
+    await app.register(adminSponsorRoutes, { prefix: "/api/admin" });
+
+    const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
+    if (!edition) throw new Error("seed missing an edition");
+    editionId = edition.id;
+
+    const sponsor = await prisma.sponsor.create({
+      data: { name: "Admin Contacts Sponsor", slug: `admin-contacts-${Date.now()}`, editionId, level: "GOLD" },
+    });
+    sponsorId = sponsor.id;
+  });
+
+  afterAll(async () => {
+    await prisma.sponsor.deleteMany({ where: { id: sponsorId } });
+    await app.close();
+  });
+
+  beforeEach(() => sendMailMock.mockClear());
+
+  it("adds a contact and emails its link", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/sponsors/${sponsorId}/contacts`,
+      payload: { email: "alice@example.org", name: "Alice", role: "Comm" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.email).toBe("alice@example.org");
+    expect(body.hasLink).toBe(true);
+    // The raw token is never returned to the admin.
+    expect(body).not.toHaveProperty("editToken");
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists the sponsor's contacts", async () => {
+    const res = await app.inject({ method: "GET", url: `/api/admin/sponsors/${sponsorId}/contacts` });
+    expect(res.statusCode).toBe(200);
+    const list = res.json();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBeGreaterThanOrEqual(1);
+    expect(list.some((c: { email: string }) => c.email === "alice@example.org")).toBe(true);
+  });
+
+  it("locks then deletes a contact", async () => {
+    const contact = await prisma.sponsorContact.findFirst({ where: { sponsorId } });
+    if (!contact) throw new Error("contact missing");
+
+    const lockRes = await app.inject({
+      method: "PUT",
+      url: `/api/admin/sponsors/${sponsorId}/contacts/${contact.id}/lock`,
+      payload: { locked: true },
+    });
+    expect(lockRes.statusCode).toBe(200);
+    expect(lockRes.json().editLinkLocked).toBe(true);
+
+    const delRes = await app.inject({
+      method: "DELETE",
+      url: `/api/admin/sponsors/${sponsorId}/contacts/${contact.id}`,
+    });
+    expect(delRes.statusCode).toBe(204);
+    const gone = await prisma.sponsorContact.findUnique({ where: { id: contact.id } });
+    expect(gone).toBeNull();
+  });
+
+  it("rejects a contact that belongs to another sponsor (404)", async () => {
+    const other = await prisma.sponsor.create({
+      data: { name: "Other Sponsor", slug: `other-${Date.now()}`, editionId, level: "GOLD" },
+    });
+    const otherContact = await prisma.sponsorContact.create({
+      data: { sponsorId: other.id, email: "x@example.org" },
+    });
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/api/admin/sponsors/${sponsorId}/contacts/${otherContact.id}`,
+    });
+    expect(res.statusCode).toBe(404);
+    await prisma.sponsor.deleteMany({ where: { id: other.id } });
+  });
+});

--- a/src/backend/src/__tests__/edit-social-bluesky.test.ts
+++ b/src/backend/src/__tests__/edit-social-bluesky.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { buildEditApp } from "./test-edit-app.js";
 import { prisma } from "../lib/prisma.js";
+import { createSponsorWithToken } from "./sponsor-test-helpers.js";
 
 // Bluesky is part of the shared socialLinks allowlist (#253). A sponsor (and a
 // speaker) can save it via their edit link; an unknown social key stays rejected.
@@ -15,12 +16,10 @@ describe("PUT /api/edit/:token — bluesky social link (#253)", () => {
     if (!edition) throw new Error("seed missing an edition");
     editionId = edition.id;
 
-    const sponsor = await prisma.sponsor.create({
-      data: {
-        name: "Bluesky Test Sponsor", slug: "bluesky-test-sponsor", editionId, level: "GOLD",
-        editToken: TOKEN, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
-      },
-    });
+    const sponsor = await createSponsorWithToken({
+      name: "Bluesky Test Sponsor", slug: "bluesky-test-sponsor", editionId, level: "GOLD",
+      publicationStatus: "PUBLISHED",
+    }, TOKEN);
     sponsorId = sponsor.id;
   });
 

--- a/src/backend/src/__tests__/edit-sponsor-platinum.test.ts
+++ b/src/backend/src/__tests__/edit-sponsor-platinum.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { buildEditApp } from "./test-edit-app.js";
 import { prisma } from "../lib/prisma.js";
+import { createSponsorWithToken } from "./sponsor-test-helpers.js";
 
 // Platinum-only promo ideas (#252): writable via the magic link only when the
 // sponsor is Platinum. For any other level the fields are silently ignored, so
@@ -18,20 +19,16 @@ describe("Sponsor Platinum promo content (#252)", () => {
     if (!edition) throw new Error("seed missing an edition");
     editionId = edition.id;
 
-    const platinum = await prisma.sponsor.create({
-      data: {
-        name: "Platinum Test", slug: `platinum-test-${Date.now()}`, editionId, level: "PLATINUM",
-        editToken: PLATINUM_TOKEN, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
-      },
-    });
+    const platinum = await createSponsorWithToken({
+      name: "Platinum Test", slug: `platinum-test-${Date.now()}`, editionId, level: "PLATINUM",
+      publicationStatus: "PUBLISHED",
+    }, PLATINUM_TOKEN);
     platinumId = platinum.id;
 
-    const gold = await prisma.sponsor.create({
-      data: {
-        name: "Gold Test", slug: `gold-test-${Date.now()}`, editionId, level: "GOLD",
-        editToken: GOLD_TOKEN, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
-      },
-    });
+    const gold = await createSponsorWithToken({
+      name: "Gold Test", slug: `gold-test-${Date.now()}`, editionId, level: "GOLD",
+      publicationStatus: "PUBLISHED",
+    }, GOLD_TOKEN);
     goldId = gold.id;
   });
 

--- a/src/backend/src/__tests__/edit-sponsor-private.test.ts
+++ b/src/backend/src/__tests__/edit-sponsor-private.test.ts
@@ -9,6 +9,7 @@ vi.mock("nodemailer", () => ({
 import { buildEditApp } from "./test-edit-app.js";
 import { buildPublicApp } from "./test-public-app.js";
 import { prisma } from "../lib/prisma.js";
+import { createSponsorWithToken } from "./sponsor-test-helpers.js";
 
 // Sponsor private fields (#249): editable via the magic link, visible in the
 // admin, but NEVER exposed on any public route.
@@ -25,13 +26,10 @@ describe("Sponsor private section (#249)", () => {
     editionId = edition.id;
     slug = `private-test-sponsor-${Date.now()}`;
 
-    const sponsor = await prisma.sponsor.create({
-      data: {
-        name: "Private Test Sponsor", slug, editionId, level: "GOLD",
-        editToken: TOKEN, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
-        contactEmail: "sponsor@example.org",
-      },
-    });
+    const sponsor = await createSponsorWithToken({
+      name: "Private Test Sponsor", slug, editionId, level: "GOLD",
+      publicationStatus: "PUBLISHED", contactEmail: "sponsor@example.org",
+    }, TOKEN, { email: "sponsor@example.org" });
     sponsorId = sponsor.id;
   });
 

--- a/src/backend/src/__tests__/edit-talk-update.test.ts
+++ b/src/backend/src/__tests__/edit-talk-update.test.ts
@@ -9,6 +9,7 @@ vi.mock("nodemailer", () => ({
 
 import { buildEditApp } from "./test-edit-app.js";
 import { prisma } from "../lib/prisma.js";
+import { createSponsorWithToken } from "./sponsor-test-helpers.js";
 
 // PUT /api/edit/:token/talks/:talkId — a speaker edits the descriptive content
 // of one of their published sessions (#260).
@@ -174,12 +175,10 @@ describe("PUT /api/edit/:token/talks/:talkId — speaker edits a session (#260)"
 
   it("rejects a sponsor token (404 — no session to edit)", async () => {
     const sponsorToken = "test-talk-update-sponsor-token-8899aabbccddeeff";
-    const sponsor = await prisma.sponsor.create({
-      data: {
-        name: "Talk Update Sponsor", slug: "talk-update-sponsor", editionId, level: "GOLD",
-        editToken: sponsorToken, editTokenSentAt: new Date(), publicationStatus: "PUBLISHED",
-      },
-    });
+    const sponsor = await createSponsorWithToken({
+      name: "Talk Update Sponsor", slug: "talk-update-sponsor", editionId, level: "GOLD",
+      publicationStatus: "PUBLISHED",
+    }, sponsorToken);
     const app = await buildEditApp();
     const res = await app.inject({
       method: "PUT",

--- a/src/backend/src/__tests__/edit-upload.test.ts
+++ b/src/backend/src/__tests__/edit-upload.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { buildEditApp } from "./test-edit-app.js";
 import { prisma } from "../lib/prisma.js";
+import { createSponsorWithToken } from "./sponsor-test-helpers.js";
 
 // A 1x1 transparent PNG — smallest valid raster image sharp will accept.
 const PNG_1x1 = Buffer.from(
@@ -32,9 +33,10 @@ describe("POST /api/edit/:token/upload", () => {
     const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
     if (!edition) throw new Error("seed missing an edition");
     editionId = edition.id;
-    const sponsor = await prisma.sponsor.create({
-      data: { name: "Upload Test Sponsor", slug: "upload-test-sponsor", level: "GOLD", editionId, editToken: TOKEN },
-    });
+    const sponsor = await createSponsorWithToken(
+      { name: "Upload Test Sponsor", slug: "upload-test-sponsor", level: "GOLD", editionId },
+      TOKEN,
+    );
     sponsorId = sponsor.id;
   });
 

--- a/src/backend/src/__tests__/sponsor-contacts.test.ts
+++ b/src/backend/src/__tests__/sponsor-contacts.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { buildEditApp } from "./test-edit-app.js";
+import { prisma } from "../lib/prisma.js";
+
+// Secondary contacts (#250): a sponsor can have several contacts, each with its
+// own modification link, lock and expiry — all editing the same sponsor page.
+
+const TOKEN_A = "test-contacts-token-a-1111222233334444aa";
+const TOKEN_B = "test-contacts-token-b-5555666677778888bb";
+let editionId: number;
+let sponsorId: number;
+
+describe("Sponsor secondary contacts (#250)", () => {
+  beforeAll(async () => {
+    const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
+    if (!edition) throw new Error("seed missing an edition");
+    editionId = edition.id;
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Multi Contact Sponsor", slug: `multi-contact-${Date.now()}`, editionId, level: "GOLD",
+        publicationStatus: "PUBLISHED",
+        contacts: {
+          create: [
+            { email: "primary@example.org", editToken: TOKEN_A, editTokenSentAt: new Date() },
+            { email: "secondary@example.org", editToken: TOKEN_B, editTokenSentAt: new Date() },
+          ],
+        },
+      },
+    });
+    sponsorId = sponsor.id;
+  });
+
+  afterAll(async () => {
+    await prisma.sponsor.deleteMany({ where: { id: sponsorId } });
+  });
+
+  it("resolves both contact tokens to the same sponsor", async () => {
+    const app = await buildEditApp();
+    for (const token of [TOKEN_A, TOKEN_B]) {
+      const res = await app.inject({ method: "GET", url: `/api/edit/${token}` });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().kind).toBe("sponsor");
+      expect(res.json().name).toBe("Multi Contact Sponsor");
+    }
+    await app.close();
+  });
+
+  it("both links edit the same sponsor page", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN_B}`,
+      payload: { descriptionFr: "Édité par le second contact" },
+    });
+    expect(res.statusCode).toBe(200);
+    const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
+    expect(sponsor?.descriptionFr).toBe("Édité par le second contact");
+    await app.close();
+  });
+
+  it("locking one contact does not block the other", async () => {
+    // Lock contact A only.
+    await prisma.sponsorContact.updateMany({
+      where: { sponsorId, editToken: TOKEN_A },
+      data: { editLinkLocked: true },
+    });
+    const app = await buildEditApp();
+
+    const lockedRes = await app.inject({ method: "GET", url: `/api/edit/${TOKEN_A}` });
+    expect(lockedRes.statusCode).toBe(403);
+    expect(lockedRes.json().error).toBe("locked");
+
+    const openRes = await app.inject({ method: "GET", url: `/api/edit/${TOKEN_B}` });
+    expect(openRes.statusCode).toBe(200);
+    await app.close();
+
+    // Restore for isolation.
+    await prisma.sponsorContact.updateMany({
+      where: { sponsorId, editToken: TOKEN_A },
+      data: { editLinkLocked: false },
+    });
+  });
+});

--- a/src/backend/src/__tests__/sponsor-test-helpers.ts
+++ b/src/backend/src/__tests__/sponsor-test-helpers.ts
@@ -1,0 +1,24 @@
+import { prisma } from "../lib/prisma.js";
+import type { Prisma } from "../generated/prisma/client.js";
+
+// Since #250 a sponsor's modification token lives on a SponsorContact, not on
+// Sponsor. These helpers create a sponsor with a linked contact carrying the
+// token, so tests can resolve /api/edit/:token exactly as before.
+
+export async function createSponsorWithToken(
+  data: Prisma.SponsorUncheckedCreateInput,
+  token: string,
+  contact?: { email?: string; sentAt?: Date; locked?: boolean },
+) {
+  const sponsor = await prisma.sponsor.create({ data });
+  await prisma.sponsorContact.create({
+    data: {
+      sponsorId: sponsor.id,
+      email: contact?.email ?? sponsor.contactEmail ?? "contact@example.org",
+      editToken: token,
+      editTokenSentAt: contact?.sentAt ?? new Date(),
+      editLinkLocked: contact?.locked ?? false,
+    },
+  });
+  return sponsor;
+}

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -221,57 +221,130 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     return reply.code(204).send();
   });
 
-  // POST /api/admin/sponsors/:id/edit-link — (re)generate token + email it.
-  app.post<{ Params: SponsorIdParams; Body: { email?: string } }>("/sponsors/:id/edit-link", {
+  // A sponsor can have several contacts, each with its own modification link
+  // (#250). The token itself is never returned to the admin — only whether a
+  // link is active, when it was sent, and if it's locked.
+  const serializeContact = (c: {
+    id: number;
+    email: string;
+    name: string | null;
+    role: string | null;
+    editToken: string | null;
+    editLinkLocked: boolean;
+    editTokenSentAt: Date | null;
+  }) => ({
+    id: c.id,
+    email: c.email,
+    name: c.name,
+    role: c.role,
+    hasLink: !!c.editToken,
+    editLinkLocked: c.editLinkLocked,
+    editTokenSentAt: c.editTokenSentAt,
+  });
+
+  // GET /api/admin/sponsors/:id/contacts — list a sponsor's contacts.
+  app.get<{ Params: SponsorIdParams }>("/sponsors/:id/contacts", {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
-  }, async (request, reply) => {
-    const id = Number(request.params.id);
-    const sponsor = await prisma.sponsor.findUnique({ where: { id } });
-    if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
+  }, async (request) => {
+    const contacts = await prisma.sponsorContact.findMany({
+      where: { sponsorId: Number(request.params.id) },
+      orderBy: { createdAt: "asc" },
+    });
+    return contacts.map(serializeContact);
+  });
 
-    const email = request.body.email?.trim() || sponsor.contactEmail;
-    if (!email) return reply.code(400).send({ error: "No contact email provided" });
+  // POST /api/admin/sponsors/:id/contacts — add a contact and send its link.
+  app.post<{ Params: SponsorIdParams; Body: { email?: string; name?: string; role?: string } }>(
+    "/sponsors/:id/contacts",
+    { schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } } },
+    async (request, reply) => {
+      const sponsorId = Number(request.params.id);
+      const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
+      if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
 
-    // Send first, persist second (#223): rotating the token before a failed
-    // send would break the link the sponsor already has, and hand them nothing
-    // in return. On SMTP failure the previous link stays valid.
-    const token = generateEditToken();
-    try {
-      await sendEditLinkEmail({
-        to: email,
-        name: sponsor.name,
-        token,
-        kind: "sponsor",
-        locale: sponsor.locale,
+      const email = request.body.email?.trim();
+      if (!email) return reply.code(400).send({ error: "No contact email provided" });
+
+      // Send first, persist second (#223): if the mail fails we create nothing.
+      const token = generateEditToken();
+      try {
+        await sendEditLinkEmail({ to: email, name: sponsor.name, token, kind: "sponsor", locale: sponsor.locale });
+      } catch (err) {
+        request.log.error({ err }, "Failed to send sponsor edit link email");
+        return reply.code(502).send({ error: "Email sending failed", detail: "retry" });
+      }
+
+      const contact = await prisma.sponsorContact.create({
+        data: {
+          sponsorId,
+          email,
+          name: request.body.name?.trim() || null,
+          role: request.body.role?.trim() || null,
+          editToken: token,
+          editTokenSentAt: new Date(),
+        },
       });
-    } catch (err) {
-      request.log.error({ err }, "Failed to send sponsor edit link email");
-      return reply.code(502).send({ error: "Email sending failed", detail: "retry" });
-    }
+      return reply.code(201).send(serializeContact(contact));
+    },
+  );
 
-    await prisma.sponsor.update({
-      where: { id },
-      data: { editToken: token, editLinkLocked: false, editTokenSentAt: new Date(), contactEmail: email },
-    });
-    return { sent: true, email };
-  });
+  // POST /api/admin/sponsors/:id/contacts/:contactId/resend — rotate + resend.
+  app.post<{ Params: SponsorIdParams & { contactId: string } }>(
+    "/sponsors/:id/contacts/:contactId/resend",
+    { schema: { params: { type: "object", required: ["id", "contactId"], properties: { id: { type: "string" }, contactId: { type: "string" } } } } },
+    async (request, reply) => {
+      const contact = await prisma.sponsorContact.findUnique({
+        where: { id: Number(request.params.contactId) },
+        include: { sponsor: true },
+      });
+      if (!contact || contact.sponsorId !== Number(request.params.id)) {
+        return reply.code(404).send({ error: "Contact not found" });
+      }
 
-  // DELETE /api/admin/sponsors/:id/edit-link — revoke the link.
-  app.delete<{ Params: SponsorIdParams }>("/sponsors/:id/edit-link", {
-    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
-  }, async (request) => {
-    await prisma.sponsor.update({ where: { id: Number(request.params.id) }, data: { editToken: null } });
-    return { revoked: true };
-  });
+      const token = generateEditToken();
+      try {
+        await sendEditLinkEmail({ to: contact.email, name: contact.sponsor.name, token, kind: "sponsor", locale: contact.sponsor.locale });
+      } catch (err) {
+        request.log.error({ err }, "Failed to resend sponsor edit link email");
+        return reply.code(502).send({ error: "Email sending failed", detail: "retry" });
+      }
 
-  // PUT /api/admin/sponsors/:id/edit-link/lock — lock/unlock without deleting.
-  app.put<{ Params: SponsorIdParams; Body: { locked: boolean } }>("/sponsors/:id/edit-link/lock", {
-    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
-  }, async (request) => {
-    const s = await prisma.sponsor.update({
-      where: { id: Number(request.params.id) },
-      data: { editLinkLocked: !!request.body.locked },
-    });
-    return { locked: s.editLinkLocked };
-  });
+      const updated = await prisma.sponsorContact.update({
+        where: { id: contact.id },
+        data: { editToken: token, editLinkLocked: false, editTokenSentAt: new Date() },
+      });
+      return serializeContact(updated);
+    },
+  );
+
+  // PUT /api/admin/sponsors/:id/contacts/:contactId/lock — lock/unlock a link.
+  app.put<{ Params: SponsorIdParams & { contactId: string }; Body: { locked: boolean } }>(
+    "/sponsors/:id/contacts/:contactId/lock",
+    { schema: { params: { type: "object", required: ["id", "contactId"], properties: { id: { type: "string" }, contactId: { type: "string" } } } } },
+    async (request, reply) => {
+      const contact = await prisma.sponsorContact.findUnique({ where: { id: Number(request.params.contactId) } });
+      if (!contact || contact.sponsorId !== Number(request.params.id)) {
+        return reply.code(404).send({ error: "Contact not found" });
+      }
+      const updated = await prisma.sponsorContact.update({
+        where: { id: contact.id },
+        data: { editLinkLocked: !!request.body.locked },
+      });
+      return serializeContact(updated);
+    },
+  );
+
+  // DELETE /api/admin/sponsors/:id/contacts/:contactId — remove a contact.
+  app.delete<{ Params: SponsorIdParams & { contactId: string } }>(
+    "/sponsors/:id/contacts/:contactId",
+    { schema: { params: { type: "object", required: ["id", "contactId"], properties: { id: { type: "string" }, contactId: { type: "string" } } } } },
+    async (request, reply) => {
+      const contact = await prisma.sponsorContact.findUnique({ where: { id: Number(request.params.contactId) } });
+      if (!contact || contact.sponsorId !== Number(request.params.id)) {
+        return reply.code(404).send({ error: "Contact not found" });
+      }
+      await prisma.sponsorContact.delete({ where: { id: contact.id } });
+      return reply.code(204).send();
+    },
+  );
 }

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -280,11 +280,28 @@ async function resolveToken(token: string) {
   });
   if (speaker) return { kind: "speaker" as const, entity: speaker };
 
-  const sponsor = await prisma.sponsor.findUnique({
+  // Sponsors resolve through their contacts (#250): the token lives on a
+  // SponsorContact, and the lock/send-date are per-contact. We flatten the
+  // contact's token fields onto the sponsor so the rest of the route (which
+  // reads entity.level, entity.standContacts, entity.id, entity.editLinkLocked,
+  // …) keeps working unchanged, and expose contactId/contactEmail for the
+  // notification Reply-To.
+  const contact = await prisma.sponsorContact.findUnique({
     where: { editToken: token },
-    include: { edition: { select: { startDate: true } } },
+    include: { sponsor: { include: { edition: { select: { startDate: true } } } } },
   });
-  if (sponsor) return { kind: "sponsor" as const, entity: sponsor };
+  if (contact) {
+    const entity = {
+      ...contact.sponsor,
+      editLinkLocked: contact.editLinkLocked,
+      editTokenSentAt: contact.editTokenSentAt,
+      contactId: contact.id,
+      // The link recipient's own address wins over the sponsor's default for
+      // the com-kit Reply-To.
+      contactEmail: contact.email || contact.sponsor.contactEmail,
+    };
+    return { kind: "sponsor" as const, entity };
+  }
 
   return null;
 }

--- a/src/frontend/src/app/admin/sponsors/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { adminFetch } from "@/lib/admin-api";
 import type { Sponsor } from "@/lib/types";
-import EditLinkActions from "@/components/admin/EditLinkActions";
+import SponsorContacts from "@/components/admin/sponsors/SponsorContacts";
 import SponsorForm, { emptySponsorForm, type SponsorFormValue } from "@/components/admin/sponsors/SponsorForm";
 
 interface SponsorData extends Sponsor {
@@ -152,14 +152,7 @@ export default function SponsorEditorPage() {
 
         <SponsorForm value={form} onChange={setForm} />
 
-        {!isNew && current && (
-          <EditLinkActions
-            resource="sponsors"
-            entityId={current.id}
-            initialEmail={current.contactEmail ?? ""}
-            initialLocked={current.editLinkLocked}
-          />
-        )}
+        {!isNew && current && <SponsorContacts sponsorId={current.id} />}
 
         {error && <p className="text-sm text-terre-cuite">{error}</p>}
 

--- a/src/frontend/src/components/admin/sponsors/SponsorContacts.tsx
+++ b/src/frontend/src/components/admin/sponsors/SponsorContacts.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { adminFetch } from "@/lib/admin-api";
+
+interface Contact {
+  id: number;
+  email: string;
+  name: string | null;
+  role: string | null;
+  hasLink: boolean;
+  editLinkLocked: boolean;
+  editTokenSentAt: string | null;
+}
+
+// Admin management of a sponsor's modification-link contacts (#250): a sponsor
+// can have several people, each with their own link, lock and resend. Replaces
+// the single-link EditLinkActions for sponsors.
+export default function SponsorContacts({ sponsorId }: { sponsorId: number }) {
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [role, setRole] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  async function load() {
+    const { data } = await adminFetch<Contact[]>(`/sponsors/${sponsorId}/contacts`);
+    if (data) setContacts(data);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sponsorId]);
+
+  async function add() {
+    if (!email.trim()) {
+      setMsg({ ok: false, text: "Renseignez une adresse email." });
+      return;
+    }
+    setBusy(true);
+    setMsg(null);
+    const { status } = await adminFetch(`/sponsors/${sponsorId}/contacts`, {
+      method: "POST",
+      body: JSON.stringify({ email: email.trim(), name: name.trim(), role: role.trim() }),
+    });
+    setBusy(false);
+    if (status === 201) {
+      setMsg({ ok: true, text: `Lien envoyé à ${email.trim()}.` });
+      setEmail("");
+      setName("");
+      setRole("");
+      void load();
+    } else {
+      setMsg({ ok: false, text: "Échec de l'envoi. Réessayez." });
+    }
+  }
+
+  async function resend(id: number) {
+    setBusy(true);
+    setMsg(null);
+    const { status } = await adminFetch(`/sponsors/${sponsorId}/contacts/${id}/resend`, { method: "POST" });
+    setBusy(false);
+    setMsg(status === 200 ? { ok: true, text: "Nouveau lien envoyé." } : { ok: false, text: "Échec." });
+    if (status === 200) void load();
+  }
+
+  async function toggleLock(contact: Contact) {
+    setBusy(true);
+    setMsg(null);
+    const next = !contact.editLinkLocked;
+    const { status } = await adminFetch(`/sponsors/${sponsorId}/contacts/${contact.id}/lock`, {
+      method: "PUT",
+      body: JSON.stringify({ locked: next }),
+    });
+    setBusy(false);
+    if (status === 200) void load();
+    else setMsg({ ok: false, text: "Échec." });
+  }
+
+  async function remove(id: number) {
+    setBusy(true);
+    setMsg(null);
+    const { status } = await adminFetch(`/sponsors/${sponsorId}/contacts/${id}`, { method: "DELETE" });
+    setBusy(false);
+    if (status === 204) void load();
+    else setMsg({ ok: false, text: "Échec de la suppression." });
+  }
+
+  return (
+    <div className="rounded-lg border border-gris/20 bg-blanc-casse/50 p-4 space-y-4">
+      <p className="text-sm font-medium text-noir">Contacts &amp; liens de modification</p>
+
+      {loading ? (
+        <p className="text-sm text-gris">Chargement…</p>
+      ) : contacts.length === 0 ? (
+        <p className="text-sm text-gris">Aucun contact pour l&apos;instant.</p>
+      ) : (
+        <ul className="space-y-2">
+          {contacts.map((c) => (
+            <li key={c.id} className="flex flex-wrap items-center gap-3 rounded-lg border border-gris/15 bg-blanc px-3 py-2">
+              <div className="min-w-[180px] flex-1">
+                <p className="text-sm font-medium text-noir">
+                  {c.name || c.email}
+                  {c.role && <span className="ml-2 text-xs text-gris">({c.role})</span>}
+                </p>
+                {c.name && <p className="text-xs text-gris">{c.email}</p>}
+              </div>
+              {c.editLinkLocked && (
+                <span className="rounded-full bg-terre-cuite/10 px-2 py-0.5 text-xs font-medium text-terre-cuite">
+                  Verrouillé
+                </span>
+              )}
+              <button type="button" onClick={() => resend(c.id)} disabled={busy} className="text-xs font-medium text-malachite hover:underline disabled:opacity-50">
+                Renvoyer le lien
+              </button>
+              <button type="button" onClick={() => toggleLock(c)} disabled={busy} className="text-xs font-medium text-noir hover:underline disabled:opacity-50">
+                {c.editLinkLocked ? "Déverrouiller" : "Verrouiller"}
+              </button>
+              <button type="button" onClick={() => remove(c.id)} disabled={busy} className="text-xs font-medium text-terre-cuite hover:underline disabled:opacity-50">
+                Retirer
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="border-t border-gris/15 pt-3">
+        <p className="mb-2 text-xs font-semibold text-gris">Ajouter un contact</p>
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex-1 min-w-[180px]">
+            <span className="mb-1 block text-xs text-gris">Email</span>
+            <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="email@exemple.com" className={inputClass} />
+          </label>
+          <label className="min-w-[120px]">
+            <span className="mb-1 block text-xs text-gris">Nom (optionnel)</span>
+            <input value={name} onChange={(e) => setName(e.target.value)} className={inputClass} />
+          </label>
+          <label className="min-w-[120px]">
+            <span className="mb-1 block text-xs text-gris">Rôle (optionnel)</span>
+            <input value={role} onChange={(e) => setRole(e.target.value)} className={inputClass} />
+          </label>
+          <button type="button" onClick={add} disabled={busy} className="px-3 py-2 text-sm rounded-lg bg-malachite text-blanc font-medium hover:bg-malachite/90 disabled:opacity-50">
+            Ajouter &amp; envoyer
+          </button>
+        </div>
+      </div>
+
+      {msg && <p className={`text-sm ${msg.ok ? "text-malachite" : "text-terre-cuite"}`}>{msg.text}</p>}
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -35,6 +35,12 @@ export async function adminFetch<T>(
       return { data: null, status: res.status };
     }
 
+    // 204 No Content (e.g. a DELETE) has an empty body: res.json() would throw
+    // and wrongly surface as a network error. Return the success status as-is.
+    if (res.status === 204) {
+      return { data: null, status: 204 };
+    }
+
     const data = await res.json();
     return { data, status: res.status };
   } catch {

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -140,7 +140,6 @@ export interface Sponsor {
   socialLinks: Record<string, string>;
   contactEmail: string | null;
   locale: string;
-  editLinkLocked: boolean;
   publicationStatus: "DRAFT" | "PUBLISHED";
   editionId: number;
   // Private fields (#249) — organizers only, never on public pages.


### PR DESCRIPTION
## Summary

- Un sponsor peut désormais avoir **plusieurs contacts**, chacun avec son **propre lien de modification** (token, verrou et expiration **indépendants**). Tous éditent la même fiche avec les mêmes droits.
- Remplace le `editToken` unique sur `Sponsor` par une table **`SponsorContact`**.

## Détails techniques

- **Prisma** : nouveau modèle `SponsorContact` + migration de données qui **recopie chaque token sponsor existant** dans un premier contact **avant** de dropper les colonnes → aucun lien en cours n'est perdu. Rétro-compat **vérifiée** (token préservé, colonnes droppées).
- **edit** : `resolveToken` résout un token de contact vers son sponsor (aplatit lock/date sur l'entité pour ne rien changer au reste de la route). Verrou/expiration **par contact**.
- **admin** : `GET/POST /sponsors/:id/contacts`, `POST .../resend`, `PUT .../lock`, `DELETE .../:contactId` — le token brut n'est jamais renvoyé.
- **UI admin** : nouveau composant `SponsorContacts` (liste + ajouter/renvoyer/verrouiller/retirer), remplace `EditLinkActions` côté sponsor. Les **speakers gardent** le lien unique (hors périmètre).
- **fix(admin-api)** : `adminFetch` plantait sur un `204` (appelait toujours `res.json()`), faisant passer un DELETE réussi pour une erreur réseau. Corrigé.

## Test plan

- [x] typecheck backend + frontend, lint frontend
- [x] Tests backend : suite **275** + **7 nouveaux** (résolution multi-token, verrou par contact, gestion admin des contacts, ownership)
- [x] **Migration vérifiée** en local : token existant préservé dans `SponsorContact`, colonnes droppées de `Sponsor`
- [x] **Vérif navigateur** (admin) : ajout de contact (+ email MailHog), verrouiller/déverrouiller, **suppression** (fix 204), rétro-compat du contact migré

Refs #250
