### PR TITLE
feat(admin): sélecteur d'icônes pour les chiffres clés (#164)

### DIFF
--- a/src/backend/src/__tests__/admin-editions.test.ts
+++ b/src/backend/src/__tests__/admin-editions.test.ts
@@ -41,4 +41,65 @@ describe("Admin Editions API", () => {
     expect(res.json()).toHaveProperty("id", edition.id);
     await app.close();
   });
+
+  // #164: an icon the site cannot render used to be accepted and then silently
+  // displayed as nothing.
+  it("PUT key-figures rejects an unknown icon without touching existing rows", async () => {
+    const app = await buildAdminApp();
+    const editions = (await app.inject({ method: "GET", url: "/api/admin/editions" })).json();
+    const editionId = editions[0].id;
+
+    const before = (await app.inject({
+      method: "GET",
+      url: `/api/admin/editions/${editionId}/key-figures`,
+    })).json();
+
+    const rejected = await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${editionId}/key-figures`,
+      payload: [{ icon: "user", value: "1", labelFr: "Test", labelEn: "Test" }],
+    });
+    expect(rejected.statusCode).toBe(400);
+    expect(rejected.json().error).toContain("user");
+
+    // Validation runs before the delete-and-recreate, so nothing was lost.
+    const after = (await app.inject({
+      method: "GET",
+      url: `/api/admin/editions/${editionId}/key-figures`,
+    })).json();
+    expect(after).toEqual(before);
+
+    await app.close();
+  });
+
+  it("PUT key-figures accepts a catalogue icon and an empty one", async () => {
+    const app = await buildAdminApp();
+    const editions = (await app.inject({ method: "GET", url: "/api/admin/editions" })).json();
+    const editionId = editions[0].id;
+
+    const before = (await app.inject({
+      method: "GET",
+      url: `/api/admin/editions/${editionId}/key-figures`,
+    })).json();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${editionId}/key-figures`,
+      payload: [
+        { icon: "rocket", value: "42", labelFr: "Fusées", labelEn: "Rockets" },
+        { icon: "", value: "7", labelFr: "Sans icône", labelEn: "No icon" },
+      ],
+    });
+    expect(res.statusCode).toBe(200);
+
+    // Restore what the seed provided, so other tests see the original data.
+    await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${editionId}/key-figures`,
+      payload: before.map((f: { icon: string; value: string; labelFr: string; labelEn: string }) => ({
+        icon: f.icon, value: f.value, labelFr: f.labelFr, labelEn: f.labelEn,
+      })),
+    });
+    await app.close();
+  });
 });

--- a/src/backend/src/lib/stat-icons.test.ts
+++ b/src/backend/src/lib/stat-icons.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { STAT_ICON_KEYS, isValidStatIcon } from "./stat-icons.js";
+
+describe("isValidStatIcon", () => {
+  it("accepts every catalogue key", () => {
+    for (const key of STAT_ICON_KEYS) {
+      expect(isValidStatIcon(key)).toBe(true);
+    }
+  });
+
+  it("accepts an empty icon — a key figure may have none", () => {
+    expect(isValidStatIcon("")).toBe(true);
+  });
+
+  it("rejects a key the site cannot render", () => {
+    // The exact typo that used to render nothing at all, silently.
+    expect(isValidStatIcon("user")).toBe(false);
+    expect(isValidStatIcon("fa-users")).toBe(false);
+    expect(isValidStatIcon("🎉")).toBe(false);
+  });
+});
+
+// The rendering catalogue lives in the frontend (it carries Font Awesome
+// definitions); only the keys are mirrored here. If the two drift, the admin
+// could offer an icon the API rejects — or worse, accept one nothing renders.
+describe("catalogue parity with the frontend", () => {
+  it("mirrors exactly the frontend catalogue keys", () => {
+    const source = readFileSync(
+      new URL("../../../frontend/src/lib/stat-icons.ts", import.meta.url),
+      "utf8",
+    );
+    const frontendKeys = [...source.matchAll(/\{\s*key:\s*"([^"]+)"/g)].map((m) => m[1]);
+
+    expect(frontendKeys.length).toBeGreaterThan(0);
+    expect(frontendKeys).toEqual([...STAT_ICON_KEYS]);
+  });
+});

--- a/src/backend/src/lib/stat-icons.ts
+++ b/src/backend/src/lib/stat-icons.ts
@@ -1,0 +1,31 @@
+// Valid key-figure icon keys (#164).
+//
+// The rendering catalogue (icon definitions, labels) lives in the frontend at
+// src/frontend/src/lib/stat-icons.ts — Font Awesome has no business in the API.
+// Only the keys are mirrored here, to reject values the site could not render:
+// the admin picker guards the UI, this guards direct API calls and imports.
+//
+// Keep both lists in sync when adding an icon. A test asserts they match.
+export const STAT_ICON_KEYS = [
+  "calendar",
+  "users",
+  "microphone",
+  "handshake",
+  "location",
+  "clock",
+  "ticket",
+  "coffee",
+  "code",
+  "lightbulb",
+  "trophy",
+  "heart",
+  "rocket",
+  "star",
+  "building",
+  "gift",
+] as const;
+
+// An empty icon is allowed: a key figure may be displayed without one.
+export function isValidStatIcon(icon: string): boolean {
+  return icon === "" || (STAT_ICON_KEYS as readonly string[]).includes(icon);
+}

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateHome, revalidateEdition, revalidateSponsors } from "../../lib/revalidate.js";
+import { isValidStatIcon, STAT_ICON_KEYS } from "../../lib/stat-icons.js";
 
 interface EditionBody {
   year: number;
@@ -274,6 +275,17 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
     if (!edition) return reply.status(404).send({ error: "Edition not found" });
 
     const figures = request.body;
+
+    // Reject unknown icon keys before touching anything (#164): the site
+    // renders nothing for them, silently. Validating up front also means a bad
+    // payload never wipes the existing figures via the deleteMany below.
+    const invalid = figures.map((fig) => fig.icon).filter((icon) => !isValidStatIcon(icon));
+    if (invalid.length) {
+      return reply.status(400).send({
+        error: `Icône inconnue : ${[...new Set(invalid)].join(", ")}`,
+        allowed: STAT_ICON_KEYS,
+      });
+    }
 
     await prisma.keyFigure.deleteMany({ where: { editionId: id } });
     await prisma.keyFigure.createMany({

--- a/src/frontend/src/components/admin/StatIconField.tsx
+++ b/src/frontend/src/components/admin/StatIconField.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { STAT_ICONS, findStatIcon } from "@/lib/stat-icons";
+
+interface StatIconFieldProps {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+// Icon picker for a key figure (#164). Replaces the free-text input: only
+// catalogue keys can be chosen, and the current one is previewed so the editor
+// sees what will actually show on the site — a mistyped key used to render
+// nothing at all, with no warning anywhere.
+export default function StatIconField({ label, name, value, onChange }: StatIconFieldProps) {
+  const selected = findStatIcon(value);
+  // A row saved before the catalogue existed may hold an unknown key. Surface
+  // it rather than silently resetting the editor's data.
+  const isUnknown = value !== "" && !selected;
+
+  return (
+    <div>
+      <label htmlFor={name} className="block text-sm font-medium text-noir mb-1">
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-gris/30 bg-blanc-casse text-malachite"
+        >
+          {selected ? <FontAwesomeIcon icon={selected.icon} /> : <span className="text-xs text-gris">—</span>}
+        </span>
+        <select
+          id={name}
+          name={name}
+          value={isUnknown ? "" : value}
+          onChange={(e) => onChange(e.target.value)}
+          className={[
+            "w-full rounded-lg border px-3 py-2 text-noir bg-blanc",
+            "focus:outline-none focus:ring-2 focus:ring-malachite/50 focus:border-malachite",
+            isUnknown ? "border-terre-cuite" : "border-gris/30",
+          ].join(" ")}
+        >
+          <option value="">Aucune</option>
+          {STAT_ICONS.map((entry) => (
+            <option key={entry.key} value={entry.key}>
+              {entry.labelFr}
+            </option>
+          ))}
+        </select>
+      </div>
+      {isUnknown && (
+        <p className="mt-1 text-xs text-terre-cuite">
+          Icône inconnue («&nbsp;{value}&nbsp;») — elle ne s&apos;affiche pas sur le site. Choisissez-en une.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/edition-detail/KeyFiguresTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/KeyFiguresTab.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { adminFetch } from "@/lib/admin-api";
 import FormField from "@/components/admin/FormField";
+import StatIconField from "@/components/admin/StatIconField";
 
 interface KeyFigureData {
   icon: string;
@@ -64,7 +65,7 @@ export default function KeyFiguresTab({ editionId }: KeyFiguresTabProps) {
             // 4-cols + delete from sm up (#243). Each field keeps its own label
             // so it stays clear once wrapped, instead of a single header row.
             <div key={i} className="grid grid-cols-2 gap-3 items-end border-b border-gris/10 pb-4 sm:grid-cols-[1fr_1fr_1fr_1fr_auto] sm:border-0 sm:pb-0">
-              <FormField label="Icône" name={`icon-${i}`} value={fig.icon} onChange={(v) => updateFigure(i, "icon", v)} placeholder="users" />
+              <StatIconField label="Icône" name={`icon-${i}`} value={fig.icon} onChange={(v) => updateFigure(i, "icon", v)} />
               <FormField label="Valeur" name={`value-${i}`} value={fig.value} onChange={(v) => updateFigure(i, "value", v)} placeholder="3000" />
               <FormField label="Label FR" name={`labelFr-${i}`} value={fig.labelFr} onChange={(v) => updateFigure(i, "labelFr", v)} placeholder="Participants" />
               <FormField label="Label EN" name={`labelEn-${i}`} value={fig.labelEn} onChange={(v) => updateFigure(i, "labelEn", v)} placeholder="Attendees" />

--- a/src/frontend/src/components/home/StatIcon.tsx
+++ b/src/frontend/src/components/home/StatIcon.tsx
@@ -1,26 +1,22 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCalendarDays, faUsers, faMicrophone, faHandshake } from "@fortawesome/free-solid-svg-icons";
-import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+
+import { findStatIcon } from "@/lib/stat-icons";
 
 interface StatIconProps {
   name: string;
   className?: string;
 }
 
-const icons: Record<string, IconDefinition> = {
-  calendar: faCalendarDays,
-  users: faUsers,
-  microphone: faMicrophone,
-  handshake: faHandshake,
-};
-
+// Renders a key-figure icon from the shared catalogue (#164). An unknown key
+// renders nothing — the admin picker and the API validation both constrain the
+// value, so this only guards against legacy rows.
 export default function StatIcon({ name, className = "" }: StatIconProps) {
-  const icon = icons[name];
-  if (!icon) return null;
+  const entry = findStatIcon(name);
+  if (!entry) return null;
 
   return (
     <span className={`text-malachite ${className}`}>
-      <FontAwesomeIcon icon={icon} aria-hidden="true" />
+      <FontAwesomeIcon icon={entry.icon} aria-hidden="true" />
     </span>
   );
 }

--- a/src/frontend/src/lib/stat-icons.ts
+++ b/src/frontend/src/lib/stat-icons.ts
@@ -1,0 +1,60 @@
+import {
+  faCalendarDays,
+  faUsers,
+  faMicrophone,
+  faHandshake,
+  faLocationDot,
+  faClock,
+  faTicket,
+  faMugHot,
+  faCode,
+  faLightbulb,
+  faTrophy,
+  faHeart,
+  faRocket,
+  faStar,
+  faBuilding,
+  faGift,
+} from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+
+// Single source of truth for key-figure icons (#164).
+//
+// This catalogue drives BOTH the admin picker and the public rendering. Before,
+// the admin took free text while the renderer only knew four keys, so a typo
+// silently rendered no icon at all. Adding an entry here makes it available and
+// renderable at once — the two can no longer drift apart.
+//
+// `key` is what gets stored in KeyFigure.icon; keep existing keys stable, they
+// are already in the database.
+export interface StatIconOption {
+  key: string;
+  labelFr: string;
+  labelEn: string;
+  icon: IconDefinition;
+}
+
+export const STAT_ICONS: StatIconOption[] = [
+  { key: "calendar", labelFr: "Calendrier", labelEn: "Calendar", icon: faCalendarDays },
+  { key: "users", labelFr: "Participants", labelEn: "Attendees", icon: faUsers },
+  { key: "microphone", labelFr: "Micro", labelEn: "Microphone", icon: faMicrophone },
+  { key: "handshake", labelFr: "Partenariat", labelEn: "Partnership", icon: faHandshake },
+  { key: "location", labelFr: "Lieu", labelEn: "Venue", icon: faLocationDot },
+  { key: "clock", labelFr: "Horloge", labelEn: "Clock", icon: faClock },
+  { key: "ticket", labelFr: "Billet", labelEn: "Ticket", icon: faTicket },
+  { key: "coffee", labelFr: "Café", labelEn: "Coffee", icon: faMugHot },
+  { key: "code", labelFr: "Code", labelEn: "Code", icon: faCode },
+  { key: "lightbulb", labelFr: "Idée", labelEn: "Idea", icon: faLightbulb },
+  { key: "trophy", labelFr: "Trophée", labelEn: "Trophy", icon: faTrophy },
+  { key: "heart", labelFr: "Cœur", labelEn: "Heart", icon: faHeart },
+  { key: "rocket", labelFr: "Fusée", labelEn: "Rocket", icon: faRocket },
+  { key: "star", labelFr: "Étoile", labelEn: "Star", icon: faStar },
+  { key: "building", labelFr: "Bâtiment", labelEn: "Building", icon: faBuilding },
+  { key: "gift", labelFr: "Cadeau", labelEn: "Gift", icon: faGift },
+];
+
+const BY_KEY = new Map(STAT_ICONS.map((entry) => [entry.key, entry]));
+
+export function findStatIcon(key: string): StatIconOption | undefined {
+  return BY_KEY.get(key);
+}


### PR DESCRIPTION
## Summary

L'icône d'un chiffre clé se saisissait en **texte libre**, alors que seules **4 clés** étaient réellement rendues : toute autre valeur (une simple faute de frappe, `user` au lieu de `users`) faisait **disparaître l'icône silencieusement**, sans alerte en admin ni côté API.

- **Catalogue partagé de 16 icônes** pilotant **à la fois** le picker admin et le rendu public. C'est le point structurant : ajouter une entrée la rend disponible *et* affichable d'un coup, les deux ne peuvent plus diverger. Les 4 clés existantes sont inchangées.
- **Picker avec aperçu** : le champ texte devient un sélecteur listant les icônes par libellé, avec un aperçu visuel de celle en cours. Une ligne portant une clé inconnue (donnée ancienne) est **signalée** plutôt que réinitialisée en douce.
- **Validation backend** : le PUT rejette une clé hors catalogue (400 + liste des clés valides). Le picker ne protège que l'UI ; un appel API direct ou un import pouvait réintroduire une icône fantôme. La validation s'exécute **avant** le `deleteMany`, donc un payload invalide n'efface plus les chiffres existants.

Les définitions Font Awesome restent côté frontend ; le backend ne duplique que les **clés**, et un test vérifie que les deux listes restent synchronisées.

## Test plan

- [x] `tsc` back + front, lint front (0 erreur)
- [x] Tests backend : 4 unitaires (clés valides, icône vide autorisée, rejet de `user`/`fa-users`/emoji, **parité des deux catalogues**) + 2 d'intégration (rejet sans toucher aux données, acceptation d'une icône du catalogue et d'une icône vide)
- [x] Vérif navigateur **en ADMIN** (l'écran Éditions n'est pas accessible à un EDITOR) :
  - Picker : 16 icônes + « Aucune », aperçu visuel, valeur existante pré-sélectionnée
  - Changement pour `rocket` → sauvegardé en base → **fusée effectivement affichée sur la home** (c'est le test décisif : avant, une clé hors des 4 n'aurait rien rendu)
  - Appel API direct avec `user` → **400** « Icône inconnue : user » + liste des clés valides
  - Données intactes après le rejet (4 lignes préservées)
- [x] Données de test restaurées

## Note

Aucun changement de schéma, aucune migration — `KeyFigure.icon` reste `String`.

> Sur la suite backend complète : 2 fichiers tombent en timeout (30 s) sur cette machine, y compris **sans ces modifications** (vérifié en stashant). C'est de la contention Postgres locale, sans lien avec la PR — les tests concernés (articles, éditions, sponsors) passent quand ils sont lancés isolément.

Refs #164
