### PR TITLE
Corbeille 145e — UI admin : consulter, restaurer, purger (#150)

### DIFF
--- a/src/backend/src/routes/admin/trash.ts
+++ b/src/backend/src/routes/admin/trash.ts
@@ -5,6 +5,7 @@ import { getAuthContext } from "../../lib/auth-context.js";
 import { onlyDeleted, notDeleted, restoreData, unparkUniqueValue } from "../../lib/admin-helpers.js";
 import { TRASH_ENTITIES, findTrashEntity, delegateFor } from "../../lib/trash-registry.js";
 import { purgeFiles } from "../../lib/trash-files.js";
+import { retentionDays } from "../../lib/trash-purge.js";
 
 /**
  * The trash, backend side (#148): consult it, restore from it, empty it.
@@ -100,6 +101,9 @@ export default async function adminTrashRoutes(app: FastifyInstance) {
 
     return {
       entity: entity.key,
+      // So the UI can show the time left before auto-purge from deletedAt,
+      // without hardcoding 30 and lying when the window is overridden (#150).
+      retentionDays: retentionDays(),
       items: rows.map((row) => {
         const raw = row[entity.labelField];
         const label = typeof raw === "string" ? unparkUniqueValue(raw) : String(raw ?? "");

--- a/src/frontend/src/app/admin/trash/page.tsx
+++ b/src/frontend/src/app/admin/trash/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { adminFetch, getAdminSession } from "@/lib/admin-api";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import StatusBadge from "@/components/admin/StatusBadge";
+
+// The twelve soft-deletable entities, in the order the trash shows them. Kept in
+// sync with the backend registry (trash-registry.ts); `adminOnly` mirrors the
+// API, which 403s an EDITOR on those — the page hides them rather than letting
+// the call fail.
+const TRASH_ENTITIES: { key: string; label: string; adminOnly: boolean }[] = [
+  { key: "articles", label: "Articles", adminOnly: false },
+  { key: "tags", label: "Tags", adminOnly: false },
+  { key: "speakers", label: "Speakers", adminOnly: false },
+  { key: "talks", label: "Conférences", adminOnly: false },
+  { key: "sponsors", label: "Sponsors", adminOnly: false },
+  { key: "categories", label: "Catégories", adminOnly: false },
+  { key: "contact-categories", label: "Catégories de contact", adminOnly: false },
+  { key: "contact-messages", label: "Messages", adminOnly: false },
+  { key: "ticket-tiers", label: "Tarifs billetterie", adminOnly: true },
+  { key: "sponsor-plans", label: "Plans sponsors", adminOnly: true },
+  { key: "editions", label: "Éditions", adminOnly: true },
+  { key: "users", label: "Utilisateurs", adminOnly: true },
+];
+
+interface TrashItem {
+  id: number | string;
+  label: string;
+  deletedAt: string;
+}
+
+interface TrashListResponse {
+  entity: string;
+  retentionDays: number;
+  items: TrashItem[];
+}
+
+interface TrashSummary {
+  entities: { entity: string; count: number }[];
+  total: number;
+}
+
+/** Days left before auto-purge, from the deletion date and the retention window. */
+function daysLeft(deletedAt: string, retentionDays: number): number {
+  const elapsedMs = Date.now() - new Date(deletedAt).getTime();
+  const elapsedDays = Math.floor(elapsedMs / (24 * 60 * 60 * 1000));
+  return Math.max(0, retentionDays - elapsedDays);
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+export default function TrashPage() {
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [roleLoaded, setRoleLoaded] = useState(false);
+  const [selectedEntity, setSelectedEntity] = useState("articles");
+  const [items, setItems] = useState<TrashItem[]>([]);
+  const [retentionDays, setRetentionDays] = useState(30);
+  const [counts, setCounts] = useState<Record<string, number>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Restore / purge targets drive the two dialogs. Purge is danger-styled.
+  const [restoreTarget, setRestoreTarget] = useState<TrashItem | null>(null);
+  const [purgeTarget, setPurgeTarget] = useState<TrashItem | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Mirror AdminShell's convention: fetch the role, gate the admin-only tabs.
+    getAdminSession().then((session) => {
+      setIsAdmin(session?.role === "ADMIN");
+      setRoleLoaded(true);
+    });
+  }, []);
+
+  const loadCounts = useCallback(async () => {
+    const { data } = await adminFetch<TrashSummary>("/trash");
+    if (data) {
+      const map: Record<string, number> = {};
+      for (const e of data.entities) map[e.entity] = e.count;
+      setCounts(map);
+    }
+  }, []);
+
+  const loadItems = useCallback(async (entity: string) => {
+    setIsLoading(true);
+    setError(null);
+    const { data, status, error: fetchError } = await adminFetch<TrashListResponse>(`/trash/${entity}`);
+    if (data) {
+      setItems(data.items);
+      setRetentionDays(data.retentionDays);
+    } else {
+      setItems([]);
+      setError(status === 403 ? "Accès réservé aux administrateurs." : fetchError ?? "Chargement impossible.");
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadCounts();
+  }, [loadCounts]);
+
+  useEffect(() => {
+    loadItems(selectedEntity);
+  }, [selectedEntity, loadItems]);
+
+  async function handleRestore() {
+    if (!restoreTarget) return;
+    setActionError(null);
+    const { status, error: restoreError } = await adminFetch(
+      `/trash/${selectedEntity}/${restoreTarget.id}/restore`,
+      { method: "POST" },
+    );
+    setRestoreTarget(null);
+
+    if (status === 409) {
+      // The slug was taken while the row waited in the trash (#148). Name it so
+      // the organizer knows to rename the live one first.
+      setActionError(restoreError ?? "Restauration impossible : un élément actif occupe déjà cette valeur.");
+      return;
+    }
+    if (status !== 200) {
+      setActionError(restoreError ?? "Restauration impossible.");
+      return;
+    }
+    await Promise.all([loadItems(selectedEntity), loadCounts()]);
+  }
+
+  async function handlePurge() {
+    if (!purgeTarget) return;
+    setActionError(null);
+    const { status, error: purgeError } = await adminFetch(
+      `/trash/${selectedEntity}/${purgeTarget.id}/purge`,
+      { method: "DELETE" },
+    );
+    setPurgeTarget(null);
+
+    if (status !== 200) {
+      setActionError(
+        status === 403
+          ? "La suppression définitive est réservée aux administrateurs."
+          : purgeError ?? "Suppression impossible.",
+      );
+      return;
+    }
+    await Promise.all([loadItems(selectedEntity), loadCounts()]);
+  }
+
+  const visibleEntities = TRASH_ENTITIES.filter((e) => isAdmin || !e.adminOnly);
+
+  // Wait for the role before rendering tabs, or an EDITOR briefly sees the
+  // admin-only ones flash in.
+  if (!roleLoaded) {
+    return <p className="text-gris">Chargement…</p>;
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold text-noir">Corbeille</h1>
+        <p className="mt-1 text-sm text-gris">
+          Les éléments supprimés sont conservés {retentionDays} jours, puis
+          définitivement effacés. Vous pouvez les restaurer ou les supprimer
+          immédiatement.
+        </p>
+      </div>
+
+      {/* Entity tabs, with a count badge each. */}
+      <div className="mb-6 flex flex-wrap gap-2">
+        {visibleEntities.map((entity) => {
+          const count = counts[entity.key] ?? 0;
+          const isActive = entity.key === selectedEntity;
+          return (
+            <button
+              key={entity.key}
+              type="button"
+              onClick={() => setSelectedEntity(entity.key)}
+              aria-pressed={isActive}
+              className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                isActive ? "bg-bismarck text-blanc" : "bg-blanc text-noir shadow-card hover:bg-blanc-casse"
+              }`}
+            >
+              {entity.label}
+              {count > 0 && (
+                <span
+                  className={`inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1.5 text-xs font-bold ${
+                    isActive ? "bg-blanc text-bismarck" : "bg-terre-cuite text-blanc"
+                  }`}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {actionError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg bg-terre-cuite/10 px-4 py-3 text-sm text-terre-cuite"
+        >
+          {actionError}
+        </div>
+      )}
+
+      <div className="rounded-2xl bg-blanc p-5 shadow-card">
+        {isLoading ? (
+          <p className="text-gris">Chargement…</p>
+        ) : error ? (
+          <p className="py-8 text-center text-gris">{error}</p>
+        ) : items.length === 0 ? (
+          <p className="py-8 text-center text-gris">La corbeille est vide pour ce type.</p>
+        ) : (
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-blanc-casse text-gris">
+                <th className="py-2 pr-4 font-medium">Élément</th>
+                <th className="py-2 pr-4 font-medium">Supprimé le</th>
+                <th className="py-2 pr-4 font-medium">Purge auto</th>
+                <th className="py-2 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => {
+                const left = daysLeft(item.deletedAt, retentionDays);
+                return (
+                  <tr key={String(item.id)} className="border-b border-blanc-casse last:border-0">
+                    <td className="py-3 pr-4 font-medium text-noir">{item.label || "—"}</td>
+                    <td className="py-3 pr-4 text-gris">{formatDate(item.deletedAt)}</td>
+                    <td className="py-3 pr-4">
+                      <StatusBadge
+                        variant={left <= 3 ? "orange" : "blue"}
+                        status={left === 0 ? "imminente" : `dans ${left} j`}
+                      />
+                    </td>
+                    <td className="py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => setRestoreTarget(item)}
+                        className="mr-2 font-medium text-bleu hover:underline"
+                      >
+                        Restaurer
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setPurgeTarget(item)}
+                        className="font-medium text-terre-cuite hover:underline"
+                      >
+                        Supprimer définitivement
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={!!restoreTarget}
+        title="Restaurer l'élément"
+        message={`Restaurer « ${restoreTarget?.label} » ? Il réapparaîtra dans les listes.`}
+        confirmLabel="Restaurer"
+        onConfirm={handleRestore}
+        onCancel={() => setRestoreTarget(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={!!purgeTarget}
+        title="Supprimer définitivement"
+        message={`Supprimer définitivement « ${purgeTarget?.label} » ? Cette action est irréversible : l'élément ne pourra plus être restauré.`}
+        confirmLabel="Supprimer définitivement"
+        variant="danger"
+        onConfirm={handlePurge}
+        onCancel={() => setPurgeTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/AdminSidebar.tsx
+++ b/src/frontend/src/components/admin/AdminSidebar.tsx
@@ -19,6 +19,7 @@ import {
   faHandshake,
   faTag,
   faStar,
+  faTrashCan,
 } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
@@ -57,6 +58,7 @@ const iconMap: Record<string, IconDefinition> = {
   handshake: faHandshake,
   tag: faTag,
   star: faStar,
+  trash: faTrashCan,
 };
 
 interface HealthInfo {

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -50,6 +50,9 @@ export const adminNavGroups: AdminNavGroup[] = [
       { label: "Éditions", path: "/admin/editions", icon: "calendar", roles: ["ADMIN"] },
       { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
       { label: "Clés API", path: "/admin/api-keys", icon: "key", roles: ["ADMIN"] },
+      // Both roles reach the page; ADMIN-only entities (users, editions…) are
+      // filtered out inside it, mirroring the API's 403 (#150).
+      { label: "Corbeille", path: "/admin/trash", icon: "trash", roles: ["ADMIN", "EDITOR"] },
       { label: "Paramètres", path: "/admin/settings", icon: "settings", roles: ["ADMIN"] },
     ],
   },


### PR DESCRIPTION
## Résumé

Étape **5/5** de la corbeille (#145) — et la seule visible par les
organisateurs. Une page **/admin/trash** avec un onglet par entité (badge de
compteur), listant les éléments supprimés, leur date de suppression et le délai
restant avant purge automatique.

> Empilée sur #302 (#149). Dernière PR de la pile corbeille.

## Fonctionnement

- **Restaurer** et **Supprimer définitivement** passent par `ConfirmDialog`. La
  purge est en variante *danger* — et son texte dit enfin vrai : « irréversible »
  y est exact, contrairement à la confirmation de suppression normale, qui
  l'affiche encore alors qu'elle ne fait plus que mettre en corbeille (voir la
  note en bas).
- Le **conflit 409** à la restauration (#148) s'affiche en message inline
  nommant le champ en cause, pas un bouton mort.
- Les entités **ADMIN-only** (Utilisateurs, Éditions, Tarifs, Plans sponsors)
  sont masquées des onglets d'un EDITOR, en miroir du 403 de l'API. L'entrée de
  navigation est ouverte aux deux rôles ; le filtrage se fait dans la page, sur
  le rôle lu via `getAdminSession()` — il n'existe pas de contexte d'auth côté
  client, donc je suis le précédent de `contact/messages`.

## Backend — un champ ajouté

La liste de corbeille renvoie désormais `retentionDays`, pour que l'UI calcule
le délai restant depuis `deletedAt` **sans coder 30 en dur** et mentir si la
fenêtre est surchargée. Une seule propriété, sur un endpoint déjà propre à cette
pile.

## ⚠️ Pas d'i18n — divergence assumée avec l'issue

L'issue demande des « libellés FR/EN dans `messages/` ». **Le back-office admin
est entièrement en français en dur** — vérifié : aucun `next-intl` sous
`app/admin/`, seul le site public est traduit. Ajouter des clés ici casserait la
convention et laisserait **une seule page** à moitié traduite.

Je signale l'écart plutôt que de suivre la lettre de l'issue. Si une
internationalisation de l'admin est souhaitée un jour, c'est un chantier à part,
transverse à toutes les pages — pas à improviser sur celle-ci.

## Test plan

- [x] `tsc --noEmit` frontend propre
- [x] Lint frontend : 0 erreur sur la page (9 warnings préexistants sans rapport)
- [x] Suite backend : **380 tests / 55 fichiers, 0 échec**
- [ ] CI verte

### Vérifié dans le navigateur (Docker local, session ADMIN puis EDITOR)

| Contrôle | Résultat |
|---|---|
| Onglets en **ADMIN** | **12** entités |
| Onglets en **EDITOR** | **8** (ADMIN-only masquées) |
| `/trash/users` forcé en EDITOR | **403** (défense en profondeur) |
| Badge de compteur | « Articles**2** » → **1** après restauration |
| **Restauration** | ligne retirée, **slug déparqué** en base (`zz-ui-recent`, `deletedAt` effacé) |
| **Purge** | dialogue danger, ligne **physiquement supprimée**, « corbeille vide », badge à 0 |
| Console | **aucune erreur** |
| Délai restant | « dans 28 j » / « dans 2 j » (badge orange ≤ 3 j) |

## Note pour un suivi

La confirmation de suppression **normale** (listes articles, etc.) affiche
toujours « Cette action est irréversible » — ce n'est plus vrai depuis #147,
l'élément va en corbeille. Reprendre ce texte est un petit correctif transverse,
hors périmètre de cette PR ; je le laisse ici pour ne pas le perdre.

Refs #150
