### PR TITLE
Corbeille 145c — endpoints list / restore / purge (#148)

### DIFF
--- a/src/backend/src/__tests__/admin-tickets.test.ts
+++ b/src/backend/src/__tests__/admin-tickets.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
 import { buildAdminApp } from "./test-admin-app.js";
+import { prisma } from "../lib/prisma.js";
+
+// Same teardown problem as admin-articles.test.ts: these tests delete through
+// the API, which only trashes since #147, so each run left its fixtures behind.
+// TicketTier cannot park its unique `sortOrder` (it is an Int), so the leftovers
+// also kept holding their slot in `@@unique([editionId, sortOrder])`.
+afterAll(async () => {
+  await prisma.ticketTier.deleteMany({ where: { deletedAt: { not: null } } });
+});
 
 describe("Admin Tickets API", () => {
   it("GET /api/admin/tickets should list ticket tiers", async () => {

--- a/src/backend/src/__tests__/trash-endpoints.test.ts
+++ b/src/backend/src/__tests__/trash-endpoints.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+import Fastify from "fastify";
+
+// The purge route carries its own `requireAdminRole`, so unlike the other admin
+// test apps this one cannot simply skip the guards — the route would 403. The
+// auth context is stubbed instead, which lets the ADMIN-only rule be tested for
+// real: `describe("purge authorisation")` at the bottom drives it as an EDITOR
+// and expects a refusal.
+const authContext = vi.hoisted(() => ({
+  current: { user: { id: "test-admin", email: "admin@test.local", name: "Test", role: "ADMIN" } },
+}));
+
+vi.mock("../lib/auth-context.js", () => ({
+  getAuthContext: async () => authContext.current,
+}));
+
+const { default: adminTrashRoutes } = await import("../routes/admin/trash.js");
+const { default: adminArticleRoutes } = await import("../routes/admin/articles.js");
+const { prisma } = await import("../lib/prisma.js");
+const { softDeleteData, parkUniqueValue } = await import("../lib/admin-helpers.js");
+const { countFileReferences } = await import("../lib/trash-files.js");
+
+async function buildTrashApp() {
+  const app = Fastify({ logger: false });
+  await app.register(adminTrashRoutes, { prefix: "/api/admin" });
+  await app.register(adminArticleRoutes, { prefix: "/api/admin" });
+  return app;
+}
+
+const createdArticleIds: number[] = [];
+
+afterEach(async () => {
+  if (createdArticleIds.length) {
+    await prisma.article.deleteMany({ where: { id: { in: createdArticleIds } } });
+    createdArticleIds.length = 0;
+  }
+});
+
+async function createArticle(slug: string, imageUrl?: string) {
+  const article = await prisma.article.create({
+    data: {
+      slug,
+      titleFr: `Titre ${slug}`,
+      titleEn: `Title ${slug}`,
+      contentFr: "<p>x</p>",
+      contentEn: "<p>x</p>",
+      publicationStatus: "PUBLISHED",
+      ...(imageUrl ? { imageUrl } : {}),
+    },
+  });
+  createdArticleIds.push(article.id);
+  return article;
+}
+
+async function trash(id: number, slug: string) {
+  await prisma.article.update({
+    where: { id },
+    data: { ...softDeleteData(), slug: parkUniqueValue(slug, id) },
+  });
+}
+
+describe("trash endpoints (#148)", () => {
+  it("lists a trashed row and unparks its label", async () => {
+    const app = await buildTrashApp();
+    const slug = `zz-trash-list-${Date.now()}`;
+    const article = await createArticle(slug);
+    await trash(article.id, slug);
+
+    const res = await app.inject({ method: "GET", url: "/api/admin/trash/articles" });
+    expect(res.statusCode).toBe(200);
+
+    const found = res.json().items.find((i: { id: number }) => i.id === article.id);
+    expect(found).toBeDefined();
+    expect(found.deletedAt).not.toBeNull();
+    // titleFr is not a parked field, so it shows as-is — the point is that no
+    // `__trash_` marker leaks into what the admin reads.
+    expect(found.label).not.toContain("__trash_");
+
+    await app.close();
+  });
+
+  it("restores a row and gives its slug back", async () => {
+    const app = await buildTrashApp();
+    const slug = `zz-trash-restore-${Date.now()}`;
+    const article = await createArticle(slug);
+    await trash(article.id, slug);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/trash/articles/${article.id}/restore`,
+    });
+    expect(res.statusCode).toBe(200);
+
+    const restored = await prisma.article.findUnique({ where: { id: article.id } });
+    expect(restored?.deletedAt).toBeNull();
+    expect(restored?.slug).toBe(slug);
+
+    await app.close();
+  });
+
+  it("refuses to restore when the slug was taken meanwhile, naming the field", async () => {
+    const app = await buildTrashApp();
+    const slug = `zz-trash-conflict-${Date.now()}`;
+    const article = await createArticle(slug);
+    await trash(article.id, slug);
+
+    // Parking freed the slug — so something else can legitimately claim it.
+    const squatter = await createArticle(slug);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/trash/articles/${article.id}/restore`,
+    });
+
+    // A raw Prisma unique-constraint error would surface as a 500 here.
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe("restore_conflict");
+    expect(res.json().fields).toContain("slug");
+
+    // The row must stay in the trash, untouched.
+    const still = await prisma.article.findUnique({ where: { id: article.id } });
+    expect(still?.deletedAt).not.toBeNull();
+    expect(still?.id).not.toBe(squatter.id);
+
+    await app.close();
+  });
+
+  it("purges a trashed row for good", async () => {
+    const app = await buildTrashApp();
+    const slug = `zz-trash-purge-${Date.now()}`;
+    const article = await createArticle(slug);
+    await trash(article.id, slug);
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/api/admin/trash/articles/${article.id}/purge`,
+    });
+    expect(res.statusCode).toBe(200);
+
+    const gone = await prisma.article.findUnique({ where: { id: article.id } });
+    expect(gone).toBeNull();
+
+    await app.close();
+  });
+
+  it("refuses to purge a row that is not in the trash", async () => {
+    const app = await buildTrashApp();
+    const slug = `zz-trash-live-${Date.now()}`;
+    const article = await createArticle(slug);
+
+    // The guard that keeps a stray call from destroying live data.
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/api/admin/trash/articles/${article.id}/purge`,
+    });
+    expect(res.statusCode).toBe(404);
+
+    const alive = await prisma.article.findUnique({ where: { id: article.id } });
+    expect(alive).not.toBeNull();
+
+    await app.close();
+  });
+
+  it("keeps a shared upload when another row still points at it", async () => {
+    const app = await buildTrashApp();
+    const shared = "/uploads/zz-shared-fixture.png";
+    const slugA = `zz-share-a-${Date.now()}`;
+    const slugB = `zz-share-b-${Date.now()}`;
+
+    const a = await createArticle(slugA, shared);
+    await createArticle(slugB, shared);
+    await trash(a.id, slugA);
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/api/admin/trash/articles/${a.id}/purge`,
+    });
+    expect(res.statusCode).toBe(200);
+
+    // Real data already had one image on two articles; deleting the file with
+    // the row would have broken the survivor's illustration.
+    const outcome = res.json().files.find((f: { url: string }) => f.url === shared);
+    expect(outcome.deleted).toBe(false);
+    expect(outcome.reason).toBe("still_referenced");
+
+    await app.close();
+  });
+
+  it("counts references across entities, not just within one", async () => {
+    const slug = `zz-refcount-${Date.now()}`;
+    const url = "/uploads/zz-refcount-fixture.png";
+    const article = await createArticle(slug, url);
+
+    // Excluding the only holder leaves nothing.
+    expect(await countFileReferences(url, { model: "article", id: article.id })).toBe(0);
+    // Excluding a different row still sees it.
+    expect(await countFileReferences(url, { model: "article", id: article.id + 999999 })).toBe(1);
+  });
+
+  it("404s on an unknown entity rather than guessing", async () => {
+    const app = await buildTrashApp();
+    const res = await app.inject({ method: "GET", url: "/api/admin/trash/nonexistent" });
+    expect(res.statusCode).toBe(404);
+    await app.close();
+  });
+
+  it("refuses the purge to an EDITOR, and still lets them restore", async () => {
+    const app = await buildTrashApp();
+    const slug = `zz-trash-editor-${Date.now()}`;
+    const article = await createArticle(slug);
+    await trash(article.id, slug);
+
+    const asAdmin = authContext.current;
+    authContext.current = {
+      user: { id: "test-editor", email: "editor@test.local", name: "Ed", role: "EDITOR" },
+    };
+
+    try {
+      // Destroying a row for good is not an editor's call.
+      const purge = await app.inject({
+        method: "DELETE",
+        url: `/api/admin/trash/articles/${article.id}/purge`,
+      });
+      expect(purge.statusCode).toBe(403);
+
+      const stillThere = await prisma.article.findUnique({ where: { id: article.id } });
+      expect(stillThere).not.toBeNull();
+
+      // Restoring is reversible, so editors keep it.
+      const restore = await app.inject({
+        method: "POST",
+        url: `/api/admin/trash/articles/${article.id}/restore`,
+      });
+      expect(restore.statusCode).toBe(200);
+    } finally {
+      authContext.current = asAdmin;
+    }
+
+    await app.close();
+  });
+
+  it("reports a per-entity summary with a total", async () => {
+    const app = await buildTrashApp();
+    const slug = `zz-trash-summary-${Date.now()}`;
+    const article = await createArticle(slug);
+    await trash(article.id, slug);
+
+    const res = await app.inject({ method: "GET", url: "/api/admin/trash" });
+    expect(res.statusCode).toBe(200);
+
+    const body = res.json();
+    const articles = body.entities.find((e: { entity: string }) => e.entity === "articles");
+    expect(articles.count).toBeGreaterThan(0);
+    expect(body.total).toBeGreaterThanOrEqual(articles.count);
+
+    await app.close();
+  });
+});

--- a/src/backend/src/__tests__/trash-endpoints.test.ts
+++ b/src/backend/src/__tests__/trash-endpoints.test.ts
@@ -240,6 +240,62 @@ describe("trash endpoints (#148)", () => {
     await app.close();
   });
 
+  it("keeps an EDITOR out of ADMIN-only entities, list and restore alike", async () => {
+    const app = await buildTrashApp();
+    const asAdmin = authContext.current;
+    authContext.current = {
+      user: { id: "test-editor", email: "editor@test.local", name: "Ed", role: "EDITOR" },
+    };
+
+    try {
+      // The trash must not become a side door around the per-entity role rules.
+      // `users` is labelled by email, so listing alone would leak admin
+      // addresses; restoring a trashed admin account escalates privilege.
+      for (const key of ["users", "editions", "ticket-tiers", "sponsor-plans"]) {
+        const list = await app.inject({ method: "GET", url: `/api/admin/trash/${key}` });
+        expect(list.statusCode, `GET ${key}`).toBe(403);
+
+        const restore = await app.inject({
+          method: "POST",
+          url: `/api/admin/trash/${key}/1/restore`,
+        });
+        expect(restore.statusCode, `restore ${key}`).toBe(403);
+      }
+
+      // Editorial entities stay reachable — that is the whole point of the split.
+      const articles = await app.inject({ method: "GET", url: "/api/admin/trash/articles" });
+      expect(articles.statusCode).toBe(200);
+    } finally {
+      authContext.current = asAdmin;
+    }
+
+    await app.close();
+  });
+
+  it("hides ADMIN-only entities from an EDITOR's summary", async () => {
+    const app = await buildTrashApp();
+    const asAdmin = authContext.current;
+
+    const adminView = await app.inject({ method: "GET", url: "/api/admin/trash" });
+    const adminKeys = adminView.json().entities.map((e: { entity: string }) => e.entity);
+    expect(adminKeys).toContain("users");
+
+    authContext.current = {
+      user: { id: "test-editor", email: "editor@test.local", name: "Ed", role: "EDITOR" },
+    };
+    try {
+      const editorView = await app.inject({ method: "GET", url: "/api/admin/trash" });
+      const editorKeys = editorView.json().entities.map((e: { entity: string }) => e.entity);
+      expect(editorKeys).not.toContain("users");
+      expect(editorKeys).not.toContain("editions");
+      expect(editorKeys).toContain("articles");
+    } finally {
+      authContext.current = asAdmin;
+    }
+
+    await app.close();
+  });
+
   it("reports a per-entity summary with a total", async () => {
     const app = await buildTrashApp();
     const slug = `zz-trash-summary-${Date.now()}`;

--- a/src/backend/src/lib/trash-files.ts
+++ b/src/backend/src/lib/trash-files.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { prisma } from "./prisma.js";
+
+const UPLOADS_DIR = process.env.UPLOADS_DIR || "/app/uploads";
+
+// Every column that can point at an /uploads/ path. Purging a row must not
+// delete a file another row still shows: uploads live in a shared library
+// (/admin/files), they are not owned by the entity that references them.
+//
+// Verified on real data before writing this: one image was already referenced
+// by two different articles. A naive "delete the row's files" purge would have
+// broken the surviving article's illustration.
+const FILE_REFERENCES: readonly { model: string; field: string }[] = [
+  { model: "article", field: "imageUrl" },
+  { model: "speaker", field: "photoUrl" },
+  { model: "sponsor", field: "logoUrl" },
+  { model: "edition", field: "heroImageUrl" },
+  { model: "edition", field: "sponsorHeroImageUrl" },
+  { model: "edition", field: "sponsorBrochureUrl" },
+];
+
+type CountDelegate = { count: (args: unknown) => Promise<number> };
+
+/**
+ * How many rows still point at this upload, ignoring one row about to go.
+ *
+ * Counts across ALL entities, trashed ones included: a trashed row can still be
+ * restored, and it would come back to a missing image otherwise.
+ */
+export async function countFileReferences(
+  url: string,
+  excluding: { model: string; id: number | string },
+): Promise<number> {
+  let total = 0;
+  for (const ref of FILE_REFERENCES) {
+    const delegate = (prisma as unknown as Record<string, CountDelegate>)[ref.model];
+    if (!delegate) continue;
+    const where: Record<string, unknown> = { [ref.field]: url };
+    if (ref.model === excluding.model) where.id = { not: excluding.id };
+    total += await delegate.count({ where });
+  }
+  return total;
+}
+
+/** Guard against a crafted path escaping the uploads directory. */
+function resolveUploadPath(url: string): string | null {
+  if (!url.startsWith("/uploads/")) return null;
+  const name = path.basename(url);
+  if (!name || name === "." || name === "..") return null;
+  const full = path.join(UPLOADS_DIR, name);
+  const root = path.resolve(UPLOADS_DIR);
+  return path.resolve(full).startsWith(root) ? full : null;
+}
+
+export interface FilePurgeOutcome {
+  url: string;
+  deleted: boolean;
+  reason?: "still_referenced" | "not_found" | "outside_uploads";
+}
+
+/**
+ * Delete the files a purged row owned, skipping any still in use elsewhere.
+ * Never throws: a purge that already removed the database row must not fail
+ * because a file was missing from disk.
+ */
+export async function purgeFiles(
+  urls: readonly (string | null | undefined)[],
+  owner: { model: string; id: number | string },
+): Promise<FilePurgeOutcome[]> {
+  const outcomes: FilePurgeOutcome[] = [];
+
+  for (const url of urls) {
+    if (!url) continue;
+
+    const stillUsed = await countFileReferences(url, owner);
+    if (stillUsed > 0) {
+      outcomes.push({ url, deleted: false, reason: "still_referenced" });
+      continue;
+    }
+
+    const full = resolveUploadPath(url);
+    if (!full) {
+      outcomes.push({ url, deleted: false, reason: "outside_uploads" });
+      continue;
+    }
+
+    try {
+      await fs.promises.unlink(full);
+      outcomes.push({ url, deleted: true });
+    } catch {
+      // Already gone, or never on this disk. The row is what mattered.
+      outcomes.push({ url, deleted: false, reason: "not_found" });
+    }
+  }
+
+  return outcomes;
+}

--- a/src/backend/src/lib/trash-registry.ts
+++ b/src/backend/src/lib/trash-registry.ts
@@ -1,0 +1,147 @@
+import { prisma } from "./prisma.js";
+
+/**
+ * What the trash knows about each soft-deletable entity (#148).
+ *
+ * Twelve entities × three operations (list / restore / purge) is thirty-six
+ * routes if written by hand. They only differ by four things — the Prisma
+ * delegate, which field labels a row in the UI, which unique fields were parked
+ * on the way in, and which fields hold uploaded files — so those differences
+ * live here and the routes stay generic.
+ */
+
+export interface TrashEntity {
+  /** URL segment: /api/admin/trash/<key>. */
+  key: string;
+  /** Prisma model name, used to reach the delegate. */
+  model: string;
+  /** Field shown to identify the row in the trash list. */
+  labelField: string;
+  /** Unique fields parked on soft delete — unparked on restore (#146). */
+  parkedFields: readonly string[];
+  /** Fields holding an /uploads/ path, checked before purging a file. */
+  fileFields: readonly string[];
+  /** ADMIN-only entities; the rest follow the ADMIN+EDITOR rule. */
+  adminOnly: boolean;
+}
+
+export const TRASH_ENTITIES: readonly TrashEntity[] = [
+  {
+    key: "articles",
+    model: "article",
+    labelField: "titleFr",
+    parkedFields: ["slug"],
+    fileFields: ["imageUrl"],
+    adminOnly: false,
+  },
+  {
+    key: "tags",
+    model: "tag",
+    labelField: "name",
+    // Both are @unique on Tag, so both are parked and both must come back.
+    parkedFields: ["name", "slug"],
+    fileFields: [],
+    adminOnly: false,
+  },
+  {
+    key: "speakers",
+    model: "speaker",
+    labelField: "name",
+    parkedFields: ["slug"],
+    fileFields: ["photoUrl"],
+    adminOnly: false,
+  },
+  {
+    key: "talks",
+    model: "talk",
+    labelField: "title",
+    parkedFields: ["slug"],
+    fileFields: [],
+    adminOnly: false,
+  },
+  {
+    key: "sponsors",
+    model: "sponsor",
+    labelField: "name",
+    parkedFields: ["slug"],
+    fileFields: ["logoUrl"],
+    adminOnly: false,
+  },
+  {
+    key: "categories",
+    model: "category",
+    labelField: "nameFr",
+    parkedFields: [],
+    fileFields: [],
+    adminOnly: false,
+  },
+  {
+    key: "ticket-tiers",
+    model: "ticketTier",
+    labelField: "nameFr",
+    // sortOrder is unique per edition but numeric — it cannot be parked under a
+    // string prefix, so it kept its slot while trashed (#147). Restoring is
+    // therefore safe; creating a new tier at that exact slot is what fails.
+    parkedFields: [],
+    fileFields: [],
+    adminOnly: true,
+  },
+  {
+    key: "sponsor-plans",
+    model: "sponsorPlan",
+    labelField: "nameFr",
+    parkedFields: [],
+    fileFields: [],
+    adminOnly: true,
+  },
+  {
+    key: "contact-categories",
+    model: "contactCategory",
+    labelField: "nameFr",
+    parkedFields: ["slug"],
+    fileFields: [],
+    adminOnly: false,
+  },
+  {
+    key: "contact-messages",
+    model: "contactMessage",
+    labelField: "email",
+    parkedFields: [],
+    fileFields: [],
+    adminOnly: false,
+  },
+  {
+    key: "editions",
+    model: "edition",
+    labelField: "year",
+    // `year` is unique but numeric — same limitation as ticket sortOrder.
+    parkedFields: [],
+    fileFields: ["heroImageUrl", "sponsorHeroImageUrl", "sponsorBrochureUrl"],
+    adminOnly: true,
+  },
+  {
+    key: "users",
+    model: "user",
+    labelField: "email",
+    parkedFields: ["email"],
+    fileFields: [],
+    adminOnly: true,
+  },
+];
+
+export function findTrashEntity(key: string): TrashEntity | undefined {
+  return TRASH_ENTITIES.find((e) => e.key === key);
+}
+
+/** Reach a Prisma delegate by model name, without `any` leaking into callers. */
+type Delegate = {
+  findMany: (args: unknown) => Promise<Record<string, unknown>[]>;
+  findFirst: (args: unknown) => Promise<Record<string, unknown> | null>;
+  update: (args: unknown) => Promise<Record<string, unknown>>;
+  delete: (args: unknown) => Promise<Record<string, unknown>>;
+  count: (args: unknown) => Promise<number>;
+};
+
+export function delegateFor(entity: TrashEntity): Delegate {
+  return (prisma as unknown as Record<string, Delegate>)[entity.model];
+}

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -18,6 +18,7 @@ import adminTalkRoutes from "./talks.js";
 import adminImportRoutes from "./import.js";
 import adminApiKeyRoutes from "./api-keys.js";
 import adminTranslateRoutes from "./translate.js";
+import adminTrashRoutes from "./trash.js";
 
 export default async function adminRoutes(app: FastifyInstance) {
   // Auth check route (does its own auth check internally)
@@ -36,6 +37,9 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminCategoryRoutes);
     await editorApp.register(adminTalkRoutes);
     await editorApp.register(adminImportRoutes);
+    // Editors may consult and restore; the purge route carries its own
+    // ADMIN-only guard, since destroying a row for good is not theirs to do.
+    await editorApp.register(adminTrashRoutes);
   });
 
   // Routes restricted to ADMIN only

--- a/src/backend/src/routes/admin/trash.ts
+++ b/src/backend/src/routes/admin/trash.ts
@@ -1,0 +1,156 @@
+import type { FastifyInstance } from "fastify";
+
+import { requireAdminRole } from "../../lib/admin-guard.js";
+import { onlyDeleted, notDeleted, restoreData, unparkUniqueValue } from "../../lib/admin-helpers.js";
+import { TRASH_ENTITIES, findTrashEntity, delegateFor } from "../../lib/trash-registry.js";
+import { purgeFiles } from "../../lib/trash-files.js";
+
+/**
+ * The trash, backend side (#148): consult it, restore from it, empty it.
+ *
+ * One generic set of routes over the registry rather than thirty-six
+ * hand-written handlers — see trash-registry.ts for what varies per entity.
+ */
+
+interface EntityParams {
+  entity: string;
+}
+interface EntityIdParams extends EntityParams {
+  id: string;
+}
+
+const entityParamSchema = {
+  type: "object",
+  required: ["entity"],
+  properties: { entity: { type: "string" } },
+} as const;
+
+const entityIdParamSchema = {
+  type: "object",
+  required: ["entity", "id"],
+  properties: { entity: { type: "string" }, id: { type: "string" } },
+} as const;
+
+// `id` is an Int everywhere except User, which Better Auth keys by cuid.
+function coerceId(entityModel: string, raw: string): number | string | null {
+  if (entityModel === "user") return raw.trim() || null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export default async function adminTrashRoutes(app: FastifyInstance) {
+  // GET /api/admin/trash — how many rows sit in the trash, per entity.
+  app.get("/trash", async () => {
+    const counts = await Promise.all(
+      TRASH_ENTITIES.map(async (entity) => ({
+        entity: entity.key,
+        count: await delegateFor(entity).count({ where: onlyDeleted }),
+      })),
+    );
+    return { entities: counts, total: counts.reduce((sum, c) => sum + c.count, 0) };
+  });
+
+  // GET /api/admin/trash/:entity — the trashed rows of one entity.
+  app.get<{ Params: EntityParams }>("/trash/:entity", {
+    schema: { params: entityParamSchema },
+  }, async (request, reply) => {
+    const entity = findTrashEntity(request.params.entity);
+    if (!entity) return reply.code(404).send({ error: "Unknown trash entity" });
+
+    const rows = await delegateFor(entity).findMany({
+      where: onlyDeleted,
+      orderBy: { deletedAt: "desc" },
+    });
+
+    return {
+      entity: entity.key,
+      items: rows.map((row) => {
+        const raw = row[entity.labelField];
+        const label = typeof raw === "string" ? unparkUniqueValue(raw) : String(raw ?? "");
+        return {
+          id: row.id,
+          // Unparked for display: when the label field is itself parked (Tag
+          // name, User email), the stored value carries the `__trash_<id>__`
+          // marker — an implementation detail, not something to show an admin.
+          label,
+          deletedAt: row.deletedAt,
+        };
+      }),
+    };
+  });
+
+  // POST /api/admin/trash/:entity/:id/restore
+  app.post<{ Params: EntityIdParams }>("/trash/:entity/:id/restore", {
+    schema: { params: entityIdParamSchema },
+  }, async (request, reply) => {
+    const entity = findTrashEntity(request.params.entity);
+    if (!entity) return reply.code(404).send({ error: "Unknown trash entity" });
+
+    const id = coerceId(entity.model, request.params.id);
+    if (id === null) return reply.code(400).send({ error: "Invalid ID" });
+
+    const delegate = delegateFor(entity);
+    const row = await delegate.findFirst({ where: { id, ...onlyDeleted } });
+    if (!row) return reply.code(404).send({ error: "Not found in trash" });
+
+    // Unpark the unique values — and check each is actually free. Anything
+    // could have taken the slug while the row sat in the trash; restoring
+    // blindly would throw a raw Prisma unique-constraint error at the admin.
+    const restored: Record<string, unknown> = { ...restoreData() };
+    const conflicts: string[] = [];
+
+    for (const field of entity.parkedFields) {
+      const parked = row[field];
+      if (typeof parked !== "string") continue;
+
+      const original = unparkUniqueValue(parked);
+      const taken = await delegate.findFirst({
+        where: { [field]: original, id: { not: id }, ...notDeleted },
+      });
+      if (taken) conflicts.push(field);
+      else restored[field] = original;
+    }
+
+    if (conflicts.length > 0) {
+      return reply.code(409).send({
+        error: "restore_conflict",
+        // Named fields so the UI can say *what* clashes, not just that it does.
+        fields: conflicts,
+        message: `Impossible de restaurer : ${conflicts.join(", ")} déjà utilisé par un élément actif.`,
+      });
+    }
+
+    await delegate.update({ where: { id }, data: restored });
+    return { restored: true, id };
+  });
+
+  // DELETE /api/admin/trash/:entity/:id/purge — ADMIN only, irreversible.
+  app.delete<{ Params: EntityIdParams }>("/trash/:entity/:id/purge", {
+    preHandler: [requireAdminRole],
+    schema: { params: entityIdParamSchema },
+  }, async (request, reply) => {
+    const entity = findTrashEntity(request.params.entity);
+    if (!entity) return reply.code(404).send({ error: "Unknown trash entity" });
+
+    const id = coerceId(entity.model, request.params.id);
+    if (id === null) return reply.code(400).send({ error: "Invalid ID" });
+
+    const delegate = delegateFor(entity);
+    // Only ever purge from the trash: a row must be soft-deleted first, so a
+    // stray call cannot destroy live data.
+    const row = await delegate.findFirst({ where: { id, ...onlyDeleted } });
+    if (!row) return reply.code(404).send({ error: "Not found in trash" });
+
+    const fileUrls = entity.fileFields.map((f) => row[f] as string | null);
+
+    await delegate.delete({ where: { id } });
+
+    // After the row is gone, so the reference count no longer sees it. Files
+    // still used elsewhere are kept — uploads are a shared library, not owned
+    // by the row that happens to point at them.
+    const files = await purgeFiles(fileUrls, { model: entity.model, id });
+
+    return { purged: true, id, files };
+  });
+}
+

--- a/src/backend/src/routes/admin/trash.ts
+++ b/src/backend/src/routes/admin/trash.ts
@@ -1,6 +1,7 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 
 import { requireAdminRole } from "../../lib/admin-guard.js";
+import { getAuthContext } from "../../lib/auth-context.js";
 import { onlyDeleted, notDeleted, restoreData, unparkUniqueValue } from "../../lib/admin-helpers.js";
 import { TRASH_ENTITIES, findTrashEntity, delegateFor } from "../../lib/trash-registry.js";
 import { purgeFiles } from "../../lib/trash-files.js";
@@ -38,11 +39,45 @@ function coerceId(entityModel: string, raw: string): number | string | null {
   return Number.isInteger(n) && n > 0 ? n : null;
 }
 
+/**
+ * The trash must not become a side door around the per-entity role rules.
+ *
+ * These routes are registered in the ADMIN+EDITOR group, so without this check
+ * an editor could list — and restore — entities that are ADMIN-only everywhere
+ * else: users, editions, ticket tiers, sponsor plans. Restoring a deleted admin
+ * account is a privilege-escalation path, and `users` is labelled by email, so
+ * merely listing it leaks admin addresses.
+ *
+ * `adminOnly` already sat in the registry describing exactly this; it was
+ * declared and never read. Enforced here.
+ */
+async function denyIfAdminOnly(
+  entity: { adminOnly: boolean },
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<boolean> {
+  if (!entity.adminOnly) return false;
+
+  const ctx = await getAuthContext(request);
+  if (!ctx || ctx.user.role !== "ADMIN") {
+    reply.code(403).send({ error: "Forbidden — admin only" });
+    return true;
+  }
+  return false;
+}
+
 export default async function adminTrashRoutes(app: FastifyInstance) {
   // GET /api/admin/trash — how many rows sit in the trash, per entity.
-  app.get("/trash", async () => {
+  app.get("/trash", async (request) => {
+    // Editors get the summary too, minus the entities they cannot open — a
+    // count they can never act on is noise at best, and a hint about deleted
+    // admin accounts at worst.
+    const ctx = await getAuthContext(request);
+    const isAdmin = ctx?.user.role === "ADMIN";
+    const visible = TRASH_ENTITIES.filter((entity) => isAdmin || !entity.adminOnly);
+
     const counts = await Promise.all(
-      TRASH_ENTITIES.map(async (entity) => ({
+      visible.map(async (entity) => ({
         entity: entity.key,
         count: await delegateFor(entity).count({ where: onlyDeleted }),
       })),
@@ -56,6 +91,7 @@ export default async function adminTrashRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const entity = findTrashEntity(request.params.entity);
     if (!entity) return reply.code(404).send({ error: "Unknown trash entity" });
+    if (await denyIfAdminOnly(entity, request, reply)) return;
 
     const rows = await delegateFor(entity).findMany({
       where: onlyDeleted,
@@ -85,6 +121,8 @@ export default async function adminTrashRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const entity = findTrashEntity(request.params.entity);
     if (!entity) return reply.code(404).send({ error: "Unknown trash entity" });
+    // Restoring a trashed ADMIN account would be a privilege-escalation path.
+    if (await denyIfAdminOnly(entity, request, reply)) return;
 
     const id = coerceId(entity.model, request.params.id);
     if (id === null) return reply.code(400).send({ error: "Invalid ID" });


### PR DESCRIPTION
## Résumé

Étape **3/5** de la corbeille (#145). La corbeille devient consultable,
restaurable et purgeable côté API.

```
GET    /api/admin/trash                       compteurs par entité + total
GET    /api/admin/trash/:entity               les éléments en corbeille
POST   /api/admin/trash/:entity/:id/restore   restauration
DELETE /api/admin/trash/:entity/:id/purge     suppression définitive (ADMIN)
```

12 entités × 3 opérations = 36 handlers écrits à la main. Ils ne diffèrent que
par quatre choses (le modèle Prisma, le champ libellé, les champs garés, les
champs fichiers) — ces différences vivent dans un registre
[trash-registry.ts](src/backend/src/lib/trash-registry.ts) et les routes restent
génériques.

> Empilée sur #299 (#147). À merger après elle.

## Trois décisions que l'issue laissait ouvertes

### Qui peut purger

Restaurer est réversible → les **EDITOR** le gardent.
Détruire définitivement ne l'est pas → **ADMIN uniquement**.

Le garde est posé **sur la route**, pas sur le groupe de routes : il tient donc
même si quelqu'un enregistre ces routes ailleurs. Vérifié par un test qui pilote
l'API en EDITOR et attend un 403 sur la purge, un 200 sur la restauration.

### Les conflits d'unicité à la restauration

Le parking libère le slug — donc **quelque chose peut légitimement le reprendre**
pendant que l'élément dort en corbeille. Restaurer sans vérifier renverrait une
erreur Prisma brute (500) à l'organisateur.

Chaque champ garé est donc contrôlé avant restauration, et un **409** nomme ce
qui bloque :

```json
{ "error": "restore_conflict", "fields": ["slug"],
  "message": "Impossible de restaurer : slug déjà utilisé par un élément actif." }
```

### ⚠️ Les fichiers partagés — le point qui a changé la conception

L'issue demande que la purge « nettoie les fichiers associés ». **J'ai vérifié
les données avant de coder** :

```
images partagées entre articles : 1
→ /uploads/1774791063243-4c6187ca.png utilisée par 2 articles
```

Une purge naïve aurait **cassé l'illustration de l'article survivant**.

Les uploads vivent dans une bibliothèque partagée (`/admin/files`) : ils
n'appartiennent pas à la ligne qui les référence. `purgeFiles()` compte donc les
références **sur toutes les entités** — y compris celles en corbeille, puisqu'une
restauration retrouverait sinon une image manquante — et conserve tout fichier
encore utilisé, en le signalant :

```json
"files": [{ "url": "/uploads/…png", "deleted": false, "reason": "still_referenced" }]
```

## Test plan

- [x] `tsc --noEmit` propre
- [x] Suite complète : **361 tests / 54 fichiers, 0 échec**
- [x] La suite ne laisse **aucun** élément en corbeille
- [ ] CI verte

### Vérifié sur le backend réel, session admin (pas seulement `app.inject`)

| Contrôle | Résultat |
|---|---|
| Résumé + liste | 200, libellé sans marqueur `__trash_` |
| **Restauration** | slug rendu, article **re-servi publiquement en 200** |
| **Conflit** | **409** nommant `slug`, élément **intact** en corbeille |
| **Purge (image partagée)** | ligne supprimée, **fichier conservé** sur disque |
| Après purge | les 2 autres articles utilisant l'image sont intacts |

10 tests unitaires couvrent en plus : purge refusée sur un élément **vivant**
(404 — un appel égaré ne peut pas détruire de la donnée active), entité inconnue
(404), et comptage de références inter-entités.

## Effet de bord corrigé

`admin-tickets.test.ts` supprimait via l'API sans purger : **5 tarifs en
corbeille**, un par exécution. Je les ai découverts *grâce au nouveau résumé de
corbeille* — ils étaient invisibles jusque-là. `TicketTier` ne pouvant pas garer
son `sortOrder` (un entier), ces résidus retenaient en plus leur créneau
`@@unique([editionId, sortOrder])`.

Corrigé par une purge en `afterAll`. J'ai vérifié le reste de la suite : aucun
autre fichier ne supprime sans teardown.

## Note

Mon premier jet de tests supposait que le garde `requireAdminRole` ne
s'appliquerait pas sans session — les 3 tests de purge ont échoué en 403. C'est
le code qui avait raison : le garde tient bien isolément. Les tests ont été
repris pour simuler le contexte d'auth, ce qui permet au passage de tester
réellement la règle ADMIN/EDITOR.

Refs #148
