### PR TITLE
feat(email): gabarit à la charte pour tous les emails (#269)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,11 @@ SMTP_AUTH=false
 # SMTP_USER=smtp-username           # only when SMTP_AUTH=true
 # SMTP_PASSWORD=smtp-password       # only when SMTP_AUTH=true
 SMTP_FROM=contact@devfesttoulouse.fr
+# Logo shown in the email layout header (#269). Defaults to
+# ${BASE_URL}/images/logo-devfest-96.png — override only if the logo must be
+# served from elsewhere (a CDN reachable from mailboxes). PNG, not SVG:
+# Gmail and Outlook don't render SVG.
+# EMAIL_LOGO_URL=https://devfesttoulouse.fr/images/logo-devfest-96.png
 
 # --- Third-party APIs ---
 # Billetweb — manual import works without these

--- a/src/backend/src/lib/auth.ts
+++ b/src/backend/src/lib/auth.ts
@@ -2,7 +2,8 @@ import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { APIError } from "better-auth/api";
 import { prisma } from "./prisma.js";
-import { sendEmail } from "./email.js";
+import { sendEmail, escapeHtml } from "./email.js";
+import { emailButton, emailHeading } from "./email-template.js";
 
 const ADMIN_EMAILS = (process.env.ADMIN_EMAILS || "")
   .split(",")
@@ -61,10 +62,10 @@ export const auth = betterAuth({
         subject: "DevFest Toulouse — Réinitialisation de mot de passe",
         text: `Bonjour ${user.name || ""},\n\nCliquez sur ce lien pour réinitialiser votre mot de passe :\n${resetUrl}\n\nCe lien expire dans 1 heure.\n\nSi vous n'avez pas demandé cette réinitialisation, ignorez cet email.`,
         html: `
-          <h3>Réinitialisation de mot de passe</h3>
-          <p>Bonjour ${user.name || ""},</p>
-          <p>Cliquez sur le lien ci-dessous pour réinitialiser votre mot de passe :</p>
-          <p><a href="${resetUrl}">Réinitialiser mon mot de passe</a></p>
+          ${emailHeading("Réinitialisation de mot de passe")}
+          <p>Bonjour ${escapeHtml(user.name || "")},</p>
+          <p>Cliquez sur le bouton ci-dessous pour réinitialiser votre mot de passe :</p>
+          ${emailButton(resetUrl, "Réinitialiser mon mot de passe")}
           <p>Ce lien expire dans 1 heure.</p>
           <p><em>Si vous n'avez pas demandé cette réinitialisation, ignorez cet email.</em></p>
         `,

--- a/src/backend/src/lib/edit-link-email.ts
+++ b/src/backend/src/lib/edit-link-email.ts
@@ -1,4 +1,5 @@
-import { sendEmail } from "./email.js";
+import { sendEmail, escapeHtml } from "./email.js";
+import { emailButton, emailHeading } from "./email-template.js";
 import { EDIT_TOKEN_TTL_DAYS } from "./edit-token.js";
 
 const baseUrl = (process.env.BASE_URL || "http://localhost:3000").replace(/\/$/, "");
@@ -24,10 +25,10 @@ function frenchTemplate(name: string, what: string, url: string): Template {
     subject: "DevFest Toulouse — Lien de modification de votre fiche",
     text: `Bonjour ${name},\n\nVoici votre lien personnel pour modifier ${what} sur le site du DevFest Toulouse :\n${url}\n\nCe lien est personnel, ne le partagez pas. Il est valable ${EDIT_TOKEN_TTL_DAYS} jours, et les modifications sont clôturées 48h avant l'événement.\n\nL'équipe DevFest Toulouse`,
     html: `
-      <h3>Lien de modification de votre fiche</h3>
-      <p>Bonjour ${name},</p>
+      ${emailHeading("Lien de modification de votre fiche")}
+      <p>Bonjour ${escapeHtml(name)},</p>
       <p>Voici votre lien personnel pour modifier ${what} sur le site du DevFest Toulouse :</p>
-      <p><a href="${url}">Modifier ma fiche</a></p>
+      ${emailButton(url, "Modifier ma fiche")}
       <p>Ce lien est personnel, ne le partagez pas. Il est valable ${EDIT_TOKEN_TTL_DAYS} jours, et les modifications sont clôturées 48h avant l'événement.</p>
       <p><em>L'équipe DevFest Toulouse</em></p>
     `,
@@ -39,10 +40,10 @@ function englishTemplate(name: string, what: string, url: string): Template {
     subject: "DevFest Toulouse — Link to edit your profile",
     text: `Hello ${name},\n\nHere is your personal link to update ${what} on the DevFest Toulouse website:\n${url}\n\nThis link is personal, please do not share it. It is valid for ${EDIT_TOKEN_TTL_DAYS} days, and editing closes 48 hours before the event.\n\nThe DevFest Toulouse team`,
     html: `
-      <h3>Link to edit your profile</h3>
-      <p>Hello ${name},</p>
+      ${emailHeading("Link to edit your profile")}
+      <p>Hello ${escapeHtml(name)},</p>
       <p>Here is your personal link to update ${what} on the DevFest Toulouse website:</p>
-      <p><a href="${url}">Edit my profile</a></p>
+      ${emailButton(url, "Edit my profile")}
       <p>This link is personal, please do not share it. It is valid for ${EDIT_TOKEN_TTL_DAYS} days, and editing closes 48 hours before the event.</p>
       <p><em>The DevFest Toulouse team</em></p>
     `,
@@ -76,5 +77,11 @@ export async function sendEditLinkEmail(opts: {
     ? englishTemplate(opts.name, what, url)
     : frenchTemplate(opts.name, what, url);
 
-  await sendEmail({ to: [opts.to], subject: tpl.subject, text: tpl.text, html: tpl.html });
+  await sendEmail({
+    to: [opts.to],
+    subject: tpl.subject,
+    text: tpl.text,
+    html: tpl.html,
+    locale: lang,
+  });
 }

--- a/src/backend/src/lib/email-template.test.ts
+++ b/src/backend/src/lib/email-template.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { renderEmail, emailButton, emailHeading } from "./email-template.js";
+
+// The shared email layout (#269): brand wrapper, bilingual footer, and the
+// email-client constraints that make it table-based with inline styles.
+
+const originalBase = process.env.BASE_URL;
+const originalLogo = process.env.EMAIL_LOGO_URL;
+
+afterEach(() => {
+  process.env.BASE_URL = originalBase;
+  if (originalLogo === undefined) delete process.env.EMAIL_LOGO_URL;
+  else process.env.EMAIL_LOGO_URL = originalLogo;
+});
+
+describe("renderEmail", () => {
+  it("wraps the body in a full HTML document with the brand colours", () => {
+    const html = renderEmail({ bodyHtml: "<p>Bonjour</p>" });
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("<p>Bonjour</p>");
+    // Brand green header + off-white page background.
+    expect(html).toContain("#0B7350");
+    expect(html).toContain("#FDF0EB");
+  });
+
+  it("uses inline styles only — no <style> block that Gmail would drop", () => {
+    const html = renderEmail({ bodyHtml: "<p>x</p>" });
+    expect(html).not.toContain("<style");
+  });
+
+  it("localizes the footer", () => {
+    expect(renderEmail({ bodyHtml: "", locale: "fr" })).toContain("merci de ne pas y répondre");
+    expect(renderEmail({ bodyHtml: "", locale: "en" })).toContain("please do not reply");
+  });
+
+  it("defaults to French when no locale is given", () => {
+    expect(renderEmail({ bodyHtml: "" })).toContain("La conférence Toulousaine");
+  });
+
+  it("derives the logo from BASE_URL and lets EMAIL_LOGO_URL override it", () => {
+    process.env.BASE_URL = "https://devfesttoulouse.fr";
+    delete process.env.EMAIL_LOGO_URL;
+    expect(renderEmail({ bodyHtml: "" })).toContain(
+      "https://devfesttoulouse.fr/images/logo-devfest-96.png",
+    );
+
+    process.env.EMAIL_LOGO_URL = "https://cdn.example.org/logo.png";
+    expect(renderEmail({ bodyHtml: "" })).toContain("https://cdn.example.org/logo.png");
+  });
+
+  it("hides the preview text from the rendered body", () => {
+    const html = renderEmail({ bodyHtml: "<p>x</p>", previewText: "Votre lien" });
+    expect(html).toContain("Votre lien");
+    expect(html).toContain("display:none");
+  });
+
+  it("omits the preview block entirely when no preview text is given", () => {
+    expect(renderEmail({ bodyHtml: "<p>x</p>" })).not.toContain("display:none");
+  });
+});
+
+describe("emailButton", () => {
+  it("renders an anchor inside a table so Outlook keeps the background", () => {
+    const html = emailButton("https://example.org/edit", "Modifier ma fiche");
+    expect(html).toContain('href="https://example.org/edit"');
+    expect(html).toContain("Modifier ma fiche");
+    expect(html).toContain("<table");
+  });
+});
+
+describe("emailHeading", () => {
+  it("renders an h1 in the brand green", () => {
+    expect(emailHeading("Titre")).toContain("#0B7350");
+    expect(emailHeading("Titre")).toContain("Titre");
+  });
+});

--- a/src/backend/src/lib/email-template.ts
+++ b/src/backend/src/lib/email-template.ts
@@ -1,0 +1,132 @@
+// Shared HTML layout for every outgoing email (#269).
+//
+// Email clients are stuck in 2005: no <style> support in Gmail, no flexbox in
+// Outlook, no external CSS anywhere. So this is table-based with inline styles
+// only — verbose on purpose. Colours come from the design system tokens in
+// src/frontend/src/app/globals.css.
+
+const COLORS = {
+  malachite: "#0B7350",
+  terreCuite: "#C24A1F",
+  noir: "#1D1D1B",
+  gris: "#737372",
+  blanc: "#FFFFFF",
+  blancCasse: "#FDF0EB",
+} as const;
+
+const SITE_NAME = "DevFest Toulouse";
+
+type Locale = "fr" | "en";
+
+function baseUrl(): string {
+  return (process.env.BASE_URL || "https://devfesttoulouse.fr").replace(/\/$/, "");
+}
+
+// PNG, not SVG: Gmail and Outlook don't render SVG. EMAIL_LOGO_URL overrides it
+// when the logo must be hosted elsewhere (e.g. a CDN reachable from mailboxes).
+function logoUrl(): string {
+  return process.env.EMAIL_LOGO_URL || `${baseUrl()}/images/logo-devfest-96.png`;
+}
+
+const FOOTER = {
+  fr: {
+    tagline: "La conférence Toulousaine par les devs et pour les devs.",
+    site: "devfesttoulouse.fr",
+    automated: "Cet email vous a été envoyé automatiquement, merci de ne pas y répondre directement.",
+  },
+  en: {
+    tagline: "The Toulouse conference by developers, for developers.",
+    site: "devfesttoulouse.fr",
+    automated: "This email was sent automatically — please do not reply to it directly.",
+  },
+} as const;
+
+/**
+ * Wraps an email body in the DevFest layout: logo header on the brand green,
+ * white content card, footer. `bodyHtml` is inserted as-is — callers are
+ * responsible for escaping any user-controlled value (see escapeHtml /
+ * interpolateHtml in email.ts).
+ *
+ * `previewText` is the snippet inboxes show next to the subject; keep it short
+ * and meaningful, it is hidden in the rendered email.
+ */
+export function renderEmail({
+  locale = "fr",
+  previewText = "",
+  bodyHtml,
+}: {
+  locale?: Locale;
+  previewText?: string;
+  bodyHtml: string;
+}): string {
+  const t = FOOTER[locale] ?? FOOTER.fr;
+  const year = new Date().getFullYear();
+
+  return `<!DOCTYPE html>
+<html lang="${locale}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${SITE_NAME}</title>
+</head>
+<body style="margin:0;padding:0;background-color:${COLORS.blancCasse};">
+${previewText ? `<div style="display:none;max-height:0;overflow:hidden;opacity:0;">${previewText}</div>` : ""}
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:${COLORS.blancCasse};">
+  <tr>
+    <td align="center" style="padding:24px 12px;">
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="max-width:600px;width:100%;">
+
+        <!-- Header -->
+        <tr>
+          <td align="center" style="background-color:${COLORS.malachite};border-radius:12px 12px 0 0;padding:24px;">
+            <img src="${logoUrl()}" alt="${SITE_NAME}" width="64" height="64" style="display:block;border:0;width:64px;height:auto;">
+          </td>
+        </tr>
+
+        <!-- Body -->
+        <tr>
+          <td style="background-color:${COLORS.blanc};padding:32px 28px;font-family:Arial,Helvetica,sans-serif;font-size:16px;line-height:1.6;color:${COLORS.noir};">
+${bodyHtml}
+          </td>
+        </tr>
+
+        <!-- Footer -->
+        <tr>
+          <td style="background-color:${COLORS.blanc};border-radius:0 0 12px 12px;border-top:1px solid #E8E0DC;padding:20px 28px;font-family:Arial,Helvetica,sans-serif;font-size:13px;line-height:1.5;color:${COLORS.gris};">
+            <p style="margin:0 0 6px;">${t.tagline}</p>
+            <p style="margin:0 0 6px;">
+              <a href="${baseUrl()}" style="color:${COLORS.malachite};text-decoration:none;">${t.site}</a>
+            </p>
+            <p style="margin:0;color:#9A9A99;font-size:12px;">${t.automated}</p>
+            <p style="margin:8px 0 0;color:#9A9A99;font-size:12px;">© ${year} ${SITE_NAME} — GDG Toulouse</p>
+          </td>
+        </tr>
+
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>`;
+}
+
+/**
+ * A call-to-action button. Uses a table so Outlook renders the background:
+ * a styled <a> alone collapses there.
+ */
+export function emailButton(href: string, label: string): string {
+  return `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:24px 0;">
+  <tr>
+    <td align="center" style="background-color:${COLORS.malachite};border-radius:12px;">
+      <a href="${href}" style="display:inline-block;padding:14px 28px;font-family:Arial,Helvetica,sans-serif;font-size:16px;font-weight:bold;color:${COLORS.blanc};text-decoration:none;">${label}</a>
+    </td>
+  </tr>
+</table>`;
+}
+
+/** Section heading inside an email body, in the brand green. */
+export function emailHeading(text: string): string {
+  return `<h1 style="margin:0 0 16px;font-family:Arial,Helvetica,sans-serif;font-size:22px;line-height:1.3;color:${COLORS.malachite};">${text}</h1>`;
+}
+
+export const EMAIL_COLORS = COLORS;

--- a/src/backend/src/lib/email.ts
+++ b/src/backend/src/lib/email.ts
@@ -1,5 +1,7 @@
 import nodemailer from "nodemailer";
 
+import { renderEmail } from "./email-template.js";
+
 // SMTP_SECURE = true forces a TLS handshake on connect (port 465 typical).
 // SMTP_AUTH = true enables plain SMTP auth via SMTP_USER / SMTP_PASSWORD.
 // Default profile (secure=false, auth=false) matches the standalone
@@ -26,6 +28,8 @@ interface SendEmailOptions {
   to: string[];
   subject: string;
   text: string;
+  // The message body. It is wrapped in the shared DevFest layout (#269) — pass
+  // the content only, no <html>/<body>.
   html: string;
   // Optional Reply-To so replying to a notification reaches the person who
   // triggered it (e.g. the visitor who filled the contact form) instead of
@@ -34,9 +38,27 @@ interface SendEmailOptions {
   // Optional CC recipients (e.g. the organizers, kept in copy of the brochure
   // confirmation sent to the requester).
   cc?: string[];
+  // Recipient language, for the layout's footer. Defaults to French.
+  locale?: "fr" | "en";
+  // Snippet inboxes show next to the subject. Defaults to the subject.
+  previewText?: string;
 }
 
-export async function sendEmail({ to, subject, text, html, replyTo, cc }: SendEmailOptions) {
+/**
+ * Sends an email, wrapping `html` in the shared brand layout. Wrapping happens
+ * here rather than at each call site so every email — including future ones —
+ * is on-brand by construction, with no way to forget it.
+ */
+export async function sendEmail({
+  to,
+  subject,
+  text,
+  html,
+  replyTo,
+  cc,
+  locale = "fr",
+  previewText,
+}: SendEmailOptions) {
   await transporter.sendMail({
     from: FROM,
     to: to.join(", "),
@@ -44,7 +66,7 @@ export async function sendEmail({ to, subject, text, html, replyTo, cc }: SendEm
     ...(replyTo ? { replyTo } : {}),
     subject,
     text,
-    html,
+    html: renderEmail({ locale, previewText: previewText ?? subject, bodyHtml: html }),
   });
 }
 
@@ -73,7 +95,7 @@ export function interpolateHtml(template: string, vars: Record<string, string>):
   });
 }
 
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
   return value
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/src/backend/src/routes/admin/contact.ts
+++ b/src/backend/src/routes/admin/contact.ts
@@ -212,7 +212,8 @@ export default async function adminContactRoutes(app: FastifyInstance) {
     }
 
     try {
-      const { sendEmail } = await import("../../lib/email.js");
+      const { sendEmail, escapeHtml } = await import("../../lib/email.js");
+      const { emailHeading } = await import("../../lib/email-template.js");
       await sendEmail({
         to: emails,
         subject: `[Fwd] Message de contact — ${msg.firstName} ${msg.lastName}`,
@@ -226,17 +227,19 @@ export default async function adminContactRoutes(app: FastifyInstance) {
           "",
           msg.message,
         ].filter(Boolean).join("\n"),
+        // The message and its fields come from the public contact form: escape
+        // them before forwarding as HTML.
         html: `
-        <h3>Message de contact transféré</h3>
-        <p><strong>De:</strong> ${msg.firstName} ${msg.lastName}</p>
-        <p><strong>Email:</strong> <a href="mailto:${msg.email}">${msg.email}</a></p>
-        ${msg.phone ? `<p><strong>Tel:</strong> ${msg.phone}</p>` : ""}
-        ${msg.company ? `<p><strong>Entreprise:</strong> ${msg.company}</p>` : ""}
-        ${msg.jobTitle ? `<p><strong>Poste:</strong> ${msg.jobTitle}</p>` : ""}
-        ${msg.categoryLabel ? `<p><strong>Categorie:</strong> ${msg.categoryLabel}</p>` : ""}
+        ${emailHeading("Message de contact transféré")}
+        <p><strong>De:</strong> ${escapeHtml(`${msg.firstName} ${msg.lastName}`)}</p>
+        <p><strong>Email:</strong> <a href="mailto:${encodeURIComponent(msg.email)}">${escapeHtml(msg.email)}</a></p>
+        ${msg.phone ? `<p><strong>Tel:</strong> ${escapeHtml(msg.phone)}</p>` : ""}
+        ${msg.company ? `<p><strong>Entreprise:</strong> ${escapeHtml(msg.company)}</p>` : ""}
+        ${msg.jobTitle ? `<p><strong>Poste:</strong> ${escapeHtml(msg.jobTitle)}</p>` : ""}
+        ${msg.categoryLabel ? `<p><strong>Categorie:</strong> ${escapeHtml(msg.categoryLabel)}</p>` : ""}
         <p><strong>Date:</strong> ${new Date(msg.createdAt).toLocaleString("fr-FR")}</p>
-        <hr>
-        <p>${msg.message.replace(/\n/g, "<br>")}</p>
+        <hr style="border:0;border-top:1px solid #E8E0DC;margin:20px 0;">
+        <p>${escapeHtml(msg.message).replace(/\n/g, "<br>")}</p>
         `,
       });
       return { success: true, forwardedTo: emails };

--- a/src/backend/src/routes/admin/users.ts
+++ b/src/backend/src/routes/admin/users.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
-import { sendEmail } from "../../lib/email.js";
+import { sendEmail, escapeHtml } from "../../lib/email.js";
+import { emailButton, emailHeading } from "../../lib/email-template.js";
 
 const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 
@@ -75,17 +76,18 @@ export default async function adminUserRoutes(app: FastifyInstance) {
     // Send invitation email with password reset link
     try {
       const resetUrl = `${BASE_URL}/admin`;
+      const roleLabel = role === "ADMIN" ? "Administrateur" : "Éditeur";
       await sendEmail({
         to: [email],
-        subject: "Invitation DevFest Toulouse — Acces admin",
-        text: `Bonjour ${name},\n\nVous avez ete invite a acceder au back-office du DevFest Toulouse.\n\nVotre role : ${role}\n\nConnectez-vous sur : ${resetUrl}\nUtilisez "Mot de passe oublie" pour definir votre mot de passe.\n\nA bientot !`,
+        subject: "Invitation DevFest Toulouse — Accès admin",
+        text: `Bonjour ${name},\n\nVous avez été invité·e à accéder au back-office du DevFest Toulouse.\n\nVotre rôle : ${roleLabel}\n\nConnectez-vous sur : ${resetUrl}\nUtilisez « Mot de passe oublié » pour définir votre mot de passe.\n\nÀ bientôt !`,
         html: `
-        <h3>Invitation DevFest Toulouse</h3>
-        <p>Bonjour ${name},</p>
-        <p>Vous avez ete invite a acceder au back-office du DevFest Toulouse.</p>
-        <p><strong>Role :</strong> ${role === "ADMIN" ? "Administrateur" : "Editeur"}</p>
-        <p>Connectez-vous sur : <a href="${resetUrl}">${resetUrl}</a></p>
-        <p>Utilisez <strong>"Mot de passe oublie"</strong> pour definir votre mot de passe.</p>
+        ${emailHeading("Invitation DevFest Toulouse")}
+        <p>Bonjour ${escapeHtml(name)},</p>
+        <p>Vous avez été invité·e à accéder au back-office du DevFest Toulouse.</p>
+        <p><strong>Rôle :</strong> ${roleLabel}</p>
+        ${emailButton(resetUrl, "Accéder au back-office")}
+        <p>Utilisez <strong>« Mot de passe oublié »</strong> pour définir votre mot de passe.</p>
         `,
       });
     } catch {

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
-import { sendEmail, interpolate, interpolateHtml } from "../lib/email.js";
+import { sendEmail, interpolate, interpolateHtml, escapeHtml } from "../lib/email.js";
+import { emailHeading } from "../lib/email-template.js";
 import { makeToken } from "../lib/brochure-token.js";
 import { sendContactWebhook } from "../lib/contact-webhook.js";
 import { getFeaturedEdition } from "./editions.js";
@@ -155,16 +156,18 @@ export default async function contactRoutes(app: FastifyInstance) {
         .filter(Boolean)
         .join("\n");
 
+      // Everything below comes from a public form: escape it all before it
+      // reaches an inbox as HTML.
       const html = `
-        <h3>Nouveau message de contact</h3>
-        <p><strong>De:</strong> ${firstName.trim()} ${lastName.trim()}</p>
-        <p><strong>Email:</strong> <a href="mailto:${email.trim()}">${email.trim()}</a></p>
-        ${phone ? `<p><strong>Téléphone:</strong> ${phone.trim()}</p>` : ""}
-        ${company?.trim() ? `<p><strong>Entreprise:</strong> ${company.trim()}</p>` : ""}
-        ${jobTitle?.trim() ? `<p><strong>Poste:</strong> ${jobTitle.trim()}</p>` : ""}
-        ${categoryLabel ? `<p><strong>Catégorie:</strong> ${categoryLabel}</p>` : ""}
-        <hr>
-        <p>${message.trim().replace(/\n/g, "<br>")}</p>
+        ${emailHeading("Nouveau message de contact")}
+        <p><strong>De:</strong> ${escapeHtml(`${firstName.trim()} ${lastName.trim()}`)}</p>
+        <p><strong>Email:</strong> <a href="mailto:${encodeURIComponent(email.trim())}">${escapeHtml(email.trim())}</a></p>
+        ${phone ? `<p><strong>Téléphone:</strong> ${escapeHtml(phone.trim())}</p>` : ""}
+        ${company?.trim() ? `<p><strong>Entreprise:</strong> ${escapeHtml(company.trim())}</p>` : ""}
+        ${jobTitle?.trim() ? `<p><strong>Poste:</strong> ${escapeHtml(jobTitle.trim())}</p>` : ""}
+        ${categoryLabel ? `<p><strong>Catégorie:</strong> ${escapeHtml(categoryLabel)}</p>` : ""}
+        <hr style="border:0;border-top:1px solid #E8E0DC;margin:20px 0;">
+        <p>${escapeHtml(message.trim()).replace(/\n/g, "<br>")}</p>
       `;
 
       // Reply-To = the visitor, so the organizers can answer the message
@@ -212,12 +215,15 @@ export default async function contactRoutes(app: FastifyInstance) {
           // with the tracked brochure link. Brochure requests only.
           const cc = requiresCompanyInfo && recipients.length > 0 ? recipients : undefined;
 
+          // The body stays exactly as authored in the admin; the layout only
+          // wraps it, in the requester's language.
           await sendEmail({
             to: [email.trim()],
             subject: renderedSubject,
             text: renderedTextBody,
             html: renderedHtmlBody,
             cc,
+            locale: lang,
           });
         } catch (err) {
           app.log.error("Failed to send confirmation email: %s", String(err));

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -10,7 +10,8 @@ import {
   revalidateSponsors,
 } from "../lib/revalidate.js";
 import { storeImageBuffer } from "../lib/image-store.js";
-import { sendEmail } from "../lib/email.js";
+import { sendEmail, escapeHtml } from "../lib/email.js";
+import { emailButton, emailHeading } from "../lib/email-template.js";
 import { getCfpNotificationEmail } from "../lib/cfp-settings.js";
 import { getSponsorContactRecipients } from "../lib/sponsor-contact.js";
 import { offerQuotaForLevel } from "../lib/job-offers.js";
@@ -307,8 +308,7 @@ async function resolveToken(token: string) {
       editLinkLocked: contact.editLinkLocked,
       editTokenSentAt: contact.editTokenSentAt,
       contactId: contact.id,
-      // The link recipient's own address wins over the sponsor's default for
-      // the com-kit Reply-To.
+      // The link recipient's own address wins over the sponsor's default.
       contactEmail: contact.email || contact.sponsor.contactEmail,
     };
     return { kind: "sponsor" as const, entity };
@@ -385,23 +385,14 @@ async function notifyTalkEdited(
     `Fiche admin : ${adminUrl}`,
   ].join("\n");
   const html = `
-    <h3>Conférence modifiée par un·e speaker</h3>
+    ${emailHeading("Conférence modifiée par un·e speaker")}
     <p><strong>${escapeHtml(speakerName)}</strong> a mis à jour sa conférence
     « ${escapeHtml(talk.titleFr)} ».</p>
     <p>Les modifications sont déjà en ligne (publication directe).</p>
-    <p><a href="${adminUrl}">Voir la fiche dans l'admin</a></p>
+    ${emailButton(adminUrl, "Voir la fiche dans l'admin")}
   `;
 
   await sendEmail({ to: [to], subject, text, html });
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 export default async function editRoutes(app: FastifyInstance) {


### PR DESCRIPTION
## Summary

- Nouveau `lib/email-template.ts` : `renderEmail()` produit un document HTML complet **table-based avec styles inline uniquement** (Gmail supprime `<style>`, Outlook ignore flexbox) — header malachite avec logo, carte blanche, footer **bilingue**. Helpers `emailButton()` et `emailHeading()`.
- **L'habillage se fait dans `sendEmail()`**, pas à chaque appelant : tout email — y compris ceux à venir — est à la charte par construction, impossible d'en oublier un. Les appelants ne fournissent que le corps, plus une `locale` optionnelle pour le footer.
- Les **7 appels** migrés : lien de modification (FR/EN), notification contact, confirmation contact (corps éditable en BDD, enveloppé sans y toucher), notification talk modifié, transfert de message, invitation admin, reset password. Les liens d'action deviennent des boutons.

## 🔒 Faille corrigée au passage

La **notification de contact** et le **transfert de message** injectaient des valeurs saisies par le visiteur (nom, entreprise, message…) **directement dans le HTML**, sans échappement — XSS dans la boîte mail des organisateurs. Elles sont désormais échappées, ainsi que le nom du destinataire dans les emails de lien de modification et de reset.

## Notes

- La qualification annonçait « 9 emails » ; il y a en réalité **7 appels `sendEmail`** (les variantes FR/EN d'un même email étaient comptées à part, et l'email kit de com a été supprimé par #271). Vérifié par grep global : aucun envoi hors de ces 7.
- `EMAIL_LOGO_URL` est **optionnelle** — défaut `${BASE_URL}/images/logo-devfest-96.png`. PNG et non SVG (Gmail/Outlook ne rendent pas le SVG). Un défaut dérivé évite un email sans logo si la var est oubliée en prod.
- Déduplication de `escapeHtml` (exporté depuis `email.ts`, doublon supprimé dans `edit.ts`), accents rétablis dans l'invitation admin, commentaire orphelin du kit de com nettoyé.

## Test plan

- [x] `tsc` backend
- [x] **298 tests backend** (289 + 9 nouveaux sur le gabarit : pas de `<style>`, bouton en `<table>`, footer bilingue, logo dérivé/override, preview text)
- [x] Vérif MailHog — email de contact : DOCTYPE, logo, couleurs de charte, footer FR, message échappé
- [x] Vérif MailHog — lien de modification **FR et EN** : footer dans la bonne langue, `lang` correct, bouton CTA rendu, nom échappé (`Jane <Doe>` affiché littéralement)
- [x] Rendu visuel contrôlé dans MailHog (capture) : header, titre, bouton, footer conformes à la charte

Refs #269
