### PR TITLE
feat(sponsors): description de la fiche entreprise en WYSIWYG (#270)

### DIFF
--- a/src/backend/src/__tests__/edit-sponsor-description.test.ts
+++ b/src/backend/src/__tests__/edit-sponsor-description.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { buildEditApp } from "./test-edit-app.js";
+import { prisma } from "../lib/prisma.js";
+import { createSponsorWithToken } from "./sponsor-test-helpers.js";
+
+// Sponsor description is rich-text HTML (#270): sanitized on write via the
+// magic link, same pipeline as article content.
+
+const TOKEN = "test-sponsor-desc-token-1a2b3c4d5e6f7081";
+let editionId: number;
+let sponsorId: number;
+
+describe("Sponsor rich-text description (#270)", () => {
+  beforeAll(async () => {
+    const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
+    if (!edition) throw new Error("seed missing an edition");
+    editionId = edition.id;
+
+    const sponsor = await createSponsorWithToken(
+      { name: "Desc Sponsor", slug: `desc-sponsor-${Date.now()}`, editionId, level: "GOLD" },
+      TOKEN,
+    );
+    sponsorId = sponsor.id;
+  });
+
+  afterAll(async () => {
+    await prisma.sponsor.deleteMany({ where: { id: sponsorId } });
+  });
+
+  it("sanitizes rich-text HTML in both descriptions", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}`,
+      payload: {
+        descriptionFr: "<p>Bonjour <strong>tous</strong></p><script>alert(1)</script>",
+        descriptionEn: "<p>Hello <em>all</em></p><img src=x onerror=alert(2)>",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
+    expect(sponsor?.descriptionFr).toBe("<p>Bonjour <strong>tous</strong></p>");
+    // The event handler is stripped; formatting is kept.
+    expect(sponsor?.descriptionEn).toContain("<em>all</em>");
+    expect(sponsor?.descriptionEn).not.toContain("onerror");
+    await app.close();
+  });
+
+  it("stores null when the description is cleared", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}`,
+      payload: { descriptionFr: "" },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
+    expect(sponsor?.descriptionFr).toBeNull();
+    await app.close();
+  });
+});

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -4,6 +4,7 @@ import { revalidateJobOffers, revalidateSponsors } from "../../lib/revalidate.js
 import { slugify, uniqueSlug } from "../../lib/slug.js";
 import { generateEditToken } from "../../lib/edit-token.js";
 import { sendEditLinkEmail, normalizeLocale } from "../../lib/edit-link-email.js";
+import { sanitizeRichHtml } from "../../lib/sanitize.js";
 
 const SPONSOR_LEVELS = ["PLATINUM", "GOLD", "SILVER", "SOUTIEN", "COMMUNAUTE"] as const;
 type SponsorLevel = (typeof SPONSOR_LEVELS)[number];
@@ -127,8 +128,9 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         level: body.level,
         logoUrl: body.logoUrl || null,
         websiteUrl: body.websiteUrl || null,
-        descriptionFr: body.descriptionFr || null,
-        descriptionEn: body.descriptionEn || null,
+        // Rich-text HTML (#270): sanitized on write, like article content.
+        descriptionFr: sanitizeRichHtml(body.descriptionFr) || null,
+        descriptionEn: sanitizeRichHtml(body.descriptionEn) || null,
         socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
         contactEmail: body.contactEmail || null,
         locale: normalizeLocale(body.locale),
@@ -169,8 +171,9 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         ...(body.level !== undefined && { level: body.level }),
         ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
         ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
-        ...(body.descriptionFr !== undefined && { descriptionFr: body.descriptionFr || null }),
-        ...(body.descriptionEn !== undefined && { descriptionEn: body.descriptionEn || null }),
+        // Rich-text HTML (#270): sanitized on write, like article content.
+        ...(body.descriptionFr !== undefined && { descriptionFr: sanitizeRichHtml(body.descriptionFr) || null }),
+        ...(body.descriptionEn !== undefined && { descriptionEn: sanitizeRichHtml(body.descriptionEn) || null }),
         ...(body.socialLinks !== undefined && {
           socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
         }),

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -541,8 +541,9 @@ export default async function editRoutes(app: FastifyInstance) {
       await prisma.sponsor.update({
         where: { id: entity.id },
         data: {
-          ...(body.descriptionFr !== undefined && { descriptionFr: body.descriptionFr || null }),
-          ...(body.descriptionEn !== undefined && { descriptionEn: body.descriptionEn || null }),
+          // Rich-text HTML (#270): sanitized on write, like article content.
+          ...(body.descriptionFr !== undefined && { descriptionFr: sanitizeRichHtml(body.descriptionFr) || null }),
+          ...(body.descriptionEn !== undefined && { descriptionEn: sanitizeRichHtml(body.descriptionEn) || null }),
           ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
           ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
           ...(body.socialLinks !== undefined && { socialLinks: cleanSocial(body.socialLinks) }),

--- a/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { getLocale, getTranslations } from "next-intl/server";
 
 import { getSponsorBySlug } from "@/lib/api";
 import { localizedField } from "@/lib/i18n-helpers";
+import { looksLikeHtml, htmlToText } from "@/lib/html";
 import Breadcrumb from "@/components/Breadcrumb";
 import { Link } from "@/i18n/navigation";
 
@@ -19,7 +20,8 @@ export async function generateMetadata({
 
   if (!sponsor) return { title: "Sponsor not found" };
 
-  const description = localizedField(sponsor, "description", locale) || sponsor.name;
+  // Meta / OG want plain text; the stored description may be rich HTML (#270).
+  const description = htmlToText(localizedField(sponsor, "description", locale)) || sponsor.name;
 
   return {
     title: sponsor.name,
@@ -84,10 +86,18 @@ export default async function SponsorDetailPage({
         <h1 className="mt-6 text-3xl lg:text-5xl font-bold text-noir">{sponsor.name}</h1>
 
         <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px]">
-          {/* Left: description */}
+          {/* Left: description. Rich-text HTML for new content (#270); older
+              plain-text descriptions keep their line breaks via pre-line. */}
           <div>
             {description ? (
-              <p className="text-lg leading-relaxed text-noir whitespace-pre-line">{description}</p>
+              looksLikeHtml(description) ? (
+                <div
+                  className="article-content text-lg leading-relaxed text-noir"
+                  dangerouslySetInnerHTML={{ __html: description }}
+                />
+              ) : (
+                <p className="text-lg leading-relaxed text-noir whitespace-pre-line">{description}</p>
+              )
             ) : null}
           </div>
 

--- a/src/frontend/src/app/edit/[token]/page.tsx
+++ b/src/frontend/src/app/edit/[token]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useEffect, useRef, useState } from "react";
 
 import BilingualTabs from "@/components/admin/BilingualTabs";
+import RichTextEditor from "@/components/admin/RichTextEditor";
 import SponsorPrivateSection, { type SponsorPrivate } from "./SponsorPrivateSection";
 import SponsorJobOffers, { type JobOffersData } from "./SponsorJobOffers";
 
@@ -354,18 +355,32 @@ export default function EditByTokenPage({ params }: { params: Promise<{ token: s
             isEmpty={(lang) =>
               isSpeaker
                 ? !(lang === "fr" ? form.bioFr : form.bioEn)?.trim()
-                : !(lang === "fr" ? form.descriptionFr : form.descriptionEn)?.trim()
+                : // Sponsor description is HTML — strip tags before the empty check.
+                  !(lang === "fr" ? form.descriptionFr : form.descriptionEn)?.replace(/<[^>]*>/g, "").trim()
             }
             renderPanel={(lang) => {
               const field = isSpeaker
                 ? lang === "fr" ? "bioFr" : "bioEn"
                 : lang === "fr" ? "descriptionFr" : "descriptionEn";
+              // Sponsor description is rich text (#270); speaker bio stays plain.
+              if (isSpeaker) {
+                return (
+                  <textarea
+                    value={form[field] ?? ""}
+                    onChange={(e) => setForm({ ...form, [field]: e.target.value })}
+                    rows={5}
+                    className={inputClass}
+                  />
+                );
+              }
               return (
-                <textarea
+                <RichTextEditor
+                  label=""
+                  name={`sponsor-${field}`}
                   value={form[field] ?? ""}
-                  onChange={(e) => setForm({ ...form, [field]: e.target.value })}
-                  rows={5}
-                  className={inputClass}
+                  onChange={(html) => setForm({ ...form, [field]: html })}
+                  showImageButton={false}
+                  minHeight="180px"
                 />
               );
             }}

--- a/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
+++ b/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import type { SponsorLevel } from "@/lib/types";
 import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
 import BilingualTabs from "@/components/admin/BilingualTabs";
+import RichTextEditor from "@/components/admin/RichTextEditor";
 
 const LEVELS: { value: SponsorLevel; label: string }[] = [
   { value: "PLATINUM", label: "Platinum" },
@@ -118,12 +119,27 @@ export default function SponsorForm({ value, onChange }: SponsorFormProps) {
 
       <BilingualTabs
         label="Description"
-        isEmpty={(lang) => !(lang === "fr" ? value.descriptionFr : value.descriptionEn).trim()}
+        // Rich text (#270) — strip tags before the empty check so <p></p> counts as empty.
+        isEmpty={(lang) => !(lang === "fr" ? value.descriptionFr : value.descriptionEn).replace(/<[^>]*>/g, "").trim()}
         renderPanel={(lang) =>
           lang === "fr" ? (
-            <textarea value={value.descriptionFr} onChange={(e) => onChange({ ...value, descriptionFr: e.target.value })} rows={4} className={inputClass} />
+            <RichTextEditor
+              label=""
+              name="sponsor-descriptionFr"
+              value={value.descriptionFr}
+              onChange={(html) => onChange({ ...value, descriptionFr: html })}
+              showImageButton={false}
+              minHeight="180px"
+            />
           ) : (
-            <textarea value={value.descriptionEn} onChange={(e) => onChange({ ...value, descriptionEn: e.target.value })} rows={4} className={inputClass} />
+            <RichTextEditor
+              label=""
+              name="sponsor-descriptionEn"
+              value={value.descriptionEn}
+              onChange={(html) => onChange({ ...value, descriptionEn: html })}
+              showImageButton={false}
+              minHeight="180px"
+            />
           )
         }
       />

--- a/src/frontend/src/lib/html.ts
+++ b/src/frontend/src/lib/html.ts
@@ -1,0 +1,17 @@
+// Small HTML helpers shared by pages that render rich text (#270).
+
+// True when a string carries HTML tags. Descriptions saved before the WYSIWYG
+// switch are plain text with newlines; new ones are Tiptap HTML. This lets a
+// page render each correctly without a data migration.
+export function looksLikeHtml(value: string): boolean {
+  return /<[a-z][\s\S]*>/i.test(value);
+}
+
+// Strips tags and collapses whitespace, for meta descriptions / OG tags where
+// only plain text belongs. Entities are left as-is (good enough for meta).
+export function htmlToText(value: string): string {
+  return value
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}


### PR DESCRIPTION
## Summary

- La description de la **fiche entreprise** (sponsor) devient éditable en **WYSIWYG** (`RichTextEditor`, comme les articles / offres d'emploi), en FR **et** EN, côté page d'édition sponsor **et** back-office admin.
- Le HTML est **sanitizé côté serveur** (édition + admin), même pipeline que le contenu d'article.
- Le site public affiche la description mise en forme, avec **rétro-compat** : les descriptions déjà saisies en texte brut gardent leurs retours à la ligne.

## Détails

- **Pas de migration** : les colonnes `descriptionFr` / `descriptionEn` existent déjà.
- **Frontend** : `page.tsx` (édition) et `SponsorForm.tsx` (admin) → `RichTextEditor` (bouton image masqué) dans `BilingualTabs` ; le test de « vide » strip les balises.
- **Backend** : `edit.ts` et `admin/sponsors.ts` sanitizent `descriptionFr`/`descriptionEn` à l'écriture.
- **Public** : `sponsors/[slug]` rend le HTML via `dangerouslySetInnerHTML` (`article-content`) ; un garde `looksLikeHtml` affiche les anciennes descriptions texte brut avec `whitespace-pre-line`. Meta/OG passent par `htmlToText`.
- Nouveau helper `lib/html.ts` (`looksLikeHtml`, `htmlToText`).

## Test plan

- [x] `tsc` back + front
- [x] 288 tests backend (dont 2 nouveaux : sanitization de la description sponsor + null au vidage)
- [x] Lint frontend : 0 erreur
- [x] Vérif navigateur (Chrome DevTools) :
  - Éditeur sponsor : onglets FR/EN + WYSIWYG (toolbar riche, sans bouton image)
  - Public : nouvelle description HTML rendue formatée (gras + liste)
  - **Rétro-compat** : ancienne description texte brut rendue avec ses sauts de ligne
  - Sanitization vérifiée (`onerror` strippé, formatage conservé)

Refs #270
