### PR TITLE
fix(sponsors): compléments par email via mailto au lieu d'un formulaire (#271)

### DIFF
--- a/src/backend/src/__tests__/edit-sponsor-private.test.ts
+++ b/src/backend/src/__tests__/edit-sponsor-private.test.ts
@@ -1,10 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
-
-// The com-kit email endpoint sends mail; stub SMTP. Must be hoisted above imports.
-const { sendMailMock } = vi.hoisted(() => ({ sendMailMock: vi.fn().mockResolvedValue({}) }));
-vi.mock("nodemailer", () => ({
-  default: { createTransport: () => ({ sendMail: sendMailMock }) },
-}));
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
 import { buildEditApp } from "./test-edit-app.js";
 import { buildPublicApp } from "./test-public-app.js";
@@ -36,8 +30,6 @@ describe("Sponsor private section (#249)", () => {
   afterAll(async () => {
     await prisma.sponsor.deleteMany({ where: { id: sponsorId } });
   });
-
-  beforeEach(() => sendMailMock.mockClear());
 
   it("accepts and persists private fields via the magic link", async () => {
     const app = await buildEditApp();
@@ -74,6 +66,16 @@ describe("Sponsor private section (#249)", () => {
     await app.close();
   });
 
+  it("exposes the sponsoring contact address so the UI can build a mailto (#271)", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({ method: "GET", url: `/api/edit/${TOKEN}` });
+    expect(res.statusCode).toBe(200);
+    // A non-empty address the client turns into a mailto: link for complements.
+    expect(typeof res.json().private.sponsorContactEmail).toBe("string");
+    expect(res.json().private.sponsorContactEmail.length).toBeGreaterThan(0);
+    await app.close();
+  });
+
   it("rejects an unsafe URL in a stand contact", async () => {
     const app = await buildEditApp();
     const res = await app.inject({
@@ -97,21 +99,6 @@ describe("Sponsor private section (#249)", () => {
     expect(body).not.toHaveProperty("comKitNotes");
     expect(body).not.toHaveProperty("private");
     expect(body).not.toHaveProperty("contactEmail");
-    await app.close();
-  });
-
-  it("sends a com-kit complement email to the sponsoring team", async () => {
-    const app = await buildEditApp();
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/edit/${TOKEN}/com-kit-email`,
-      payload: { message: "J'ai un PDF de charte à envoyer." },
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ sent: true });
-    expect(sendMailMock).toHaveBeenCalledTimes(1);
-    // Reply-To points back to the sponsor so the orga can ask for the files.
-    expect(sendMailMock.mock.calls[0][0].replyTo).toBe("sponsor@example.org");
     await app.close();
   });
 });

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -441,6 +441,9 @@ export default async function editRoutes(app: FastifyInstance) {
         talks: entity.talks,
       };
     }
+    // Where the sponsor should email complements that don't fit as links (#271):
+    // the sponsoring contact address, so the client can build a mailto: link.
+    const sponsorContactEmail = (await getSponsorContactRecipients())[0];
     return {
       kind,
       locale,
@@ -467,6 +470,9 @@ export default async function editRoutes(app: FastifyInstance) {
         // fields only when level === PLATINUM.
         platinumPromoIdea: entity.platinumPromoIdea,
         platinumCoBuildIdea: entity.platinumCoBuildIdea,
+        // Address the sponsor should email complements to (#271). The UI builds
+        // a mailto: link from it — no server-side send for this case anymore.
+        sponsorContactEmail,
       },
       // Job offers (#251): the sponsor's offers plus its level quota, so the
       // UI can disable "add" at the cap.
@@ -641,68 +647,6 @@ export default async function editRoutes(app: FastifyInstance) {
       }
 
       return { saved: true };
-    },
-  );
-
-  // POST /api/edit/:token/com-kit-email — a sponsor asks the organizers to
-  // collect com-kit complements that don't fit as links (#249). We don't accept
-  // attachments here (the token is unauthenticated); instead we email the
-  // sponsoring team with Reply-To set to the sponsor, so they can reply and the
-  // sponsor answers with the files attached.
-  app.post<{ Params: { token: string }; Body: { message?: string } }>(
-    "/edit/:token/com-kit-email",
-    {
-      config: { rateLimit: { max: 5, timeWindow: "1 minute" } },
-      schema: {
-        params: { type: "object", required: ["token"], properties: { token: { type: "string" } } },
-        body: {
-          type: "object",
-          additionalProperties: false,
-          properties: { message: { type: "string", maxLength: TEXT_MAX } },
-        },
-      },
-    },
-    async (request, reply) => {
-      const resolved = await resolveToken(request.params.token);
-      if (!resolved || resolved.kind !== "sponsor") return reply.code(404).send({ error: "invalid_token" });
-
-      const { entity } = resolved;
-      const blocked = editingBlockedReason(entity);
-      if (blocked) return reply.code(403).send({ error: blocked });
-
-      const recipients = await getSponsorContactRecipients();
-      const message = request.body?.message?.trim();
-
-      const subject = `Compléments kit de com — ${entity.name}`;
-      const text = [
-        `${entity.name} souhaite transmettre des compléments pour son kit de communication.`,
-        message ? `\nMessage :\n${message}` : "",
-        entity.contactEmail
-          ? `\nRépondez à cet email pour demander les pièces jointes (Reply-To : ${entity.contactEmail}).`
-          : "\nRépondez à cet email pour demander les pièces jointes.",
-      ].join("\n");
-      const html = `
-        <h3>Compléments kit de com — ${escapeHtml(entity.name)}</h3>
-        <p><strong>${escapeHtml(entity.name)}</strong> souhaite transmettre des compléments
-        pour son kit de communication.</p>
-        ${message ? `<p><strong>Message :</strong><br>${escapeHtml(message).replace(/\n/g, "<br>")}</p>` : ""}
-        <p>Répondez à cet email pour demander les pièces jointes.</p>
-      `;
-
-      try {
-        await sendEmail({
-          to: recipients,
-          subject,
-          text,
-          html,
-          ...(entity.contactEmail ? { replyTo: entity.contactEmail } : {}),
-        });
-      } catch (err) {
-        request.log.error("Failed to send com-kit email: %s", String(err));
-        return reply.code(502).send({ error: "email_failed" });
-      }
-
-      return { sent: true };
     },
   );
 

--- a/src/frontend/src/app/edit/[token]/SponsorPrivateSection.tsx
+++ b/src/frontend/src/app/edit/[token]/SponsorPrivateSection.tsx
@@ -22,6 +22,8 @@ export interface SponsorPrivate {
   // Platinum-only ideas (#252).
   platinumPromoIdea: string | null;
   platinumCoBuildIdea: string | null;
+  // Where to email complements that don't fit as links (#271).
+  sponsorContactEmail: string;
 }
 
 // Only the string labels this section needs. The parent passes its whole dict
@@ -47,10 +49,8 @@ interface Labels {
   comKitNotes: string;
   comKitEmailIntro: string;
   comKitEmailButton: string;
-  comKitEmailMessage: string;
-  comKitEmailSending: string;
-  comKitEmailSent: string;
-  comKitEmailError: string;
+  comKitEmailSubject: string;
+  comKitEmailBody: string;
   platinumSection: string;
   platinumPromoIdea: string;
   platinumPromoIdeaHint: string;
@@ -65,10 +65,12 @@ const inputClass =
 // own save (PUT sends only the private fields; the profile save is separate).
 export default function SponsorPrivateSection({
   token,
+  sponsorName,
   initial,
   t,
 }: {
   token: string;
+  sponsorName: string;
   initial: SponsorPrivate;
   t: Labels;
 }) {
@@ -222,62 +224,30 @@ export default function SponsorPrivateSection({
         )}
       </div>
 
-      {/* Send com-kit complements by email */}
-      <ComKitEmail token={token} t={t} />
+      {/* Complements go by email — a mailto: to the sponsoring team (#271). */}
+      <ComKitEmailLink email={initial.sponsorContactEmail} sponsorName={sponsorName} t={t} />
     </section>
   );
 }
 
-// Lets the sponsor ask the organizers to collect files that don't fit as links
-// (#249). Posts to a dedicated endpoint that emails the sponsoring team with
-// Reply-To set to the sponsor.
-function ComKitEmail({ token, t }: { token: string; t: Labels }) {
-  const [message, setMessage] = useState("");
-  const [sending, setSending] = useState(false);
-  const [sent, setSent] = useState(false);
-  const [error, setError] = useState(false);
-
-  async function send() {
-    setSending(true);
-    setSent(false);
-    setError(false);
-    const res = await fetch(`/api/edit/${token}/com-kit-email`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message }),
-    });
-    setSending(false);
-    if (res.ok) {
-      setSent(true);
-      setMessage("");
-      return;
-    }
-    setError(true);
-  }
+// Complements that don't fit as links are sent by email, not through the site
+// (#271): a mailto: link opens the sponsor's own mail client, pre-filled with
+// the sponsoring address, a subject and a body naming the company. No server
+// send — the sponsor attaches the files and hits send themselves.
+function ComKitEmailLink({ email, sponsorName, t }: { email: string; sponsorName: string; t: Labels }) {
+  const subject = t.comKitEmailSubject.replace("{name}", sponsorName);
+  const body = t.comKitEmailBody.replace(/\{name\}/g, sponsorName);
+  const href = `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 
   return (
     <div className="mt-6 rounded-lg bg-blanc p-4">
-      <p className="mb-2 text-sm text-noir">{t.comKitEmailIntro}</p>
-      <label className="mb-3 block">
-        <span className="mb-1 block text-xs text-gris">{t.comKitEmailMessage}</span>
-        <textarea value={message} onChange={(e) => setMessage(e.target.value)} rows={2} className={inputClass} />
-      </label>
-      <div className="flex flex-wrap items-center gap-3">
-        <button
-          type="button"
-          onClick={send}
-          disabled={sending}
-          className="rounded-lg border border-gris/30 bg-blanc px-4 py-2 text-sm font-medium text-noir hover:bg-blanc-casse disabled:opacity-50"
-        >
-          {sending ? t.comKitEmailSending : t.comKitEmailButton}
-        </button>
-        {sent && <span className="text-sm font-medium text-malachite">{t.comKitEmailSent}</span>}
-        {error && (
-          <span role="alert" className="text-sm font-medium text-terre-cuite">
-            {t.comKitEmailError}
-          </span>
-        )}
-      </div>
+      <p className="mb-3 text-sm text-noir">{t.comKitEmailIntro}</p>
+      <a
+        href={href}
+        className="inline-block rounded-lg border border-gris/30 bg-blanc px-4 py-2 text-sm font-medium text-noir hover:bg-blanc-casse"
+      >
+        ✉ {t.comKitEmailButton}
+      </a>
     </div>
   );
 }

--- a/src/frontend/src/app/edit/[token]/page.tsx
+++ b/src/frontend/src/app/edit/[token]/page.tsx
@@ -90,12 +90,12 @@ const T = {
     comKitLogoPrint: "Logo (version Print)",
     comKitCharter: "Charte graphique",
     comKitNotes: "Notes / autres supports",
-    comKitEmailIntro: "Des fichiers à transmettre qui ne tiennent pas en lien ?",
-    comKitEmailButton: "Envoyer les compléments par email",
-    comKitEmailMessage: "Message (optionnel)",
-    comKitEmailSending: "Envoi…",
-    comKitEmailSent: "Demande envoyée ! L'organisation vous recontactera pour les pièces jointes.",
-    comKitEmailError: "Envoi impossible. Réessayez plus tard.",
+    comKitEmailIntro:
+      "Des fichiers ou informations complémentaires à transmettre qui ne tiennent pas dans un lien ? Envoyez-les par email à l'organisation.",
+    comKitEmailButton: "Envoyer par email",
+    comKitEmailSubject: "Compléments kit de communication — {name}",
+    comKitEmailBody:
+      "Bonjour,\n\nVeuillez trouver ci-joint des informations complémentaires pour {name}.\n\n[joindre les fichiers]\n",
     platinumSection: "Réservé aux partenaires Platinum",
     platinumPromoIdea: "Contenu promotionnel à mettre en avant",
     platinumPromoIdeaHint: "Vidéo, produit, campagne… que nous pourrions relayer.",
@@ -175,12 +175,12 @@ const T = {
     comKitLogoPrint: "Logo (print version)",
     comKitCharter: "Brand guidelines",
     comKitNotes: "Notes / other assets",
-    comKitEmailIntro: "Files to send that don't fit as a link?",
-    comKitEmailButton: "Send complements by email",
-    comKitEmailMessage: "Message (optional)",
-    comKitEmailSending: "Sending…",
-    comKitEmailSent: "Request sent! The organisers will get back to you for the attachments.",
-    comKitEmailError: "Sending failed. Please try again later.",
+    comKitEmailIntro:
+      "Extra files or information to share that don't fit in a link? Email them to the organisers.",
+    comKitEmailButton: "Send by email",
+    comKitEmailSubject: "Communication kit complements — {name}",
+    comKitEmailBody:
+      "Hello,\n\nPlease find attached some additional information for {name}.\n\n[attach the files]\n",
     platinumSection: "Platinum partners only",
     platinumPromoIdea: "Promotional content to highlight",
     platinumPromoIdeaHint: "Video, product, campaign… we could relay.",
@@ -437,7 +437,7 @@ export default function EditByTokenPage({ params }: { params: Promise<{ token: s
               Rendered after the public save so the public/private boundary is
               visually explicit. */}
           {!isSpeaker && data!.private && (
-            <SponsorPrivateSection token={token} initial={data!.private} t={t} />
+            <SponsorPrivateSection token={token} sponsorName={data!.name} initial={data!.private} t={t} />
           )}
 
           {/* Job offers (#251) — sponsor only, published directly. */}


### PR DESCRIPTION
## Summary

- Le bloc « Des fichiers à transmettre qui ne tiennent pas en lien ? » de la section privée sponsor n'envoyait plus un message via l'interface : il ouvre désormais le **client mail par défaut** (`mailto:`), pré-rempli avec l'adresse de contact sponsors, un objet et un corps mentionnant le nom de l'entreprise.
- L'adresse de contact sponsors est exposée dans le payload GET de l'édition ; le bouton la transforme en lien `mailto:`.
- Suppression de l'endpoint serveur `POST /api/edit/:token/com-kit-email` (et de son test), devenu inutile.

## Test plan

- [x] `tsc` backend + frontend
- [x] 286 tests backend (endpoint supprimé, GET expose `sponsorContactEmail`)
- [x] Lint frontend : 0 erreur
- [x] Vérif navigateur (Chrome DevTools) : le bouton porte un `href` `mailto:sponsors@devfesttoulouse.fr` avec objet + corps encodés et le nom de l'entreprise ; FR OK

Refs #271
