### PR TITLE
Sécurité — SSRF import Sessionize + XSS via upload SVG (#306)

### DIFF
--- a/src/backend/src/__tests__/admin-files-svg.test.ts
+++ b/src/backend/src/__tests__/admin-files-svg.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+
+import Fastify from "fastify";
+import multipart from "@fastify/multipart";
+import adminFileRoutes from "../routes/admin/files.js";
+
+// The admin uploader used to accept image/svg+xml. Served same-origin from
+// /uploads/, an SVG carrying <script> runs in our origin (#306). The magic-link
+// uploader already refuses SVG; this proves the admin one now does too.
+
+async function buildFilesApp() {
+  const app = Fastify({ logger: false });
+  await app.register(multipart);
+  await app.register(adminFileRoutes, { prefix: "/api/admin" });
+  return app;
+}
+
+const PNG_1x1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+  "base64",
+);
+
+function multipartBody(filename: string, contentType: string, content: Buffer) {
+  const boundary = "----svgtest";
+  const head = Buffer.from(
+    `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+      `Content-Type: ${contentType}\r\n\r\n`,
+  );
+  const tail = Buffer.from(`\r\n--${boundary}--\r\n`);
+  return {
+    payload: Buffer.concat([head, content, tail]),
+    headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+  };
+}
+
+describe("admin uploader rejects SVG (#306)", () => {
+  it("refuses an image/svg+xml upload", async () => {
+    const app = await buildFilesApp();
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+    const { payload, headers } = multipartBody("payload.svg", "image/svg+xml", svg);
+
+    const res = await app.inject({ method: "POST", url: "/api/admin/files", payload, headers });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("Invalid file type");
+
+    await app.close();
+  });
+
+  it("still accepts a PNG", async () => {
+    const app = await buildFilesApp();
+    const { payload, headers } = multipartBody("ok.png", "image/png", PNG_1x1);
+
+    const res = await app.inject({ method: "POST", url: "/api/admin/files", payload, headers });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().url).toMatch(/^\/uploads\//);
+
+    // Clean up the file this test wrote to the uploads dir.
+    const { UPLOADS_DIR } = await import("../lib/image-store.js");
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const name = res.json().filename as string;
+    await fs.promises.unlink(path.join(UPLOADS_DIR, name)).catch(() => {});
+
+    await app.close();
+  });
+});

--- a/src/backend/src/lib/image-store.ts
+++ b/src/backend/src/lib/image-store.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import crypto from "node:crypto";
 import sharp from "sharp";
 
+import { validateWebhookUrl } from "./webhook-url.js";
+
 // Single source of truth for where uploaded media lives. Served publicly at
 // /uploads/ (see index.ts static route). The container mounts it at /app/uploads;
 // UPLOADS_DIR overrides the path when running outside Docker.
@@ -76,6 +78,12 @@ export async function storeImageBuffer(buffer: Buffer, mimetype: string): Promis
 // Throws on any problem (bad status, non-image, oversized, timeout) so callers
 // can decide whether to warn and carry on.
 export async function fetchAndStoreImage(url: string): Promise<string> {
+  // The URL comes from an imported payload (Sessionize speaker photos), so it is
+  // attacker-influenced: guard against SSRF before fetching (#306). Less severe
+  // than the JSON endpoint — sharp rejects non-images and errors are swallowed
+  // by the caller — but it is still a blind internal-port probe otherwise.
+  await validateWebhookUrl(url);
+
   const res = await fetch(url, {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     headers: { accept: "image/*" },

--- a/src/backend/src/lib/sessionize-import-ssrf.test.ts
+++ b/src/backend/src/lib/sessionize-import-ssrf.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { loadSessionizeData } from "./sessionize-import.js";
+
+// The Sessionize import URL comes from a back-office form. Before #306 it was
+// fetched with no SSRF guard, so an editor could aim it at the cloud metadata
+// endpoint or an internal service on the shared network. These check the guard
+// runs *before* any fetch — a rejected URL must never reach the network.
+
+describe("loadSessionizeData SSRF guard (#306)", () => {
+  it("rejects a loopback URL before fetching", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(loadSessionizeData({ url: "http://127.0.0.1/all" })).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("rejects the cloud metadata address before fetching", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(
+      loadSessionizeData({ url: "http://169.254.169.254/latest/meta-data/" }),
+    ).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("rejects an internal container hostname (private range) before fetching", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // 10.x is one of the private ranges validateWebhookUrl blocks.
+    await expect(loadSessionizeData({ url: "http://10.0.0.5:5432/" })).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("rejects a non-http scheme", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(loadSessionizeData({ url: "file:///etc/passwd" })).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("still accepts inline JSON without touching the network", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // Minimal valid-ish payload: the guard is URL-only, JSON goes straight through.
+    const data = await loadSessionizeData({ json: JSON.stringify({ sessions: [], speakers: [] }) });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(data).toBeDefined();
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/backend/src/lib/sessionize-import.ts
+++ b/src/backend/src/lib/sessionize-import.ts
@@ -1,6 +1,7 @@
 import { fetchAndStoreImage } from "./image-store.js";
 import { prisma } from "./prisma.js";
 import { slugify, uniqueSlug } from "./slug.js";
+import { validateWebhookUrl } from "./webhook-url.js";
 
 // --- Sessionize "All data" JSON shapes (only the fields we consume) ---
 
@@ -372,6 +373,12 @@ export async function loadSessionizeData(opts: { json?: string; url?: string }):
   if (opts.json?.trim()) {
     raw = JSON.parse(opts.json);
   } else if (opts.url?.trim()) {
+    // The URL comes from a back-office form, so guard it against SSRF before
+    // fetching: without this an editor could point it at the cloud metadata
+    // endpoint, an internal DB, or another backend on the shared Coolify network
+    // (#306). validateWebhookUrl rejects loopback/private/link-local hosts and
+    // throws on a bad scheme — same guard the contact webhook already uses.
+    await validateWebhookUrl(opts.url.trim());
     const res = await fetch(opts.url, { headers: { accept: "application/json" } });
     if (!res.ok) throw new Error(`Sessionize fetch failed: HTTP ${res.status}`);
     raw = await res.json();

--- a/src/backend/src/routes/admin/files.ts
+++ b/src/backend/src/routes/admin/files.ts
@@ -14,8 +14,12 @@ import {
 import { TranslationError, QuotaExhaustedError } from "../../lib/translation/errors.js";
 
 const ALLOWED_MIMES = [
-  // Images
-  "image/jpeg", "image/png", "image/webp", "image/gif", "image/svg+xml",
+  // Images. SVG is deliberately excluded (#306): served same-origin from
+  // /uploads/ with its native content-type, an SVG carrying <script> executes
+  // in our origin (the CSP allows inline scripts). The magic-link uploader
+  // (edit.ts) already excludes it for this reason; the admin uploader now
+  // matches. No SVG is used anywhere in the product, so nothing regresses.
+  "image/jpeg", "image/png", "image/webp", "image/gif",
   "image/x-icon", "image/vnd.microsoft.icon",
   // Documents
   "application/pdf",


### PR DESCRIPTION
Corrige **#306**. Deux failles nécessitant un compte back-office (EDITOR), donc sévérité plafonnée, mais réelles.

**SSRF** — l URL d import Sessionize et les URL de photos speaker étaient fetchées sans garde. Un éditeur pouvait viser les métadonnées cloud, une base interne, ou un autre backend du réseau Coolify partagé. Les deux passent désormais par `validateWebhookUrl()` — le garde existant du webhook contact (rejette loopback/privé/link-local). Le test vérifie que la garde agit **avant** tout fetch.

**XSS stocké** — l uploader admin acceptait `image/svg+xml`. Servi same-origin depuis `/uploads/`, un SVG avec `<script>` s exécute dans notre origine. Le flux magic-link l excluait déjà ; l admin s aligne. Vérifié qu **aucun SVG n est utilisé** (0 sur disque, 0 en base) → retrait sec, pas de sanitiseur à ajouter.

## Test plan

- [x] `tsc` propre
- [x] **5 tests SSRF** (loopback, métadonnées, IP privée, mauvais schéma — `fetch` jamais appelé) + **2 tests SVG** (refusé 400, PNG toujours accepté)
- [x] Suite : **387 tests / 57 fichiers, 0 échec**
- [ ] CI verte

Refs #306