### PR TITLE
fix(nav): doublon Sponsors + « Offres d'emploi » conditionnée aux offres publiées (#276)

### DIFF
--- a/src/backend/src/__tests__/editions.test.ts
+++ b/src/backend/src/__tests__/editions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { buildApp } from "./test-app.js";
+import { prisma } from "../lib/prisma.js";
 
 describe("GET /api/editions/current", () => {
   it("should return the current edition", async () => {
@@ -12,6 +13,36 @@ describe("GET /api/editions/current", () => {
     expect(body).toHaveProperty("status", "ANNOUNCEMENT");
     expect(body).toHaveProperty("aftermovieUrl");
     await app.close();
+  });
+
+  // hasJobOffers drives the "Offres d'emploi" nav sub-entry: it must only be
+  // true while a published sponsor actually has an offer.
+  it("flags hasJobOffers only when a published sponsor has an offer", async () => {
+    const edition = await prisma.edition.findFirst({ orderBy: { year: "desc" } });
+    if (!edition) throw new Error("seed missing an edition");
+
+    // Baseline: the seed ships no job offer.
+    const app = await buildApp();
+    const before = await app.inject({ method: "GET", url: "/api/editions/current" });
+    expect(before.json().hasJobOffers).toBe(false);
+    await app.close();
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Nav Offers", slug: `nav-offers-${Date.now()}`, editionId: edition.id,
+        level: "GOLD", publicationStatus: "PUBLISHED",
+      },
+    });
+    await prisma.sponsorJobOffer.create({
+      data: { sponsorId: sponsor.id, title: "Dev", descriptionFr: "", descriptionEn: "", url: "https://x.org" },
+    });
+
+    const app2 = await buildApp();
+    const after = await app2.inject({ method: "GET", url: "/api/editions/current" });
+    expect(after.json().hasJobOffers).toBe(true);
+    await app2.close();
+
+    await prisma.sponsor.deleteMany({ where: { id: sponsor.id } });
   });
 });
 

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
+import { areOffersVisible } from "../lib/job-offers.js";
 
 type TicketStatus = "AVAILABLE" | "SOLD_OUT" | "COMING_SOON";
 
@@ -192,8 +193,13 @@ export default async function editionRoutes(app: FastifyInstance) {
     // scheduledTalkCount additionally tells whether the schedule (planning) is
     // ready: at least one published talk has been given a time slot (startsAt),
     // which promotes the flat "Conférences" link to a "Programme" menu (#203).
-    const [publishedTalkCount, scheduledTalkCount, publishedSpeakerCount, publishedSponsorCount] =
-      await Promise.all([
+    const [
+      publishedTalkCount,
+      scheduledTalkCount,
+      publishedSpeakerCount,
+      publishedSponsorCount,
+      jobOfferCount,
+    ] = await Promise.all([
         prisma.talk.count({
           where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
         }),
@@ -205,6 +211,10 @@ export default async function editionRoutes(app: FastifyInstance) {
         }),
         prisma.sponsor.count({
           where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+        }),
+        // Offers of published sponsors only — same set the recap page lists.
+        prisma.sponsorJobOffer.count({
+          where: { sponsor: { editionId: edition.id, publicationStatus: "PUBLISHED" } },
         }),
       ]);
 
@@ -232,6 +242,9 @@ export default async function editionRoutes(app: FastifyInstance) {
       isScheduleReady: scheduledTalkCount > 0,
       hasSpeakers: publishedSpeakerCount > 0,
       hasSponsors: publishedSponsorCount > 0,
+      // Drives the "Offres d'emploi" sub-entry: shown only while at least one
+      // offer is published AND the post-event visibility window is still open.
+      hasJobOffers: jobOfferCount > 0 && areOffersVisible(edition),
     };
   });
 

--- a/src/frontend/src/lib/nav.ts
+++ b/src/frontend/src/lib/nav.ts
@@ -17,15 +17,14 @@ const CONFERENCES_ENTRY: NavEntry = {
 };
 
 const SPEAKERS_ENTRY: NavEntry = { key: "speakers", labelKey: "speakers", href: "/speakers" };
-const SPONSORS_ENTRY: NavEntry = {
-  key: "sponsors",
-  labelKey: "sponsors",
-  href: "/sponsors",
-  // Partner job offers live under Sponsors (#251).
-  children: [
-    { key: "sponsors-all", labelKey: "sponsors", href: "/sponsors" },
-    { key: "job-offers", labelKey: "jobOffers", href: "/offres-emploi-partenaires" },
-  ],
+const SPONSORS_ENTRY: NavEntry = { key: "sponsors", labelKey: "sponsors", href: "/sponsors" };
+// Partner job offers hang under Sponsors (#251). The parent link already leads
+// to /sponsors, so the submenu lists only the offers — no duplicate entry — and
+// appears only once an offer is actually published.
+const JOB_OFFERS_CHILD: NavEntry = {
+  key: "job-offers",
+  labelKey: "jobOffers",
+  href: "/offres-emploi-partenaires",
 };
 const BLOG_ENTRY: NavEntry = { key: "blog", labelKey: "blog", href: "/actualites" };
 
@@ -52,7 +51,11 @@ export function getPublicNavEntries(edition: Edition | null): NavEntry[] {
   }
 
   if (edition?.hasSpeakers) entries.push(SPEAKERS_ENTRY);
-  if (edition?.hasSponsors) entries.push(SPONSORS_ENTRY);
+  if (edition?.hasSponsors) {
+    entries.push(
+      edition.hasJobOffers ? { ...SPONSORS_ENTRY, children: [JOB_OFFERS_CHILD] } : SPONSORS_ENTRY,
+    );
+  }
   entries.push(BLOG_ENTRY);
 
   return entries;

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -24,6 +24,9 @@ export interface Edition {
   isScheduleReady: boolean;
   hasSpeakers: boolean;
   hasSponsors: boolean;
+  // At least one partner job offer is published and still within its
+  // post-event visibility window.
+  hasJobOffers: boolean;
 }
 
 export interface EditionSummary {


### PR DESCRIPTION
## Summary

- Le sous-menu **Sponsors** ne répète plus « Sponsors » : il ne contient que **« Offres d'emploi »**. Le parent reste cliquable et mène toujours à `/sponsors`.
- L'entrée **« Offres d'emploi » n'apparaît que si au moins une offre est publiée** par un partenaire (et encore dans sa fenêtre de visibilité — expiration un mois après l'événement, cf. #251). Sans offre, « Sponsors » redevient un lien simple sans sous-menu.

## Détails

- **Backend** : nouveau flag `hasJobOffers` sur `GET /api/editions/current` ([editions.ts](src/backend/src/routes/editions.ts)), calculé comme les autres flags de nav — au moins une offre rattachée à un sponsor **PUBLISHED** de l'édition **et** `areOffersVisible(edition)`.
- **Frontend** : `hasJobOffers` ajouté au type `Edition` ; [nav.ts](src/frontend/src/lib/nav.ts) retire l'enfant `sponsors-all` (doublon) et n'attache le sous-menu que si `hasJobOffers`.

## Test plan

- [x] `tsc` back + front
- [x] 289 tests backend (dont 1 nouveau : `hasJobOffers` false sans offre → true avec une offre d'un sponsor publié)
- [x] Lint frontend : 0 erreur
- [x] Vérif du HTML rendu :
  - **Sans offre** : 0 occurrence du lien `/offres-emploi-partenaires` dans la nav
  - **Avec offre** : lien présent avec le bon libellé, et **aucun doublon** « Sponsors » en sous-menu

> Note : la vérification a été faite sur le HTML servi (Chrome DevTools MCP indisponible dans cette session).

Refs #276
