### PR TITLE
feat(sponsors): partner job offers (#251)

### DIFF
--- a/src/backend/prisma/migrations/20260718182045_sponsor_job_offers/migration.sql
+++ b/src/backend/prisma/migrations/20260718182045_sponsor_job_offers/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "SponsorJobOffer" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "sponsorId" INTEGER NOT NULL,
+
+    CONSTRAINT "SponsorJobOffer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SponsorJobOffer_sponsorId_idx" ON "SponsorJobOffer"("sponsorId");
+
+-- AddForeignKey
+ALTER TABLE "SponsorJobOffer" ADD CONSTRAINT "SponsorJobOffer_sponsorId_fkey" FOREIGN KEY ("sponsorId") REFERENCES "Sponsor"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -581,6 +581,9 @@ model Sponsor {
   // modification link (#250). Replaces the single editToken on Sponsor.
   contacts         SponsorContact[]
 
+  // Job offers the sponsor wants relayed (#251). Count capped by level.
+  jobOffers        SponsorJobOffer[]
+
   @@unique([editionId, slug])
   @@index([editionId])
 }
@@ -601,6 +604,26 @@ model SponsorContact {
   editToken        String?   @unique
   editLinkLocked   Boolean   @default(false)
   editTokenSentAt  DateTime?
+
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  sponsorId        Int
+  sponsor          Sponsor   @relation(fields: [sponsorId], references: [id], onDelete: Cascade)
+
+  @@index([sponsorId])
+}
+
+// A job offer a sponsor wants relayed during the DevFest (#251). Shown on the
+// sponsor's public page and on a dedicated "partner job offers" page. The
+// number of offers per sponsor is capped by its level (4 Platinum / 2 Gold /
+// 1 otherwise); the description is rich text (same editor as articles).
+model SponsorJobOffer {
+  id               Int       @id @default(autoincrement())
+  title            String
+  // Rich-text HTML, sanitized on write (same pipeline as article content).
+  description      String
+  url              String
 
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt

--- a/src/backend/src/__tests__/sponsor-job-offers.test.ts
+++ b/src/backend/src/__tests__/sponsor-job-offers.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { buildEditApp } from "./test-edit-app.js";
+import { buildPublicApp } from "./test-public-app.js";
+import { prisma } from "../lib/prisma.js";
+import { createSponsorWithToken } from "./sponsor-test-helpers.js";
+
+// Sponsor job offers (#251): CRUD via the magic link, quota per level, HTML
+// sanitized, exposed publicly.
+
+const GOLD_TOKEN = "test-offers-gold-token-aabbccddee001122";
+let editionId: number;
+let goldSponsorId: number;
+let goldSlug: string;
+
+describe("Sponsor job offers (#251)", () => {
+  beforeAll(async () => {
+    const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
+    if (!edition) throw new Error("seed missing an edition");
+    editionId = edition.id;
+    goldSlug = `offers-gold-${Date.now()}`;
+
+    const sponsor = await createSponsorWithToken(
+      { name: "Offers Gold", slug: goldSlug, editionId, level: "GOLD", publicationStatus: "PUBLISHED" },
+      GOLD_TOKEN,
+    );
+    goldSponsorId = sponsor.id;
+  });
+
+  afterAll(async () => {
+    await prisma.sponsor.deleteMany({ where: { id: goldSponsorId } });
+  });
+
+  it("exposes the level quota in the GET private payload", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({ method: "GET", url: `/api/edit/${GOLD_TOKEN}` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().jobOffers.quota).toBe(2); // Gold
+    expect(res.json().jobOffers.items).toHaveLength(0);
+    await app.close();
+  });
+
+  it("creates an offer and sanitizes its description", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/edit/${GOLD_TOKEN}/job-offers`,
+      payload: { title: "Dev", description: "<p>Ok</p><script>alert(1)</script>", url: "https://jobs.example.org/1" },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().description).toBe("<p>Ok</p>");
+    await app.close();
+  });
+
+  it("enforces the level quota (Gold = 2)", async () => {
+    const app = await buildEditApp();
+    // One already exists; add a second (ok) then a third (rejected).
+    const ok = await app.inject({
+      method: "POST", url: `/api/edit/${GOLD_TOKEN}/job-offers`,
+      payload: { title: "Second", url: "https://jobs.example.org/2" },
+    });
+    expect(ok.statusCode).toBe(201);
+
+    const rejected = await app.inject({
+      method: "POST", url: `/api/edit/${GOLD_TOKEN}/job-offers`,
+      payload: { title: "Third", url: "https://jobs.example.org/3" },
+    });
+    expect(rejected.statusCode).toBe(409);
+    expect(rejected.json().error).toBe("quota_reached");
+    await app.close();
+  });
+
+  it("rejects an unsafe URL", async () => {
+    const app = await buildEditApp();
+    // Delete one first so quota isn't the blocker.
+    const offer = await prisma.sponsorJobOffer.findFirst({ where: { sponsorId: goldSponsorId } });
+    await prisma.sponsorJobOffer.delete({ where: { id: offer!.id } });
+
+    const res = await app.inject({
+      method: "POST", url: `/api/edit/${GOLD_TOKEN}/job-offers`,
+      payload: { title: "Bad", url: "javascript:alert(1)" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("invalid_url");
+    await app.close();
+  });
+
+  it("only edits offers belonging to the token's sponsor", async () => {
+    const other = await prisma.sponsor.create({
+      data: { name: "Other", slug: `offers-other-${Date.now()}`, editionId, level: "GOLD" },
+    });
+    const foreignOffer = await prisma.sponsorJobOffer.create({
+      data: { sponsorId: other.id, title: "Foreign", description: "", url: "https://x.org" },
+    });
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${GOLD_TOKEN}/job-offers/${foreignOffer.id}`,
+      payload: { title: "hack" },
+    });
+    expect(res.statusCode).toBe(404);
+    await app.close();
+    await prisma.sponsor.deleteMany({ where: { id: other.id } });
+  });
+
+  it("exposes offers on the public sponsor page and the recap list", async () => {
+    const app = await buildPublicApp();
+
+    const detail = await app.inject({ method: "GET", url: `/api/sponsors/${goldSlug}` });
+    expect(detail.statusCode).toBe(200);
+    expect(Array.isArray(detail.json().jobOffers)).toBe(true);
+    expect(detail.json().jobOffers.length).toBeGreaterThanOrEqual(1);
+
+    const list = await app.inject({ method: "GET", url: `/api/job-offers` });
+    expect(list.statusCode).toBe(200);
+    expect(list.json().some((s: { slug: string }) => s.slug === goldSlug)).toBe(true);
+    await app.close();
+  });
+});

--- a/src/backend/src/lib/job-offers.test.ts
+++ b/src/backend/src/lib/job-offers.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { offerQuotaForLevel, areOffersVisible, offersVisibilityCutoff } from "./job-offers.js";
+
+// Quota per level and the one-month-after-the-event visibility window (#251).
+
+describe("offerQuotaForLevel", () => {
+  it("gives 4 to Platinum, 2 to Gold, 1 to the rest", () => {
+    expect(offerQuotaForLevel("PLATINUM")).toBe(4);
+    expect(offerQuotaForLevel("GOLD")).toBe(2);
+    expect(offerQuotaForLevel("SILVER")).toBe(1);
+    expect(offerQuotaForLevel("SOUTIEN")).toBe(1);
+    expect(offerQuotaForLevel("COMMUNAUTE")).toBe(1);
+  });
+
+  it("defaults to 1 for an unknown level", () => {
+    expect(offerQuotaForLevel("MYSTERY")).toBe(1);
+  });
+});
+
+describe("offers visibility window", () => {
+  const start = new Date("2026-11-19T09:00:00Z");
+  const end = new Date("2026-11-19T18:00:00Z");
+
+  it("stays visible up to one month after the end date", () => {
+    const cutoff = offersVisibilityCutoff({ startDate: start, endDate: end });
+    expect(cutoff).not.toBeNull();
+    // Just before the cutoff → visible.
+    expect(areOffersVisible({ startDate: start, endDate: end }, new Date("2026-12-15T00:00:00Z"))).toBe(true);
+    // Well after → hidden.
+    expect(areOffersVisible({ startDate: start, endDate: end }, new Date("2027-01-15T00:00:00Z"))).toBe(false);
+  });
+
+  it("falls back to the start date when there is no end date", () => {
+    expect(areOffersVisible({ startDate: start, endDate: null }, new Date("2026-12-01T00:00:00Z"))).toBe(true);
+    expect(areOffersVisible({ startDate: start, endDate: null }, new Date("2027-02-01T00:00:00Z"))).toBe(false);
+  });
+
+  it("is always visible when the event isn't scheduled yet", () => {
+    expect(offersVisibilityCutoff({ startDate: null, endDate: null })).toBeNull();
+    expect(areOffersVisible({ startDate: null, endDate: null })).toBe(true);
+  });
+});

--- a/src/backend/src/lib/job-offers.ts
+++ b/src/backend/src/lib/job-offers.ts
@@ -1,0 +1,39 @@
+// Job-offer business rules (#251).
+
+// How many job offers a sponsor may publish, by level. A stricter cap for
+// lower tiers keeps the perk proportionate to the sponsorship.
+const OFFER_QUOTA: Record<string, number> = {
+  PLATINUM: 4,
+  GOLD: 2,
+  SILVER: 1,
+  SOUTIEN: 1,
+  COMMUNAUTE: 1,
+};
+
+export function offerQuotaForLevel(level: string): number {
+  return OFFER_QUOTA[level] ?? 1;
+}
+
+// Offers stay visible until one month after the event. We anchor on the
+// edition's end date (fall back to its start date), so the cut-off follows the
+// real event, not the calendar. A null date means the event isn't scheduled
+// yet — nothing to hide.
+const ONE_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function offersVisibilityCutoff(
+  edition: { startDate: Date | null; endDate: Date | null },
+): Date | null {
+  const anchor = edition.endDate ?? edition.startDate;
+  if (!anchor) return null;
+  return new Date(anchor.getTime() + ONE_MONTH_MS);
+}
+
+// True while the sponsor's offers should still be shown publicly.
+export function areOffersVisible(
+  edition: { startDate: Date | null; endDate: Date | null },
+  now: Date = new Date(),
+): boolean {
+  const cutoff = offersVisibilityCutoff(edition);
+  if (!cutoff) return true;
+  return now.getTime() <= cutoff.getTime();
+}

--- a/src/backend/src/lib/revalidate.ts
+++ b/src/backend/src/lib/revalidate.ts
@@ -74,6 +74,11 @@ export function revalidateSponsors(): Promise<void> {
   ]);
 }
 
+// The partner job-offers recap page (#251).
+export function revalidateJobOffers(): Promise<void> {
+  return revalidatePaths([...bilingualPaths("/offres-emploi-partenaires")]);
+}
+
 export function revalidateSpeakers(): Promise<void> {
   return revalidatePaths([
     ...bilingualPaths(""),

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
-import { revalidateSponsors } from "../../lib/revalidate.js";
+import { revalidateJobOffers, revalidateSponsors } from "../../lib/revalidate.js";
 import { slugify, uniqueSlug } from "../../lib/slug.js";
 import { generateEditToken } from "../../lib/edit-token.js";
 import { sendEditLinkEmail, normalizeLocale } from "../../lib/edit-link-email.js";
@@ -91,7 +91,11 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const sponsor = await prisma.sponsor.findUnique({
       where: { id: Number(request.params.id) },
-      include: { edition: { select: { id: true, year: true } } },
+      include: {
+        edition: { select: { id: true, year: true } },
+        // Job offers for admin consultation/moderation (#251).
+        jobOffers: { orderBy: { createdAt: "asc" } },
+      },
     });
     if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
     return serialize(sponsor);
@@ -344,6 +348,22 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         return reply.code(404).send({ error: "Contact not found" });
       }
       await prisma.sponsorContact.delete({ where: { id: contact.id } });
+      return reply.code(204).send();
+    },
+  );
+
+  // DELETE /api/admin/sponsors/:id/job-offers/:offerId — moderate an offer (#251).
+  app.delete<{ Params: SponsorIdParams & { offerId: string } }>(
+    "/sponsors/:id/job-offers/:offerId",
+    { schema: { params: { type: "object", required: ["id", "offerId"], properties: { id: { type: "string" }, offerId: { type: "string" } } } } },
+    async (request, reply) => {
+      const offer = await prisma.sponsorJobOffer.findUnique({ where: { id: Number(request.params.offerId) } });
+      if (!offer || offer.sponsorId !== Number(request.params.id)) {
+        return reply.code(404).send({ error: "Offer not found" });
+      }
+      await prisma.sponsorJobOffer.delete({ where: { id: offer.id } });
+      revalidateSponsors();
+      revalidateJobOffers();
       return reply.code(204).send();
     },
   );

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -5,6 +5,7 @@ import { normalizeLocale } from "../lib/edit-link-email.js";
 import { isSafeUrl } from "../lib/sanitize.js";
 import {
   revalidateConferences,
+  revalidateJobOffers,
   revalidateSpeakers,
   revalidateSponsors,
 } from "../lib/revalidate.js";
@@ -12,6 +13,8 @@ import { storeImageBuffer } from "../lib/image-store.js";
 import { sendEmail } from "../lib/email.js";
 import { getCfpNotificationEmail } from "../lib/cfp-settings.js";
 import { getSponsorContactRecipients } from "../lib/sponsor-contact.js";
+import { offerQuotaForLevel } from "../lib/job-offers.js";
+import { sanitizeRichHtml } from "../lib/sanitize.js";
 
 // This is the only unauthenticated endpoint that writes to the database and
 // whose content is rendered on public pages, so everything below is an
@@ -288,7 +291,15 @@ async function resolveToken(token: string) {
   // notification Reply-To.
   const contact = await prisma.sponsorContact.findUnique({
     where: { editToken: token },
-    include: { sponsor: { include: { edition: { select: { startDate: true } } } } },
+    include: {
+      sponsor: {
+        include: {
+          edition: { select: { startDate: true, endDate: true } },
+          // Job offers the sponsor can manage from the link (#251).
+          jobOffers: { orderBy: { createdAt: "asc" } },
+        },
+      },
+    },
   });
   if (contact) {
     const entity = {
@@ -456,6 +467,12 @@ export default async function editRoutes(app: FastifyInstance) {
         // fields only when level === PLATINUM.
         platinumPromoIdea: entity.platinumPromoIdea,
         platinumCoBuildIdea: entity.platinumCoBuildIdea,
+      },
+      // Job offers (#251): the sponsor's offers plus its level quota, so the
+      // UI can disable "add" at the cap.
+      jobOffers: {
+        items: entity.jobOffers.map((o) => ({ id: o.id, title: o.title, description: o.description, url: o.url })),
+        quota: offerQuotaForLevel(entity.level),
       },
     };
   });
@@ -686,6 +703,136 @@ export default async function editRoutes(app: FastifyInstance) {
       }
 
       return { sent: true };
+    },
+  );
+
+  // --- Job offers (#251): a sponsor manages the offers we relay for them,
+  // from the same link, capped by its level. Direct publication + revalidation.
+  const jobOfferBodySchema = {
+    type: "object",
+    additionalProperties: false,
+    required: ["title", "url"],
+    properties: {
+      title: { type: "string", maxLength: SHORT_MAX },
+      description: { type: "string", maxLength: TEXT_MAX },
+      url: { type: "string", maxLength: URL_MAX },
+    },
+  };
+
+  // POST /api/edit/:token/job-offers — create an offer, enforcing the quota.
+  app.post<{ Params: { token: string }; Body: { title: string; description?: string; url: string } }>(
+    "/edit/:token/job-offers",
+    {
+      config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+      schema: {
+        params: { type: "object", required: ["token"], properties: { token: { type: "string" } } },
+        body: jobOfferBodySchema,
+      },
+    },
+    async (request, reply) => {
+      const resolved = await resolveToken(request.params.token);
+      if (!resolved || resolved.kind !== "sponsor") return reply.code(404).send({ error: "invalid_token" });
+      const { entity } = resolved;
+      const blocked = editingBlockedReason(entity);
+      if (blocked) return reply.code(403).send({ error: blocked });
+
+      const { title, url } = request.body;
+      if (!title.trim()) return reply.code(400).send({ error: "empty_title" });
+      if (!isSafeUrl(url)) return reply.code(400).send({ error: "invalid_url", field: "url" });
+
+      // Quota is per level (#251). Count what's already there; a lowered level
+      // keeps existing offers but blocks new ones beyond the new cap.
+      const quota = offerQuotaForLevel(entity.level);
+      if (entity.jobOffers.length >= quota) {
+        return reply.code(409).send({ error: "quota_reached", quota });
+      }
+
+      const offer = await prisma.sponsorJobOffer.create({
+        data: {
+          sponsorId: entity.id,
+          title: title.trim(),
+          description: sanitizeRichHtml(request.body.description),
+          url: url.trim(),
+        },
+      });
+      revalidateSponsors();
+      revalidateJobOffers();
+      return reply.code(201).send({ id: offer.id, title: offer.title, description: offer.description, url: offer.url });
+    },
+  );
+
+  // PUT /api/edit/:token/job-offers/:offerId — edit one of the sponsor's offers.
+  app.put<{ Params: { token: string; offerId: string }; Body: { title?: string; description?: string; url?: string } }>(
+    "/edit/:token/job-offers/:offerId",
+    {
+      config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+      schema: {
+        params: {
+          type: "object",
+          required: ["token", "offerId"],
+          properties: { token: { type: "string" }, offerId: { type: "string", pattern: "^[0-9]+$" } },
+        },
+        body: { type: "object", additionalProperties: false, properties: jobOfferBodySchema.properties },
+      },
+    },
+    async (request, reply) => {
+      const resolved = await resolveToken(request.params.token);
+      if (!resolved || resolved.kind !== "sponsor") return reply.code(404).send({ error: "invalid_token" });
+      const { entity } = resolved;
+      const blocked = editingBlockedReason(entity);
+      if (blocked) return reply.code(403).send({ error: blocked });
+
+      // Ownership: only offers already attached to this sponsor.
+      const offerId = Number(request.params.offerId);
+      const offer = entity.jobOffers.find((o) => o.id === offerId);
+      if (!offer) return reply.code(404).send({ error: "offer_not_found" });
+
+      const body = request.body;
+      if (body.title !== undefined && !body.title.trim()) return reply.code(400).send({ error: "empty_title" });
+      if (body.url !== undefined && !isSafeUrl(body.url)) return reply.code(400).send({ error: "invalid_url", field: "url" });
+
+      await prisma.sponsorJobOffer.update({
+        where: { id: offer.id },
+        data: {
+          ...(body.title !== undefined && { title: body.title.trim() }),
+          ...(body.description !== undefined && { description: sanitizeRichHtml(body.description) }),
+          ...(body.url !== undefined && { url: body.url.trim() }),
+        },
+      });
+      revalidateSponsors();
+      revalidateJobOffers();
+      return { saved: true };
+    },
+  );
+
+  // DELETE /api/edit/:token/job-offers/:offerId — remove an offer.
+  app.delete<{ Params: { token: string; offerId: string } }>(
+    "/edit/:token/job-offers/:offerId",
+    {
+      config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+      schema: {
+        params: {
+          type: "object",
+          required: ["token", "offerId"],
+          properties: { token: { type: "string" }, offerId: { type: "string", pattern: "^[0-9]+$" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const resolved = await resolveToken(request.params.token);
+      if (!resolved || resolved.kind !== "sponsor") return reply.code(404).send({ error: "invalid_token" });
+      const { entity } = resolved;
+      const blocked = editingBlockedReason(entity);
+      if (blocked) return reply.code(403).send({ error: blocked });
+
+      const offerId = Number(request.params.offerId);
+      const offer = entity.jobOffers.find((o) => o.id === offerId);
+      if (!offer) return reply.code(404).send({ error: "offer_not_found" });
+
+      await prisma.sponsorJobOffer.delete({ where: { id: offer.id } });
+      revalidateSponsors();
+      revalidateJobOffers();
+      return reply.code(204).send();
     },
   );
 

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { getFeaturedEdition } from "./editions.js";
+import { areOffersVisible } from "../lib/job-offers.js";
 
 // Decreasing importance order (RG-221), used to sort levels for display.
 const LEVEL_ORDER: Record<string, number> = {
@@ -60,10 +61,17 @@ export default async function sponsorRoutes(app: FastifyInstance) {
           select: { slug: true, name: true, photoUrl: true, company: true },
           orderBy: { name: "asc" },
         },
+        jobOffers: {
+          select: { id: true, title: true, description: true, url: true },
+          orderBy: { createdAt: "asc" },
+        },
       },
     });
 
     if (!sponsor) return reply.status(404).send({ error: "Sponsor not found" });
+
+    // Offers disappear one month after the event (#251).
+    const jobOffers = areOffersVisible(edition) ? sponsor.jobOffers : [];
 
     return {
       id: sponsor.id,
@@ -76,6 +84,37 @@ export default async function sponsorRoutes(app: FastifyInstance) {
       descriptionEn: sponsor.descriptionEn,
       socialLinks: parseSocial(sponsor.socialLinks),
       speakers: sponsor.speakers,
+      jobOffers,
     };
+  });
+
+  // GET /api/job-offers — all partner job offers for the featured edition,
+  // grouped by sponsor, for the recap page (#251). Hidden once the offers'
+  // visibility window has passed.
+  app.get("/job-offers", async (_request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+    if (!areOffersVisible(edition)) return [];
+
+    const sponsors = await prisma.sponsor.findMany({
+      where: {
+        editionId: edition.id,
+        publicationStatus: "PUBLISHED",
+        jobOffers: { some: {} },
+      },
+      select: {
+        slug: true,
+        name: true,
+        logoUrl: true,
+        level: true,
+        jobOffers: {
+          select: { id: true, title: true, description: true, url: true },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+      orderBy: { name: "asc" },
+    });
+
+    return sponsors;
   });
 }

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -14,6 +14,7 @@
     "program": "Schedule",
     "speakers": "Speakers",
     "sponsors": "Sponsors",
+    "jobOffers": "Job offers",
     "blog": "News"
   },
   "cta": {
@@ -316,6 +317,8 @@
     "empty": "Sponsors will be announced soon.",
     "visitWebsite": "Visit website",
     "speakersOf": "Speakers from {name}",
+    "jobOffersTitle": "Job offers",
+    "jobOfferCta": "View offer",
     "level": {
       "PLATINUM": "Platinum",
       "GOLD": "Gold",
@@ -323,5 +326,15 @@
       "SOUTIEN": "Supporter",
       "COMMUNAUTE": "Community"
     }
+  },
+  "jobOffers": {
+    "title": "Partner job offers",
+    "description": "Job offers from DevFest Toulouse partners.",
+    "heading": "Partner job offers",
+    "intro": "Our partners are hiring. Browse their offers and apply directly.",
+    "empty": "No job offers yet. Check back soon!",
+    "home": "Home",
+    "cta": "View offer",
+    "offersAt": "Offers at {name}"
   }
 }

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -14,6 +14,7 @@
     "program": "Programme",
     "speakers": "Speakers",
     "sponsors": "Sponsors",
+    "jobOffers": "Offres d'emploi",
     "blog": "Actus"
   },
   "cta": {
@@ -316,6 +317,8 @@
     "empty": "Les sponsors seront annoncés prochainement.",
     "visitWebsite": "Visiter le site",
     "speakersOf": "Speakers de {name}",
+    "jobOffersTitle": "Offres d'emploi",
+    "jobOfferCta": "Voir l'offre",
     "level": {
       "PLATINUM": "Platinum",
       "GOLD": "Gold",
@@ -323,5 +326,15 @@
       "SOUTIEN": "Soutien",
       "COMMUNAUTE": "Communauté"
     }
+  },
+  "jobOffers": {
+    "title": "Offres d'emploi des partenaires",
+    "description": "Les offres d'emploi proposées par les partenaires du DevFest Toulouse.",
+    "heading": "Offres d'emploi des partenaires",
+    "intro": "Nos partenaires recrutent. Découvrez leurs offres et postulez directement.",
+    "empty": "Aucune offre d'emploi pour le moment. Revenez bientôt !",
+    "home": "Accueil",
+    "cta": "Voir l'offre",
+    "offersAt": "Offres chez {name}"
   }
 }

--- a/src/frontend/src/app/[locale]/offres-emploi-partenaires/page.tsx
+++ b/src/frontend/src/app/[locale]/offres-emploi-partenaires/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { getJobOffers } from "@/lib/api";
+import Breadcrumb from "@/components/Breadcrumb";
+import { Link } from "@/i18n/navigation";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  const t = await getTranslations("jobOffers");
+  return {
+    title: t("title"),
+    description: t("description"),
+    alternates: {
+      canonical: `/${locale}/offres-emploi-partenaires`,
+      languages: {
+        fr: "/fr/offres-emploi-partenaires",
+        en: "/en/offres-emploi-partenaires",
+        "x-default": "/fr/offres-emploi-partenaires",
+      },
+    },
+  };
+}
+
+export default async function JobOffersPage() {
+  const t = await getTranslations("jobOffers");
+  const sponsors = await getJobOffers();
+
+  return (
+    <div className="bg-blanc-casse">
+      <div className="mx-auto max-w-4xl px-6 py-12">
+        <Breadcrumb items={[{ label: t("home"), href: "/" }, { label: t("title"), href: "/offres-emploi-partenaires" }]} />
+
+        <h1 className="mt-4 text-3xl font-bold text-noir lg:text-4xl">{t("heading")}</h1>
+        <p className="mt-3 max-w-prose text-gris">{t("intro")}</p>
+
+        {sponsors.length === 0 ? (
+          <p className="mt-12 text-gris">{t("empty")}</p>
+        ) : (
+          <div className="mt-10 space-y-12">
+            {sponsors.map((sponsor) => (
+              <section key={sponsor.slug}>
+                <div className="mb-4 flex items-center gap-3">
+                  {sponsor.logoUrl && (
+                    <div className="relative h-10 w-10 overflow-hidden rounded bg-blanc">
+                      <Image src={sponsor.logoUrl} alt={sponsor.name} fill className="object-contain p-1" sizes="40px" />
+                    </div>
+                  )}
+                  <h2 className="text-xl font-bold text-noir">
+                    <Link href={`/sponsors/${sponsor.slug}`} className="hover:text-bleu">
+                      {sponsor.name}
+                    </Link>
+                  </h2>
+                </div>
+                <div className="space-y-4">
+                  {sponsor.jobOffers.map((offer) => (
+                    <article key={offer.id} className="rounded-2xl border border-gris/15 bg-blanc p-5 shadow-sm">
+                      <h3 className="text-lg font-bold text-noir">{offer.title}</h3>
+                      {offer.description && (
+                        <div
+                          className="article-content mt-2 text-sm text-gris"
+                          dangerouslySetInnerHTML={{ __html: offer.description }}
+                        />
+                      )}
+                      <a
+                        href={offer.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-3 inline-block font-bold text-bleu hover:underline"
+                      >
+                        {t("cta")} →
+                      </a>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
@@ -156,6 +156,34 @@ export default async function SponsorDetailPage({
             </div>
           </section>
         )}
+
+        {/* Job offers to relay (#251). Description is server-sanitized HTML. */}
+        {sponsor.jobOffers.length > 0 && (
+          <section className="mt-14">
+            <h2 className="mb-6 text-2xl font-bold text-noir">{t("jobOffersTitle")}</h2>
+            <div className="space-y-4">
+              {sponsor.jobOffers.map((offer) => (
+                <article key={offer.id} className="rounded-2xl border border-gris/15 bg-blanc p-5 shadow-sm">
+                  <h3 className="text-lg font-bold text-noir">{offer.title}</h3>
+                  {offer.description && (
+                    <div
+                      className="article-content mt-2 text-sm text-gris"
+                      dangerouslySetInnerHTML={{ __html: offer.description }}
+                    />
+                  )}
+                  <a
+                    href={offer.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-3 inline-block font-bold text-bleu hover:underline"
+                  >
+                    {t("jobOfferCta")} →
+                  </a>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/src/frontend/src/app/edit/[token]/SponsorJobOffers.tsx
+++ b/src/frontend/src/app/edit/[token]/SponsorJobOffers.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState } from "react";
+
+export interface JobOffer {
+  id: number;
+  title: string;
+  description: string;
+  url: string;
+}
+
+export interface JobOffersData {
+  items: JobOffer[];
+  quota: number;
+}
+
+interface Labels {
+  save: string;
+  saving: string;
+  jobOffers: string;
+  jobOffersHint: string;
+  jobOfferTitle: string;
+  jobOfferDescription: string;
+  jobOfferUrl: string;
+  addJobOffer: string;
+  removeJobOffer: string;
+  jobOfferQuotaReached: string;
+  jobOfferSaved: string;
+  jobOfferRejected: string;
+}
+
+// A draft has no server id yet; it becomes a real offer on first save.
+interface Draft {
+  key: string;
+  title: string;
+  description: string;
+  url: string;
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";
+
+// Sponsor job offers (#251): the sponsor manages the offers we relay, capped by
+// its level. "Add" appends an empty draft; the row saves itself (POST for a
+// draft, PUT once it has an id), so we never send placeholder values.
+export default function SponsorJobOffers({
+  token,
+  initial,
+  t,
+}: {
+  token: string;
+  initial: JobOffersData;
+  t: Labels;
+}) {
+  const [offers, setOffers] = useState<JobOffer[]>(initial.items);
+  const [drafts, setDrafts] = useState<Draft[]>([]);
+
+  const total = offers.length + drafts.length;
+  const atCap = total >= initial.quota;
+
+  // Deterministic key without Date.now()/Math.random (unavailable server-side,
+  // but this is client code — still, a simple counter keeps keys stable).
+  const [draftSeq, setDraftSeq] = useState(0);
+  function addDraft() {
+    setDrafts((prev) => [...prev, { key: `draft-${draftSeq}`, title: "", description: "", url: "" }]);
+    setDraftSeq((n) => n + 1);
+  }
+
+  function removeDraft(key: string) {
+    setDrafts((prev) => prev.filter((d) => d.key !== key));
+  }
+
+  function onDraftCreated(key: string, created: JobOffer) {
+    setDrafts((prev) => prev.filter((d) => d.key !== key));
+    setOffers((prev) => [...prev, created]);
+  }
+
+  function onSaved(updated: JobOffer) {
+    setOffers((prev) => prev.map((o) => (o.id === updated.id ? updated : o)));
+  }
+
+  function onRemoved(id: number) {
+    setOffers((prev) => prev.filter((o) => o.id !== id));
+  }
+
+  return (
+    <div>
+      <p className="mb-1 text-sm font-semibold text-noir">{t.jobOffers}</p>
+      <p className="mb-4 text-sm text-gris">
+        {t.jobOffersHint} ({total}/{initial.quota})
+      </p>
+
+      <div className="space-y-6">
+        {offers.map((offer) => (
+          <OfferRow
+            key={offer.id}
+            token={token}
+            offer={offer}
+            t={t}
+            onSaved={onSaved}
+            onRemoved={onRemoved}
+          />
+        ))}
+        {drafts.map((draft) => (
+          <OfferRow
+            key={draft.key}
+            token={token}
+            draftKey={draft.key}
+            t={t}
+            onCreated={onDraftCreated}
+            onRemoveDraft={removeDraft}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={addDraft}
+        disabled={atCap}
+        className="mt-4 rounded-lg border border-gris/30 bg-blanc px-4 py-2 text-sm font-medium text-noir hover:bg-blanc-casse disabled:opacity-50"
+        title={atCap ? t.jobOfferQuotaReached : undefined}
+      >
+        + {t.addJobOffer}
+      </button>
+      {atCap && <p className="mt-2 text-xs text-gris">{t.jobOfferQuotaReached}</p>}
+    </div>
+  );
+}
+
+// One offer row — an existing offer (has `offer`) or a draft (has `draftKey`).
+function OfferRow({
+  token,
+  offer,
+  draftKey,
+  t,
+  onSaved,
+  onRemoved,
+  onCreated,
+  onRemoveDraft,
+}: {
+  token: string;
+  offer?: JobOffer;
+  draftKey?: string;
+  t: Labels;
+  onSaved?: (o: JobOffer) => void;
+  onRemoved?: (id: number) => void;
+  onCreated?: (key: string, o: JobOffer) => void;
+  onRemoveDraft?: (key: string) => void;
+}) {
+  const [title, setTitle] = useState(offer?.title ?? "");
+  const [description, setDescription] = useState(offer?.description ?? "");
+  const [url, setUrl] = useState(offer?.url ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState("");
+
+  async function save() {
+    setSaving(true);
+    setSaved(false);
+    setError("");
+    const isDraft = !offer;
+    const res = await fetch(
+      isDraft ? `/api/edit/${token}/job-offers` : `/api/edit/${token}/job-offers/${offer!.id}`,
+      {
+        method: isDraft ? "POST" : "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, description, url }),
+      },
+    );
+    setSaving(false);
+    if (res.ok) {
+      if (isDraft) {
+        const created = (await res.json()) as JobOffer;
+        onCreated?.(draftKey!, created);
+      } else {
+        setSaved(true);
+        onSaved?.({ id: offer!.id, title, description, url });
+      }
+      return;
+    }
+    if (res.status === 409) setError(t.jobOfferQuotaReached);
+    else setError(t.jobOfferRejected);
+  }
+
+  async function remove() {
+    if (!offer) {
+      onRemoveDraft?.(draftKey!);
+      return;
+    }
+    setSaving(true);
+    setError("");
+    const res = await fetch(`/api/edit/${token}/job-offers/${offer.id}`, { method: "DELETE" });
+    setSaving(false);
+    if (res.status === 204) onRemoved?.(offer.id);
+    else setError(t.jobOfferRejected);
+  }
+
+  return (
+    <div className="rounded-lg border border-gris/15 bg-blanc-casse p-4 sm:p-5">
+      <div className="space-y-4">
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-noir">{t.jobOfferTitle}</span>
+          <input value={title} onChange={(e) => setTitle(e.target.value)} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-noir">{t.jobOfferDescription}</span>
+          <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={4} className={inputClass} />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-noir">{t.jobOfferUrl}</span>
+          <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://" className={inputClass} />
+        </label>
+        <div className="flex flex-wrap items-center gap-4">
+          <button
+            onClick={save}
+            disabled={saving}
+            className="rounded-[12px] bg-malachite px-5 py-2.5 text-sm font-bold text-blanc hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {saving ? t.saving : t.save}
+          </button>
+          <button
+            type="button"
+            onClick={remove}
+            disabled={saving}
+            className="text-sm font-medium text-terre-cuite hover:underline disabled:opacity-50"
+          >
+            {t.removeJobOffer}
+          </button>
+          {saved && <span className="text-sm font-medium text-malachite">{t.jobOfferSaved}</span>}
+          {error && (
+            <span role="alert" className="text-sm font-medium text-terre-cuite">
+              {error}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/edit/[token]/page.tsx
+++ b/src/frontend/src/app/edit/[token]/page.tsx
@@ -4,6 +4,7 @@ import { use, useEffect, useRef, useState } from "react";
 
 import BilingualTabs from "@/components/admin/BilingualTabs";
 import SponsorPrivateSection, { type SponsorPrivate } from "./SponsorPrivateSection";
+import SponsorJobOffers, { type JobOffersData } from "./SponsorJobOffers";
 
 type Locale = "fr" | "en";
 
@@ -32,6 +33,8 @@ interface EditData {
   talks?: EditTalk[];
   // Sponsor only, private section (#249).
   private?: SponsorPrivate;
+  // Sponsor only, job offers (#251).
+  jobOffers?: JobOffersData;
 }
 
 type SocialLinks = Record<string, string>;
@@ -97,6 +100,16 @@ const T = {
     platinumPromoIdea: "Contenu promotionnel à mettre en avant",
     platinumPromoIdeaHint: "Vidéo, produit, campagne… que nous pourrions relayer.",
     platinumCoBuildIdea: "Idées de contenu à co-construire",
+    jobOffers: "Offres d'emploi à relayer",
+    jobOffersHint: "Publiées sur votre fiche et la page « Offres d'emploi des partenaires ».",
+    jobOfferTitle: "Intitulé du poste",
+    jobOfferDescription: "Description",
+    jobOfferUrl: "Lien vers l'offre complète",
+    addJobOffer: "Ajouter une offre",
+    removeJobOffer: "Supprimer",
+    jobOfferQuotaReached: "Vous avez atteint le nombre maximum d'offres pour votre niveau de partenariat.",
+    jobOfferSaved: "Offre enregistrée !",
+    jobOfferRejected: "Une valeur est invalide : le titre est obligatoire et le lien doit commencer par http:// ou https://.",
     upload: "Choisir une image…",
     uploading: "Envoi…",
     uploadHint: "JPEG, PNG, WebP ou GIF — 5 Mo max.",
@@ -172,6 +185,16 @@ const T = {
     platinumPromoIdea: "Promotional content to highlight",
     platinumPromoIdeaHint: "Video, product, campaign… we could relay.",
     platinumCoBuildIdea: "Ideas for content to co-build",
+    jobOffers: "Job offers to relay",
+    jobOffersHint: "Published on your page and the “Partner job offers” page.",
+    jobOfferTitle: "Job title",
+    jobOfferDescription: "Description",
+    jobOfferUrl: "Link to the full offer",
+    addJobOffer: "Add an offer",
+    removeJobOffer: "Delete",
+    jobOfferQuotaReached: "You have reached the maximum number of offers for your sponsorship level.",
+    jobOfferSaved: "Offer saved!",
+    jobOfferRejected: "A value is invalid: the title is required and the link must start with http:// or https://.",
     upload: "Choose an image…",
     uploading: "Uploading…",
     uploadHint: "JPEG, PNG, WebP or GIF — 5 MB max.",
@@ -415,6 +438,13 @@ export default function EditByTokenPage({ params }: { params: Promise<{ token: s
               visually explicit. */}
           {!isSpeaker && data!.private && (
             <SponsorPrivateSection token={token} initial={data!.private} t={t} />
+          )}
+
+          {/* Job offers (#251) — sponsor only, published directly. */}
+          {!isSpeaker && data!.jobOffers && (
+            <div className="border-t border-gris/15 pt-6">
+              <SponsorJobOffers token={token} initial={data!.jobOffers} t={t} />
+            </div>
           )}
           {saveError && (
             <p role="alert" className="font-medium text-terre-cuite">

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   SponsorPlan,
   SponsorPublic,
   SponsorDetail,
+  SponsorWithOffers,
   SpeakerPublic,
   SpeakerDetail,
   TalkDetail,
@@ -150,6 +151,10 @@ export async function getSponsors(): Promise<SponsorPublic[]> {
 
 export async function getSponsorBySlug(slug: string): Promise<SponsorDetail | null> {
   return fetchAPI<SponsorDetail>(`/api/sponsors/${slug}`);
+}
+
+export async function getJobOffers(): Promise<SponsorWithOffers[]> {
+  return (await fetchAPI<SponsorWithOffers[]>("/api/job-offers")) || [];
 }
 
 export async function getSpeakers(): Promise<SpeakerPublic[]> {

--- a/src/frontend/src/lib/nav.ts
+++ b/src/frontend/src/lib/nav.ts
@@ -17,7 +17,16 @@ const CONFERENCES_ENTRY: NavEntry = {
 };
 
 const SPEAKERS_ENTRY: NavEntry = { key: "speakers", labelKey: "speakers", href: "/speakers" };
-const SPONSORS_ENTRY: NavEntry = { key: "sponsors", labelKey: "sponsors", href: "/sponsors" };
+const SPONSORS_ENTRY: NavEntry = {
+  key: "sponsors",
+  labelKey: "sponsors",
+  href: "/sponsors",
+  // Partner job offers live under Sponsors (#251).
+  children: [
+    { key: "sponsors-all", labelKey: "sponsors", href: "/sponsors" },
+    { key: "job-offers", labelKey: "jobOffers", href: "/offres-emploi-partenaires" },
+  ],
+};
 const BLOG_ENTRY: NavEntry = { key: "blog", labelKey: "blog", href: "/actualites" };
 
 // Build the ordered public nav entries for the given edition. Conference-,

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -170,6 +170,14 @@ export interface SponsorSpeakerRef {
   company: string | null;
 }
 
+// A job offer a sponsor wants relayed (#251).
+export interface JobOfferPublic {
+  id: number;
+  title: string;
+  description: string;
+  url: string;
+}
+
 export interface SponsorDetail {
   id: number;
   slug: string;
@@ -181,6 +189,16 @@ export interface SponsorDetail {
   descriptionEn: string | null;
   socialLinks: Record<string, string>;
   speakers: SponsorSpeakerRef[];
+  jobOffers: JobOfferPublic[];
+}
+
+// A sponsor with its job offers, for the recap page (#251).
+export interface SponsorWithOffers {
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  level: SponsorLevel;
+  jobOffers: JobOfferPublic[];
 }
 
 // Public speaker list item.


### PR DESCRIPTION
## Summary

- Les sponsors peuvent publier des **offres d'emploi** relayées pendant le DevFest, depuis leur lien de modification, dans la limite de leur niveau (**4 Platinum / 2 Gold / 1 autres**).
- Affichées sur **leur fiche publique** + une nouvelle page **« Offres d'emploi des partenaires »** sous le menu Sponsors, **jusqu'à 1 mois après l'événement**.

## Détails techniques

- **Prisma** : `SponsorJobOffer` (titre + description rich-text + lien), migration additive.
- **lib/job-offers** : quota par niveau + fenêtre de visibilité (J+1 mois après l'événement).
- **edit** : `POST/PUT/DELETE /edit/:token/job-offers` — **quota strict** (409 au max), contrôle d'appartenance, URL allowlistée, HTML **sanitisé** (même pipeline que les articles). Publication directe + revalidation.
- **public** : la fiche sponsor expose les offres visibles ; nouveau `GET /api/job-offers` groupé par sponsor pour la page récap. Les deux masqués après la fenêtre.
- **admin** : offres incluses dans le détail sponsor + un DELETE pour modérer.
- **frontend** : section offres sur la page d'édition (ajout d'un **brouillon** enregistré au 1er submit → aucune valeur placeholder postée), rendu public sur la fiche + la page récap, et entrée **« Offres d'emploi »** sous Sponsors dans la nav (FR/EN).

**Note** : la description utilise un `textarea` (pas le RichTextEditor admin, qui requiert l'image picker authentifié). Le HTML est **sanitisé côté serveur** quoi qu'il arrive.

## Test plan

- [x] typecheck backend + frontend, lint frontend
- [x] Tests backend : quota, sanitize, ownership, rejet URL, exposition publique + lib quota/visibilité — suite **286**
- [x] **Vérif navigateur** : ajout d'offre (brouillon → enregistrement), quota (0/4 Platinum), affichage fiche sponsor, **page récap** avec offre + lien, entrée de nav sous Sponsors

Refs #251
