### PR TITLE
chore(version): la ligne dev porte la version à venir (1.4.0-beta)

### DIFF
--- a/docs/mise-en-production.md
+++ b/docs/mise-en-production.md
@@ -105,6 +105,27 @@ Mettre à jour, dans la même PR :
 > Le tag git (`v1.2.3`) et la release GitHub, eux, se posent **après** le
 > déploiement vérifié (étape 6) — pas maintenant.
 
+### La ligne `dev` porte la version à venir, suffixée `-beta`
+
+Sans ça, la bêta et la prod afficheraient le **même** numéro tout en contenant
+un code différent — et rien ne le signalerait dans l'admin.
+
+Convention :
+
+| Branche | Version | Exemple |
+|---------|---------|---------|
+| `main` (prod) | version publiée | `1.3.0` |
+| `dev` / `dev-{initiale}` (bêta) | **version à venir** + `-beta` | `1.4.0-beta` |
+
+- Le suffixe dit « numéro pressenti, pas encore figé » : il reste ajustable tant
+  que la promotion n'a pas eu lieu (si le périmètre change, `1.4.0-beta` peut
+  devenir `2.0.0-beta`). C'est un pre-release SemVer valide : `1.4.0-beta` < `1.4.0`.
+- **La PR de promotion `dev → main` retire simplement le suffixe** (`1.4.0-beta`
+  → `1.4.0`) dans les 3 fichiers ci-dessus — c'est ça, le « bump » de l'étape 1.
+- **Juste après le tag**, repasser la ligne `dev` sur la version suivante en
+  `-beta` (`1.4.1-beta` ou `1.5.0-beta`), sinon la bêta réaffiche le numéro de
+  la prod. Voir l'étape 7.
+
 ---
 
 ## 2. Promouvoir le code sur `main`
@@ -269,6 +290,26 @@ Reporter la release dans [`CHANGELOG.md`](../CHANGELOG.md) (format
 hors GitHub, versionné avec le code. En pratique, l'ajouter dans la **PR de
 promotion** (étape 1) : une section `## [1.2.3] - AAAA-MM-JJ` listant les
 changements (Ajouté / Corrigé / Modifié). La release GitHub peut réutiliser ce texte.
+
+### Redescendre la version sur la ligne `dev` (à ne pas oublier)
+
+Le bump de l'étape 1 n'existe que sur `main`. Sans cette étape, `dev` et
+`dev-{initiale}` restent sur l'ancien numéro : la bêta finit par annoncer une
+version **plus ancienne que la prod**, ce qui rend le badge de l'admin trompeur.
+
+Après le tag, ouvrir une PR `main → dev` (puis `dev → dev-{initiale}`) qui :
+
+1. reporte `CHANGELOG.md` (la section de la release qui vient d'être publiée) ;
+2. repositionne les 3 fichiers de version sur la **prochaine** version en
+   pre-release — `1.4.0` publiée → `1.4.1-beta` (ou `1.5.0-beta` selon ce qui
+   s'annonce).
+
+```bash
+# Contrôle : les 3 lignes doivent concorder
+git show origin/main:src/backend/src/lib/version.ts | grep APP_VERSION  # 1.4.0
+git show origin/dev:src/backend/src/lib/version.ts  | grep APP_VERSION  # 1.4.1-beta
+curl -s https://beta.site.devfesttoulouse.fr/api/health                 # 1.4.1-beta
+```
 
 > ℹ️ La skill **`deploy-to-prod`** (`.claude/skills/deploy-to-prod`) automatise
 > le choix du bump, le rappel de tous ces garde-fous et la génération de ces

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devfest-toulouse-backend",
-  "version": "1.3.0",
+  "version": "1.4.0-beta",
   "description": "DevFest Toulouse 2026 — REST API backend",
   "type": "module",
   "scripts": {

--- a/src/backend/src/lib/version.ts
+++ b/src/backend/src/lib/version.ts
@@ -2,7 +2,11 @@
 // (see #171). Kept as a code constant rather than read from package.json:
 // package.json lives outside tsconfig's rootDir ("src"), so importing it would
 // break the build. An APP_VERSION env var can still override at runtime.
-export const APP_VERSION = process.env.APP_VERSION || "1.3.0";
+//
+// The dev line carries the *upcoming* version with a `-beta` pre-release
+// suffix, so beta never reports the same number as production while holding
+// different code. The promotion PR to `main` drops the suffix.
+export const APP_VERSION = process.env.APP_VERSION || "1.4.0-beta";
 
 // Deployment environment name (local / beta / prod). ENV_NAME already exists
 // for Docker network aliasing; here we surface it so the admin knows which

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devfest-toulouse-frontend",
-  "version": "1.3.0",
+  "version": "1.4.0-beta",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Problème

Bêta et prod affichaient toutes deux **1.3.0** alors qu'elles contiennent un code très différent (14 issues d'écart). Le badge de version de l'admin n'apprenait donc rien sur ce qui tourne réellement.

## Correctif

La ligne `dev` porte désormais la **version à venir**, suffixée `-beta` :

| Branche | Version |
|---|---|
| `main` (prod) | `1.3.0` |
| `dev` / `dev-j` (bêta) | **`1.4.0-beta`** |

Le suffixe dit « numéro pressenti, pas encore figé » — il reste ajustable tant que la promotion n'a pas eu lieu. C'est un pre-release SemVer valide (`1.4.0-beta` < `1.4.0`), et la PR de promotion vers `main` n'aura qu'à **retirer le suffixe**.

**Calibre du bump vérifié** sur le diff `main..dev`, comme le prévoit la procédure : 70 commits `feat`, **aucun** `BREAKING CHANGE` ni `feat!` → **MINOR**, donc 1.4.0.

## Documentation

`docs/mise-en-production.md` gagne deux sections :

1. **La convention `-beta`** dans l'étape 1 (bump), avec le tableau ci-dessus.
2. **L'étape manquante qui a causé la dérive** (fin de l'étape 7) : après le tag, redescendre la version vers la ligne `dev` en `-beta` suivant. Sans elle, `dev` reste sur l'ancien numéro et la bêta finit par annoncer une version *plus ancienne* que la prod — exactement ce qui vient d'arriver avec 1.2.0 et 1.3.0, restées sur `main` seulement.

## Contrôles

- [x] Les 3 fichiers de version concordent sur `1.4.0-beta`
- [x] `tsc` backend OK
- [x] Aucun code applicatif touché (seuls les 3 manifestes + la doc)

Après déploiement, `/api/health` et le badge admin doivent afficher **1.4.0-beta · beta**.
