### PR TITLE
chore(version): remonter la 1.3.0 de main vers la ligne dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,58 @@ GitHub). Voir [`docs/mise-en-production.md`](docs/mise-en-production.md).
 
 _Changements mergés sur `dev` (beta), pas encore en production._
 
+## [1.3.0] - 2026-07-18
+
+Grande promotion du Lot 2/3 en production : back-office complet (speakers,
+sessions, sponsors, catégories), programme public riche, import Sessionize, et
+une série d'améliorations UX/SEO/mobile.
+
+### Ajouté
+
+- **Programme public** : liste des conférences de l'édition en cours, avec
+  recherche et filtres (format, niveau, catégorie, langue) dont l'état est
+  partagé dans l'URL (#107, #207).
+- **Filtres compacts** : niveau et langue repliés derrière « Plus de filtres »
+  sur desktop (#246) ; sur mobile, toute la zone de filtres est repliée derrière
+  un bouton « Filtres » avec badge du nombre de filtres actifs (#256).
+- **Avatars des speakers** en bulles sur les cartes de conférences (#248).
+- **Filtres des actualités** par édition et par tag (#179).
+- **Fiche speaker** : le speaker consulte ses sessions retenues (lecture seule)
+  depuis son lien de modification (#229).
+- **Saisie bilingue FR/EN par onglets de langue** dans l'admin et sur la page de
+  modification (#222).
+- **Web app manifest + `theme-color`** (PWA de base : ajout à l'écran d'accueil,
+  barre d'outils mobile aux couleurs de la marque) (#234).
+- **Jetons d'API** : rotation d'un jeton en place (#227) et création avec date
+  d'expiration (#228).
+- **Import Sessionize** : rapatriement local des photos de speakers, et
+  reconnaissance des formats/niveaux/langues (#205, #247).
+
+### Corrigé
+
+- **Import Sessionize** : la langue était mal mappée (fausses catégories
+  « Français »/« English »), le niveau « Avancé » et le format « Workshop »
+  n'étaient pas reconnus ; ajout de la valeur `WORKSHOP` et d'avertissements
+  d'import (#247).
+- **Contact** : ajout d'un `Reply-To` vers l'adresse du visiteur sur la
+  notification, et mise en copie de l'organisation sur la confirmation de
+  demande de plaquette (#230).
+- **SEO** : `eventStatus` invalide corrigé sur la home (`previousStartDate`
+  retiré, #239) et sur les pages bilan (`EventCompleted` → `EventScheduled`,
+  #240).
+- **Revalidation du cache** inopérante en production, faute de `FRONTEND_URL`
+  scopé par environnement (#232).
+- **Admin mobile** : bouton « Enregistrer » masqué sous la barre du navigateur
+  (#257) ; listes « Données » impossibles à scroller au-delà de ~10 lignes
+  (#244) ; scroll des onglets qui décalait la page (#233) ; colonnes FR/EN des
+  avantages de plan sponsor qui débordaient (#243).
+- **Fiche speaker/sponsor** : page de modification illisible sur PC + upload de
+  logo manquant (#241).
+
+### Modifié
+
+- **CI** : exécution des tests backend activée (Postgres + seed) (#236).
+
 ## [1.1.3] - 2026-07-10
 
 Correctif d'infrastructure : prépare des déploiements sans coupure.

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devfest-toulouse-backend",
-  "version": "1.1.3",
+  "version": "1.3.0",
   "description": "DevFest Toulouse 2026 — REST API backend",
   "type": "module",
   "scripts": {

--- a/src/backend/src/lib/version.ts
+++ b/src/backend/src/lib/version.ts
@@ -2,7 +2,7 @@
 // (see #171). Kept as a code constant rather than read from package.json:
 // package.json lives outside tsconfig's rootDir ("src"), so importing it would
 // break the build. An APP_VERSION env var can still override at runtime.
-export const APP_VERSION = process.env.APP_VERSION || "1.1.3";
+export const APP_VERSION = process.env.APP_VERSION || "1.3.0";
 
 // Deployment environment name (local / beta / prod). ENV_NAME already exists
 // for Docker network aliasing; here we surface it so the admin knows which

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devfest-toulouse-frontend",
-  "version": "1.1.3",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Problème

L'admin bêta affiche **v1.1.3** alors que la dernière version publiée en production est **v1.3.0** — la bêta annonce donc une version *plus ancienne* que la prod.

**Cause** : le bump SemVer se fait dans la PR de promotion vers `main`. Les commits `Release v1.2.0` (#231) et `Release v1.3.0` (#259) vivent donc **uniquement sur `main`** et n'ont jamais été redescendus. `dev` et `dev-j` sont restés à `1.1.3`.

Vérifié : ce sont les **2 seuls** commits de `main` absents de `dev`, et les seuls fichiers en écart hors code applicatif sont les 4 fichiers de versioning.

## Correctif

Reprise depuis `main` de :
- `src/backend/src/lib/version.ts` — `APP_VERSION` 1.1.3 → 1.3.0
- `src/backend/package.json` et `src/frontend/package.json` — `version` 1.1.3 → 1.3.0
- `CHANGELOG.md` — sections 1.2.0 et 1.3.0

**Ce n'est pas une nouvelle release** : c'est un rattrapage pour que la bêta annonce la version dont elle est réellement issue. Le prochain passage en prod bumpera à partir de 1.3.0.

## Contrôles

- [x] Diff des 3 manifestes : **seul le numéro de version change**, aucune dépendance touchée
- [x] `CHANGELOG.md` : **52 lignes ajoutées, 0 supprimée** (purement additif)
- [x] `git diff origin/dev-j --name-only` ne liste que ces 4 fichiers — aucun code applicatif écrasé
- [x] `tsc` backend OK

## Suite

Après merge ici, je promeus vers `dev` pour que la bêta affiche 1.3.0.
