### PR TITLE
fix(admin): erreurs de validation remontées + titleEn optionnel (#262)

### DIFF
--- a/src/backend/src/__tests__/admin-articles.test.ts
+++ b/src/backend/src/__tests__/admin-articles.test.ts
@@ -148,6 +148,44 @@ describe("Admin Articles API", () => {
     await app.close();
   });
 
+  // #262: titleEn is optional at creation — the AI translation only runs on an
+  // already-saved article, so requiring it made a FR-only draft impossible.
+  it("POST /api/admin/articles creates an article without titleEn", async () => {
+    const app = await buildAdminApp();
+    const slug = `fr-only-${Date.now()}`;
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/admin/articles",
+      payload: { slug, titleFr: "Titre FR", contentFr: "<p>Contenu</p>" },
+    });
+    expect(res.statusCode).toBe(201);
+
+    const { id } = res.json();
+    const created = await app.inject({ method: "GET", url: `/api/admin/articles/${id}` });
+    expect(created.json().titleFr).toBe("Titre FR");
+    expect(created.json().titleEn).toBe("");
+
+    await app.inject({ method: "DELETE", url: `/api/admin/articles/${id}` });
+    await app.close();
+  });
+
+  it("POST /api/admin/articles names the missing required fields", async () => {
+    const app = await buildAdminApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/admin/articles",
+      payload: { titleFr: "", contentFr: "" },
+    });
+    expect(res.statusCode).toBe(400);
+    // The message must be actionable, not a generic failure (#262).
+    expect(res.json().fields).toEqual(["slug", "titleFr"]);
+    expect(res.json().error).toContain("slug");
+    expect(res.json().error).toContain("titleFr");
+    await app.close();
+  });
+
   it("GET /api/admin/tags should return tags", async () => {
     const app = await buildAdminApp();
     const res = await app.inject({ method: "GET", url: "/api/admin/tags" });

--- a/src/backend/src/routes/admin/articles.ts
+++ b/src/backend/src/routes/admin/articles.ts
@@ -22,7 +22,8 @@ function parsePublishedAt(value: string | undefined): Date | null {
 interface ArticleBody {
   slug: string;
   titleFr: string;
-  titleEn: string;
+  // Optional at creation (#262) — filled in later by hand or by AI translation.
+  titleEn?: string;
   contentFr: string;
   contentEn: string;
   excerptFr?: string;
@@ -125,8 +126,18 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
   app.post<{ Body: ArticleBody }>("/articles", async (request, reply) => {
     const body = request.body;
 
-    if (!body.slug?.trim() || !body.titleFr?.trim() || !body.titleEn?.trim()) {
-      return reply.status(400).send({ error: "slug, titleFr, titleEn are required" });
+    // titleEn is optional at creation (#262): the AI translation only runs on an
+    // already-saved article, so requiring it up front made a FR-only draft
+    // impossible to create. The sitemap already gates /en on a non-empty titleEn.
+    const missing = [
+      !body.slug?.trim() && "slug",
+      !body.titleFr?.trim() && "titleFr",
+    ].filter(Boolean) as string[];
+    if (missing.length) {
+      return reply.status(400).send({
+        error: `Champs obligatoires manquants : ${missing.join(", ")}`,
+        fields: missing,
+      });
     }
 
     const existing = await prisma.article.findUnique({ where: { slug: body.slug.trim() } });
@@ -141,7 +152,7 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
       data: {
         slug: body.slug.trim(),
         titleFr: body.titleFr.trim(),
-        titleEn: body.titleEn.trim(),
+        titleEn: body.titleEn?.trim() || "",
         contentFr: sanitizeRichHtml(body.contentFr),
         contentEn: sanitizeRichHtml(body.contentEn),
         excerptFr: body.excerptFr?.trim() || null,

--- a/src/frontend/src/app/admin/articles/[id]/page.tsx
+++ b/src/frontend/src/app/admin/articles/[id]/page.tsx
@@ -152,7 +152,7 @@ export default function ArticleEditorPage() {
     setIsTranslating(true);
     setTranslateError(null);
 
-    const { status, data } = await adminFetch<{ error?: string; message?: string }>(
+    const { status, error: translateApiError } = await adminFetch<{ error?: string; message?: string }>(
       `/articles/${articleId}/translate-fields`,
       { method: "POST", body: JSON.stringify({ from }) },
     );
@@ -172,7 +172,7 @@ export default function ArticleEditorPage() {
       return;
     }
     if (status >= 400) {
-      setTranslateError(data?.message || "La traduction a échoué.");
+      setTranslateError(translateApiError || "La traduction a échoué.");
       return;
     }
 
@@ -204,7 +204,7 @@ export default function ArticleEditorPage() {
       autoTranslatedEn: form.autoTranslatedEn,
     };
 
-    const { data, status } = isNew
+    const { data, status, error: apiError } = isNew
       ? await adminFetch<{ id: number }>("/articles", {
           method: "POST",
           body: JSON.stringify(payload),
@@ -222,7 +222,8 @@ export default function ArticleEditorPage() {
     }
 
     if (!data) {
-      setError("Erreur lors de la sauvegarde");
+      // Prefer the backend's message: it names the offending field (#262).
+      setError(apiError || "Erreur lors de la sauvegarde");
       return;
     }
 
@@ -354,7 +355,9 @@ export default function ArticleEditorPage() {
             aria-labelledby="tab-en"
             className={activeLang === "en" ? "space-y-4" : "hidden"}
           >
-            <FormField label="Title" name="titleEn" value={form.titleEn} onChange={(v) => updateForm("titleEn", v)} required />
+            {/* Not required (#262): an article can be created FR-only and
+                translated afterwards, by hand or via the AI translation. */}
+            <FormField label="Title" name="titleEn" value={form.titleEn} onChange={(v) => updateForm("titleEn", v)} />
             <FormField label="Excerpt" name="excerptEn" value={form.excerptEn} onChange={(v) => updateForm("excerptEn", v)} multiline rows={2} />
             <RichTextEditor label="Content" name="contentEn" value={form.contentEn} onChange={(v) => updateForm("contentEn", v)} minHeight="320px" />
             {form.autoTranslatedEn && (

--- a/src/frontend/src/app/admin/editions/page.tsx
+++ b/src/frontend/src/app/admin/editions/page.tsx
@@ -68,9 +68,9 @@ export default function EditionsPage() {
 
   async function handleDelete() {
     if (!deleteTarget) return;
-    const { status, data } = await adminFetch<{ error?: string }>(`/editions/${deleteTarget.id}`, { method: "DELETE" });
+    const { status, error: apiError } = await adminFetch(`/editions/${deleteTarget.id}`, { method: "DELETE" });
     if (status === 409) {
-      setError(data?.error || "Impossible de supprimer cette édition");
+      setError(apiError || "Impossible de supprimer cette édition");
     }
     setDeleteTarget(null);
     loadEditions();

--- a/src/frontend/src/app/admin/users/page.tsx
+++ b/src/frontend/src/app/admin/users/page.tsx
@@ -45,14 +45,14 @@ export default function UsersAdminPage() {
     }
     setIsSaving(true);
     setError(null);
-    const { status, data } = await adminFetch<{ error?: string }>("/users", {
+    const { status, error: apiError } = await adminFetch("/users", {
       method: "POST",
       body: JSON.stringify(form),
     });
     if (status === 409) {
       setError("Un utilisateur avec cet email existe déjà");
     } else if (status !== 201) {
-      setError(data?.error || "Erreur lors de la création");
+      setError(apiError || "Erreur lors de la création");
     } else {
       setShowForm(false);
       setForm({ email: "", name: "", role: "EDITOR" });
@@ -62,9 +62,9 @@ export default function UsersAdminPage() {
   }
 
   async function handleToggleBan(userId: string) {
-    const { status, data } = await adminFetch<{ error?: string }>(`/users/${userId}/ban`, { method: "PUT" });
+    const { status, error: apiError } = await adminFetch(`/users/${userId}/ban`, { method: "PUT" });
     if (status === 400) {
-      setError(data?.error || "Impossible de bloquer cet utilisateur");
+      setError(apiError || "Impossible de bloquer cet utilisateur");
     }
     loadUsers();
   }
@@ -80,9 +80,9 @@ export default function UsersAdminPage() {
 
   async function handleDelete() {
     if (!deleteTarget) return;
-    const { status, data } = await adminFetch<{ error?: string }>(`/users/${deleteTarget.id}`, { method: "DELETE" });
+    const { status, error: apiError } = await adminFetch(`/users/${deleteTarget.id}`, { method: "DELETE" });
     if (status === 400) {
-      setError(data?.error || "Impossible de supprimer cet utilisateur");
+      setError(apiError || "Impossible de supprimer cet utilisateur");
     }
     setDeleteTarget(null);
     loadUsers();

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -11,7 +11,7 @@ interface AdminUser {
 export async function adminFetch<T>(
   path: string,
   options: RequestInit = {},
-): Promise<{ data: T | null; status: number }> {
+): Promise<{ data: T | null; status: number; error?: string }> {
   try {
     const headers: Record<string, string> = {};
     if (options.body && !(options.body instanceof FormData)) {
@@ -31,8 +31,13 @@ export async function adminFetch<T>(
       return { data: null, status: 403 };
     }
 
+    // Surface the backend's own message (#262) — a generic "save failed" left
+    // editors guessing which field was rejected. `data` stays null on error, so
+    // callers that only check it keep working.
     if (!res.ok) {
-      return { data: null, status: res.status };
+      const body = await res.json().catch(() => null);
+      const error = body?.error || body?.message;
+      return { data: null, status: res.status, ...(error ? { error } : {}) };
     }
 
     // 204 No Content (e.g. a DELETE) has an empty body: res.json() would throw


### PR DESCRIPTION
## Summary

Une éditrice ne pouvait pas créer d'article : échec avec un « Erreur lors de la sauvegarde » générique, sans moyen de savoir pourquoi. Deux causes cumulées, corrigées :

- **L'erreur backend était masquée** : `adminFetch` jetait le corps JSON sur tout non-2xx. Il renvoie désormais un `error` optionnel, **à côté** de `data`/`status` inchangés — aucun appelant existant n'est impacté.
- **`titleEn` obligatoire à la création** (Option A retenue) : la traduction IA ne tourne que sur un article **déjà enregistré**, rendant impossible la création d'un brouillon FR-only — blocage circulaire. Seuls `slug` et `titleFr` sont désormais requis, et le 400 **nomme les champs manquants**. Le sitemap filtre déjà `/en` sur un `titleEn` non vide. Le champ EN n'est plus marqué requis dans le formulaire.

## Bonus — même bug à 5 autres endroits

Cinq autres appelants lisaient `data?.error` sur une requête en échec, où `data` était **toujours `null`** : leur message backend ne s'affichait donc jamais. Corrigés au passage — traduction d'article, suppression d'édition, et les trois actions de gestion des utilisateurs.

## Test plan

- [x] `tsc` back + front, lint front (0 erreur)
- [x] **300 tests backend** (2 nouveaux : création sans `titleEn` → 201 avec `titleEn: ""` ; 400 renvoyant `fields: ["slug","titleFr"]`)
- [x] Vérif navigateur **connectée en EDITOR** (le rôle concerné) :
  - Sauvegarde à vide → « **Champs obligatoires manquants : slug, titleFr** » au lieu du générique
  - Création **FR-only** → 201, redirection vers la fiche, aucune erreur
  - Onglet English : le titre n'est plus marqué requis, la traduction IA est accessible
- [x] Non-régression : les autres écrans admin utilisant `adminFetch` fonctionnent (ajout purement additif)

## Hors périmètre

L'image `blob:` bloquée par la CSP (mentionnée comme secondaire dans l'issue) n'est pas traitée ici — à ouvrir séparément si le besoin se confirme (upload auto des images collées dans l'éditeur).

> À noter : #263 généralisera la règle (sauvegarde permissive en brouillon, validation stricte à la publication). Cette PR corrige le bug immédiat sans préempter ce choix.

Refs #262
