### PR TITLE
chore(release): backport v1.4.0 et ouverture de 1.4.1-beta sur dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ GitHub). Voir [`docs/mise-en-production.md`](docs/mise-en-production.md).
 
 _Changements mergés sur `dev` (beta), pas encore en production._
 
+## [1.4.0] - 2026-07-20
+
+Épique « communication sponsors » : contacts multiples, informations privées,
+offres d'emploi et description en WYSIWYG. Côté speakers, l'édition d'une
+conférence devient un droit accordé au cas par cas. Les emails passent à la
+charte graphique.
+
+### Ajouté
+
+- **Sponsors — contacts secondaires** : plusieurs personnes par sponsor, chacune
+  avec son propre lien de modification, son verrou et sa date d'envoi (#250).
+- **Sponsors — informations privées** réservées à l'organisation : kit de
+  communication (logos web/print, charte, notes) et suivi de réception (#249).
+- **Sponsors Platinum** : contenu promotionnel et idées de co-construction (#252).
+- **Sponsors — offres d'emploi** à relayer, avec une page publique dédiée
+  « Offres d'emploi partenaires » (#251), description bilingue en WYSIWYG (#273).
+- **Sponsors — description de la fiche entreprise en WYSIWYG**, comme les
+  articles (#270), et ajout de Bluesky aux réseaux de la fiche publique (#253).
+- **Speakers — édition de leur conférence** depuis le lien de modification,
+  **en lecture seule par défaut** : l'organisation ouvre le droit conférence par
+  conférence, et uniquement sur le titre et le résumé (#260, #289).
+- **Emails à la charte graphique** : gabarit HTML commun à tous les envois (#269).
+- **Icônes des chiffres clés** sélectionnables dans l'admin (#164).
+- **Identification du build déployé** : `/api/health` expose le commit court, et
+  l'admin l'affiche en badge cliquable vers GitHub (#290).
+
+### Corrigé
+
+- **Articles** : création impossible sans titre EN, et l'erreur réelle n'était
+  pas affichée (#262) ; la sauvegarde en brouillon devient permissive, la
+  validation stricte s'applique à la publication (#263).
+- **Sponsors — « compléments par email »** : ouvre le client mail (`mailto`) au
+  lieu d'un formulaire d'envoi (#271).
+- **Menu Sponsors** : entrée dupliquée, et « Offres d'emploi » affichée même en
+  l'absence d'offre (#276).
+- **CI backend instable** : une édition de test datée 2099 captait les fixtures
+  des autres tests (#292).
+
+### Modifié
+
+- **Conférences — une seule langue** pour le titre et la description : une
+  conférence se donne dans une langue, déjà portée par son champ « langue ». Les
+  quatre colonnes bilingues fusionnent en deux ; les URL publiques sont
+  inchangées (#293).
+
 ## [1.3.0] - 2026-07-18
 
 Grande promotion du Lot 2/3 en production : back-office complet (speakers,

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devfest-toulouse-backend",
-  "version": "1.4.0-beta",
+  "version": "1.4.1-beta",
   "description": "DevFest Toulouse 2026 — REST API backend",
   "type": "module",
   "scripts": {

--- a/src/backend/src/lib/version.ts
+++ b/src/backend/src/lib/version.ts
@@ -6,7 +6,7 @@
 // The dev line carries the *upcoming* version with a `-beta` pre-release
 // suffix, so beta never reports the same number as production while holding
 // different code. The promotion PR to `main` drops the suffix.
-export const APP_VERSION = process.env.APP_VERSION || "1.4.0-beta";
+export const APP_VERSION = process.env.APP_VERSION || "1.4.1-beta";
 
 // Deployment environment name (local / beta / prod). ENV_NAME already exists
 // for Docker network aliasing; here we surface it so the admin knows which

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devfest-toulouse-frontend",
-  "version": "1.4.0-beta",
+  "version": "1.4.1-beta",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Résumé

Suite de la release **v1.4.0**, déployée et vérifiée en production
(commit `38e7e5e`, `/api/health` → `"version":"1.4.0"`).

Le bump de version n'existait que sur `main`. Cette PR le redescend sur la ligne
`dev`, comme le prévoit `docs/mise-en-production.md` §7 :

- **CHANGELOG** — la section `[1.4.0]` est reprise **telle quelle** depuis `main`,
  pour que les deux lignes portent les mêmes notes de release.
- **Version** — les 3 fichiers passent de `1.4.0-beta` à **`1.4.1-beta`**.

## Pourquoi c'est nécessaire

Sans cette étape, `dev` continue d'annoncer `1.4.0-beta` alors que la production
sert déjà `1.4.0`. La bêta afficherait donc un numéro à la fois **plus ancien que
la prod** et **déjà publié** — le badge de version de l'admin deviendrait
trompeur, ce qui est précisément ce que #171 cherchait à éviter.

Le `1.4.1-beta` est le défaut prévu par la doc : il sera bumpé en `1.5.0-beta` si
la prochaine release embarque des fonctionnalités.

## Test plan

- [x] Diff limité à 4 fichiers : CHANGELOG + les 3 emplacements de version
- [x] CHANGELOG identique à celui de `main` (repris via `git checkout origin/main`)
- [ ] Après merge : `/api/health` de la bêta annonce `1.4.1-beta`
- [ ] Les 3 lignes concordent (`main` = 1.4.0, `dev` = 1.4.1-beta, prod = 1.4.0)

## Note

Aucune issue à référencer : c'est une opération de release, pas un correctif.
