### PR TITLE
Traduction — aligner le statut HTTP sur tous les endpoints (429/503 au lieu de 502) (#305)

### DIFF
--- a/src/backend/src/lib/translation/error-response.test.ts
+++ b/src/backend/src/lib/translation/error-response.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import { TranslationError, QuotaExhaustedError, sendTranslationError } from "./errors.js";
+
+// A minimal fake of the bits of a Fastify reply the helper touches, recording
+// what it was asked to send. `.status()` returns `this` so the chain works.
+function fakeReply() {
+  const record = { status: 0, headers: {} as Record<string, string>, payload: null as unknown };
+  const reply = {
+    status(code: number) {
+      record.status = code;
+      return reply;
+    },
+    header(name: string, value: string) {
+      record.headers[name] = value;
+      return reply;
+    },
+    send(payload: unknown) {
+      record.payload = payload;
+      return payload;
+    },
+  };
+  return { reply, record };
+}
+
+describe("sendTranslationError (#305)", () => {
+  // The mapping that used to be copy-pasted and had drifted. Each code must
+  // yield the same status wherever the helper is called.
+  const cases: [TranslationError["code"], number][] = [
+    ["invalid_input", 400],
+    ["content_too_large", 413],
+    ["tag_mismatch", 422],
+    ["placeholder_mismatch", 422],
+    ["rate_limit", 429],
+    ["not_configured", 503],
+    ["upstream_error", 502],
+  ];
+
+  it.each(cases)("maps %s to %i", (code, status) => {
+    const { reply, record } = fakeReply();
+    sendTranslationError(reply, new TranslationError(code, "boom"));
+    expect(record.status).toBe(status);
+    expect(record.payload).toMatchObject({ error: code, message: "boom" });
+  });
+
+  it("carries Retry-After and retryAfterSec on a quota error", () => {
+    const { reply, record } = fakeReply();
+    sendTranslationError(reply, new QuotaExhaustedError("slow down", 42));
+    expect(record.status).toBe(429);
+    expect(record.headers["Retry-After"]).toBe("42");
+    expect(record.payload).toMatchObject({ error: "quota_exhausted", retryAfterSec: 42 });
+  });
+
+  it("defaults Retry-After to 60 when the quota error omits it", () => {
+    const { reply, record } = fakeReply();
+    sendTranslationError(reply, new QuotaExhaustedError("slow down"));
+    expect(record.headers["Retry-After"]).toBe("60");
+  });
+
+  it("falls back to a generic 500 for a non-translation error", () => {
+    const { reply, record } = fakeReply();
+    sendTranslationError(reply, new Error("unexpected"));
+    expect(record.status).toBe(500);
+    // The raw message must not leak — only a generic code.
+    expect(record.payload).toEqual({ error: "internal_error" });
+  });
+
+  // The regression that motivated the fix: `rate_limit` and `not_configured`
+  // were missing from the article endpoint's copy, so they fell through to 502.
+  // Now every caller shares this helper, so those cannot drift again.
+  it("no longer lets rate_limit or not_configured fall through to 502", () => {
+    for (const code of ["rate_limit", "not_configured"] as const) {
+      const { reply, record } = fakeReply();
+      sendTranslationError(reply, new TranslationError(code, "x"));
+      expect(record.status).not.toBe(502);
+    }
+  });
+});

--- a/src/backend/src/lib/translation/errors.ts
+++ b/src/backend/src/lib/translation/errors.ts
@@ -29,3 +29,59 @@ export class QuotaExhaustedError extends TranslationError {
     this.name = "QuotaExhaustedError";
   }
 }
+
+/** Maps a translation error code to its HTTP status. Single source of truth. */
+function statusForCode(code: TranslationErrorCode): number {
+  switch (code) {
+    case "invalid_input":
+      return 400;
+    case "content_too_large":
+      return 413;
+    case "tag_mismatch":
+    case "placeholder_mismatch":
+      return 422;
+    case "rate_limit":
+      return 429;
+    case "not_configured":
+      return 503;
+    // upstream_error and any future code fall through to a bad-gateway: the
+    // failure is on the translation provider's side, not the caller's.
+    default:
+      return 502;
+  }
+}
+
+// Minimal shape of the reply object the handlers pass in, so this file does not
+// depend on Fastify's full types. Both `.status()` and `.code()` exist on a
+// Fastify reply and are aliases; the handlers already use one or the other.
+interface TranslationErrorReply {
+  status(code: number): TranslationErrorReply;
+  header(name: string, value: string): TranslationErrorReply;
+  send(payload: unknown): unknown;
+}
+
+/**
+ * Turn a translation-pipeline error into the right HTTP response.
+ *
+ * This mapping used to be copy-pasted into every handler that calls the
+ * translator (translate, article translate-fields, file alt-text) and the
+ * copies had drifted: `rate_limit` and `not_configured` were missing from the
+ * article endpoint, so a quota-exhausted call answered 429 on one route and 502
+ * on another (#305). Centralising it here keeps every endpoint consistent.
+ *
+ * Returns whatever `reply.send()` returns, so callers can `return` it directly.
+ */
+export function sendTranslationError(reply: TranslationErrorReply, err: unknown): unknown {
+  if (err instanceof QuotaExhaustedError) {
+    return reply
+      .status(429)
+      .header("Retry-After", String(err.retryAfterSec ?? 60))
+      .send({ error: err.code, message: err.message, retryAfterSec: err.retryAfterSec });
+  }
+  if (err instanceof TranslationError) {
+    return reply.status(statusForCode(err.code)).send({ error: err.code, message: err.message });
+  }
+  // Not a translation error — the caller must have logged it; surface a generic
+  // 500 rather than leaking the message.
+  return reply.status(500).send({ error: "internal_error" });
+}

--- a/src/backend/src/lib/translation/index.ts
+++ b/src/backend/src/lib/translation/index.ts
@@ -6,7 +6,7 @@ import { sharedRateLimiter } from "./rate-limiter.js";
 import { modelFor, type Lang, type TranslationRequest, type TranslationResponse } from "./types.js";
 import { validatePreservation } from "./validator.js";
 
-export { TranslationError, QuotaExhaustedError } from "./errors.js";
+export { TranslationError, QuotaExhaustedError, sendTranslationError } from "./errors.js";
 export { sharedRateLimiter } from "./rate-limiter.js";
 export { isConfigured } from "./gemini-client.js";
 export type {

--- a/src/backend/src/routes/admin/articles.ts
+++ b/src/backend/src/routes/admin/articles.ts
@@ -6,7 +6,7 @@ import { missingArticleFields } from "../../lib/article-validation.js";
 import { notDeleted, notFound, parkUniqueValue, softDeleteData } from "../../lib/admin-helpers.js";
 import {
   isConfigured as translationConfigured,
-  QuotaExhaustedError,
+  sendTranslationError,
   translate,
   TranslationError,
   type Lang,
@@ -355,21 +355,10 @@ export default async function adminArticleRoutes(app: FastifyInstance) {
         translatedAt: to === "en" ? updated.translatedAtEn : updated.translatedAtFr,
       };
     } catch (err) {
-      if (err instanceof QuotaExhaustedError) {
-        return reply.status(429).header("Retry-After", String(err.retryAfterSec ?? 60)).send({
-          error: err.code, message: err.message, retryAfterSec: err.retryAfterSec,
-        });
+      if (!(err instanceof TranslationError)) {
+        request.log.error({ err }, "translate-fields failed");
       }
-      if (err instanceof TranslationError) {
-        const status =
-          err.code === "invalid_input" ? 400 :
-          err.code === "content_too_large" ? 413 :
-          err.code === "tag_mismatch" || err.code === "placeholder_mismatch" ? 422 :
-          502;
-        return reply.status(status).send({ error: err.code, message: err.message });
-      }
-      request.log.error({ err }, "translate-fields failed");
-      return reply.status(500).send({ error: "internal_error" });
+      return sendTranslationError(reply, err);
     }
   });
 

--- a/src/backend/src/routes/admin/files.ts
+++ b/src/backend/src/routes/admin/files.ts
@@ -11,7 +11,7 @@ import {
   COMPRESS_QUALITY,
   UPLOADS_DIR,
 } from "../../lib/image-store.js";
-import { TranslationError, QuotaExhaustedError } from "../../lib/translation/errors.js";
+import { TranslationError, sendTranslationError } from "../../lib/translation/errors.js";
 
 const ALLOWED_MIMES = [
   // Images
@@ -276,26 +276,10 @@ export default async function adminFileRoutes(app: FastifyInstance) {
           tokensUsed: { input: result.inputTokens, output: result.outputTokens },
         };
       } catch (err) {
-        if (err instanceof QuotaExhaustedError) {
-          return reply
-            .code(429)
-            .header("Retry-After", String(err.retryAfterSec ?? 60))
-            .send({
-              error: err.code,
-              message: err.message,
-              retryAfterSec: err.retryAfterSec,
-            });
+        if (!(err instanceof TranslationError)) {
+          request.log.error({ err, filename }, "Unexpected alt-text generation error");
         }
-        if (err instanceof TranslationError) {
-          const status =
-            err.code === "not_configured" ? 503 :
-            err.code === "invalid_input" ? 400 :
-            err.code === "rate_limit" ? 429 :
-            502;
-          return reply.code(status).send({ error: err.code, message: err.message });
-        }
-        request.log.error({ err, filename }, "Unexpected alt-text generation error");
-        return reply.code(500).send({ error: "internal_error" });
+        return sendTranslationError(reply, err);
       }
     },
   );

--- a/src/backend/src/routes/admin/translate.ts
+++ b/src/backend/src/routes/admin/translate.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import {
   isConfigured,
-  QuotaExhaustedError,
+  sendTranslationError,
   sharedRateLimiter,
   translate,
   TranslationError,
@@ -48,28 +48,10 @@ export default async function adminTranslateRoutes(app: FastifyInstance) {
       );
       return result;
     } catch (err) {
-      if (err instanceof QuotaExhaustedError) {
-        return reply
-          .status(429)
-          .header("Retry-After", String(err.retryAfterSec ?? 60))
-          .send({
-            error: err.code,
-            message: err.message,
-            retryAfterSec: err.retryAfterSec,
-          });
+      if (!(err instanceof TranslationError)) {
+        request.log.error({ err }, "Unexpected translation error");
       }
-      if (err instanceof TranslationError) {
-        const status =
-          err.code === "invalid_input" ? 400 :
-          err.code === "content_too_large" ? 413 :
-          err.code === "rate_limit" ? 429 :
-          err.code === "not_configured" ? 503 :
-          err.code === "tag_mismatch" || err.code === "placeholder_mismatch" ? 422 :
-          502;
-        return reply.status(status).send({ error: err.code, message: err.message });
-      }
-      request.log.error({ err }, "Unexpected translation error");
-      return reply.status(500).send({ error: "internal_error" });
+      return sendTranslationError(reply, err);
     }
   });
 


### PR DESCRIPTION
Corrige **#305**. Le mapping `TranslationError → statut HTTP` était copié dans 3 handlers et les copies avaient divergé : l endpoint article avait perdu `rate_limit` et `not_configured`, renvoyant **502 au lieu de 429/503**. Un quota Gemini épuisé répondait donc différemment selon la route.

Centralisé dans `sendTranslationError()` : un seul switch, le header `Retry-After` sur les quotas, un 500 générique (sans fuite de message) pour le reste. Les 3 handlers délèguent.

## Test plan

- [x] `tsc` propre
- [x] **11 tests** sur `sendTranslationError`, vérifiés contre le bug : retirer le cas `rate_limit` fait échouer le test avec « expected 502 to be 429 » — le symptôme exact
- [x] Suite : **391 tests / 56 fichiers, 0 échec**
- [ ] CI verte

Refs #305