### PR TITLE
fix(sponsors): description des offres d'emploi bilingue + WYSIWYG (#273)

### DIFF
--- a/src/backend/prisma/migrations/20260719090000_job_offer_bilingual_description/migration.sql
+++ b/src/backend/prisma/migrations/20260719090000_job_offer_bilingual_description/migration.sql
@@ -1,0 +1,13 @@
+-- Make the job offer description bilingual (#273). Order matters: add the new
+-- columns, copy the existing single description into the French one (no data
+-- loss), then drop the old column.
+
+-- Add the two localized columns (empty default so existing rows are valid).
+ALTER TABLE "SponsorJobOffer" ADD COLUMN "descriptionFr" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "SponsorJobOffer" ADD COLUMN "descriptionEn" TEXT NOT NULL DEFAULT '';
+
+-- Preserve what's already there: the previous single description was French.
+UPDATE "SponsorJobOffer" SET "descriptionFr" = "description";
+
+-- Drop the now-replaced column.
+ALTER TABLE "SponsorJobOffer" DROP COLUMN "description";

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -621,8 +621,9 @@ model SponsorContact {
 model SponsorJobOffer {
   id               Int       @id @default(autoincrement())
   title            String
-  // Rich-text HTML, sanitized on write (same pipeline as article content).
-  description      String
+  // Bilingual rich-text HTML, sanitized on write (same pipeline as articles).
+  descriptionFr    String    @default("")
+  descriptionEn    String    @default("")
   url              String
 
   createdAt        DateTime  @default(now())

--- a/src/backend/src/__tests__/sponsor-job-offers.test.ts
+++ b/src/backend/src/__tests__/sponsor-job-offers.test.ts
@@ -39,15 +39,21 @@ describe("Sponsor job offers (#251)", () => {
     await app.close();
   });
 
-  it("creates an offer and sanitizes its description", async () => {
+  it("creates an offer and sanitizes both descriptions", async () => {
     const app = await buildEditApp();
     const res = await app.inject({
       method: "POST",
       url: `/api/edit/${GOLD_TOKEN}/job-offers`,
-      payload: { title: "Dev", description: "<p>Ok</p><script>alert(1)</script>", url: "https://jobs.example.org/1" },
+      payload: {
+        title: "Dev",
+        descriptionFr: "<p>Ok</p><script>alert(1)</script>",
+        descriptionEn: "<p>Fine</p><script>alert(2)</script>",
+        url: "https://jobs.example.org/1",
+      },
     });
     expect(res.statusCode).toBe(201);
-    expect(res.json().description).toBe("<p>Ok</p>");
+    expect(res.json().descriptionFr).toBe("<p>Ok</p>");
+    expect(res.json().descriptionEn).toBe("<p>Fine</p>");
     await app.close();
   });
 
@@ -89,7 +95,7 @@ describe("Sponsor job offers (#251)", () => {
       data: { name: "Other", slug: `offers-other-${Date.now()}`, editionId, level: "GOLD" },
     });
     const foreignOffer = await prisma.sponsorJobOffer.create({
-      data: { sponsorId: other.id, title: "Foreign", description: "", url: "https://x.org" },
+      data: { sponsorId: other.id, title: "Foreign", descriptionFr: "", descriptionEn: "", url: "https://x.org" },
     });
     const app = await buildEditApp();
     const res = await app.inject({
@@ -109,6 +115,11 @@ describe("Sponsor job offers (#251)", () => {
     expect(detail.statusCode).toBe(200);
     expect(Array.isArray(detail.json().jobOffers)).toBe(true);
     expect(detail.json().jobOffers.length).toBeGreaterThanOrEqual(1);
+    // Both localized descriptions are exposed; the old single field is gone (#273).
+    const offer = detail.json().jobOffers[0];
+    expect(offer).toHaveProperty("descriptionFr");
+    expect(offer).toHaveProperty("descriptionEn");
+    expect(offer).not.toHaveProperty("description");
 
     const list = await app.inject({ method: "GET", url: `/api/job-offers` });
     expect(list.statusCode).toBe(200);

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -477,7 +477,13 @@ export default async function editRoutes(app: FastifyInstance) {
       // Job offers (#251): the sponsor's offers plus its level quota, so the
       // UI can disable "add" at the cap.
       jobOffers: {
-        items: entity.jobOffers.map((o) => ({ id: o.id, title: o.title, description: o.description, url: o.url })),
+        items: entity.jobOffers.map((o) => ({
+          id: o.id,
+          title: o.title,
+          descriptionFr: o.descriptionFr,
+          descriptionEn: o.descriptionEn,
+          url: o.url,
+        })),
         quota: offerQuotaForLevel(entity.level),
       },
     };
@@ -658,13 +664,14 @@ export default async function editRoutes(app: FastifyInstance) {
     required: ["title", "url"],
     properties: {
       title: { type: "string", maxLength: SHORT_MAX },
-      description: { type: "string", maxLength: TEXT_MAX },
+      descriptionFr: { type: "string", maxLength: TEXT_MAX },
+      descriptionEn: { type: "string", maxLength: TEXT_MAX },
       url: { type: "string", maxLength: URL_MAX },
     },
   };
 
   // POST /api/edit/:token/job-offers — create an offer, enforcing the quota.
-  app.post<{ Params: { token: string }; Body: { title: string; description?: string; url: string } }>(
+  app.post<{ Params: { token: string }; Body: { title: string; descriptionFr?: string; descriptionEn?: string; url: string } }>(
     "/edit/:token/job-offers",
     {
       config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
@@ -695,18 +702,25 @@ export default async function editRoutes(app: FastifyInstance) {
         data: {
           sponsorId: entity.id,
           title: title.trim(),
-          description: sanitizeRichHtml(request.body.description),
+          descriptionFr: sanitizeRichHtml(request.body.descriptionFr),
+          descriptionEn: sanitizeRichHtml(request.body.descriptionEn),
           url: url.trim(),
         },
       });
       revalidateSponsors();
       revalidateJobOffers();
-      return reply.code(201).send({ id: offer.id, title: offer.title, description: offer.description, url: offer.url });
+      return reply.code(201).send({
+        id: offer.id,
+        title: offer.title,
+        descriptionFr: offer.descriptionFr,
+        descriptionEn: offer.descriptionEn,
+        url: offer.url,
+      });
     },
   );
 
   // PUT /api/edit/:token/job-offers/:offerId — edit one of the sponsor's offers.
-  app.put<{ Params: { token: string; offerId: string }; Body: { title?: string; description?: string; url?: string } }>(
+  app.put<{ Params: { token: string; offerId: string }; Body: { title?: string; descriptionFr?: string; descriptionEn?: string; url?: string } }>(
     "/edit/:token/job-offers/:offerId",
     {
       config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
@@ -739,7 +753,8 @@ export default async function editRoutes(app: FastifyInstance) {
         where: { id: offer.id },
         data: {
           ...(body.title !== undefined && { title: body.title.trim() }),
-          ...(body.description !== undefined && { description: sanitizeRichHtml(body.description) }),
+          ...(body.descriptionFr !== undefined && { descriptionFr: sanitizeRichHtml(body.descriptionFr) }),
+          ...(body.descriptionEn !== undefined && { descriptionEn: sanitizeRichHtml(body.descriptionEn) }),
           ...(body.url !== undefined && { url: body.url.trim() }),
         },
       });

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -62,7 +62,7 @@ export default async function sponsorRoutes(app: FastifyInstance) {
           orderBy: { name: "asc" },
         },
         jobOffers: {
-          select: { id: true, title: true, description: true, url: true },
+          select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
           orderBy: { createdAt: "asc" },
         },
       },
@@ -108,7 +108,7 @@ export default async function sponsorRoutes(app: FastifyInstance) {
         logoUrl: true,
         level: true,
         jobOffers: {
-          select: { id: true, title: true, description: true, url: true },
+          select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
           orderBy: { createdAt: "asc" },
         },
       },

--- a/src/frontend/src/app/[locale]/offres-emploi-partenaires/page.tsx
+++ b/src/frontend/src/app/[locale]/offres-emploi-partenaires/page.tsx
@@ -25,6 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function JobOffersPage() {
   const t = await getTranslations("jobOffers");
+  const locale = await getLocale();
   const sponsors = await getJobOffers();
 
   return (
@@ -54,13 +55,19 @@ export default async function JobOffersPage() {
                   </h2>
                 </div>
                 <div className="space-y-4">
-                  {sponsor.jobOffers.map((offer) => (
+                  {sponsor.jobOffers.map((offer) => {
+                    // Locale description with fallback to the other language (#273).
+                    const description =
+                      (locale === "en" ? offer.descriptionEn : offer.descriptionFr) ||
+                      offer.descriptionFr ||
+                      offer.descriptionEn;
+                    return (
                     <article key={offer.id} className="rounded-2xl border border-gris/15 bg-blanc p-5 shadow-sm">
                       <h3 className="text-lg font-bold text-noir">{offer.title}</h3>
-                      {offer.description && (
+                      {description && (
                         <div
                           className="article-content mt-2 text-sm text-gris"
-                          dangerouslySetInnerHTML={{ __html: offer.description }}
+                          dangerouslySetInnerHTML={{ __html: description }}
                         />
                       )}
                       <a
@@ -72,7 +79,8 @@ export default async function JobOffersPage() {
                         {t("cta")} →
                       </a>
                     </article>
-                  ))}
+                    );
+                  })}
                 </div>
               </section>
             ))}

--- a/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
@@ -162,13 +162,20 @@ export default async function SponsorDetailPage({
           <section className="mt-14">
             <h2 className="mb-6 text-2xl font-bold text-noir">{t("jobOffersTitle")}</h2>
             <div className="space-y-4">
-              {sponsor.jobOffers.map((offer) => (
+              {sponsor.jobOffers.map((offer) => {
+                // Show the description in the page locale, falling back to the
+                // other language when the translation is missing (#273).
+                const description =
+                  (locale === "en" ? offer.descriptionEn : offer.descriptionFr) ||
+                  offer.descriptionFr ||
+                  offer.descriptionEn;
+                return (
                 <article key={offer.id} className="rounded-2xl border border-gris/15 bg-blanc p-5 shadow-sm">
                   <h3 className="text-lg font-bold text-noir">{offer.title}</h3>
-                  {offer.description && (
+                  {description && (
                     <div
                       className="article-content mt-2 text-sm text-gris"
-                      dangerouslySetInnerHTML={{ __html: offer.description }}
+                      dangerouslySetInnerHTML={{ __html: description }}
                     />
                   )}
                   <a
@@ -180,7 +187,8 @@ export default async function SponsorDetailPage({
                     {t("jobOfferCta")} →
                   </a>
                 </article>
-              ))}
+                );
+              })}
             </div>
           </section>
         )}

--- a/src/frontend/src/app/edit/[token]/SponsorJobOffers.tsx
+++ b/src/frontend/src/app/edit/[token]/SponsorJobOffers.tsx
@@ -2,10 +2,14 @@
 
 import { useState } from "react";
 
+import BilingualTabs from "@/components/admin/BilingualTabs";
+import RichTextEditor from "@/components/admin/RichTextEditor";
+
 export interface JobOffer {
   id: number;
   title: string;
-  description: string;
+  descriptionFr: string;
+  descriptionEn: string;
   url: string;
 }
 
@@ -17,6 +21,8 @@ export interface JobOffersData {
 interface Labels {
   save: string;
   saving: string;
+  langFr: string;
+  langEn: string;
   jobOffers: string;
   jobOffersHint: string;
   jobOfferTitle: string;
@@ -27,14 +33,6 @@ interface Labels {
   jobOfferQuotaReached: string;
   jobOfferSaved: string;
   jobOfferRejected: string;
-}
-
-// A draft has no server id yet; it becomes a real offer on first save.
-interface Draft {
-  key: string;
-  title: string;
-  description: string;
-  url: string;
 }
 
 const inputClass =
@@ -53,7 +51,7 @@ export default function SponsorJobOffers({
   t: Labels;
 }) {
   const [offers, setOffers] = useState<JobOffer[]>(initial.items);
-  const [drafts, setDrafts] = useState<Draft[]>([]);
+  const [drafts, setDrafts] = useState<string[]>([]);
 
   const total = offers.length + drafts.length;
   const atCap = total >= initial.quota;
@@ -62,16 +60,16 @@ export default function SponsorJobOffers({
   // but this is client code — still, a simple counter keeps keys stable).
   const [draftSeq, setDraftSeq] = useState(0);
   function addDraft() {
-    setDrafts((prev) => [...prev, { key: `draft-${draftSeq}`, title: "", description: "", url: "" }]);
+    setDrafts((prev) => [...prev, `draft-${draftSeq}`]);
     setDraftSeq((n) => n + 1);
   }
 
   function removeDraft(key: string) {
-    setDrafts((prev) => prev.filter((d) => d.key !== key));
+    setDrafts((prev) => prev.filter((k) => k !== key));
   }
 
   function onDraftCreated(key: string, created: JobOffer) {
-    setDrafts((prev) => prev.filter((d) => d.key !== key));
+    setDrafts((prev) => prev.filter((k) => k !== key));
     setOffers((prev) => [...prev, created]);
   }
 
@@ -101,11 +99,11 @@ export default function SponsorJobOffers({
             onRemoved={onRemoved}
           />
         ))}
-        {drafts.map((draft) => (
+        {drafts.map((key) => (
           <OfferRow
-            key={draft.key}
+            key={key}
             token={token}
-            draftKey={draft.key}
+            draftKey={key}
             t={t}
             onCreated={onDraftCreated}
             onRemoveDraft={removeDraft}
@@ -148,7 +146,8 @@ function OfferRow({
   onRemoveDraft?: (key: string) => void;
 }) {
   const [title, setTitle] = useState(offer?.title ?? "");
-  const [description, setDescription] = useState(offer?.description ?? "");
+  const [descriptionFr, setDescriptionFr] = useState(offer?.descriptionFr ?? "");
+  const [descriptionEn, setDescriptionEn] = useState(offer?.descriptionEn ?? "");
   const [url, setUrl] = useState(offer?.url ?? "");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -164,7 +163,7 @@ function OfferRow({
       {
         method: isDraft ? "POST" : "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title, description, url }),
+        body: JSON.stringify({ title, descriptionFr, descriptionEn, url }),
       },
     );
     setSaving(false);
@@ -174,7 +173,7 @@ function OfferRow({
         onCreated?.(draftKey!, created);
       } else {
         setSaved(true);
-        onSaved?.({ id: offer!.id, title, description, url });
+        onSaved?.({ id: offer!.id, title, descriptionFr, descriptionEn, url });
       }
       return;
     }
@@ -202,10 +201,34 @@ function OfferRow({
           <span className="mb-1 block text-sm font-medium text-noir">{t.jobOfferTitle}</span>
           <input value={title} onChange={(e) => setTitle(e.target.value)} className={inputClass} />
         </label>
-        <label className="block">
-          <span className="mb-1 block text-sm font-medium text-noir">{t.jobOfferDescription}</span>
-          <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={4} className={inputClass} />
-        </label>
+        {/* Bilingual rich-text description (#273). No image button — an offer is
+            plain formatted text, not an article. */}
+        <BilingualTabs
+          label={t.jobOfferDescription}
+          labels={{ fr: t.langFr, en: t.langEn }}
+          isEmpty={(lang) => !(lang === "fr" ? descriptionFr : descriptionEn)?.replace(/<[^>]*>/g, "").trim()}
+          renderPanel={(lang) =>
+            lang === "fr" ? (
+              <RichTextEditor
+                label=""
+                name={`offer-desc-fr-${offer?.id ?? draftKey}`}
+                value={descriptionFr}
+                onChange={setDescriptionFr}
+                showImageButton={false}
+                minHeight="160px"
+              />
+            ) : (
+              <RichTextEditor
+                label=""
+                name={`offer-desc-en-${offer?.id ?? draftKey}`}
+                value={descriptionEn}
+                onChange={setDescriptionEn}
+                showImageButton={false}
+                minHeight="160px"
+              />
+            )
+          }
+        />
         <label className="block">
           <span className="mb-1 block text-sm font-medium text-noir">{t.jobOfferUrl}</span>
           <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://" className={inputClass} />

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -170,11 +170,13 @@ export interface SponsorSpeakerRef {
   company: string | null;
 }
 
-// A job offer a sponsor wants relayed (#251).
+// A job offer a sponsor wants relayed (#251). The description is bilingual
+// rich-text HTML (#273) — the page picks the field for the current locale.
 export interface JobOfferPublic {
   id: number;
   title: string;
-  description: string;
+  descriptionFr: string;
+  descriptionEn: string;
   url: string;
 }
 


### PR DESCRIPTION
## Summary

- La description des offres d'emploi devient **bilingue** (`descriptionFr` / `descriptionEn`) et éditable en **WYSIWYG** (`RichTextEditor`, comme les articles), au lieu d'un `<textarea>` texte brut unique.
- Migration Prisma **data-preserving** : la description existante est copiée dans `descriptionFr` (aucune perte).
- Le site public (fiche sponsor + page récap) affiche la description dans la langue de la page, avec repli sur l'autre langue si vide.

## Détails

- **Prisma** : `SponsorJobOffer.description` → `descriptionFr` + `descriptionEn` (migration `20260719090000_job_offer_bilingual_description`).
- **Backend** : `edit.ts` (schema body, POST/PUT sanitize des deux champs, GET payload), `sponsors.ts` public (select des deux champs). Admin inchangé (le `serialize` propage déjà l'offre complète).
- **Frontend édition** : `BilingualTabs` + `RichTextEditor` (bouton image masqué), un éditeur par langue.
- **Frontend public** : `sponsors/[slug]` et `offres-emploi-partenaires` choisissent la description selon la locale.

## ⚠️ Migration destructive

Cette PR embarque un **DROP de colonne** (`description`) avec copie préalable vers `descriptionFr`. Backup DB requis lors de la mise en prod (déjà noté pour l'ensemble sponsors).

## Test plan

- [x] `tsc` back + front
- [x] 286 tests backend (POST/PUT/GET, sanitization des deux champs, fiche publique expose `descriptionFr`/`descriptionEn`, plus de `description`)
- [x] Lint frontend : 0 erreur
- [x] Vérif navigateur (Chrome DevTools) :
  - Éditeur : onglets FR/EN + 2 éditeurs WYSIWYG (toolbar riche, sans bouton image)
  - Public FR → description française ; public EN → description anglaise
  - API `/api/job-offers` bilingue, `<strong>` sanitizé conservé
- [x] Rétro-compat migration vérifiée (copie `description` → `descriptionFr`)

Refs #273
