### PR TITLE
fix(docker): cache .next local sur un volume nommé (404 fantômes en dev)

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -6,6 +6,11 @@ services:
     volumes:
       - ./src/frontend:/app
       - frontend_node_modules:/app/node_modules
+      # Keep the build cache off the Windows bind mount: Turbopack rewrites its
+      # route manifest constantly, and a restart mid-write leaves it truncated —
+      # Next then compiles /_not-found instead of /[locale] and serves 404 on
+      # every page until .next is wiped. A named volume is native Linux fs.
+      - frontend_next:/app/.next
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     environment:
@@ -91,5 +96,6 @@ services:
 
 volumes:
   frontend_node_modules:
+  frontend_next:
   backend_node_modules:
   pgdata:


### PR DESCRIPTION
## Problème

En local (Windows), le service `frontend` bind-monte `./src/frontend` sur `/app` : le cache de build Turbopack (`.next`) vivait donc sur le filesystem Windows. Next le signalait lui-même :

```
⚠ Slow filesystem detected. The benchmark took 373ms.
  If /app/.next/dev is a network drive, consider moving it to a local folder.
```

Conséquence observée à répétition : un redémarrage du conteneur **pendant** que Turbopack réécrit son manifeste de routes laissait celui-ci tronqué. Next compilait alors `/_not-found/page` **au lieu de** `/[locale]` et renvoyait **404 sur toutes les pages**, jusqu'à suppression manuelle de `.next`.

Trace typique :
```
✓ Ready in 1296ms
⚠ Slow filesystem detected...
○ Compiling /_not-found/page ...     ← au lieu de /[locale]
 GET /fr 404
```

## Correctif

Donner à `.next` un volume nommé — exactement le traitement déjà appliqué à `node_modules` — pour qu'il soit sur le filesystem Linux natif.

## Test plan

- [x] Démarrage à froid : compile `/[locale]`, `GET /fr` → 200, plus de 404
- [x] **3 redémarrages** simples → 200 à chaque fois
- [x] **4 redémarrages déclenchés en pleine compilation** (le scénario qui cassait) → 200 à chaque fois
- [x] Volume bien monté (`docker inspect`) : `frontend_next/_data → /app/.next`

## À savoir

Purger le cache se fait désormais côté Docker :
```bash
docker exec devfest-local-frontend rm -rf /app/.next   # ou
docker compose -f docker-compose.local.yml down -v
```
Un `rm -rf src/frontend/.next` côté Windows n'a plus d'effet. Corollaire utile : `.next/dev/types/` ne pollue plus le `tsc --noEmit` lancé depuis l'hôte.
