### PR TITLE
feat(articles): sauvegarde permissive en brouillon, validation stricte à la publication (#263)

### DIFF
--- a/src/backend/src/__tests__/admin-articles.test.ts
+++ b/src/backend/src/__tests__/admin-articles.test.ts
@@ -80,8 +80,9 @@ describe("Admin Articles API", () => {
         slug,
         titleFr: "Daté FR",
         titleEn: "Dated EN",
-        contentFr: "",
-        contentEn: "",
+        // Publishing requires both languages filled in (#263).
+        contentFr: "<p>Contenu</p>",
+        contentEn: "<p>Content</p>",
         publicationStatus: "PUBLISHED",
         publishedAt: originalDate,
       },
@@ -108,8 +109,9 @@ describe("Admin Articles API", () => {
         slug,
         titleFr: "Now FR",
         titleEn: "Now EN",
-        contentFr: "",
-        contentEn: "",
+        // Publishing requires both languages filled in (#263).
+        contentFr: "<p>Contenu</p>",
+        contentEn: "<p>Content</p>",
         publicationStatus: "PUBLISHED",
       },
     });
@@ -183,6 +185,82 @@ describe("Admin Articles API", () => {
     expect(res.json().fields).toEqual(["slug", "titleFr"]);
     expect(res.json().error).toContain("slug");
     expect(res.json().error).toContain("titleFr");
+    await app.close();
+  });
+
+  // #263: saving a draft stays permissive, publishing is the strict gate.
+  it("refuses to publish an incomplete article, then accepts it once complete", async () => {
+    const app = await buildAdminApp();
+    const slug = `publish-gate-${Date.now()}`;
+
+    // A FR-only draft saves fine.
+    const draft = await app.inject({
+      method: "POST",
+      url: "/api/admin/articles",
+      payload: { slug, titleFr: "Titre FR", contentFr: "<p>Contenu</p>" },
+    });
+    expect(draft.statusCode).toBe(201);
+    const { id } = draft.json();
+
+    // Flipping it to PUBLISHED without the English side is refused — and the
+    // status must be judged on the merged article, not on this partial body.
+    const rejected = await app.inject({
+      method: "PUT",
+      url: `/api/admin/articles/${id}`,
+      payload: { publicationStatus: "PUBLISHED" },
+    });
+    expect(rejected.statusCode).toBe(400);
+    expect(rejected.json().fields).toEqual(["titleEn", "contentEn"]);
+
+    // It is still a draft.
+    const untouched = await app.inject({ method: "GET", url: `/api/admin/articles/${id}` });
+    expect(untouched.json().publicationStatus).toBe("DRAFT");
+
+    // Completing the English side unlocks publication.
+    const published = await app.inject({
+      method: "PUT",
+      url: `/api/admin/articles/${id}`,
+      payload: { titleEn: "Title EN", contentEn: "<p>Content</p>", publicationStatus: "PUBLISHED" },
+    });
+    expect(published.statusCode).toBe(200);
+
+    await app.inject({ method: "DELETE", url: `/api/admin/articles/${id}` });
+    await app.close();
+  });
+
+  it("refuses to create an article directly as PUBLISHED when incomplete", async () => {
+    const app = await buildAdminApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/admin/articles",
+      payload: { slug: `direct-publish-${Date.now()}`, titleFr: "FR", publicationStatus: "PUBLISHED" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("Publication impossible");
+    expect(res.json().fields).toEqual(["titleEn", "contentFr", "contentEn"]);
+    await app.close();
+  });
+
+  it("keeps saving an existing draft permissive", async () => {
+    const app = await buildAdminApp();
+    const slug = `draft-permissive-${Date.now()}`;
+
+    const created = await app.inject({
+      method: "POST",
+      url: "/api/admin/articles",
+      payload: { slug, titleFr: "Titre" },
+    });
+    const { id } = created.json();
+
+    // No English, no content — still saves as a draft.
+    const saved = await app.inject({
+      method: "PUT",
+      url: `/api/admin/articles/${id}`,
+      payload: { titleFr: "Titre modifié" },
+    });
+    expect(saved.statusCode).toBe(200);
+
+    await app.inject({ method: "DELETE", url: `/api/admin/articles/${id}` });
     await app.close();
   });
 

--- a/src/backend/src/lib/article-validation.test.ts
+++ b/src/backend/src/lib/article-validation.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { missingArticleFields } from "./article-validation.js";
+
+// Drafts are permissive, publishing is strict (#263).
+
+const complete = {
+  slug: "mon-article",
+  titleFr: "Titre",
+  titleEn: "Title",
+  contentFr: "<p>Contenu</p>",
+  contentEn: "<p>Content</p>",
+};
+
+describe("missingArticleFields — DRAFT", () => {
+  it("only requires slug and titleFr", () => {
+    expect(missingArticleFields({ slug: "s", titleFr: "T" }, "DRAFT")).toEqual([]);
+  });
+
+  it("reports what is missing, in a stable order", () => {
+    expect(missingArticleFields({}, "DRAFT")).toEqual(["slug", "titleFr"]);
+  });
+
+  it("never fails on a missing translation or body", () => {
+    expect(missingArticleFields({ slug: "s", titleFr: "T", titleEn: "", contentFr: "" }, "DRAFT")).toEqual([]);
+  });
+});
+
+describe("missingArticleFields — PUBLISHED", () => {
+  it("accepts a complete article", () => {
+    expect(missingArticleFields(complete, "PUBLISHED")).toEqual([]);
+  });
+
+  it("requires both languages", () => {
+    expect(missingArticleFields({ ...complete, titleEn: "" }, "PUBLISHED")).toEqual(["titleEn"]);
+    expect(missingArticleFields({ ...complete, contentEn: "" }, "PUBLISHED")).toEqual(["contentEn"]);
+  });
+
+  it("lists every missing field at once", () => {
+    expect(missingArticleFields({ slug: "s", titleFr: "T" }, "PUBLISHED")).toEqual([
+      "titleEn",
+      "contentFr",
+      "contentEn",
+    ]);
+  });
+
+  it("treats an empty rich-text editor as empty content", () => {
+    // Tiptap sends <p></p> for an untouched editor — that is not content.
+    expect(missingArticleFields({ ...complete, contentEn: "<p></p>" }, "PUBLISHED")).toEqual(["contentEn"]);
+    expect(missingArticleFields({ ...complete, contentFr: "<p>&nbsp;</p>" }, "PUBLISHED")).toEqual(["contentFr"]);
+  });
+
+  it("accepts content that only carries markup around real text", () => {
+    expect(missingArticleFields({ ...complete, contentEn: "<p><strong>Hi</strong></p>" }, "PUBLISHED")).toEqual([]);
+  });
+
+  it("ignores whitespace-only titles", () => {
+    expect(missingArticleFields({ ...complete, titleEn: "   " }, "PUBLISHED")).toEqual(["titleEn"]);
+  });
+});

--- a/src/backend/src/lib/article-validation.ts
+++ b/src/backend/src/lib/article-validation.ts
@@ -1,0 +1,45 @@
+// Article completeness rules (#263).
+//
+// Saving and publishing have different bars: a draft is work in progress and
+// must always be storable, while publishing is what guarantees a complete
+// bilingual article on the public site.
+
+export interface ArticleFields {
+  slug?: string | null;
+  titleFr?: string | null;
+  titleEn?: string | null;
+  contentFr?: string | null;
+  contentEn?: string | null;
+}
+
+// Rich-text content arrives as HTML: an "empty" Tiptap editor still sends
+// <p></p>, so strip tags (and non-breaking spaces) before judging emptiness.
+function isBlank(value: string | null | undefined): boolean {
+  if (!value) return true;
+  return !value.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim();
+}
+
+// The minimum to store anything at all — without these an article has no
+// identity and could not be listed or reopened.
+const DRAFT_REQUIRED = ["slug", "titleFr"] as const;
+
+// Everything a published article needs to stand on its own in both languages.
+// Excerpt and image stay optional: the excerpt falls back to the content, and
+// not every article carries an illustration.
+const PUBLISHED_REQUIRED = ["slug", "titleFr", "titleEn", "contentFr", "contentEn"] as const;
+
+/**
+ * Returns the names of the fields missing for the target status, in the order
+ * listed above. Empty array means the article may be saved / published.
+ *
+ * Pass the *resulting* article state, not just the request body: a partial
+ * update that flips the status to PUBLISHED must be judged on what the article
+ * will look like once merged, otherwise the check is trivially bypassed.
+ */
+export function missingArticleFields(
+  article: ArticleFields,
+  status: "DRAFT" | "PUBLISHED",
+): string[] {
+  const required = status === "PUBLISHED" ? PUBLISHED_REQUIRED : DRAFT_REQUIRED;
+  return required.filter((field) => isBlank(article[field]));
+}

--- a/src/backend/src/routes/admin/articles.ts
+++ b/src/backend/src/routes/admin/articles.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateArticle } from "../../lib/revalidate.js";
 import { sanitizeRichHtml } from "../../lib/sanitize.js";
+import { missingArticleFields } from "../../lib/article-validation.js";
 import {
   isConfigured as translationConfigured,
   QuotaExhaustedError,
@@ -126,16 +127,17 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
   app.post<{ Body: ArticleBody }>("/articles", async (request, reply) => {
     const body = request.body;
 
-    // titleEn is optional at creation (#262): the AI translation only runs on an
+    // Drafts stay permissive, publishing is strict (#263). titleEn in particular
+    // is optional until publication: the AI translation only runs on an
     // already-saved article, so requiring it up front made a FR-only draft
-    // impossible to create. The sitemap already gates /en on a non-empty titleEn.
-    const missing = [
-      !body.slug?.trim() && "slug",
-      !body.titleFr?.trim() && "titleFr",
-    ].filter(Boolean) as string[];
+    // impossible to create (#262).
+    const targetStatus = body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT";
+    const missing = missingArticleFields(body, targetStatus);
     if (missing.length) {
       return reply.status(400).send({
-        error: `Champs obligatoires manquants : ${missing.join(", ")}`,
+        error: targetStatus === "PUBLISHED"
+          ? `Publication impossible, champs manquants : ${missing.join(", ")}`
+          : `Champs obligatoires manquants : ${missing.join(", ")}`,
         fields: missing,
       });
     }
@@ -191,6 +193,31 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
 
     const newContentFr = body.contentFr !== undefined ? sanitizeRichHtml(body.contentFr) : existing.contentFr;
     const newContentEn = body.contentEn !== undefined ? sanitizeRichHtml(body.contentEn) : existing.contentEn;
+
+    // Validate what the article will look like once merged, not just the body:
+    // a partial update flipping the status to PUBLISHED must still be complete
+    // (#263). Publishing is the gate, saving a draft never fails on completeness.
+    const targetStatus = body.publicationStatus === "PUBLISHED"
+      ? "PUBLISHED"
+      : body.publicationStatus === "DRAFT"
+        ? "DRAFT"
+        : existing.publicationStatus;
+    const merged = {
+      slug: body.slug?.trim() || existing.slug,
+      titleFr: body.titleFr?.trim() || existing.titleFr,
+      titleEn: body.titleEn?.trim() || existing.titleEn,
+      contentFr: newContentFr,
+      contentEn: newContentEn,
+    };
+    const missing = missingArticleFields(merged, targetStatus);
+    if (missing.length) {
+      return reply.status(400).send({
+        error: targetStatus === "PUBLISHED"
+          ? `Publication impossible, champs manquants : ${missing.join(", ")}`
+          : `Champs obligatoires manquants : ${missing.join(", ")}`,
+        fields: missing,
+      });
+    }
 
     // If the editor sent an explicit flag, honour it. Otherwise auto-clear
     // the auto-translated flag whenever the corresponding content actually


### PR DESCRIPTION
## Summary

La sauvegarde et la publication appliquaient la même validation, empêchant d'enregistrer un travail en cours. Les deux sont désormais dissociées : **c'est la publication qui garantit la complétude**, pas la sauvegarde.

| Champ | DRAFT | PUBLISHED |
|---|:---:|:---:|
| `slug` | requis | requis |
| `titleFr` | requis | requis |
| `titleEn` | optionnel | **requis** |
| `contentFr` | optionnel | **requis** |
| `contentEn` | optionnel | **requis** |
| `excerptFr/En`, `imageUrl` | optionnel | optionnel |

L'extrait et l'image restent optionnels : l'extrait a un fallback sur le contenu, et tous les articles n'ont pas d'illustration.

## Détails

- Nouveau `lib/article-validation.ts` : `missingArticleFields(article, status)`. Le rich-text est jugé **sur son texte**, donc un éditeur non touché (`<p></p>`, `<p>&nbsp;</p>`) compte comme vide.
- **POST et PUT valident l'état _résultant_**, pas le body : un PUT partiel `{ publicationStatus: "PUBLISHED" }` contournerait sinon complètement le contrôle. C'est le cas le plus important, couvert par un test dédié.
- Le 400 nomme les champs manquants et préfixe « Publication impossible » quand il s'agit d'une publication — le front l'affiche déjà depuis #262.
- **UI inchangée** (option retenue) : le sélecteur Brouillon/Publié et le bouton Sauvegarder restent tels quels ; l'erreur au save porte l'information.

## Test plan

- [x] `tsc` backend, lint front (0 erreur)
- [x] **312 tests backend** (+12) : 9 unitaires sur le helper (dont `<p></p>` et espaces insécables), 3 d'intégration — publication incomplète refusée puis acceptée une fois complétée, création directe en PUBLISHED refusée, sauvegarde de brouillon toujours permissive
- [x] Vérif navigateur **en EDITOR**, parcours complet :
  - Brouillon FR-only → enregistré sans erreur
  - Bascule en Publié → refus « **Publication impossible, champs manquants : titleEn, contentFr, contentEn** », et l'article **reste DRAFT** en base (vérifié en SQL)
  - Complétion FR + EN → publication réussie, `publishedAt` renseigné

## Note

Deux tests existants créaient des articles PUBLISHED avec un contenu vide. Ils portent sur la gestion de `publishedAt`, pas sur la validation : leur fixture reçoit désormais du contenu, leur intention est inchangée.

Refs #263
