### PR TITLE
Corbeille 145b — soft-delete complet : handlers, lectures admin ET publiques (#147)

### DIFF
--- a/src/backend/src/__tests__/admin-articles.test.ts
+++ b/src/backend/src/__tests__/admin-articles.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
 import { buildAdminApp } from "./test-admin-app.js";
+import { prisma } from "../lib/prisma.js";
+
+// These tests use the DELETE endpoint as their teardown. Since #147 that only
+// moves the row to the trash, so every run used to leave its fixtures behind —
+// they piled up run after run, and their parked slugs kept holding the unique
+// index. Purge them for real once the file is done.
+afterAll(async () => {
+  await prisma.article.deleteMany({
+    where: { deletedAt: { not: null }, slug: { contains: "__trash_" } },
+  });
+  await prisma.tag.deleteMany({
+    where: { deletedAt: { not: null }, slug: { contains: "__trash_" } },
+  });
+});
 
 describe("Admin Articles API", () => {
   it("GET /api/admin/articles should list articles with pagination", async () => {

--- a/src/backend/src/__tests__/soft-delete-public.test.ts
+++ b/src/backend/src/__tests__/soft-delete-public.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import Fastify from "fastify";
+
+import { buildApp } from "./test-app.js";
+import talkRoutes from "../routes/talks.js";
+import { prisma } from "../lib/prisma.js";
+import { softDeleteData, parkUniqueValue } from "../lib/admin-helpers.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+
+// `test-app.ts` does not register the public talk routes, so the category test
+// builds its own app. Without this it 404s on every call, and asserting
+// `.category` on an error body silently passes (undefined !== null).
+async function buildTalkApp() {
+  const app = Fastify({ logger: false });
+  await app.register(talkRoutes, { prefix: "/api" });
+  return app;
+}
+
+// Part A filtered the admin reads and left the public ones untouched. A trashed
+// article was still served on `/api/articles/:slug` — a 200 on content the
+// organizers had deleted. These tests exist so that regression cannot come back
+// silently: nothing in the type system or the existing suite caught it.
+
+const createdArticleIds: number[] = [];
+const createdTalkIds: number[] = [];
+const createdCategoryIds: number[] = [];
+
+afterEach(async () => {
+  // Hard-delete the fixtures — soft delete is the thing under test, so cleaning
+  // up through it would leave rows behind on every run. Cleanup lives here
+  // rather than at the end of each test: a failing assertion aborts the test
+  // body, and inline cleanup would never run.
+  if (createdArticleIds.length) {
+    await prisma.article.deleteMany({ where: { id: { in: createdArticleIds } } });
+    createdArticleIds.length = 0;
+  }
+  if (createdTalkIds.length) {
+    await prisma.talk.deleteMany({ where: { id: { in: createdTalkIds } } });
+    createdTalkIds.length = 0;
+  }
+  if (createdCategoryIds.length) {
+    await prisma.category.deleteMany({ where: { id: { in: createdCategoryIds } } });
+    createdCategoryIds.length = 0;
+  }
+});
+
+async function createArticle(slug: string) {
+  const article = await prisma.article.create({
+    data: {
+      slug,
+      titleFr: "Article de test corbeille",
+      titleEn: "Trash test article",
+      contentFr: "<p>Contenu.</p>",
+      contentEn: "<p>Content.</p>",
+      publicationStatus: "PUBLISHED",
+      publishedAt: new Date(),
+    },
+  });
+  createdArticleIds.push(article.id);
+  return article;
+}
+
+async function trashArticle(id: number, slug: string) {
+  await prisma.article.update({
+    where: { id },
+    data: { ...softDeleteData(), slug: parkUniqueValue(slug, id) },
+  });
+}
+
+describe("public API hides trashed content (#147)", () => {
+  it("404s on a trashed article instead of serving it", async () => {
+    const app = await buildApp();
+    const slug = `zz-public-trash-${Date.now()}`;
+    const article = await createArticle(slug);
+
+    const live = await app.inject({ method: "GET", url: `/api/articles/${slug}` });
+    expect(live.statusCode).toBe(200);
+
+    await trashArticle(article.id, slug);
+
+    const trashed = await app.inject({ method: "GET", url: `/api/articles/${slug}` });
+    expect(trashed.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it("404s on the parked slug too, so the internal prefix is not a live URL", async () => {
+    const app = await buildApp();
+    const slug = `zz-public-parked-${Date.now()}`;
+    const article = await createArticle(slug);
+    await trashArticle(article.id, slug);
+
+    // Parking rewrites the slug in place. Without a deletedAt filter the row is
+    // still reachable — just under `__trash_<id>__…`, which leaks the marker.
+    const parked = await prisma.article.findUnique({ where: { id: article.id } });
+    const res = await app.inject({ method: "GET", url: `/api/articles/${parked!.slug}` });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it("drops the trashed article from the public list", async () => {
+    const app = await buildApp();
+    const slug = `zz-public-list-${Date.now()}`;
+    const article = await createArticle(slug);
+
+    const before = await app.inject({ method: "GET", url: "/api/articles?page=1" });
+    expect(JSON.stringify(before.json())).toContain(slug);
+
+    await trashArticle(article.id, slug);
+
+    const after = await app.inject({ method: "GET", url: "/api/articles?page=1" });
+    expect(JSON.stringify(after.json())).not.toContain(slug);
+
+    await app.close();
+  });
+
+  it("keeps a live talk but drops its category once the category is trashed", async () => {
+    const app = await buildTalkApp();
+    const edition = await getSeededEdition();
+
+    const category = await prisma.category.create({
+      data: { editionId: edition.id, nameFr: "ZZ Piste test", nameEn: "ZZ Test track", color: "#123456" },
+    });
+    createdCategoryIds.push(category.id);
+    const talk = await prisma.talk.create({
+      data: {
+        editionId: edition.id,
+        categoryId: category.id,
+        title: "ZZ Talk with a trashed category",
+        description: "Checks the to-one relation case.",
+        slug: `zz-cat-trash-${Date.now()}`,
+        format: "CONFERENCE",
+        language: "fr",
+        publicationStatus: "PUBLISHED",
+      },
+    });
+    createdTalkIds.push(talk.id);
+
+    // Assert the status first: `.category` on a 404 body is `undefined`, which
+    // would slip past `not.toBeNull()` and make this test pass while proving
+    // nothing.
+    const before = await app.inject({ method: "GET", url: `/api/talks/${talk.slug}` });
+    expect(before.statusCode).toBe(200);
+    expect(before.json().category).toMatchObject({ nameFr: "ZZ Piste test" });
+
+    // A to-one relation takes no `where` in Prisma, so the query cannot filter
+    // this out — only the serializer can. Without that, the trashed category
+    // would keep rendering its coloured badge on the public page.
+    await prisma.category.update({ where: { id: category.id }, data: softDeleteData() });
+
+    const after = await app.inject({ method: "GET", url: `/api/talks/${talk.slug}` });
+    expect(after.statusCode).toBe(200); // the talk itself is untouched
+    expect(after.json().category).toBeNull();
+
+    await app.close();
+  });
+});

--- a/src/backend/src/__tests__/soft-delete.test.ts
+++ b/src/backend/src/__tests__/soft-delete.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import Fastify from "fastify";
+import adminTalkRoutes from "../routes/admin/talks.js";
+import { prisma } from "../lib/prisma.js";
+import { isParkedValue, unparkUniqueValue } from "../lib/admin-helpers.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+
+// The existing DELETE tests assert "404 after delete", which a hard delete
+// satisfies just as well as a soft one — they would stay green if #147 were
+// reverted. These check what actually distinguishes the two: the row survives.
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(adminTalkRoutes, { prefix: "/api/admin" });
+  return app;
+}
+
+const createdTalkIds: number[] = [];
+
+afterEach(async () => {
+  // Hard-delete the fixtures: soft delete is what we are testing, so cleaning
+  // up with it would leave rows behind in every run.
+  if (createdTalkIds.length) {
+    await prisma.talk.deleteMany({ where: { id: { in: createdTalkIds } } });
+    createdTalkIds.length = 0;
+  }
+});
+
+async function createTalk(title: string) {
+  const edition = await getSeededEdition();
+  const talk = await prisma.talk.create({
+    data: {
+      editionId: edition.id,
+      title,
+      description: "Fixture for the soft-delete tests.",
+      slug: `soft-delete-fixture-${Date.now()}-${Math.round(performance.now() * 1000)}`,
+      format: "CONFERENCE",
+      language: "fr",
+      publicationStatus: "PUBLISHED",
+    },
+  });
+  createdTalkIds.push(talk.id);
+  return talk;
+}
+
+describe("soft delete on DELETE /api/admin/talks/:id (#147)", () => {
+  it("keeps the row in the database with deletedAt set", async () => {
+    const app = await buildApp();
+    const talk = await createTalk("Soft delete keeps the row");
+
+    const res = await app.inject({ method: "DELETE", url: `/api/admin/talks/${talk.id}` });
+    expect(res.statusCode).toBe(204);
+
+    // The point of the whole feature: the record is still there.
+    const stored = await prisma.talk.findUnique({ where: { id: talk.id } });
+    expect(stored).not.toBeNull();
+    expect(stored?.deletedAt).toBeInstanceOf(Date);
+
+    await app.close();
+  });
+
+  it("parks the slug so the live namespace frees up", async () => {
+    const app = await buildApp();
+    const talk = await createTalk("Soft delete parks the slug");
+
+    await app.inject({ method: "DELETE", url: `/api/admin/talks/${talk.id}` });
+
+    const stored = await prisma.talk.findUnique({ where: { id: talk.id } });
+    expect(isParkedValue(stored!.slug)).toBe(true);
+    expect(unparkUniqueValue(stored!.slug)).toBe(talk.slug);
+
+    await app.close();
+  });
+
+  it("hides the trashed talk from the admin list", async () => {
+    const app = await buildApp();
+    const talk = await createTalk("Soft delete hides from list");
+    const edition = await getSeededEdition();
+
+    const before = await app.inject({
+      method: "GET",
+      url: `/api/admin/talks?editionId=${edition.id}`,
+    });
+    expect(before.json().some((t: { id: number }) => t.id === talk.id)).toBe(true);
+
+    await app.inject({ method: "DELETE", url: `/api/admin/talks/${talk.id}` });
+
+    const after = await app.inject({
+      method: "GET",
+      url: `/api/admin/talks?editionId=${edition.id}`,
+    });
+    expect(after.json().some((t: { id: number }) => t.id === talk.id)).toBe(false);
+
+    await app.close();
+  });
+
+  it("returns 404 on the detail route once trashed", async () => {
+    const app = await buildApp();
+    const talk = await createTalk("Soft delete 404s on detail");
+
+    await app.inject({ method: "DELETE", url: `/api/admin/talks/${talk.id}` });
+
+    const res = await app.inject({ method: "GET", url: `/api/admin/talks/${talk.id}` });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it("refuses to trash the same talk twice", async () => {
+    const app = await buildApp();
+    const talk = await createTalk("Soft delete is not idempotent");
+
+    const first = await app.inject({ method: "DELETE", url: `/api/admin/talks/${talk.id}` });
+    expect(first.statusCode).toBe(204);
+
+    // A second DELETE must 404 rather than re-stamp deletedAt — otherwise the
+    // 30-day purge clock (#145d) would restart on every stray call.
+    const second = await app.inject({ method: "DELETE", url: `/api/admin/talks/${talk.id}` });
+    expect(second.statusCode).toBe(404);
+
+    await app.close();
+  });
+
+  it("frees the slug for a new talk carrying the same title", async () => {
+    const app = await buildApp();
+    const edition = await getSeededEdition();
+    const talk = await createTalk("Soft delete frees the slug");
+    const freedSlug = talk.slug;
+
+    await app.inject({ method: "DELETE", url: `/api/admin/talks/${talk.id}` });
+
+    // Parking exists precisely so this insert does not hit the unique index.
+    const recreated = await prisma.talk.create({
+      data: {
+        editionId: edition.id,
+        title: "Soft delete frees the slug",
+        description: "Recreated after the original went to the trash.",
+        slug: freedSlug,
+        format: "CONFERENCE",
+        language: "fr",
+        publicationStatus: "DRAFT",
+      },
+    });
+    createdTalkIds.push(recreated.id);
+
+    expect(recreated.slug).toBe(freedSlug);
+
+    await app.close();
+  });
+});

--- a/src/backend/src/lib/admin-helpers.test.ts
+++ b/src/backend/src/lib/admin-helpers.test.ts
@@ -85,6 +85,25 @@ describe("soft-delete helpers (#146)", () => {
     expect(isParkedValue("x")).toBe(false);
   });
 
+  it("round-trips with a cuid primary key (User is keyed by string, not Int)", () => {
+    const email = "jane@example.com";
+    const cuid = "clh3k2j9x0000qwer1234asdf";
+    expect(unparkUniqueValue(parkUniqueValue(email, cuid))).toBe(email);
+  });
+
+  it("keeps two rows parked under distinct ids distinct", () => {
+    // Same email parked twice must not collide, or the unique constraint that
+    // parking exists to free would be hit by the parked values themselves.
+    const a = parkUniqueValue("jane@example.com", "cuid-a");
+    const b = parkUniqueValue("jane@example.com", "cuid-b");
+    expect(a).not.toBe(b);
+  });
+
+  it("round-trips an email, whose local part may hold dots and plus signs", () => {
+    const email = "jane.doe+devfest@example.com";
+    expect(unparkUniqueValue(parkUniqueValue(email, 12))).toBe(email);
+  });
+
   it("stamps the deletion date", () => {
     const now = new Date("2026-07-20T12:00:00Z");
     expect(softDeleteData(now)).toEqual({ deletedAt: now });

--- a/src/backend/src/lib/admin-helpers.ts
+++ b/src/backend/src/lib/admin-helpers.ts
@@ -119,6 +119,22 @@ export function isParkedValue(value: string): boolean {
   return value.startsWith(TRASH_PREFIX);
 }
 
+/**
+ * Drop a to-one relation whose row sits in the trash.
+ *
+ * Prisma accepts no `where` on a to-one `include`/`select`, so a trashed
+ * category stays attached to a live talk and would keep rendering its coloured
+ * badge on the public site. The query cannot filter it; the serializer can.
+ * Select `deletedAt` on the relation and pass it through here.
+ */
+export function visibleCategory<T extends { deletedAt: Date | null }>(
+  relation: T | null,
+): Omit<T, "deletedAt"> | null {
+  if (!relation || relation.deletedAt) return null;
+  const { deletedAt: _deletedAt, ...rest } = relation;
+  return rest;
+}
+
 /** Payload marking a row as trashed. */
 export function softDeleteData(now: Date = new Date()) {
   return { deletedAt: now };

--- a/src/backend/src/lib/admin-helpers.ts
+++ b/src/backend/src/lib/admin-helpers.ts
@@ -91,8 +91,14 @@ export const onlyDeleted = { deletedAt: { not: null } } as const;
 // enforces. A visible prefix beats an invisible divergence.
 const TRASH_PREFIX = "__trash_";
 
-/** Park a unique value so the live namespace frees up. Idempotent. */
-export function parkUniqueValue(value: string, id: number): string {
+/**
+ * Park a unique value so the live namespace frees up. Idempotent.
+ *
+ * `id` is the row's primary key — an Int on most models, a cuid string on User
+ * (Better Auth owns that table). It only has to make the marker unique, so both
+ * are fine as long as the value round-trips.
+ */
+export function parkUniqueValue(value: string, id: number | string): string {
   if (isParkedValue(value)) return value;
   return `${TRASH_PREFIX}${id}__${value}`;
 }
@@ -102,7 +108,10 @@ export function parkUniqueValue(value: string, id: number): string {
  * is free, since anything could have taken the slot while the row was away.
  */
 export function unparkUniqueValue(value: string): string {
-  const match = value.match(/^__trash_\d+__(.*)$/s);
+  // The id segment is `[^_]+` rather than `\d+` so cuid keys round-trip too.
+  // Non-greedy would stop at the first `__` inside a cuid; anchoring on the
+  // first `__` after a run of non-underscore characters keeps it unambiguous.
+  const match = value.match(/^__trash_[^_]+__(.*)$/s);
   return match ? match[1] : value;
 }
 

--- a/src/backend/src/lib/auth-context.ts
+++ b/src/backend/src/lib/auth-context.ts
@@ -5,6 +5,7 @@ import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "./auth.js";
 import { prisma } from "./prisma.js";
 import { extractPrefix, verifyApiKey } from "./api-key.js";
+import { notDeleted } from "./admin-helpers.js";
 
 // Update `lastUsedAt` at most once per minute to avoid spamming the DB on
 // high-traffic keys. Good enough for "seen recently" UI hints.
@@ -30,8 +31,13 @@ async function resolveSession(request: FastifyRequest): Promise<AuthenticatedUse
   });
   if (!session) return null;
 
-  const user = await prisma.user.findUnique({
-    where: { email: session.user.email },
+  // findFirst so the trash filter can ride along: a trashed account must lose
+  // its access immediately (#147). Deleting it also parks the email, which
+  // would already make this lookup miss — but access control must not depend on
+  // that side effect. Rows trashed before #147, or half-restored, would slip
+  // through. `deletedAt` is the authority.
+  const user = await prisma.user.findFirst({
+    where: { email: session.user.email, ...notDeleted },
     select: { id: true, email: true, name: true, role: true, banned: true },
   });
   if (!user || user.banned) {
@@ -58,7 +64,12 @@ async function resolveBearer(request: FastifyRequest): Promise<AuthenticatedUser
   const apiKey = await prisma.apiKey.findUnique({
     where: { prefix },
     include: {
-      user: { select: { id: true, email: true, name: true, role: true, banned: true } },
+      // `deletedAt` comes along so the trashed-owner check below can run: the
+      // filter cannot live in the include (Prisma takes no `where` on a to-one
+      // relation), so it is enforced right after the lookup.
+      user: {
+        select: { id: true, email: true, name: true, role: true, banned: true, deletedAt: true },
+      },
     },
   });
   if (!apiKey) {
@@ -75,6 +86,13 @@ async function resolveBearer(request: FastifyRequest): Promise<AuthenticatedUser
   }
   if (apiKey.user.banned) {
     request.log.debug({ authPhase: "auth-context.bearer.reject", reason: "user_banned", keyId: apiKey.id });
+    return null;
+  }
+  // A key outlives its owner otherwise: trashing the account leaves the ApiKey
+  // row untouched (it is not cascaded, by design), so the token would keep
+  // working until the 30-day purge (#147).
+  if (apiKey.user.deletedAt) {
+    request.log.debug({ authPhase: "auth-context.bearer.reject", reason: "user_trashed", keyId: apiKey.id });
     return null;
   }
 

--- a/src/backend/src/lib/contact-webhook.ts
+++ b/src/backend/src/lib/contact-webhook.ts
@@ -1,5 +1,6 @@
 import { prisma } from "./prisma.js";
 import { validateWebhookUrl } from "./webhook-url.js";
+import { notDeleted } from "./admin-helpers.js";
 
 // Common shape of the JSON sent to the configured webhook URL.
 // Mirrors what the form already POSTed before this refactor — keep
@@ -113,8 +114,10 @@ export async function sendContactWebhook(
 
 /** Build the payload from a stored ContactMessage (used by the retry endpoint). */
 export async function buildPayloadFromStored(messageId: number): Promise<ContactWebhookPayload | null> {
-  const m = await prisma.contactMessage.findUnique({
-    where: { id: messageId },
+  // findFirst so the trash filter fits (#147): re-sending the webhook for a
+  // message the organizers deleted would push it back out to third parties.
+  const m = await prisma.contactMessage.findFirst({
+    where: { id: messageId, ...notDeleted },
     include: { category: true },
   });
   if (!m) return null;

--- a/src/backend/src/lib/sessionize-import.ts
+++ b/src/backend/src/lib/sessionize-import.ts
@@ -212,6 +212,10 @@ export async function importSessionize(
   }
 
   // 2. Upsert track categories, keyed by nameFr within the edition.
+  // Deliberately NOT filtered on deletedAt (#147): these lookups drive upserts,
+  // so they must see trashed rows. Skipping them would recreate a category that
+  // already exists in the trash, and the slug sets below would hand out names
+  // still held by trashed rows — the create would then hit the unique index.
   const existingCategories = await prisma.category.findMany({
     where: { editionId },
     select: { id: true, nameFr: true },

--- a/src/backend/src/lib/sponsor-contact.ts
+++ b/src/backend/src/lib/sponsor-contact.ts
@@ -1,11 +1,15 @@
 import { prisma } from "./prisma.js";
+import { notDeleted } from "./admin-helpers.js";
 
 // Where sponsor-related notifications go (e.g. a sponsor sending com-kit
 // complements, #249). Reuses the "sponsoring" contact category recipients so
 // the address stays configurable in the admin, with a safe fallback.
 export async function getSponsorContactRecipients(): Promise<string[]> {
-  const category = await prisma.contactCategory.findUnique({
-    where: { slug: "sponsoring" },
+  // findFirst carries the trash filter (#147). A trashed category falls through
+  // to the default address below — better a fallback that reaches someone than
+  // recipients the organizers deleted.
+  const category = await prisma.contactCategory.findFirst({
+    where: { slug: "sponsoring", ...notDeleted },
   });
   const recipients = category?.emailRecipients
     ?.split(",")

--- a/src/backend/src/routes/admin/articles.ts
+++ b/src/backend/src/routes/admin/articles.ts
@@ -3,6 +3,7 @@ import { prisma } from "../../lib/prisma.js";
 import { revalidateArticle } from "../../lib/revalidate.js";
 import { sanitizeRichHtml } from "../../lib/sanitize.js";
 import { missingArticleFields } from "../../lib/article-validation.js";
+import { notDeleted, notFound, parkUniqueValue, softDeleteData } from "../../lib/admin-helpers.js";
 import {
   isConfigured as translationConfigured,
   QuotaExhaustedError,
@@ -52,7 +53,9 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
     const limit = Math.min(Number(request.query.limit) || 20, 100);
     const status = request.query.status;
 
-    const where = status ? { publicationStatus: status as "DRAFT" | "PUBLISHED" } : {};
+    const where = status
+      ? { publicationStatus: status as "DRAFT" | "PUBLISHED", ...notDeleted }
+      : { ...notDeleted };
 
     const [articles, total] = await Promise.all([
       prisma.article.findMany({
@@ -60,7 +63,10 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
         orderBy: [{ publishedAt: { sort: "desc", nulls: "first" } }, { createdAt: "desc" }],
         skip: (page - 1) * limit,
         take: limit,
-        include: { tags: true, editions: true },
+        // Nested reads need their own filter: a query extension would not reach
+        // them (Prisma applies those to the top-level operation only), and a
+        // trashed tag or edition would otherwise still show up on a live article.
+        include: { tags: { where: notDeleted }, editions: { where: notDeleted } },
       }),
       prisma.article.count({ where }),
     ]);
@@ -94,9 +100,11 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const article = await prisma.article.findUnique({
-      where: { id },
-      include: { tags: true, editions: true },
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const article = await prisma.article.findFirst({
+      where: { id, ...notDeleted },
+      include: { tags: { where: notDeleted }, editions: { where: notDeleted } },
     });
 
     if (!article) return reply.status(404).send({ error: "Article not found" });
@@ -142,6 +150,10 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
       });
     }
 
+    // Deliberately NOT filtered on deletedAt: uniqueness is a database-wide
+    // constraint, so a trashed article still owns its slug until purged. Parking
+    // frees the readable form, but a row keeping an unparked slug (restored, or
+    // trashed before #147) must still be detected or the create would collide.
     const existing = await prisma.article.findUnique({ where: { slug: body.slug.trim() } });
     if (existing) {
       return reply.status(409).send({ error: "An article with this slug already exists" });
@@ -183,7 +195,9 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const existing = await prisma.article.findUnique({ where: { id } });
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const existing = await prisma.article.findFirst({ where: { id, ...notDeleted } });
     if (!existing) return reply.status(404).send({ error: "Article not found" });
 
     const body = request.body;
@@ -278,7 +292,9 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const article = await prisma.article.findUnique({ where: { id } });
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const article = await prisma.article.findFirst({ where: { id, ...notDeleted } });
     if (!article) return reply.status(404).send({ error: "Article not found" });
 
     const from = request.body?.from;
@@ -357,24 +373,31 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
     }
   });
 
-  // DELETE /api/admin/articles/:id
+  // DELETE /api/admin/articles/:id — moves the article to the trash (#147). The
+  // row survives with `deletedAt` set; #145c restores it, #145d purges it.
   app.delete<{
     Params: { id: string };
   }>("/articles/:id", async (request, reply) => {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const existing = await prisma.article.findUnique({ where: { id } });
-    if (!existing) return reply.status(404).send({ error: "Article not found" });
+    const existing = await prisma.article.findFirst({ where: { id, ...notDeleted } });
+    if (!existing) return notFound(reply, "Article");
 
-    await prisma.article.delete({ where: { id } });
+    // The slug is globally unique and a trashed row keeps its slot, so park it
+    // out of the live namespace — otherwise re-creating an article under the
+    // same slug would hit the constraint (#146).
+    await prisma.article.update({
+      where: { id },
+      data: { ...softDeleteData(), slug: parkUniqueValue(existing.slug, id) },
+    });
     revalidateArticle(existing.slug);
     return { success: true };
   });
 
   // GET /api/admin/tags — list all tags
   app.get("/tags", async () => {
-    return prisma.tag.findMany({ orderBy: { name: "asc" } });
+    return prisma.tag.findMany({ where: notDeleted, orderBy: { name: "asc" } });
   });
 
   // POST /api/admin/tags — create a tag
@@ -391,6 +414,10 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "");
 
+    // Deliberately NOT filtered on deletedAt: both `name` and `slug` are
+    // database-wide unique constraints, so a trashed tag still owns them until
+    // purged. Parking frees the readable form, but a row keeping unparked
+    // values (restored, or trashed before #147) must still be detected.
     const existing = await prisma.tag.findFirst({
       where: { OR: [{ name }, { slug }] },
     });
@@ -400,14 +427,27 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
     return reply.status(201).send(tag);
   });
 
-  // DELETE /api/admin/tags/:id
+  // DELETE /api/admin/tags/:id — moves the tag to the trash (#147).
   app.delete<{
     Params: { id: string };
   }>("/tags/:id", async (request, reply) => {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    await prisma.tag.delete({ where: { id } });
+    const existing = await prisma.tag.findFirst({ where: { id, ...notDeleted } });
+    if (!existing) return notFound(reply, "Tag");
+
+    // Both `name` and `slug` are globally unique and a trashed row keeps its
+    // slots, so park them both — otherwise re-creating a tag under the same
+    // name would hit either constraint (#146).
+    await prisma.tag.update({
+      where: { id },
+      data: {
+        ...softDeleteData(),
+        name: parkUniqueValue(existing.name, id),
+        slug: parkUniqueValue(existing.slug, id),
+      },
+    });
     return { success: true };
   });
 }

--- a/src/backend/src/routes/admin/categories.ts
+++ b/src/backend/src/routes/admin/categories.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateConferences } from "../../lib/revalidate.js";
+import { notDeleted, notFound, softDeleteData } from "../../lib/admin-helpers.js";
 
 interface CategoryCreateBody {
   editionId: number;
@@ -28,7 +29,7 @@ export default async function adminCategoryRoutes(app: FastifyInstance) {
     const { editionId } = request.query;
 
     return prisma.category.findMany({
-      where: editionId ? { editionId: Number(editionId) } : {},
+      where: editionId ? { editionId: Number(editionId), ...notDeleted } : notDeleted,
       include: editionId ? undefined : { edition: { select: { id: true, year: true } } },
       orderBy: editionId ? { sortOrder: "asc" } : [{ edition: { year: "desc" } }, { sortOrder: "asc" }],
     });
@@ -38,8 +39,10 @@ export default async function adminCategoryRoutes(app: FastifyInstance) {
   app.get<{ Params: CategoryIdParams }>("/categories/:id", {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
   }, async (request, reply) => {
-    const category = await prisma.category.findUnique({
-      where: { id: Number(request.params.id) },
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const category = await prisma.category.findFirst({
+      where: { id: Number(request.params.id), ...notDeleted },
       include: { edition: { select: { id: true, year: true } } },
     });
     if (!category) return reply.code(404).send({ error: "Category not found" });
@@ -92,8 +95,16 @@ export default async function adminCategoryRoutes(app: FastifyInstance) {
   app.delete<{ Params: CategoryIdParams }>("/categories/:id", {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
   }, async (request, reply) => {
-    const { id } = request.params;
-    await prisma.category.delete({ where: { id: Number(id) } });
+    const categoryId = Number(request.params.id);
+    const category = await prisma.category.findFirst({ where: { id: categoryId, ...notDeleted } });
+    if (!category) return notFound(reply, "Category");
+
+    // No slug or unique name to park: Category has no unique constraint beyond
+    // its primary key, so the trashed row blocks nothing.
+    await prisma.category.update({
+      where: { id: categoryId },
+      data: softDeleteData(),
+    });
     revalidateConferences();
     return reply.code(204).send();
   });

--- a/src/backend/src/routes/admin/contact.ts
+++ b/src/backend/src/routes/admin/contact.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { requireAdminRole } from "../../lib/admin-guard.js";
+import { notDeleted, parkUniqueValue, softDeleteData } from "../../lib/admin-helpers.js";
 
 interface ContactCategoryBody {
   nameFr: string;
@@ -19,8 +20,11 @@ export default async function adminContactRoutes(app: FastifyInstance) {
   // GET /api/admin/contact/categories (ADMIN + EDITOR can read)
   app.get("/contact/categories", async () => {
     const categories = await prisma.contactCategory.findMany({
+      where: notDeleted,
       orderBy: { sortOrder: "asc" },
-      include: { _count: { select: { messages: true } } },
+      // The message count must exclude trashed messages too, otherwise the
+      // admin shows a category as busy when its messages are all in the trash.
+      include: { _count: { select: { messages: { where: notDeleted } } } },
     });
 
     return categories.map((c) => ({
@@ -75,7 +79,8 @@ export default async function adminContactRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const existing = await prisma.contactCategory.findUnique({ where: { id } });
+    // findFirst: findUnique cannot carry the deletedAt filter (#147).
+    const existing = await prisma.contactCategory.findFirst({ where: { id, ...notDeleted } });
     if (!existing) return reply.status(404).send({ error: "Category not found" });
 
     const body = request.body;
@@ -106,14 +111,24 @@ export default async function adminContactRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const existing = await prisma.contactCategory.findUnique({ where: { id } });
+    // findFirst rather than findUnique: only the latter's where is restricted to
+    // unique fields, so it cannot carry the deletedAt filter (#147).
+    const existing = await prisma.contactCategory.findFirst({ where: { id, ...notDeleted } });
     if (!existing) return reply.status(404).send({ error: "Category not found" });
 
     if (existing.isSystem) {
       return reply.status(409).send({ error: "System categories cannot be deleted" });
     }
 
-    await prisma.contactCategory.delete({ where: { id } });
+    // Moves to the trash (#147). The slug is optional here but unique when set,
+    // so park it to free the live namespace.
+    await prisma.contactCategory.update({
+      where: { id },
+      data: {
+        ...softDeleteData(),
+        ...(existing.slug ? { slug: parkUniqueValue(existing.slug, id) } : {}),
+      },
+    });
     return { success: true };
   });
 
@@ -125,7 +140,8 @@ export default async function adminContactRoutes(app: FastifyInstance) {
     const limit = Math.min(Number(request.query.limit) || 20, 100);
     const unreadOnly = request.query.unreadOnly === "true";
 
-    const where = unreadOnly ? { isRead: false } : {};
+    // Shared by the list and the count below, so both stay consistent (#147).
+    const where = unreadOnly ? { isRead: false, ...notDeleted } : { ...notDeleted };
 
     const [messages, total] = await Promise.all([
       prisma.contactMessage.findMany({
@@ -187,7 +203,11 @@ export default async function adminContactRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    await prisma.contactMessage.delete({ where: { id } });
+    // Moves to the trash (#147). No unique field to park on a message.
+    const existing = await prisma.contactMessage.findFirst({ where: { id, ...notDeleted } });
+    if (!existing) return reply.status(404).send({ error: "Message not found" });
+
+    await prisma.contactMessage.update({ where: { id }, data: softDeleteData() });
     return { success: true };
   });
 
@@ -199,7 +219,8 @@ export default async function adminContactRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const msg = await prisma.contactMessage.findUnique({ where: { id } });
+    // findFirst: findUnique cannot carry the deletedAt filter (#147).
+    const msg = await prisma.contactMessage.findFirst({ where: { id, ...notDeleted } });
     if (!msg) return reply.status(404).send({ error: "Message not found" });
 
     const emails = request.body.emails

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateHome, revalidateEdition, revalidateSponsors } from "../../lib/revalidate.js";
 import { isValidStatIcon, STAT_ICON_KEYS } from "../../lib/stat-icons.js";
+import { notDeleted, softDeleteData } from "../../lib/admin-helpers.js";
 
 interface EditionBody {
   year: number;
@@ -27,8 +28,11 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
   // GET /api/admin/editions — list all editions
   app.get("/editions", async () => {
     const editions = await prisma.edition.findMany({
+      where: notDeleted,
       orderBy: { year: "desc" },
-      include: { _count: { select: { ticketTiers: true, articles: true } } },
+      include: {
+        _count: { select: { ticketTiers: { where: notDeleted }, articles: { where: notDeleted } } },
+      },
     });
 
     return editions.map((e: (typeof editions)[number]) => ({
@@ -52,6 +56,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
   // GET /api/admin/editions/current
   app.get("/editions/current", async (_request, reply) => {
     const edition = await prisma.edition.findFirst({
+      where: notDeleted,
       orderBy: { year: "desc" },
     });
 
@@ -89,17 +94,19 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       const id = Number(request.params.id);
       if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-      const edition = await prisma.edition.findUnique({
-        where: { id },
+      // findFirst: findUnique cannot carry the deletedAt filter (#147). The
+      // counts drive the admin synthesis panel, so they must ignore the trash.
+      const edition = await prisma.edition.findFirst({
+        where: { id, ...notDeleted },
         include: {
           _count: {
             select: {
-              ticketTiers: true,
-              articles: true,
-              speakers: true,
-              talks: true,
-              sponsors: true,
-              categories: true,
+              ticketTiers: { where: notDeleted },
+              articles: { where: notDeleted },
+              speakers: { where: notDeleted },
+              talks: { where: notDeleted },
+              sponsors: { where: notDeleted },
+              categories: { where: notDeleted },
             },
           },
         },
@@ -143,7 +150,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const existing = await prisma.edition.findUnique({ where: { id } });
+    const existing = await prisma.edition.findFirst({ where: { id, ...notDeleted } });
     if (!existing) return reply.status(404).send({ error: "Edition not found" });
 
     const body = request.body;
@@ -192,6 +199,9 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
 
     if (!body.year) return reply.status(400).send({ error: "year is required" });
 
+    // Deliberately NOT filtered on deletedAt: `year` is unique database-wide and
+    // a trashed edition still owns it. Filtering here would let the create pass
+    // validation only to fail on the constraint — a 409 explains it better.
     const existing = await prisma.edition.findUnique({ where: { year: body.year } });
     if (existing) return reply.status(409).send({ error: "Edition for this year already exists" });
 
@@ -221,18 +231,47 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       const id = Number(request.params.id);
       if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-      const existing = await prisma.edition.findUnique({
-        where: { id },
-        include: { _count: { select: { articles: true } } },
+      // findFirst: findUnique cannot carry the deletedAt filter (#147).
+      // Counts exclude trashed children — an edition whose talks are all in the
+      // trash is genuinely empty and should be removable.
+      const existing = await prisma.edition.findFirst({
+        where: { id, ...notDeleted },
+        include: {
+          _count: {
+            select: {
+              articles: { where: notDeleted },
+              talks: { where: notDeleted },
+              speakers: { where: notDeleted },
+              sponsors: { where: notDeleted },
+              categories: { where: notDeleted },
+              sponsorPlans: { where: notDeleted },
+              ticketTiers: { where: notDeleted },
+            },
+          },
+        },
       });
 
       if (!existing) return reply.status(404).send({ error: "Edition not found" });
 
-      if (existing._count.articles > 0) {
-        return reply.status(409).send({ error: "Cannot delete edition with linked articles" });
+      // Trashing a parent refuses rather than cascading (#147). A logical
+      // cascade would force restore to tell rows trashed *before* from rows
+      // trashed *by* the cascade — otherwise it resurrects what should stay
+      // gone. The article check below already worked this way; the other
+      // children now follow the same rule.
+      const blocking = Object.entries(existing._count)
+        .filter(([, count]) => count > 0)
+        .map(([relation, count]) => `${relation} (${count})`);
+
+      if (blocking.length > 0) {
+        return reply.status(409).send({
+          error: `Cannot delete edition with linked records: ${blocking.join(", ")}`,
+        });
       }
 
-      await prisma.edition.delete({ where: { id } });
+      // Year is unique but numeric — no string parking possible, so a trashed
+      // edition keeps its year until purged. Creating that year again is
+      // blocked meanwhile; the trash has to be emptied first.
+      await prisma.edition.update({ where: { id }, data: softDeleteData() });
       revalidateEdition(existing.year);
       return { success: true };
     }
@@ -271,7 +310,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const edition = await prisma.edition.findUnique({ where: { id } });
+    const edition = await prisma.edition.findFirst({ where: { id, ...notDeleted } });
     if (!edition) return reply.status(404).send({ error: "Edition not found" });
 
     const figures = request.body;
@@ -311,7 +350,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
     async (request, reply) => {
       const { editionId } = request.body;
 
-      const edition = await prisma.edition.findUnique({ where: { id: editionId } });
+      const edition = await prisma.edition.findFirst({ where: { id: editionId, ...notDeleted } });
       if (!edition) return reply.status(404).send({ error: "Edition not found" });
 
       await prisma.siteSetting.upsert({

--- a/src/backend/src/routes/admin/speakers.ts
+++ b/src/backend/src/routes/admin/speakers.ts
@@ -5,6 +5,7 @@ import { revalidateSpeakers } from "../../lib/revalidate.js";
 import { slugify, uniqueSlug } from "../../lib/slug.js";
 import { generateEditToken } from "../../lib/edit-token.js";
 import { sendEditLinkEmail, normalizeLocale } from "../../lib/edit-link-email.js";
+import { notDeleted, notFound, parkUniqueValue, softDeleteData } from "../../lib/admin-helpers.js";
 
 interface SpeakerCreateBody {
   editionId: number;
@@ -50,7 +51,7 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
     const { editionId } = request.query;
 
     const speakers = await prisma.speaker.findMany({
-      where: editionId ? { editionId: Number(editionId) } : {},
+      where: editionId ? { editionId: Number(editionId), ...notDeleted } : notDeleted,
       include: editionId ? undefined : { edition: { select: { id: true, year: true } } },
       orderBy: editionId ? { name: "asc" } : [{ edition: { year: "desc" } }, { name: "asc" }],
     });
@@ -61,8 +62,10 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
   app.get<{ Params: SpeakerIdParams }>("/speakers/:id", {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
   }, async (request, reply) => {
-    const speaker = await prisma.speaker.findUnique({
-      where: { id: Number(request.params.id) },
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const speaker = await prisma.speaker.findFirst({
+      where: { id: Number(request.params.id), ...notDeleted },
       include: { edition: { select: { id: true, year: true } } },
     });
     if (!speaker) return reply.code(404).send({ error: "Speaker not found" });
@@ -76,6 +79,10 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
       return reply.code(400).send({ error: "editionId and name are required" });
     }
 
+    // Deliberately NOT filtered on deletedAt: uniqueness is a database-wide
+    // constraint, so a trashed speaker still owns its slug until purged. Parking
+    // frees the readable form, but a row keeping an unparked slug (restored, or
+    // trashed before #147) must still be counted or the create would collide.
     const existing = await prisma.speaker.findMany({
       where: { editionId: body.editionId },
       select: { slug: true },
@@ -165,17 +172,30 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
       return reply.code(400).send({ error: "unknown action" });
     }
 
-    const { count } = await prisma.speaker.updateMany({ where: { id: { in: ids } }, data });
+    const { count } = await prisma.speaker.updateMany({
+      where: { id: { in: ids }, ...notDeleted },
+      data,
+    });
     revalidateSpeakers();
     return { count };
   });
 
-  // DELETE /api/admin/speakers/:id
+  // DELETE /api/admin/speakers/:id — moves the speaker to the trash (#147). The
+  // row survives with `deletedAt` set; #145c restores it, #145d purges it.
   app.delete<{ Params: SpeakerIdParams }>("/speakers/:id", {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
   }, async (request, reply) => {
-    const { id } = request.params;
-    await prisma.speaker.delete({ where: { id: Number(id) } });
+    const speakerId = Number(request.params.id);
+    const speaker = await prisma.speaker.findFirst({ where: { id: speakerId, ...notDeleted } });
+    if (!speaker) return notFound(reply, "Speaker");
+
+    // The slug is unique per edition and a trashed row keeps its slot, so park
+    // it out of the live namespace — otherwise re-creating a speaker under the
+    // same name would hit the constraint (#146).
+    await prisma.speaker.update({
+      where: { id: speakerId },
+      data: { ...softDeleteData(), slug: parkUniqueValue(speaker.slug, speakerId) },
+    });
     revalidateSpeakers();
     return reply.code(204).send();
   });
@@ -186,7 +206,8 @@ export default async function adminSpeakerRoutes(app: FastifyInstance) {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
   }, async (request, reply) => {
     const id = Number(request.params.id);
-    const speaker = await prisma.speaker.findUnique({ where: { id } });
+    // findFirst, not findUnique: a trashed speaker must not get a fresh edit link.
+    const speaker = await prisma.speaker.findFirst({ where: { id, ...notDeleted } });
     if (!speaker) return reply.code(404).send({ error: "Speaker not found" });
 
     const email = request.body.email?.trim() || speaker.contactEmail;

--- a/src/backend/src/routes/admin/sponsor-plans.ts
+++ b/src/backend/src/routes/admin/sponsor-plans.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateSponsors } from "../../lib/revalidate.js";
+import { notDeleted, notFound, softDeleteData } from "../../lib/admin-helpers.js";
 
 interface SponsorPlanCreateBody {
   editionId: number;
@@ -43,7 +44,7 @@ export default async function adminSponsorPlanRoutes(app: FastifyInstance) {
     if (!editionId) return reply.code(400).send({ error: "editionId required" });
 
     const plans = await prisma.sponsorPlan.findMany({
-      where: { editionId: Number(editionId) },
+      where: { editionId: Number(editionId), ...notDeleted },
       orderBy: { sortOrder: "asc" },
     });
 
@@ -130,8 +131,16 @@ export default async function adminSponsorPlanRoutes(app: FastifyInstance) {
       },
     },
   }, async (request, reply) => {
-    const { id } = request.params;
-    await prisma.sponsorPlan.delete({ where: { id: Number(id) } });
+    const planId = Number(request.params.id);
+    const plan = await prisma.sponsorPlan.findFirst({ where: { id: planId, ...notDeleted } });
+    if (!plan) return notFound(reply, "Sponsor plan");
+
+    // No slug or unique name to park: SponsorPlan has no unique constraint
+    // beyond its primary key, so the trashed row blocks nothing.
+    await prisma.sponsorPlan.update({
+      where: { id: planId },
+      data: softDeleteData(),
+    });
     revalidateSponsors();
     return reply.code(204).send();
   });

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -5,6 +5,7 @@ import { slugify, uniqueSlug } from "../../lib/slug.js";
 import { generateEditToken } from "../../lib/edit-token.js";
 import { sendEditLinkEmail, normalizeLocale } from "../../lib/edit-link-email.js";
 import { sanitizeRichHtml } from "../../lib/sanitize.js";
+import { notDeleted, notFound, parkUniqueValue, softDeleteData } from "../../lib/admin-helpers.js";
 
 const SPONSOR_LEVELS = ["PLATINUM", "GOLD", "SILVER", "SOUTIEN", "COMMUNAUTE"] as const;
 type SponsorLevel = (typeof SPONSOR_LEVELS)[number];
@@ -77,7 +78,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     const { editionId } = request.query;
 
     const sponsors = await prisma.sponsor.findMany({
-      where: editionId ? { editionId: Number(editionId) } : {},
+      where: editionId ? { editionId: Number(editionId), ...notDeleted } : notDeleted,
       include: editionId ? undefined : { edition: { select: { id: true, year: true } } },
       orderBy: editionId
         ? [{ level: "asc" }, { name: "asc" }]
@@ -90,8 +91,10 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
   app.get<{ Params: SponsorIdParams }>("/sponsors/:id", {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
   }, async (request, reply) => {
-    const sponsor = await prisma.sponsor.findUnique({
-      where: { id: Number(request.params.id) },
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const sponsor = await prisma.sponsor.findFirst({
+      where: { id: Number(request.params.id), ...notDeleted },
       include: {
         edition: { select: { id: true, year: true } },
         // Job offers for admin consultation/moderation (#251).
@@ -113,7 +116,11 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
       return reply.code(422).send({ error: `Invalid level. Allowed: ${SPONSOR_LEVELS.join(", ")}` });
     }
 
-    // Build a slug unique within the edition.
+    // Build a slug unique within the edition. Deliberately NOT filtered on
+    // deletedAt: uniqueness is a database-wide constraint, so a trashed sponsor
+    // still owns its slug until purged. Parking frees the readable form, but a
+    // row keeping an unparked slug (restored, or trashed before #147) must still
+    // be counted or the create would collide.
     const existing = await prisma.sponsor.findMany({
       where: { editionId: body.editionId },
       select: { slug: true },
@@ -209,21 +216,31 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     }
 
     const { count } = await prisma.sponsor.updateMany({
-      where: { id: { in: ids } },
+      where: { id: { in: ids }, ...notDeleted },
       data: { publicationStatus: value },
     });
     revalidateSponsors();
     return { count };
   });
 
-  // DELETE /api/admin/sponsors/:id
+  // DELETE /api/admin/sponsors/:id — moves the sponsor to the trash (#147). The
+  // row survives with `deletedAt` set; #145c restores it, #145d purges it.
   app.delete<{ Params: SponsorIdParams }>("/sponsors/:id", {
     schema: {
       params: { type: "object", required: ["id"], properties: { id: { type: "string" } } },
     },
   }, async (request, reply) => {
-    const { id } = request.params;
-    await prisma.sponsor.delete({ where: { id: Number(id) } });
+    const sponsorId = Number(request.params.id);
+    const sponsor = await prisma.sponsor.findFirst({ where: { id: sponsorId, ...notDeleted } });
+    if (!sponsor) return notFound(reply, "Sponsor");
+
+    // The slug is unique per edition and a trashed row keeps its slot, so park
+    // it out of the live namespace — otherwise re-creating a sponsor under the
+    // same name would hit the constraint (#146).
+    await prisma.sponsor.update({
+      where: { id: sponsorId },
+      data: { ...softDeleteData(), slug: parkUniqueValue(sponsor.slug, sponsorId) },
+    });
     revalidateSponsors();
     return reply.code(204).send();
   });
@@ -266,7 +283,8 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     { schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } } },
     async (request, reply) => {
       const sponsorId = Number(request.params.id);
-      const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
+      // findFirst, not findUnique: a trashed sponsor must not gain new contacts.
+      const sponsor = await prisma.sponsor.findFirst({ where: { id: sponsorId, ...notDeleted } });
       if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
 
       const email = request.body.email?.trim();

--- a/src/backend/src/routes/admin/talks.ts
+++ b/src/backend/src/routes/admin/talks.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateConferences } from "../../lib/revalidate.js";
 import { slugify, uniqueSlug } from "../../lib/slug.js";
+import { notDeleted, notFound, parkUniqueValue, softDeleteData } from "../../lib/admin-helpers.js";
 
 const FORMATS = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"] as const;
 type TalkFormat = (typeof FORMATS)[number];
@@ -56,10 +57,13 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
     const { editionId } = request.query;
 
     const talks = await prisma.talk.findMany({
-      where: editionId ? { editionId: Number(editionId) } : {},
+      where: editionId ? { editionId: Number(editionId), ...notDeleted } : notDeleted,
       orderBy: editionId ? { title: "asc" } : [{ edition: { year: "desc" } }, { title: "asc" }],
       include: {
-        speakers: { select: { id: true, name: true } },
+        // Nested reads need their own filter: a query extension would not reach
+        // them (Prisma applies those to the top-level operation only), and a
+        // trashed speaker would otherwise still show up on a live talk.
+        speakers: { where: notDeleted, select: { id: true, name: true } },
         category: { select: { id: true, nameFr: true, color: true } },
         ...(editionId ? {} : { edition: { select: { id: true, year: true } } }),
       },
@@ -71,10 +75,12 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
   app.get<{ Params: TalkIdParams }>("/talks/:id", {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
   }, async (request, reply) => {
-    const talk = await prisma.talk.findUnique({
-      where: { id: Number(request.params.id) },
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const talk = await prisma.talk.findFirst({
+      where: { id: Number(request.params.id), ...notDeleted },
       include: {
-        speakers: { select: { id: true, name: true } },
+        speakers: { where: notDeleted, select: { id: true, name: true } },
         category: { select: { id: true, nameFr: true, color: true } },
         edition: { select: { id: true, year: true } },
       },
@@ -99,6 +105,10 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
       return reply.code(400).send({ error: "language is required" });
     }
 
+    // Deliberately NOT filtered on deletedAt: uniqueness is a database-wide
+    // constraint, so a trashed talk still owns its slug until purged. Parking
+    // frees the readable form, but a row keeping an unparked slug (restored, or
+    // trashed before #147) must still be counted or the create would collide.
     const existing = await prisma.talk.findMany({
       where: { editionId: body.editionId },
       select: { slug: true },
@@ -177,19 +187,29 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
     }
 
     const { count } = await prisma.talk.updateMany({
-      where: { id: { in: ids } },
+      where: { id: { in: ids }, ...notDeleted },
       data: { publicationStatus: value },
     });
     revalidateConferences();
     return { count };
   });
 
-  // DELETE /api/admin/talks/:id
+  // DELETE /api/admin/talks/:id — moves the talk to the trash (#147). The row
+  // survives with `deletedAt` set; #145c restores it, #145d purges it for good.
   app.delete<{ Params: TalkIdParams }>("/talks/:id", {
     schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
   }, async (request, reply) => {
-    const { id } = request.params;
-    await prisma.talk.delete({ where: { id: Number(id) } });
+    const talkId = Number(request.params.id);
+    const talk = await prisma.talk.findFirst({ where: { id: talkId, ...notDeleted } });
+    if (!talk) return notFound(reply, "Talk");
+
+    // The slug is unique per edition and a trashed row keeps its slot, so park
+    // it out of the live namespace — otherwise re-creating a talk under the
+    // same title would hit the constraint (#146).
+    await prisma.talk.update({
+      where: { id: talkId },
+      data: { ...softDeleteData(), slug: parkUniqueValue(talk.slug, talkId) },
+    });
     revalidateConferences();
     return reply.code(204).send();
   });

--- a/src/backend/src/routes/admin/tickets.ts
+++ b/src/backend/src/routes/admin/tickets.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { computeTicketStatus } from "../editions.js";
 import { revalidateBilletterie } from "../../lib/revalidate.js";
+import { notDeleted, notFound, softDeleteData } from "../../lib/admin-helpers.js";
 
 type TicketStatus = "AVAILABLE" | "SOLD_OUT" | "COMING_SOON";
 const TICKET_STATUSES: TicketStatus[] = ["AVAILABLE", "SOLD_OUT", "COMING_SOON"];
@@ -147,7 +148,13 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
     // Fetch per-ticket availability (sold-out) to seed isSoldOut (best-effort).
     const soldOutByTicket = await fetchBilletwebSoldOut(billetwebEventId, params);
 
-    // Delete existing tiers for this edition
+    // Replace the edition's tiers wholesale. This stays a HARD delete on
+    // purpose, unlike the single-tier DELETE below (#147): the loop right after
+    // re-creates tiers at sortOrder 0..n-1, and a soft-deleted row keeps its
+    // sortOrder slot — `@@unique([editionId, sortOrder])` would reject the
+    // re-import. sortOrder is an Int, so it cannot be parked out of the way the
+    // way a slug can. Tiers replaced by a re-import are mirror images of what
+    // BilletWeb just returned, so there is nothing worth keeping in the trash.
     await prisma.ticketTier.deleteMany({ where: { editionId } });
 
     // Create new tiers from Billetweb data
@@ -183,7 +190,7 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
     Querystring: { editionId?: string };
   }>("/tickets", async (request) => {
     const editionId = request.query.editionId ? Number(request.query.editionId) : undefined;
-    const where = editionId ? { editionId } : {};
+    const where = editionId ? { editionId, ...notDeleted } : { ...notDeleted };
 
     const tiers = await prisma.ticketTier.findMany({
       where,
@@ -224,6 +231,10 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
     // constraint as soon as the edition already has a tier at 0.
     let sortOrder = body.sortOrder;
     if (sortOrder === undefined || sortOrder === null) {
+      // Deliberately NOT filtered on deletedAt: `@@unique([editionId, sortOrder])`
+      // is a database-wide constraint and a trashed tier keeps its slot until
+      // purged (sortOrder is an Int, so it cannot be parked). Skipping trashed
+      // rows here would hand out a slot that is still taken.
       const last = await prisma.ticketTier.findFirst({
         where: { editionId: body.editionId },
         orderBy: { sortOrder: "desc" },
@@ -258,7 +269,9 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    const existing = await prisma.ticketTier.findUnique({ where: { id } });
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const existing = await prisma.ticketTier.findFirst({ where: { id, ...notDeleted } });
     if (!existing) return reply.status(404).send({ error: "Ticket tier not found" });
 
     const body = request.body;
@@ -294,14 +307,27 @@ export default async function adminTicketRoutes(app: FastifyInstance) {
     return { id: tier.id };
   });
 
-  // DELETE /api/admin/tickets/:id
+  // DELETE /api/admin/tickets/:id — moves the tier to the trash (#147). The row
+  // survives with `deletedAt` set; #145c restores it, #145d purges it.
   app.delete<{
     Params: { id: string };
   }>("/tickets/:id", async (request, reply) => {
     const id = Number(request.params.id);
     if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
 
-    await prisma.ticketTier.delete({ where: { id } });
+    const existing = await prisma.ticketTier.findFirst({ where: { id, ...notDeleted } });
+    if (!existing) return notFound(reply, "Ticket tier");
+
+    // sortOrder is deliberately left untouched. The unique slot it holds under
+    // `@@unique([editionId, sortOrder])` cannot be parked the way a slug can —
+    // parking relies on a string prefix and sortOrder is an Int. So a trashed
+    // tier keeps its slot until purged: creating a new tier at that exact
+    // sortOrder fails until then. Appending (the default path in POST) is
+    // unaffected, since it reads past the trashed rows too.
+    await prisma.ticketTier.update({
+      where: { id },
+      data: softDeleteData(),
+    });
     revalidateBilletterie();
     return { success: true };
   });

--- a/src/backend/src/routes/admin/users.ts
+++ b/src/backend/src/routes/admin/users.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { sendEmail, escapeHtml } from "../../lib/email.js";
 import { emailButton, emailHeading } from "../../lib/email-template.js";
+import { notDeleted, parkUniqueValue, softDeleteData } from "../../lib/admin-helpers.js";
 
 const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 
@@ -20,6 +21,7 @@ export default async function adminUserRoutes(app: FastifyInstance) {
   // GET /api/admin/users — list all admin users
   app.get("/users", async () => {
     const users = await prisma.user.findMany({
+      where: notDeleted,
       orderBy: { createdAt: "desc" },
       select: {
         id: true,
@@ -58,6 +60,9 @@ export default async function adminUserRoutes(app: FastifyInstance) {
       return reply.code(400).send({ error: "Email and name are required" });
     }
 
+    // Deliberately NOT filtered on deletedAt: `email` is unique database-wide.
+    // A trashed account parks its address, so this only matches a live user or
+    // one trashed before #147 — either way, inviting it again must be refused.
     const existing = await prisma.user.findUnique({ where: { email } });
     if (existing) {
       return reply.code(409).send({ error: "A user with this email already exists" });
@@ -110,7 +115,7 @@ export default async function adminUserRoutes(app: FastifyInstance) {
     const { id } = request.params;
     const { role, name } = request.body;
 
-    const existing = await prisma.user.findUnique({ where: { id } });
+    const existing = await prisma.user.findFirst({ where: { id, ...notDeleted } });
     if (!existing) return reply.code(404).send({ error: "User not found" });
 
     const data: Record<string, string> = {};
@@ -131,7 +136,7 @@ export default async function adminUserRoutes(app: FastifyInstance) {
         return reply.code(400).send({ error: "You cannot ban yourself" });
       }
 
-      const existing = await prisma.user.findUnique({ where: { id } });
+      const existing = await prisma.user.findFirst({ where: { id, ...notDeleted } });
       if (!existing) return reply.code(404).send({ error: "User not found" });
 
       const user = await prisma.user.update({
@@ -157,10 +162,21 @@ export default async function adminUserRoutes(app: FastifyInstance) {
         return reply.code(400).send({ error: "You cannot delete your own account" });
       }
 
-      const existing = await prisma.user.findUnique({ where: { id } });
+      // findFirst: findUnique cannot carry the deletedAt filter (#147).
+      const existing = await prisma.user.findFirst({ where: { id, ...notDeleted } });
       if (!existing) return reply.code(404).send({ error: "User not found" });
 
-      await prisma.user.delete({ where: { id } });
+      // Moves to the trash (#147). `email` is unique, so park it — otherwise
+      // re-inviting that address before the purge would hit the constraint.
+      await prisma.user.update({
+        where: { id },
+        data: { ...softDeleteData(), email: parkUniqueValue(existing.email, id) },
+      });
+
+      // Kill live sessions: a trashed account must not stay signed in. Without
+      // this, the user keeps their admin access until the cookie expires.
+      await prisma.session.deleteMany({ where: { userId: id } });
+
       return { success: true };
     }
   );

--- a/src/backend/src/routes/articles.ts
+++ b/src/backend/src/routes/articles.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
+import { notDeleted } from "../lib/admin-helpers.js";
 
 function mapArticleSummary(article: {
   id: number;
@@ -38,6 +39,7 @@ export default async function articleRoutes(app: FastifyInstance) {
 
     const where = {
       publicationStatus: "PUBLISHED" as const,
+      ...notDeleted,
       ...(editionId
         ? { OR: [{ editions: { some: { id: editionId } } }, { editions: { none: {} } }] }
         : {}),
@@ -47,7 +49,10 @@ export default async function articleRoutes(app: FastifyInstance) {
       where,
       orderBy: { publishedAt: "desc" },
       take: limit,
-      include: { tags: true },
+      // Nested reads need their own filter: a query extension would not reach
+      // them (Prisma applies those to the top-level operation only), and a
+      // trashed tag would otherwise still show up on a live article.
+      include: { tags: { where: notDeleted } },
     });
 
     return articles.map(mapArticleSummary);
@@ -68,8 +73,9 @@ export default async function articleRoutes(app: FastifyInstance) {
 
     const where = {
       publicationStatus: "PUBLISHED" as const,
-      ...(tagSlug ? { tags: { some: { slug: tagSlug } } } : {}),
-      ...(editionId ? { editions: { some: { id: editionId } } } : {}),
+      ...notDeleted,
+      ...(tagSlug ? { tags: { some: { slug: tagSlug, ...notDeleted } } } : {}),
+      ...(editionId ? { editions: { some: { id: editionId, ...notDeleted } } } : {}),
     };
 
     const [articles, total] = await Promise.all([
@@ -78,7 +84,7 @@ export default async function articleRoutes(app: FastifyInstance) {
         orderBy: { publishedAt: "desc" },
         skip: (page - 1) * limit,
         take: limit,
-        include: { tags: true },
+        include: { tags: { where: notDeleted } },
       }),
       prisma.article.count({ where }),
     ]);
@@ -95,9 +101,11 @@ export default async function articleRoutes(app: FastifyInstance) {
   app.get<{
     Params: { slug: string };
   }>("/articles/:slug", async (request, reply) => {
-    const article = await prisma.article.findUnique({
-      where: { slug: request.params.slug },
-      include: { tags: true },
+    // findFirst, not findUnique: the latter only accepts unique fields in its
+    // top-level where, so it cannot carry the `deletedAt` filter (#147).
+    const article = await prisma.article.findFirst({
+      where: { slug: request.params.slug, ...notDeleted },
+      include: { tags: { where: notDeleted } },
     });
 
     if (!article || article.publicationStatus !== "PUBLISHED") {
@@ -129,6 +137,7 @@ export default async function articleRoutes(app: FastifyInstance) {
   // GET /api/tags — all tags
   app.get("/tags", async () => {
     const tags = await prisma.tag.findMany({
+      where: notDeleted,
       orderBy: { name: "asc" },
     });
     return tags.map((tag) => ({ id: tag.id, name: tag.name, slug: tag.slug }));

--- a/src/backend/src/routes/categories.ts
+++ b/src/backend/src/routes/categories.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { getFeaturedEdition } from "./editions.js";
+import { notDeleted } from "../lib/admin-helpers.js";
 
 export default async function categoryRoutes(app: FastifyInstance) {
   // GET /api/categories — tracks of the featured edition (used by session filters).
@@ -9,7 +10,7 @@ export default async function categoryRoutes(app: FastifyInstance) {
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
     return prisma.category.findMany({
-      where: { editionId: edition.id },
+      where: { editionId: edition.id, ...notDeleted },
       orderBy: { sortOrder: "asc" },
       select: { id: true, nameFr: true, nameEn: true, color: true },
     });

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -5,6 +5,7 @@ import { emailHeading } from "../lib/email-template.js";
 import { makeToken } from "../lib/brochure-token.js";
 import { sendContactWebhook } from "../lib/contact-webhook.js";
 import { getFeaturedEdition } from "./editions.js";
+import { notDeleted } from "../lib/admin-helpers.js";
 
 interface ContactBody {
   firstName: string;
@@ -35,7 +36,7 @@ export default async function contactRoutes(app: FastifyInstance) {
   // /contact <select> filters them out client-side.
   app.get("/contact/categories", async () => {
     const categories = await prisma.contactCategory.findMany({
-      where: { isActive: true },
+      where: { isActive: true, ...notDeleted },
       orderBy: { sortOrder: "asc" },
     });
 
@@ -63,8 +64,10 @@ export default async function contactRoutes(app: FastifyInstance) {
     // Resolve the category upfront so the validator knows whether the
     // submission is a sponsor-brochure request (where company + jobTitle
     // are mandatory) or a generic contact (where both fields are optional).
+    // findFirst so the trash filter fits (#147): a message must not be routed
+    // to a category the organizers deleted — its recipients would never see it.
     const category = categoryId
-      ? await prisma.contactCategory.findUnique({ where: { id: categoryId } })
+      ? await prisma.contactCategory.findFirst({ where: { id: categoryId, ...notDeleted } })
       : null;
     const requiresCompanyInfo = category?.slug === "sponsor-brochure";
 

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { areOffersVisible } from "../lib/job-offers.js";
+import { notDeleted, visibleCategory } from "../lib/admin-helpers.js";
 
 type TicketStatus = "AVAILABLE" | "SOLD_OUT" | "COMING_SOON";
 
@@ -28,14 +29,18 @@ export async function getFeaturedEdition() {
   });
 
   if (setting) {
-    const edition = await prisma.edition.findUnique({
-      where: { id: Number(setting.value) },
+    // findFirst so the trash filter fits (#147). A trashed featured edition
+    // falls through to the fallback below rather than driving the whole public
+    // site — this function decides what every visitor sees.
+    const edition = await prisma.edition.findFirst({
+      where: { id: Number(setting.value), ...notDeleted },
     });
     if (edition) return edition;
   }
 
   // 2. Fallback: latest edition by year
   return prisma.edition.findFirst({
+    where: notDeleted,
     orderBy: { year: "desc" },
   });
 }
@@ -44,6 +49,7 @@ export default async function editionRoutes(app: FastifyInstance) {
   // GET /api/editions — returns all editions (summary)
   app.get("/editions", async () => {
     const editions = await prisma.edition.findMany({
+      where: notDeleted,
       orderBy: { year: "desc" },
       select: { id: true, year: true, status: true, archivedSiteUrl: true, startDate: true },
     });
@@ -64,15 +70,18 @@ export default async function editionRoutes(app: FastifyInstance) {
     const yearNum = Number(year);
     if (isNaN(yearNum)) return reply.status(400).send({ error: "Invalid year" });
 
-    const edition = await prisma.edition.findUnique({
-      where: { year: yearNum },
+    // findFirst: findUnique cannot carry the deletedAt filter (#147). Both
+    // nested levels need their own — the filter does not propagate down an
+    // include, so a trashed article (or tag) would still surface here.
+    const edition = await prisma.edition.findFirst({
+      where: { year: yearNum, ...notDeleted },
       include: {
         keyFigures: { orderBy: { sortOrder: "asc" } },
         articles: {
-          where: { publicationStatus: "PUBLISHED" },
+          where: { publicationStatus: "PUBLISHED", ...notDeleted },
           orderBy: { publishedAt: "desc" },
           take: 4,
-          include: { tags: true },
+          include: { tags: { where: notDeleted } },
         },
       },
     });
@@ -120,11 +129,11 @@ export default async function editionRoutes(app: FastifyInstance) {
     const yearNum = Number(request.params.year);
     if (isNaN(yearNum)) return reply.status(400).send({ error: "Invalid year" });
 
-    const edition = await prisma.edition.findUnique({ where: { year: yearNum }, select: { id: true } });
+    const edition = await prisma.edition.findFirst({ where: { year: yearNum, ...notDeleted }, select: { id: true } });
     if (!edition) return reply.status(404).send({ error: "Edition not found" });
 
     const speakers = await prisma.speaker.findMany({
-      where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
       orderBy: { name: "asc" },
       select: { slug: true, name: true, photoUrl: true, company: true },
     });
@@ -139,19 +148,23 @@ export default async function editionRoutes(app: FastifyInstance) {
     const yearNum = Number(request.params.year);
     if (isNaN(yearNum)) return reply.status(400).send({ error: "Invalid year" });
 
-    const edition = await prisma.edition.findUnique({ where: { year: yearNum }, select: { id: true } });
+    const edition = await prisma.edition.findFirst({ where: { year: yearNum, ...notDeleted }, select: { id: true } });
     if (!edition) return reply.status(404).send({ error: "Edition not found" });
 
     const talks = await prisma.talk.findMany({
-      where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
       orderBy: { title: "asc" },
       include: {
+        // Nested: the filter does not reach here on its own, and a trashed
+        // speaker would keep appearing under a live talk (#147).
         speakers: {
-          where: { publicationStatus: "PUBLISHED" },
+          where: { publicationStatus: "PUBLISHED", ...notDeleted },
           select: { slug: true, name: true, photoUrl: true },
           orderBy: { name: "asc" },
         },
-        category: { select: { nameFr: true, nameEn: true, color: true } },
+        // `category` is to-one — Prisma takes no `where` there, so `deletedAt`
+        // rides along and the serializer drops a trashed one (#147).
+        category: { select: { nameFr: true, nameEn: true, color: true, deletedAt: true } },
       },
     });
 
@@ -163,7 +176,7 @@ export default async function editionRoutes(app: FastifyInstance) {
       level: t.level,
       language: t.language,
       videoUrl: t.videoUrl,
-      category: t.category,
+      category: visibleCategory(t.category),
       speakers: t.speakers,
     }));
   });
@@ -180,7 +193,7 @@ export default async function editionRoutes(app: FastifyInstance) {
     // home page to link back to last edition's content during preparation
     // and announcement phases.
     const previousEdition = await prisma.edition.findFirst({
-      where: { year: { lt: edition.year } },
+      where: { year: { lt: edition.year }, ...notDeleted },
       orderBy: { year: "desc" },
       select: { year: true, aftermovieUrl: true, galleryUrl: true },
     });
@@ -198,21 +211,33 @@ export default async function editionRoutes(app: FastifyInstance) {
       publishedSponsorCount,
       jobOfferCount,
     ] = await Promise.all([
+        // These counts decide whether the nav links show at all, so the trash
+        // has to be excluded: an edition whose talks are all trashed must not
+        // keep advertising a "Conférences" menu that leads to an empty page.
         prisma.talk.count({
-          where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+          where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
         }),
         prisma.talk.count({
-          where: { editionId: edition.id, publicationStatus: "PUBLISHED", startsAt: { not: null } },
+          where: {
+            editionId: edition.id,
+            publicationStatus: "PUBLISHED",
+            startsAt: { not: null },
+            ...notDeleted,
+          },
         }),
         prisma.speaker.count({
-          where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+          where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
         }),
         prisma.sponsor.count({
-          where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+          where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
         }),
         // Offers of published sponsors only — same set the recap page lists.
+        // SponsorJobOffer itself is out of the trash's scope, but its sponsor is
+        // not: offers of a trashed sponsor must stop counting.
         prisma.sponsorJobOffer.count({
-          where: { sponsor: { editionId: edition.id, publicationStatus: "PUBLISHED" } },
+          where: {
+            sponsor: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
+          },
         }),
       ]);
 
@@ -258,6 +283,7 @@ export default async function editionRoutes(app: FastifyInstance) {
       where: {
         editionId: edition.id,
         isVisible: true,
+        ...notDeleted,
       },
       orderBy: { sortOrder: "asc" },
     });
@@ -290,6 +316,7 @@ export default async function editionRoutes(app: FastifyInstance) {
       where: {
         editionId: edition.id,
         isVisible: true,
+        ...notDeleted,
       },
       orderBy: { sortOrder: "asc" },
     });

--- a/src/backend/src/routes/speakers.ts
+++ b/src/backend/src/routes/speakers.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { getFeaturedEdition } from "./editions.js";
+import { notDeleted } from "../lib/admin-helpers.js";
 
 function parseSocial(raw: string | null): Record<string, string> {
   if (!raw) return {};
@@ -19,7 +20,7 @@ export default async function speakerRoutes(app: FastifyInstance) {
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
     const speakers = await prisma.speaker.findMany({
-      where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
       orderBy: { name: "asc" },
       select: { id: true, slug: true, name: true, photoUrl: true, company: true, isFeatured: true },
     });
@@ -32,7 +33,7 @@ export default async function speakerRoutes(app: FastifyInstance) {
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
     const speakers = await prisma.speaker.findMany({
-      where: { editionId: edition.id, publicationStatus: "PUBLISHED", isFeatured: true },
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED", isFeatured: true, ...notDeleted },
       orderBy: { name: "asc" },
       take: 8,
       select: { id: true, slug: true, name: true, photoUrl: true, company: true },
@@ -50,10 +51,18 @@ export default async function speakerRoutes(app: FastifyInstance) {
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
     const speaker = await prisma.speaker.findFirst({
-      where: { editionId: edition.id, slug: request.params.slug, publicationStatus: "PUBLISHED" },
+      where: {
+        editionId: edition.id,
+        slug: request.params.slug,
+        publicationStatus: "PUBLISHED",
+        ...notDeleted,
+      },
       include: {
+        // Nested reads need their own filter: a query extension would not reach
+        // them (Prisma applies those to the top-level operation only), and a
+        // trashed talk would otherwise still show up on a live speaker page.
         talks: {
-          where: { publicationStatus: "PUBLISHED" },
+          where: { publicationStatus: "PUBLISHED", ...notDeleted },
           select: { slug: true, title: true, format: true },
           orderBy: { title: "asc" },
         },

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { getFeaturedEdition } from "./editions.js";
 import { areOffersVisible } from "../lib/job-offers.js";
+import { notDeleted } from "../lib/admin-helpers.js";
 
 // Decreasing importance order (RG-221), used to sort levels for display.
 const LEVEL_ORDER: Record<string, number> = {
@@ -29,7 +30,7 @@ export default async function sponsorRoutes(app: FastifyInstance) {
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
     const sponsors = await prisma.sponsor.findMany({
-      where: { editionId: edition.id, publicationStatus: "PUBLISHED" },
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
     });
 
     return sponsors
@@ -54,10 +55,18 @@ export default async function sponsorRoutes(app: FastifyInstance) {
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
     const sponsor = await prisma.sponsor.findFirst({
-      where: { editionId: edition.id, slug: request.params.slug, publicationStatus: "PUBLISHED" },
+      where: {
+        editionId: edition.id,
+        slug: request.params.slug,
+        publicationStatus: "PUBLISHED",
+        ...notDeleted,
+      },
       include: {
+        // Nested reads need their own filter: a query extension would not reach
+        // them (Prisma applies those to the top-level operation only), and a
+        // trashed speaker would otherwise still show up on a live sponsor page.
         speakers: {
-          where: { publicationStatus: "PUBLISHED" },
+          where: { publicationStatus: "PUBLISHED", ...notDeleted },
           select: { slug: true, name: true, photoUrl: true, company: true },
           orderBy: { name: "asc" },
         },
@@ -100,6 +109,7 @@ export default async function sponsorRoutes(app: FastifyInstance) {
       where: {
         editionId: edition.id,
         publicationStatus: "PUBLISHED",
+        ...notDeleted,
         jobOffers: { some: {} },
       },
       select: {

--- a/src/backend/src/routes/talks.ts
+++ b/src/backend/src/routes/talks.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { getFeaturedEdition } from "./editions.js";
+import { notDeleted, visibleCategory } from "../lib/admin-helpers.js";
 
 export default async function talkRoutes(app: FastifyInstance) {
   // GET /api/talks/:slug — detail of a published talk + its published speakers
@@ -14,14 +15,25 @@ export default async function talkRoutes(app: FastifyInstance) {
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
     const talk = await prisma.talk.findFirst({
-      where: { editionId: edition.id, slug: request.params.slug, publicationStatus: "PUBLISHED" },
+      where: {
+        editionId: edition.id,
+        slug: request.params.slug,
+        publicationStatus: "PUBLISHED",
+        ...notDeleted,
+      },
       include: {
+        // Nested reads need their own filter: a query extension would not reach
+        // them (Prisma applies those to the top-level operation only), and a
+        // trashed speaker would otherwise still show up on a live talk page.
         speakers: {
-          where: { publicationStatus: "PUBLISHED" },
+          where: { publicationStatus: "PUBLISHED", ...notDeleted },
           select: { slug: true, name: true, photoUrl: true, company: true },
           orderBy: { name: "asc" },
         },
-        category: { select: { nameFr: true, nameEn: true, color: true } },
+        // `category` is to-one: Prisma takes no `where` there, so a trashed
+        // category cannot be filtered out by the query. `deletedAt` comes along
+        // and the serializer below drops it (#147).
+        category: { select: { nameFr: true, nameEn: true, color: true, deletedAt: true } },
       },
     });
 
@@ -35,7 +47,7 @@ export default async function talkRoutes(app: FastifyInstance) {
       format: talk.format,
       level: talk.level,
       language: talk.language,
-      category: talk.category,
+      category: visibleCategory(talk.category),
       speakers: talk.speakers,
     };
   });


### PR DESCRIPTION
## Résumé

**Partie A de #147.** Les 12 handlers DELETE de l'admin cessent de supprimer
physiquement, et **toutes les lectures admin** filtrent la corbeille.

Les lectures **publiques / SSR / SEO** font l'objet d'une **partie B** séparée :
c'est là que se situe le risque de régression, et elle mérite sa propre revue.

> Empilée sur #298 (#146). À merger après elle.

## Les deux décisions de #146, appliquées

**Unicité** — un élément mis en corbeille gare ses valeurs uniques pour libérer
le namespace : slugs de `Talk`/`Speaker`/`Sponsor`/`Article`, `name` **et**
`slug` de `Tag`, `slug` de `ContactCategory` si renseigné, `email` de `User`.

Deux exceptions assumées : `Edition.year` et `TicketTier.sortOrder` sont des
entiers, impossibles à garer par préfixe. Ils conservent leur créneau jusqu'à la
purge — commenté à chaque endroit.

**Cascades** — mettre une `Edition` à la corbeille **refuse** s'il reste des
enfants vivants, en listant ce qui bloque. Le contrôle sur les articles
fonctionnait déjà ainsi ; talks, speakers, sponsors, catégories, plans et tarifs
suivent désormais la même règle. Les comptes ignorent les enfants en corbeille :
une édition dont tous les talks sont supprimés est réellement vide.

## Deux pièges mécaniques

**`findUnique` ne peut pas porter le filtre** — son `where` de premier niveau
n'accepte que des champs uniques. Les recherches par id deviennent `findFirst`.
Vérifié dans la documentation Prisma 7, pas supposé.

**Les lectures imbriquées ont besoin de leur propre `where`.** Une extension
`$extends` était l'alternative évidente ; elle a été **écartée précisément pour
ça** : le source de Prisma 7 applique les extensions de requête à l'opération de
premier niveau **uniquement**. Elle aurait donc manqué silencieusement chaque
relation imbriquée — tout en donnant l'illusion d'une couverture complète.

## Ce qui n'est délibérément PAS filtré

Les gardes d'unicité (collisions de slug / name / year / email). Elles **doivent**
continuer à voir les éléments en corbeille, sinon une création passe la
validation puis échoue sur la contrainte SQL. Commenté à chaque appel.

## Ce qui reste en suppression physique

`keyFigure`, `fileMetadata`, `sponsorContact`, `sponsorJobOffer` et `session`
sont hors périmètre de la corbeille.

Le `deleteMany` de la **réimportation BilletWeb** reste également physique : un
soft-delete y conserverait les `sortOrder`, et le second import d'une édition
heurterait `@@unique([editionId, sortOrder])`. `sortOrder` étant un entier, il
n'existe pas d'échappatoire par parking. Les tarifs remplacés sont de simples
copies de ce que BilletWeb vient de renvoyer — rien à conserver en corbeille.

## Test plan

- [x] `tsc --noEmit` propre
- [x] Suite complète : **347 tests / 52 fichiers, 0 échec**
- [x] Audit des `delete` restants : les 7 sont hors périmètre ou justifiés
- [ ] CI verte
- [ ] Vérification navigateur (admin) — **à faire avant merge**

### Les nouveaux tests couvrent ce que les anciens ne pouvaient pas voir

Les tests DELETE existants vérifient « 404 après suppression » — **un hard delete
satisfait cette assertion aussi bien qu'un soft delete**. Ils resteraient verts
si cette PR était annulée.

`soft-delete.test.ts` teste ce qui distingue réellement les deux :

- [x] La ligne **survit** en base avec `deletedAt` renseigné
- [x] Le slug est **garé** et récupérable (`unparkUniqueValue` rend l'original)
- [x] Le slug libéré est **réutilisable** par une nouvelle conférence
- [x] Un second DELETE renvoie **404** au lieu de réarmer l'horloge de purge (#145d)
- [x] L'élément disparaît de la liste admin
- [x] La route de détail renvoie 404

## Note de méthode

Les fichiers `speakers.ts`/`sponsors.ts` et
`articles.ts`/`categories.ts`/`sponsor-plans.ts`/`tickets.ts` ont été traités par
deux agents en parallèle, à partir de `talks.ts` que j'avais implémenté comme
référence. J'ai relu leurs diffs avant de les endosser, et vérifié leurs
affirmations sur le schéma (`SponsorJobOffer` et `SponsorContact` n'ont
effectivement pas de `deletedAt`).

L'un d'eux **a contredit ma consigne** sur le `deleteMany` de BilletWeb, avec le
raisonnement repris ci-dessus. Après vérification, il avait raison : ma consigne
aurait cassé la réimportation.

Refs #147
