### PR TITLE
Corbeille 145d — purge automatique à 30 jours via cron externe (#149)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ REVALIDATE_SECRET=change-me-revalidate-secret-minimum-32-characters
 # HMAC secret to sign per-message brochure download links sent by email.
 # If absent, confirmation emails fall back to the raw URL (no per-message tracking).
 BROCHURE_TOKEN_SECRET=change-me-brochure-token-secret-min-32-chars
+# Lets the scheduled task call the trash purge without a session, via the
+# X-Purge-Secret header. Without it the endpoint only accepts an ADMIN session:
+# the automatic purge stops running, nothing breaks, nothing opens up.
+TRASH_PURGE_SECRET=change-me-trash-purge-secret-minimum-32-chars
+# Days a deleted item stays recoverable in the trash. Defaults to 30; an invalid
+# or < 1 value falls back to 30 so a typo cannot empty the trash.
+TRASH_RETENTION_DAYS=30
 
 # --- OAuth (Google + GitHub) — Lot 2 ---
 OAUTH_GOOGLE_CLIENT_ID=your-google-client-id

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,6 +56,10 @@ services:
       - SMTP_FROM=${SMTP_FROM:-contact@devfesttoulouse.fr}
       - BILLETWEB_USER=${BILLETWEB_USER:-}
       - BILLETWEB_KEY=${BILLETWEB_KEY:-}
+      # Scheduled trash purge (#149). Unset means the endpoint only accepts an
+      # ADMIN session — the purge stops running, nothing opens up.
+      - TRASH_PURGE_SECRET=${TRASH_PURGE_SECRET:-}
+      - TRASH_RETENTION_DAYS=${TRASH_RETENTION_DAYS:-}
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -57,6 +57,11 @@ services:
       - BILLETWEB_KEY=${BILLETWEB_KEY:-}
       - REVALIDATE_SECRET=${REVALIDATE_SECRET:-}
       - BROCHURE_TOKEN_SECRET=${BROCHURE_TOKEN_SECRET:-}
+      # Lets the scheduled trash purge authenticate without a session (#149).
+      # Unset locally by default: the endpoint then only accepts an ADMIN
+      # session, which is the safe fallback rather than an open door.
+      - TRASH_PURGE_SECRET=${TRASH_PURGE_SECRET:-}
+      - TRASH_RETENTION_DAYS=${TRASH_RETENTION_DAYS:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-}
     command: >

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -97,6 +97,11 @@ services:
       # HMAC secret to sign per-message brochure download links sent by email.
       # If unset, confirmation emails fall back to the raw URL (no tracking).
       - BROCHURE_TOKEN_SECRET=${BROCHURE_TOKEN_SECRET:-}
+      # Scheduled trash purge (#149) — see docs/variables-environnement.md for
+      # the Coolify task. Unset means the endpoint only accepts an ADMIN
+      # session: the purge stops running, nothing opens up.
+      - TRASH_PURGE_SECRET=${TRASH_PURGE_SECRET:-}
+      - TRASH_RETENTION_DAYS=${TRASH_RETENTION_DAYS:-}
       # Google Gemini key for the back-office FR<->EN translator. If unset,
       # POST /api/admin/translate returns 503 and the UI button is disabled.
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}

--- a/docs/variables-environnement.md
+++ b/docs/variables-environnement.md
@@ -43,6 +43,8 @@ Un fichier `.env.example` est fourni à la racine du projet avec des valeurs fic
 |----------|:-----------:|-------------|---------|
 | `SESSION_SECRET` | oui | Secret pour signer les cookies et sessions. Minimum 32 caractères aléatoires. | `a1b2c3d4...` |
 | `MAGIC_LINK_SECRET` | oui | Secret pour générer et vérifier les liens de modification speakers/sponsors. Distinct du `SESSION_SECRET`. | `e5f6g7h8...` |
+| `TRASH_PURGE_SECRET` | non | Secret partagé permettant à la tâche planifiée d'appeler la purge de corbeille sans session (en-tête `X-Purge-Secret`). **Sans cette variable, l'endpoint n'accepte qu'une session ADMIN** — la purge automatique ne tourne pas, mais rien ne casse. | (32+ caractères aléatoires) |
+| `TRASH_RETENTION_DAYS` | non | Délai de conservation en corbeille avant purge définitive. Défaut **30**. Une valeur invalide ou `< 1` retombe sur 30 : une faute de frappe ne doit pas vider la corbeille. | `30` |
 
 ## OAuth — Google + GitHub (backend uniquement)
 
@@ -108,6 +110,78 @@ Utilisé pour le formulaire de contact (Lot 1) et l'envoi des liens de modificat
 | **Lot 3 — Programme** | aucune variable supplémentaire |
 | **Lot 4 — Contenu** | aucune variable supplémentaire |
 | **Lot 5 — Jour J** | aucune variable supplémentaire (OAuth Google déjà configuré au Lot 2) |
+
+---
+
+## Tâche planifiée — purge de la corbeille (#149)
+
+Supprimer un élément depuis l'admin le place en **corbeille** : la ligne survit,
+masquée de l'admin comme du site public, et reste restaurable. Au-delà du délai
+de conservation (`TRASH_RETENTION_DAYS`, 30 jours par défaut), elle doit être
+détruite pour de bon — ainsi que les fichiers qu'elle était seule à utiliser.
+
+Le déclencheur est **externe au backend** : pas de minuterie applicative. Elle se
+réinitialiserait à chaque redéploiement, se déclencherait deux fois si un jour
+deux conteneurs tournent, et serait invisible depuis la configuration.
+
+### Mise en place dans Coolify
+
+1. Générer un secret et le poser en variable d'environnement du backend :
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+   → `TRASH_PURGE_SECRET` (runtime, **pas** « Available at Buildtime » : il n'est
+   lu qu'à l'exécution).
+
+2. Créer une **Scheduled Task** sur la ressource backend :
+
+   | Champ | Valeur |
+   |---|---|
+   | Command | voir ci-dessous |
+   | Frequency | `0 4 * * *` (tous les jours à 4 h) |
+   | Container | le conteneur backend |
+
+   ```bash
+   curl -fsS -X POST http://localhost:4000/api/maintenance/purge-trash \
+     -H "X-Purge-Secret: $TRASH_PURGE_SECRET"
+   ```
+
+   L'appel se fait **depuis le conteneur**, sur `localhost` : le secret ne
+   transite jamais par le réseau public.
+
+3. Vérifier — la commande est sans effet de bord, elle ne fait que lire :
+
+   ```bash
+   curl -fsS http://localhost:4000/api/maintenance/purge-trash \
+     -H "X-Purge-Secret: $TRASH_PURGE_SECRET"
+   # → {"retentionDays":30,"cutoff":"2026-06-20T…"}
+   ```
+
+### Ce que renvoie la purge
+
+```json
+{
+  "cutoff": "2026-06-20T04:00:00.000Z",
+  "retentionDays": 30,
+  "totalPurged": 3,
+  "entities": [{ "entity": "articles", "purged": 3, "filesDeleted": 1, "filesKept": 2 }]
+}
+```
+
+`filesKept` compte les fichiers **conservés parce qu'un autre élément les
+utilise encore** : les uploads sont une bibliothèque partagée, purger une ligne
+ne doit pas casser l'illustration d'une autre.
+
+### Garde-fous
+
+- **Idempotente** : relancée, elle ne trouve plus rien (`purged: 0`). Un cron qui
+  se déclenche deux fois, ou qui rejoue après un timeout, est sans danger.
+- **Sans secret configuré**, l'endpoint n'accepte qu'une **session ADMIN** : la
+  purge automatique ne tourne pas, mais rien ne casse et rien ne s'ouvre.
+- **Un EDITOR ne peut pas** déclencher la purge, même connecté.
+- Les éléments **vivants** ne sont jamais touchés, quel que soit le délai.
 
 ---
 

--- a/src/backend/src/__tests__/trash-purge.test.ts
+++ b/src/backend/src/__tests__/trash-purge.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+
+import Fastify from "fastify";
+
+
+// No session by default: the cron path must work on the secret alone. Tests
+// that need an ADMIN flip `authContext.current`.
+const authContext = vi.hoisted(() => ({
+  current: null as { user: { id: string; email: string; name: string; role: string } } | null,
+}));
+
+vi.mock("../lib/auth-context.js", () => ({
+  getAuthContext: async () => authContext.current,
+}));
+
+const { default: maintenanceRoutes } = await import("../routes/maintenance.js");
+const { prisma } = await import("../lib/prisma.js");
+const { softDeleteData, parkUniqueValue } = await import("../lib/admin-helpers.js");
+const { isValidPurgeSecret, retentionDays, purgeExpiredTrash } = await import("../lib/trash-purge.js");
+
+const SECRET = "test-purge-secret-0123456789";
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(maintenanceRoutes, { prefix: "/api" });
+  return app;
+}
+
+const createdArticleIds: number[] = [];
+
+beforeEach(() => {
+  process.env.TRASH_PURGE_SECRET = SECRET;
+  authContext.current = null;
+});
+
+afterEach(async () => {
+  delete process.env.TRASH_PURGE_SECRET;
+  delete process.env.TRASH_RETENTION_DAYS;
+  if (createdArticleIds.length) {
+    await prisma.article.deleteMany({ where: { id: { in: createdArticleIds } } });
+    createdArticleIds.length = 0;
+  }
+});
+
+/** An article already in the trash, deleted `daysAgo` days ago. */
+async function trashedArticle(slug: string, daysAgo: number) {
+  const article = await prisma.article.create({
+    data: {
+      slug,
+      titleFr: `Titre ${slug}`,
+      titleEn: `Title ${slug}`,
+      contentFr: "<p>x</p>",
+      contentEn: "<p>x</p>",
+      publicationStatus: "DRAFT",
+    },
+  });
+  createdArticleIds.push(article.id);
+
+  const deletedAt = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+  await prisma.article.update({
+    where: { id: article.id },
+    data: { ...softDeleteData(deletedAt), slug: parkUniqueValue(slug, article.id) },
+  });
+  return article;
+}
+
+describe("purge secret (#149)", () => {
+  it("accepts the configured secret", () => {
+    expect(isValidPurgeSecret(SECRET)).toBe(true);
+  });
+
+  it("rejects a wrong secret of the same length", () => {
+    // Same length on purpose: this is the case a length check alone would pass.
+    const wrong = "x".repeat(SECRET.length);
+    expect(wrong.length).toBe(SECRET.length);
+    expect(isValidPurgeSecret(wrong)).toBe(false);
+  });
+
+  it("rejects a prefix of the real secret", () => {
+    expect(isValidPurgeSecret(SECRET.slice(0, 10))).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isValidPurgeSecret(undefined)).toBe(false);
+  });
+
+  it("denies everything when no secret is configured", () => {
+    delete process.env.TRASH_PURGE_SECRET;
+    // The dangerous failure mode is "no secret set" meaning "let anyone in".
+    expect(isValidPurgeSecret("anything")).toBe(false);
+    expect(isValidPurgeSecret("")).toBe(false);
+  });
+});
+
+describe("retention window (#149)", () => {
+  it("defaults to 30 days", () => {
+    expect(retentionDays()).toBe(30);
+  });
+
+  it("honours the environment override", () => {
+    process.env.TRASH_RETENTION_DAYS = "7";
+    expect(retentionDays()).toBe(7);
+  });
+
+  it("falls back on a nonsensical value rather than purging everything", () => {
+    // "0" would mean "delete the whole trash right now" — a typo must not do that.
+    process.env.TRASH_RETENTION_DAYS = "0";
+    expect(retentionDays()).toBe(30);
+    process.env.TRASH_RETENTION_DAYS = "-5";
+    expect(retentionDays()).toBe(30);
+    process.env.TRASH_RETENTION_DAYS = "abc";
+    expect(retentionDays()).toBe(30);
+  });
+});
+
+describe("POST /api/maintenance/purge-trash (#149)", () => {
+  it("401s without a secret or a session", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "POST", url: "/api/maintenance/purge-trash" });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it("401s on a wrong secret", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/maintenance/purge-trash",
+      headers: { "x-purge-secret": "nope" },
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it("401s for an EDITOR session — this destroys data", async () => {
+    authContext.current = {
+      user: { id: "e", email: "e@test.local", name: "Ed", role: "EDITOR" },
+    };
+    const app = await buildApp();
+    const res = await app.inject({ method: "POST", url: "/api/maintenance/purge-trash" });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it("accepts an ADMIN session, so it can be triggered by hand", async () => {
+    authContext.current = {
+      user: { id: "a", email: "a@test.local", name: "Ad", role: "ADMIN" },
+    };
+    const app = await buildApp();
+    const res = await app.inject({ method: "POST", url: "/api/maintenance/purge-trash" });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+  });
+
+  it("purges what is past the window and keeps what is not", async () => {
+    const stamp = Date.now();
+    const old = await trashedArticle(`zz-purge-old-${stamp}`, 40);
+    const recent = await trashedArticle(`zz-purge-recent-${stamp}`, 5);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/maintenance/purge-trash",
+      headers: { "x-purge-secret": SECRET },
+    });
+    expect(res.statusCode).toBe(200);
+
+    expect(await prisma.article.findUnique({ where: { id: old.id } })).toBeNull();
+    // The whole point of a grace period: 5 days in, it is still recoverable.
+    expect(await prisma.article.findUnique({ where: { id: recent.id } })).not.toBeNull();
+
+    await app.close();
+  });
+
+  it("never touches live rows", async () => {
+    const slug = `zz-purge-live-${Date.now()}`;
+    const live = await prisma.article.create({
+      data: {
+        slug,
+        titleFr: "Vivant",
+        titleEn: "Live",
+        contentFr: "<p>x</p>",
+        contentEn: "<p>x</p>",
+        publicationStatus: "PUBLISHED",
+      },
+    });
+    createdArticleIds.push(live.id);
+
+    const app = await buildApp();
+    await app.inject({
+      method: "POST",
+      url: "/api/maintenance/purge-trash",
+      headers: { "x-purge-secret": SECRET },
+    });
+
+    expect(await prisma.article.findUnique({ where: { id: live.id } })).not.toBeNull();
+    await app.close();
+  });
+
+  it("is idempotent — a second run finds nothing left", async () => {
+    const old = await trashedArticle(`zz-purge-idem-${Date.now()}`, 40);
+    const app = await buildApp();
+
+    const first = await app.inject({
+      method: "POST",
+      url: "/api/maintenance/purge-trash",
+      headers: { "x-purge-secret": SECRET },
+    });
+    const firstArticles = first.json().entities.find((e: { entity: string }) => e.entity === "articles");
+    expect(firstArticles.purged).toBeGreaterThanOrEqual(1);
+
+    // A cron that fires twice, or retries after a timeout, must be harmless.
+    const second = await app.inject({
+      method: "POST",
+      url: "/api/maintenance/purge-trash",
+      headers: { "x-purge-secret": SECRET },
+    });
+    const secondArticles = second.json().entities.find((e: { entity: string }) => e.entity === "articles");
+    expect(secondArticles.purged).toBe(0);
+
+    expect(await prisma.article.findUnique({ where: { id: old.id } })).toBeNull();
+    await app.close();
+  });
+
+  it("reports the cutoff it used", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/maintenance/purge-trash",
+      headers: { "x-purge-secret": SECRET },
+    });
+    const body = res.json();
+    expect(body.retentionDays).toBe(30);
+    expect(new Date(body.cutoff).getTime()).toBeLessThan(Date.now());
+    expect(Array.isArray(body.entities)).toBe(true);
+    await app.close();
+  });
+
+  it("respects a custom retention window", async () => {
+    process.env.TRASH_RETENTION_DAYS = "3";
+    // 5 days old: kept under the 30-day default, purged under a 3-day window.
+    const article = await trashedArticle(`zz-purge-window-${Date.now()}`, 5);
+
+    await purgeExpiredTrash();
+
+    expect(await prisma.article.findUnique({ where: { id: article.id } })).toBeNull();
+  });
+});

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -23,6 +23,7 @@ import speakerRoutes from "./routes/speakers.js";
 import categoryRoutes from "./routes/categories.js";
 import talkRoutes from "./routes/talks.js";
 import editRoutes from "./routes/edit.js";
+import maintenanceRoutes from "./routes/maintenance.js";
 import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
 
@@ -279,6 +280,11 @@ await app.register(editRoutes, { prefix: "/api" });
 
 // Per-user routes (any authenticated back-office user — own resources only)
 await app.register(myApiKeysRoutes, { prefix: "/api/me" });
+
+// Maintenance routes driven by an external scheduler (#149). Deliberately
+// outside the admin group: the cron has no session, so the route checks a
+// shared secret or an ADMIN session itself.
+await app.register(maintenanceRoutes, { prefix: "/api" });
 
 // Admin routes (protected by requireAdmin hook)
 await app.register(adminRoutes, { prefix: "/api/admin" });

--- a/src/backend/src/lib/trash-purge.ts
+++ b/src/backend/src/lib/trash-purge.ts
@@ -1,0 +1,127 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { TRASH_ENTITIES, delegateFor } from "./trash-registry.js";
+import { purgeFiles } from "./trash-files.js";
+
+/**
+ * Automatic purge of the trash (#149).
+ *
+ * Rows are kept for a grace period after deletion, then destroyed for good. The
+ * schedule lives outside the process (a Coolify cron calling the endpoint)
+ * rather than in an in-process timer: nothing to restart, nothing that fires
+ * twice when two containers run, and it stays visible in the deploy config.
+ */
+
+const DEFAULT_RETENTION_DAYS = 30;
+
+/** Retention window, overridable per environment. Falls back on a bad value. */
+export function retentionDays(): number {
+  const raw = process.env.TRASH_RETENTION_DAYS;
+  if (!raw) return DEFAULT_RETENTION_DAYS;
+  const parsed = Number(raw);
+  // A typo must not silently become "purge everything immediately".
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_RETENTION_DAYS;
+  return Math.floor(parsed);
+}
+
+export function cutoffDate(now: Date = new Date(), days: number = retentionDays()): Date {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Is this request allowed to run the purge?
+ *
+ * The cron has no session, so it carries a shared secret instead. Compared in
+ * constant time — a byte-by-byte early exit leaks the secret one character at a
+ * time to anyone who can measure the response.
+ */
+export function isValidPurgeSecret(provided: string | undefined): boolean {
+  const expected = process.env.TRASH_PURGE_SECRET;
+  // No secret configured means no secret-based access — never "allow anyone".
+  if (!expected || !provided) return false;
+
+  const a = Buffer.from(expected);
+  const b = Buffer.from(provided);
+  // timingSafeEqual throws on length mismatch, so guard first. The length of a
+  // secret is not the secret.
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+export interface EntityPurgeResult {
+  entity: string;
+  purged: number;
+  filesDeleted: number;
+  filesKept: number;
+}
+
+export interface PurgeReport {
+  cutoff: string;
+  retentionDays: number;
+  entities: EntityPurgeResult[];
+  totalPurged: number;
+}
+
+/**
+ * Destroy every trashed row older than the cutoff, and the files they owned.
+ *
+ * Idempotent: with nothing old enough, every counter is zero and no write
+ * happens — a cron firing twice, or retrying, is harmless.
+ */
+export async function purgeExpiredTrash(now: Date = new Date()): Promise<PurgeReport> {
+  const days = retentionDays();
+  const cutoff = cutoffDate(now, days);
+  const entities: EntityPurgeResult[] = [];
+
+  for (const entity of TRASH_ENTITIES) {
+    const delegate = delegateFor(entity);
+
+    // `{ lt: cutoff }` alone is the filter: SQL comparisons never match NULL,
+    // so live rows are excluded by construction. Spreading `onlyDeleted` here
+    // would set the same key twice and read as if both applied.
+    const expired = await delegate.findMany({
+      where: { deletedAt: { lt: cutoff } },
+    });
+
+    let purged = 0;
+    let filesDeleted = 0;
+    let filesKept = 0;
+
+    for (const row of expired) {
+      const id = row.id as number | string;
+      const fileUrls = entity.fileFields.map((f) => row[f] as string | null);
+
+      // One row at a time rather than a bulk deleteMany: each row's files have
+      // to be reference-counted after its own deletion, and a failure on one
+      // row must not abort the rest of the sweep.
+      try {
+        await delegate.delete({ where: { id } });
+      } catch {
+        // Already gone (a manual purge raced us), or blocked by a foreign key.
+        // Skip it; the next run will retry.
+        continue;
+      }
+
+      purged++;
+
+      const outcomes = await purgeFiles(fileUrls, { model: entity.model, id });
+      for (const o of outcomes) {
+        if (o.deleted) filesDeleted++;
+        else if (o.reason === "still_referenced") filesKept++;
+      }
+    }
+
+    entities.push({ entity: entity.key, purged, filesDeleted, filesKept });
+  }
+
+  return {
+    cutoff: cutoff.toISOString(),
+    retentionDays: days,
+    entities,
+    totalPurged: entities.reduce((sum, e) => sum + e.purged, 0),
+  };
+}

--- a/src/backend/src/routes/maintenance.ts
+++ b/src/backend/src/routes/maintenance.ts
@@ -1,0 +1,56 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+
+import { getAuthContext } from "../lib/auth-context.js";
+import { isValidPurgeSecret, purgeExpiredTrash, retentionDays, cutoffDate } from "../lib/trash-purge.js";
+
+/**
+ * Maintenance endpoints driven by an external scheduler (#149).
+ *
+ * Registered outside the admin auth group on purpose: the cron has no session,
+ * so this route does its own two-way check — a shared secret OR an ADMIN
+ * session, never neither.
+ */
+
+const PURGE_SECRET_HEADER = "x-purge-secret";
+
+export default async function maintenanceRoutes(app: FastifyInstance) {
+  // GET /api/maintenance/purge-trash — what the next run would delete.
+  // Same auth as the purge itself: it discloses how much sits in the trash.
+  app.get("/maintenance/purge-trash", async (request, reply) => {
+    if (!(await isAuthorised(request))) {
+      return reply.code(401).send({ error: "Unauthorized" });
+    }
+    const days = retentionDays();
+    return { retentionDays: days, cutoff: cutoffDate(new Date(), days).toISOString() };
+  });
+
+  // POST /api/maintenance/purge-trash — destroy everything past the window.
+  app.post("/maintenance/purge-trash", async (request, reply) => {
+    if (!(await isAuthorised(request))) {
+      // 401, not 403: the caller is unidentified rather than known-and-refused.
+      return reply.code(401).send({ error: "Unauthorized" });
+    }
+
+    const report = await purgeExpiredTrash();
+
+    // Worth a log line even when nothing happens: this is the one operation
+    // that destroys data with no human watching.
+    request.log.info(
+      { purged: report.totalPurged, cutoff: report.cutoff, retentionDays: report.retentionDays },
+      "trash purge completed",
+    );
+
+    return report;
+  });
+}
+
+async function isAuthorised(request: FastifyRequest): Promise<boolean> {
+  const header = request.headers[PURGE_SECRET_HEADER];
+  const provided = typeof header === "string" ? header : undefined;
+  if (isValidPurgeSecret(provided)) return true;
+
+  // Falls back to an ADMIN session so the purge can also be triggered by hand
+  // from the back-office (#150) without minting a secret for a browser.
+  const ctx = await getAuthContext(request);
+  return ctx?.user.role === "ADMIN";
+}

--- a/src/backend/vitest.config.ts
+++ b/src/backend/vitest.config.ts
@@ -1,16 +1,50 @@
 import { defineConfig } from "vitest/config";
 
+// Only run the TypeScript source tests — the compiled `dist/` output is a stale
+// artefact of an earlier build and re-running those generated .js copies
+// produces duplicate, outdated results.
+const include = ["src/**/*.{test,spec}.ts", "scripts/**/*.{test,spec}.ts"];
+const exclude = ["node_modules", "dist"];
+
+// The trash purge (#149) sweeps every soft-deletable entity of the shared test
+// database in one pass, and its cascades reach past the rows it deletes
+// (removing an Edition takes its KeyFigures with it). Run alongside the other
+// files it races their fixtures — the same class of cross-file interference
+// as #292.
+//
+// Vitest offers no per-file concurrency pragma; a project matched by glob is the
+// documented way to isolate one file without dropping parallelism for the rest.
+// `groupOrder` puts it in its own pass, after everything else.
+const SEQUENTIAL = ["src/**/trash-purge.test.ts"];
+
+// The integration tests boot a real Fastify app and hit Postgres. The first few
+// pay the one-off tsx transform + cold connection cost, which blows past
+// Vitest's 5s default on a shared CI runner. 30s is a safety margin for that
+// startup latency, not for any single slow assertion.
+const testTimeout = 30000;
+
 export default defineConfig({
   test: {
-    // Only run the TypeScript source tests — the compiled `dist/` output
-    // is a stale artefact of an earlier build and re-running those
-    // generated .js copies produces duplicate, outdated results.
-    include: ["src/**/*.{test,spec}.ts", "scripts/**/*.{test,spec}.ts"],
-    exclude: ["node_modules", "dist"],
-    // The integration tests boot a real Fastify app and hit Postgres. The
-    // first few pay the one-off tsx transform + cold connection cost, which
-    // blows past Vitest's 5s default on a shared CI runner. 30s is a safety
-    // margin for that startup latency, not for any single slow assertion.
-    testTimeout: 30000,
+    projects: [
+      {
+        test: {
+          name: "parallel",
+          include,
+          exclude: [...exclude, ...SEQUENTIAL],
+          testTimeout,
+          sequence: { groupOrder: 0 },
+        },
+      },
+      {
+        test: {
+          name: "sequential",
+          include: SEQUENTIAL,
+          exclude,
+          testTimeout,
+          fileParallelism: false,
+          sequence: { groupOrder: 1 },
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Résumé

Étape **4/5** de la corbeille (#145). Les éléments supprimés restent
récupérables pendant un délai de grâce, puis sont détruits définitivement — avec
les fichiers dont ils étaient les seuls utilisateurs.

```
GET  /api/maintenance/purge-trash   ce que la prochaine purge supprimerait
POST /api/maintenance/purge-trash   l'exécuter
```

Le déclencheur est **externe au backend** (tâche planifiée Coolify), pas une
minuterie applicative : celle-ci se réinitialiserait à chaque redéploiement, se
déclencherait deux fois si un jour deux conteneurs tournent, et serait invisible
depuis la configuration.

> Empilée sur #301 (#148). À merger après elle.

## Sécurité

L'authentification accepte **soit** un secret partagé (`X-Purge-Secret`, pour le
cron qui n'a pas de session), **soit** une session ADMIN — ce qui permettra à
#150 d'offrir un bouton « vider la corbeille » sans fabriquer un secret côté
navigateur.

Trois points à souligner :

- **Comparaison en temps constant**, sur le modèle de `brochure-token.ts` :
  contrôle de longueur puis `timingSafeEqual` dans un `try`. Une comparaison
  octet par octet livre le secret un caractère à la fois à qui mesure le temps
  de réponse.
- **Aucun secret configuré = personne ne passe par secret.** Jamais « laisse
  entrer n'importe qui ». La purge automatique cesse simplement de tourner.
- **Un EDITOR est refusé**, même connecté. Cette opération détruit des données.

## Délai configurable

`TRASH_RETENTION_DAYS` surcharge les 30 jours par défaut. Une valeur invalide ou
`< 1` **retombe sur 30** au lieu d'être prise au mot : `TRASH_RETENTION_DAYS=0`
signifierait sinon « vider toute la corbeille maintenant » sur une faute de
frappe.

## Documentation

`docs/variables-environnement.md` : les deux variables, la tâche Coolify (`curl`
**depuis le conteneur** sur `localhost`, pour que le secret ne transite jamais
par le réseau public), la vérification par le GET en lecture seule, et les
garde-fous. Les trois fichiers compose sont câblés.

## Test plan

- [x] `tsc --noEmit` propre
- [x] **Cinq exécutions consécutives** : 380 tests, 0 échec, base intacte
- [x] Syntaxe des 3 compose validée
- [ ] CI verte

### Vérifié sur le backend réel

| Contrôle | Résultat |
|---|---|
| Mauvais secret | **401** |
| Secret absent | **401** |
| Aucun secret configuré | **401** (repli sûr, pas d'ouverture) |
| Bon secret | **200** + fenêtre de rétention |
| Élément de **40 jours** | **purgé** |
| Élément de **5 jours** | **conservé** |
| 2ᵉ et 3ᵉ exécutions | `totalPurged: 0` |

17 tests couvrent en plus : mauvais secret **de même longueur** (le cas qu'un
simple contrôle de longueur laisserait passer), préfixe du vrai secret, EDITOR
refusé, éléments vivants jamais touchés.

## ⚠️ L'isolation des tests a coûté plus cher que la fonctionnalité

La purge balaie les 12 entités de la base de test partagée, et ses cascades vont
plus loin que les lignes supprimées : purger une `Edition` emporte ses
`KeyFigure`, ce qui cassait `settings.test.ts`. Vitest exécutant les fichiers en
parallèle, tout se percutait.

Vitest n'offre **aucun pragma de concurrence par fichier** (vérifié dans la doc
v4, pas supposé). La configuration se scinde donc en deux projets : le reste
reste parallèle, le fichier de purge tourne seul dans un groupe ultérieur.

**Deux approches essayées puis annulées** — un paramètre `only` sur
`purgeExpiredTrash`, puis un en-tête `x-purge-only` : les deux façonnaient une
API de production autour d'une contrainte de test. Un plafond `maxWorkers: 4` a
aussi été tenté et **empirait les choses** (5 échecs, durée doublée) ; retiré.

> Une seule exécution verte ne prouve rien sur une suite instable — la branche de
> base échouait elle aussi par intermittence, ce que j'ai vérifié en remisant mon
> travail. D'où les **cinq** exécutions, le critère déjà retenu pour #292.

Refs #149
