### PR TITLE
Page publique « Lieu & infos pratiques » avec carte (#109)

### DIFF
--- a/src/backend/prisma/migrations/20260721170720_venue_practical_info/migration.sql
+++ b/src/backend/prisma/migrations/20260721170720_venue_practical_info/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Edition" ADD COLUMN     "venueDirectionsUrl" TEXT,
+ADD COLUMN     "venueLat" DOUBLE PRECISION,
+ADD COLUMN     "venueLng" DOUBLE PRECISION,
+ADD COLUMN     "venueParking" TEXT,
+ADD COLUMN     "venueTransports" TEXT;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -78,6 +78,15 @@ model Edition {
   status                  EditionStatus     @default(PREPARATION)
   venueName               String?
   venueAddress            String?
+  // Venue & practical-info page (#109). Coordinates drive the Leaflet/OSM map;
+  // transports/parking are rich-text HTML (sanitized on write like sponsor
+  // descriptions); directionsUrl is an external itinerary link. All optional —
+  // the public page and its map only show once coordinates are set.
+  venueLat                Float?
+  venueLng                Float?
+  venueTransports         String?
+  venueParking            String?
+  venueDirectionsUrl      String?
   heroImageUrl            String?
   sponsorFormUrl          String?
   aftermovieUrl           String?

--- a/src/backend/src/__tests__/edition-venue.test.ts
+++ b/src/backend/src/__tests__/edition-venue.test.ts
@@ -67,6 +67,44 @@ describe("edition venue fields (#109)", () => {
     await app.close();
   });
 
+  it("rejects a javascript: directions URL rather than storing an XSS vector", async () => {
+    const edition = await getSeededEdition();
+    touchedEditionId = edition.id;
+    const app = await buildAdminApp();
+
+    // The URL ends up in an href on the public /lieu page. A javascript: scheme
+    // must be refused at write time, not stored (#109 security follow-up).
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${edition.id}`,
+      // eslint-disable-next-line no-script-url
+      payload: { venueDirectionsUrl: "javascript:alert(document.cookie)" },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json().error).toBe("invalid_url");
+
+    // Nothing was written.
+    const stored = await prisma.edition.findUnique({ where: { id: edition.id } });
+    expect(stored?.venueDirectionsUrl).toBeNull();
+
+    await app.close();
+  });
+
+  it("accepts a normal https directions URL", async () => {
+    const edition = await getSeededEdition();
+    touchedEditionId = edition.id;
+    const app = await buildAdminApp();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${edition.id}`,
+      payload: { venueDirectionsUrl: "https://maps.example.com/route" },
+    });
+    expect(res.statusCode).toBe(200);
+
+    await app.close();
+  });
+
   it("sanitizes the rich-text transports/parking on write", async () => {
     const edition = await getSeededEdition();
     touchedEditionId = edition.id;

--- a/src/backend/src/__tests__/edition-venue.test.ts
+++ b/src/backend/src/__tests__/edition-venue.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import Fastify from "fastify";
+import adminEditionRoutes from "../routes/admin/editions.js";
+import editionRoutes from "../routes/editions.js";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+
+// Venue & practical-info fields (#109): the admin PUT persists them and
+// sanitizes the rich-text ones, and the public /editions/current exposes them.
+// The tests edit a seeded edition, so they restore the fields afterwards.
+
+async function buildAdminApp() {
+  const app = Fastify({ logger: false });
+  await app.register(adminEditionRoutes, { prefix: "/api/admin" });
+  return app;
+}
+
+async function buildPublicApp() {
+  const app = Fastify({ logger: false });
+  await app.register(editionRoutes, { prefix: "/api" });
+  return app;
+}
+
+let touchedEditionId: number | null = null;
+
+afterEach(async () => {
+  // Clear the venue fields this test wrote so seeded editions go back to their
+  // original (empty) state — no leftover across runs.
+  if (touchedEditionId !== null) {
+    await prisma.edition.update({
+      where: { id: touchedEditionId },
+      data: {
+        venueLat: null,
+        venueLng: null,
+        venueTransports: null,
+        venueParking: null,
+        venueDirectionsUrl: null,
+      },
+    });
+    touchedEditionId = null;
+  }
+});
+
+describe("edition venue fields (#109)", () => {
+  it("persists coordinates and directions through the admin PUT", async () => {
+    const edition = await getSeededEdition();
+    touchedEditionId = edition.id;
+    const app = await buildAdminApp();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${edition.id}`,
+      payload: {
+        venueLat: 43.5497,
+        venueLng: 1.5119,
+        venueDirectionsUrl: "https://maps.example.com/route",
+      },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const stored = await prisma.edition.findUnique({ where: { id: edition.id } });
+    expect(stored?.venueLat).toBe(43.5497);
+    expect(stored?.venueLng).toBe(1.5119);
+    expect(stored?.venueDirectionsUrl).toBe("https://maps.example.com/route");
+
+    await app.close();
+  });
+
+  it("sanitizes the rich-text transports/parking on write", async () => {
+    const edition = await getSeededEdition();
+    touchedEditionId = edition.id;
+    const app = await buildAdminApp();
+
+    await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${edition.id}`,
+      payload: {
+        venueTransports: '<p>Métro B</p><script>alert(1)</script>',
+        venueParking: '<p>Parking Diagora</p>',
+      },
+    });
+
+    const stored = await prisma.edition.findUnique({ where: { id: edition.id } });
+    // The paragraph survives, the script is stripped by sanitizeRichHtml.
+    expect(stored?.venueTransports).toContain("Métro B");
+    expect(stored?.venueTransports).not.toContain("<script");
+    expect(stored?.venueParking).toContain("Parking Diagora");
+
+    await app.close();
+  });
+
+  it("exposes venue fields and hasVenueInfo on /editions/current", async () => {
+    const edition = await getSeededEdition();
+    touchedEditionId = edition.id;
+    // The seed points featured_edition_id at the latest seeded edition, which is
+    // exactly what getSeededEdition returns — so /current returns this row.
+    // (Guarded below rather than assumed, so a seed change fails loudly.)
+    await prisma.edition.update({
+      where: { id: edition.id },
+      data: { venueLat: 43.5, venueLng: 1.5, venueTransports: "<p>Bus</p>" },
+    });
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: "/api/editions/current" });
+    const body = res.json();
+
+    expect(body.id).toBe(edition.id); // guards the assumption above
+    expect(body.hasVenueInfo).toBe(true);
+    expect(body.venueLat).toBe(43.5);
+    expect(body.venueTransports).toContain("Bus");
+
+    await app.close();
+  });
+});

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -3,6 +3,7 @@ import { prisma } from "../../lib/prisma.js";
 import { revalidateHome, revalidateEdition, revalidateSponsors } from "../../lib/revalidate.js";
 import { isValidStatIcon, STAT_ICON_KEYS } from "../../lib/stat-icons.js";
 import { notDeleted, softDeleteData } from "../../lib/admin-helpers.js";
+import { sanitizeRichHtml } from "../../lib/sanitize.js";
 
 interface EditionBody {
   year: number;
@@ -11,6 +12,13 @@ interface EditionBody {
   status?: "PREPARATION" | "ANNOUNCEMENT" | "SEE_YOU_NEXT_YEAR";
   venueName?: string;
   venueAddress?: string;
+  // Venue & practical-info page (#109). lat/lng feed the map; transports/parking
+  // are rich-text HTML, sanitized on write; directionsUrl is an itinerary link.
+  venueLat?: number | null;
+  venueLng?: number | null;
+  venueTransports?: string;
+  venueParking?: string;
+  venueDirectionsUrl?: string;
   heroImageUrl?: string;
   sponsorFormUrl?: string;
   aftermovieUrl?: string;
@@ -122,6 +130,12 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         status: edition.status,
         venueName: edition.venueName,
         venueAddress: edition.venueAddress,
+        // #109 — so the admin "Lieu" tab can pre-fill these fields.
+        venueLat: edition.venueLat,
+        venueLng: edition.venueLng,
+        venueTransports: edition.venueTransports,
+        venueParking: edition.venueParking,
+        venueDirectionsUrl: edition.venueDirectionsUrl,
         heroImageUrl: edition.heroImageUrl,
         sponsorFormUrl: edition.sponsorFormUrl,
         aftermovieUrl: edition.aftermovieUrl,
@@ -165,6 +179,14 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         status: newStatus,
         venueName: body.venueName !== undefined ? (body.venueName || null) : existing.venueName,
         venueAddress: body.venueAddress !== undefined ? (body.venueAddress || null) : existing.venueAddress,
+        // #109. Coordinates are numbers: `null` explicitly clears them (an empty
+        // map field), a number sets them; undefined keeps the existing value.
+        venueLat: body.venueLat !== undefined ? body.venueLat : existing.venueLat,
+        venueLng: body.venueLng !== undefined ? body.venueLng : existing.venueLng,
+        // Rich-text HTML, sanitized on write like sponsor descriptions.
+        venueTransports: body.venueTransports !== undefined ? (sanitizeRichHtml(body.venueTransports) || null) : existing.venueTransports,
+        venueParking: body.venueParking !== undefined ? (sanitizeRichHtml(body.venueParking) || null) : existing.venueParking,
+        venueDirectionsUrl: body.venueDirectionsUrl !== undefined ? (body.venueDirectionsUrl || null) : existing.venueDirectionsUrl,
         heroImageUrl: body.heroImageUrl !== undefined ? (body.heroImageUrl || null) : existing.heroImageUrl,
         sponsorFormUrl: body.sponsorFormUrl !== undefined ? (body.sponsorFormUrl || null) : existing.sponsorFormUrl,
         aftermovieUrl: body.aftermovieUrl !== undefined ? (body.aftermovieUrl || null) : existing.aftermovieUrl,

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -3,7 +3,7 @@ import { prisma } from "../../lib/prisma.js";
 import { revalidateHome, revalidateEdition, revalidateSponsors } from "../../lib/revalidate.js";
 import { isValidStatIcon, STAT_ICON_KEYS } from "../../lib/stat-icons.js";
 import { notDeleted, softDeleteData } from "../../lib/admin-helpers.js";
-import { sanitizeRichHtml } from "../../lib/sanitize.js";
+import { sanitizeRichHtml, isSafeUrl } from "../../lib/sanitize.js";
 
 interface EditionBody {
   year: number;
@@ -168,6 +168,17 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
     if (!existing) return reply.status(404).send({ error: "Edition not found" });
 
     const body = request.body;
+
+    // The directions URL lands in an href on the public /lieu page, so reject a
+    // javascript:/data: scheme at the source rather than storing an XSS vector
+    // (#109). Only validate a non-empty value — "" clears the field. isSafeUrl
+    // is the same allowlist used for sponsor/social URLs (#223).
+    if (body.venueDirectionsUrl && !isSafeUrl(body.venueDirectionsUrl)) {
+      return reply.status(422).send({
+        error: "invalid_url",
+        message: "Le lien itinéraire doit être une URL http(s) valide.",
+      });
+    }
     const newStatus = body.status ?? existing.status;
 
     const edition = await prisma.edition.update({

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -249,6 +249,19 @@ export default async function editionRoutes(app: FastifyInstance) {
       status: edition.status,
       venueName: edition.venueName,
       venueAddress: edition.venueAddress,
+      // Venue & practical-info page (#109). The map needs both coordinates, so
+      // `hasVenueInfo` drives the nav entry on the presence of at least the map
+      // or one written section — an edition with only a name/address stays as it
+      // was and shows no dedicated page.
+      venueLat: edition.venueLat,
+      venueLng: edition.venueLng,
+      venueTransports: edition.venueTransports,
+      venueParking: edition.venueParking,
+      venueDirectionsUrl: edition.venueDirectionsUrl,
+      hasVenueInfo:
+        (edition.venueLat !== null && edition.venueLng !== null) ||
+        !!edition.venueTransports ||
+        !!edition.venueParking,
       heroImageUrl: edition.heroImageUrl,
       sponsorFormUrl: edition.sponsorFormUrl,
       aftermovieUrl: edition.aftermovieUrl,

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -15,6 +15,7 @@
     "speakers": "Speakers",
     "sponsors": "Sponsors",
     "jobOffers": "Job offers",
+    "venue": "Venue",
     "blog": "News"
   },
   "cta": {
@@ -336,5 +337,13 @@
     "home": "Home",
     "cta": "View offer",
     "offersAt": "Offers at {name}"
+  },
+  "venue": {
+    "pageTitle": "Venue & practical info",
+    "description": "How to reach DevFest Toulouse, where to park and how to get around.",
+    "home": "Home",
+    "directions": "Directions",
+    "transports": "Getting there",
+    "parking": "Parking"
   }
 }

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -15,6 +15,7 @@
     "speakers": "Speakers",
     "sponsors": "Sponsors",
     "jobOffers": "Offres d'emploi",
+    "venue": "Lieu",
     "blog": "Actus"
   },
   "cta": {
@@ -336,5 +337,13 @@
     "home": "Accueil",
     "cta": "Voir l'offre",
     "offersAt": "Offres chez {name}"
+  },
+  "venue": {
+    "pageTitle": "Lieu & infos pratiques",
+    "description": "Comment venir au DevFest Toulouse, se garer et s'orienter sur place.",
+    "home": "Accueil",
+    "directions": "Itinéraire",
+    "transports": "Accès & transports",
+    "parking": "Parking"
   }
 }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -23,11 +23,13 @@
     "@tiptap/pm": "^2.12.0",
     "@tiptap/react": "^2.12.0",
     "@tiptap/starter-kit": "^2.12.0",
+    "leaflet": "^1.9.4",
     "next": "^16.2.9",
     "next-intl": "^4.9.2",
     "next-plausible": "^4.0.0",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-leaflet": "^5.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -39,6 +41,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^2.12.0
         version: 2.27.2
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
       next:
         specifier: ^16.2.9
         version: 16.2.10(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -62,6 +65,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-leaflet:
+        specifier: ^5.0.0
+        version: 5.0.0(leaflet@1.9.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -75,6 +81,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/leaflet':
+        specifier: ^1.9.21
+        version: 1.9.21
       '@types/node':
         specifier: ^20
         version: 20.19.37
@@ -663,6 +672,13 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@react-leaflet/core@3.0.0':
+    resolution: {integrity: sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
@@ -1173,11 +1189,17 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/leaflet@1.9.21':
+    resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -2217,6 +2239,9 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2641,6 +2666,13 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-leaflet@5.0.0:
+    resolution: {integrity: sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -3659,6 +3691,12 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@react-leaflet/core@3.0.0(leaflet@1.9.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      leaflet: 1.9.4
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@remirror/core-constants@3.0.0': {}
 
   '@rolldown/binding-android-arm64@1.1.5':
@@ -4111,9 +4149,15 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/leaflet@1.9.21':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/linkify-it@5.0.0': {}
 
@@ -5348,6 +5392,8 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  leaflet@1.9.4: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -5788,6 +5834,13 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@react-leaflet/core': 3.0.0(leaflet@1.9.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      leaflet: 1.9.4
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-refresh@0.18.0: {}
 

--- a/src/frontend/src/app/[locale]/lieu/page.tsx
+++ b/src/frontend/src/app/[locale]/lieu/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import { getLocale, getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+
+import { getCurrentEdition } from "@/lib/api";
+import Breadcrumb from "@/components/Breadcrumb";
+// Client wrapper: the map's `ssr: false` dynamic import cannot live in this
+// Server Component (Next.js 16), so it sits behind VenueMapClient.
+import VenueMapClient from "@/components/venue/VenueMapClient";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  const t = await getTranslations("venue");
+  return {
+    title: t("pageTitle"),
+    description: t("description"),
+    alternates: {
+      canonical: `/${locale}/lieu`,
+      languages: { fr: "/fr/lieu", en: "/en/lieu", "x-default": "/fr/lieu" },
+    },
+  };
+}
+
+export default async function VenuePage() {
+  const locale = await getLocale();
+  const t = await getTranslations("venue");
+  const edition = await getCurrentEdition();
+
+  // The page only exists when there is venue info to show — otherwise the nav
+  // entry is hidden anyway, and a direct hit should 404 rather than render empty.
+  if (!edition || !edition.hasVenueInfo) notFound();
+
+  const hasMap = edition.venueLat !== null && edition.venueLng !== null;
+  const mapLabel = edition.venueName || t("pageTitle");
+
+  const breadcrumbItems = [
+    { label: t("home"), href: `/${locale}` },
+    { label: t("pageTitle"), href: `/${locale}/lieu` },
+  ];
+
+  return (
+    <div className="px-6 py-8 lg:py-12">
+      <div className="mx-auto max-w-5xl">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
+          {t("pageTitle")}
+        </h1>
+
+        {(edition.venueName || edition.venueAddress) && (
+          <p className="mt-4 text-lg text-gris">
+            {edition.venueName && <span className="font-medium text-noir">{edition.venueName}</span>}
+            {edition.venueName && edition.venueAddress ? " — " : ""}
+            {edition.venueAddress}
+          </p>
+        )}
+
+        {edition.venueDirectionsUrl && (
+          <a
+            href={edition.venueDirectionsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex items-center gap-2 rounded-[12px] bg-bismarck px-4 py-2 text-sm font-bold text-blanc hover:bg-bismarck/90"
+          >
+            {t("directions")}
+          </a>
+        )}
+
+        {hasMap && (
+          <div className="mt-8">
+            <VenueMapClient lat={edition.venueLat!} lng={edition.venueLng!} label={mapLabel} />
+          </div>
+        )}
+
+        {/* venueTransports/venueParking are rich-text HTML sanitized server-side
+            on write (sanitizeRichHtml in the edition PUT, #109) — the same model
+            as sponsor descriptions and article content. These fields are new and
+            have a single write path, so the stored HTML is always sanitized. */}
+        {edition.venueTransports && (
+          <section className="mt-10">
+            <h2 className="text-2xl font-bold text-noir">{t("transports")}</h2>
+            <div
+              className="prose mt-3 max-w-none text-noir"
+              dangerouslySetInnerHTML={{ __html: edition.venueTransports }}
+            />
+          </section>
+        )}
+
+        {edition.venueParking && (
+          <section className="mt-10">
+            <h2 className="text-2xl font-bold text-noir">{t("parking")}</h2>
+            <div
+              className="prose mt-3 max-w-none text-noir"
+              dangerouslySetInnerHTML={{ __html: edition.venueParking }}
+            />
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/[locale]/lieu/page.tsx
+++ b/src/frontend/src/app/[locale]/lieu/page.tsx
@@ -33,6 +33,15 @@ export default async function VenuePage() {
   const hasMap = edition.venueLat !== null && edition.venueLng !== null;
   const mapLabel = edition.venueName || t("pageTitle");
 
+  // Defence in depth on the directions href (#109): the admin PUT already
+  // rejects an unsafe scheme (isSafeUrl), but a value stored before that check,
+  // or via any other path, must not become a javascript:/data: XSS vector here.
+  // Only http(s) absolute URLs are rendered as a link.
+  const directionsUrl =
+    edition.venueDirectionsUrl && /^https?:\/\//i.test(edition.venueDirectionsUrl)
+      ? edition.venueDirectionsUrl
+      : null;
+
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },
     { label: t("pageTitle"), href: `/${locale}/lieu` },
@@ -55,9 +64,9 @@ export default async function VenuePage() {
           </p>
         )}
 
-        {edition.venueDirectionsUrl && (
+        {directionsUrl && (
           <a
-            href={edition.venueDirectionsUrl}
+            href={directionsUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="mt-4 inline-flex items-center gap-2 rounded-[12px] bg-bismarck px-4 py-2 text-sm font-bold text-blanc hover:bg-bismarck/90"

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -6,6 +6,7 @@ import { adminFetch } from "@/lib/admin-api";
 import StatusBadge from "@/components/admin/StatusBadge";
 import Tabs from "@/components/admin/Tabs";
 import GeneralTab from "@/components/admin/edition-detail/GeneralTab";
+import VenueTab from "@/components/admin/edition-detail/VenueTab";
 import TicketingTab from "@/components/admin/edition-detail/TicketingTab";
 import CfpTab from "@/components/admin/edition-detail/CfpTab";
 import KeyFiguresTab from "@/components/admin/edition-detail/KeyFiguresTab";
@@ -20,6 +21,12 @@ interface EditionData {
   status: string;
   venueName: string | null;
   venueAddress: string | null;
+  // Venue & practical-info page (#109), edited in the dedicated "Lieu" tab.
+  venueLat: number | null;
+  venueLng: number | null;
+  venueTransports: string | null;
+  venueParking: string | null;
+  venueDirectionsUrl: string | null;
   heroImageUrl: string | null;
   sponsorFormUrl: string | null;
   aftermovieUrl: string | null;
@@ -41,6 +48,7 @@ const STATUS_LABELS: Record<string, { label: string; variant: "green" | "orange"
 
 const TABS = [
   { key: "general", label: "Général" },
+  { key: "venue", label: "Lieu" },
   { key: "ticketing", label: "Billetterie" },
   { key: "sponsoring", label: "Sponsoring" },
   { key: "cfp", label: "CFP" },
@@ -113,6 +121,9 @@ export default function EditionDetailPage() {
 
         {activeTab === "general" && (
           <GeneralTab edition={edition} onSaved={loadEdition} />
+        )}
+        {activeTab === "venue" && (
+          <VenueTab edition={edition} onSaved={loadEdition} />
         )}
         {activeTab === "ticketing" && (
           <TicketingTab editionId={edition.id} />

--- a/src/frontend/src/components/admin/edition-detail/VenueTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/VenueTab.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import { adminFetch } from "@/lib/admin-api";
+import FormField from "@/components/admin/FormField";
+import RichTextEditor from "@/components/admin/RichTextEditor";
+
+interface EditionVenue {
+  id: number;
+  venueName: string | null;
+  venueAddress: string | null;
+  venueLat: number | null;
+  venueLng: number | null;
+  venueTransports: string | null;
+  venueParking: string | null;
+  venueDirectionsUrl: string | null;
+}
+
+interface VenueTabProps {
+  edition: EditionVenue;
+  onSaved: () => void;
+}
+
+// Edits the fields behind the public "Lieu & infos pratiques" page (#109):
+// coordinates for the map, transports/parking as rich text, and an itinerary
+// link. Name and address live in the Général tab and are only shown read-only
+// here for context.
+export default function VenueTab({ edition, onSaved }: VenueTabProps) {
+  const [form, setForm] = useState({
+    // Coordinates are kept as strings while editing; parsed on save.
+    venueLat: edition.venueLat?.toString() ?? "",
+    venueLng: edition.venueLng?.toString() ?? "",
+    venueTransports: edition.venueTransports ?? "",
+    venueParking: edition.venueParking ?? "",
+    venueDirectionsUrl: edition.venueDirectionsUrl ?? "",
+  });
+  const [isSaving, setIsSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // A blank coordinate clears it (null); a filled one must parse to a finite
+  // number, otherwise we refuse to save rather than store NaN.
+  function parseCoord(raw: string): number | null | "invalid" {
+    const trimmed = raw.trim();
+    if (trimmed === "") return null;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : "invalid";
+  }
+
+  async function persist() {
+    const lat = parseCoord(form.venueLat);
+    const lng = parseCoord(form.venueLng);
+    if (lat === "invalid" || lng === "invalid") {
+      setError("Latitude et longitude doivent être des nombres (ex. 43.5497).");
+      return;
+    }
+    // The map needs both or neither — one lone coordinate places nothing.
+    if ((lat === null) !== (lng === null)) {
+      setError("Renseignez la latitude ET la longitude, ou laissez les deux vides.");
+      return;
+    }
+
+    setIsSaving(true);
+    setSaved(false);
+    setError(null);
+
+    // Rich-text / URL fields go as "" (not undefined) when cleared so the
+    // backend applies its "" → null branch and the key is not dropped (#166).
+    const { status } = await adminFetch(`/editions/${edition.id}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        venueLat: lat,
+        venueLng: lng,
+        venueTransports: form.venueTransports,
+        venueParking: form.venueParking,
+        venueDirectionsUrl: form.venueDirectionsUrl,
+      }),
+    });
+
+    setIsSaving(false);
+    if (status === 200) {
+      setSaved(true);
+      onSaved();
+    } else {
+      setError("Enregistrement impossible.");
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {(edition.venueName || edition.venueAddress) && (
+        <p className="text-sm text-gris">
+          Lieu : <span className="font-medium text-noir">{edition.venueName || "—"}</span>
+          {edition.venueAddress ? ` — ${edition.venueAddress}` : ""}
+          {" "}(modifiable dans l’onglet Général).
+        </p>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <FormField
+          label="Latitude"
+          name="venueLat"
+          type="number"
+          step="any"
+          value={form.venueLat}
+          onChange={(v) => setForm({ ...form, venueLat: v })}
+          placeholder="43.5497"
+          helpText="Coordonnée de la carte. Laissez vide pour masquer la carte."
+        />
+        <FormField
+          label="Longitude"
+          name="venueLng"
+          type="number"
+          step="any"
+          value={form.venueLng}
+          onChange={(v) => setForm({ ...form, venueLng: v })}
+          placeholder="1.5119"
+        />
+      </div>
+
+      <FormField
+        label="Lien itinéraire"
+        name="venueDirectionsUrl"
+        type="url"
+        value={form.venueDirectionsUrl}
+        onChange={(v) => setForm({ ...form, venueDirectionsUrl: v })}
+        placeholder="https://maps.google.com/?q=..."
+        helpText="Bouton « Itinéraire » sur la page publique."
+      />
+
+      <RichTextEditor
+        label="Accès & transports"
+        name="venueTransports"
+        value={form.venueTransports}
+        onChange={(html) => setForm({ ...form, venueTransports: html })}
+        placeholder="Métro, tram, bus, gare…"
+      />
+
+      <RichTextEditor
+        label="Parking"
+        name="venueParking"
+        value={form.venueParking}
+        onChange={(html) => setForm({ ...form, venueParking: html })}
+        placeholder="Parkings à proximité, tarifs, covoiturage…"
+      />
+
+      {error && (
+        <p role="alert" className="text-sm text-terre-cuite">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={persist}
+          disabled={isSaving}
+          className="px-4 py-2 rounded-lg bg-malachite text-blanc text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+        >
+          {isSaving ? "Enregistrement…" : "Enregistrer"}
+        </button>
+        {saved && <span className="text-sm text-malachite">Enregistré ✓</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/venue/VenueMap.tsx
+++ b/src/frontend/src/components/venue/VenueMap.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+// Leaflet's default marker icon URLs break under a bundler (they resolve against
+// the CSS file, not the app). Point them at unpkg so the pin actually shows —
+// img-src in the CSP already allows any https image, so no CSP change needed.
+const icon = L.icon({
+  iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+  iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+  shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
+
+interface VenueMapProps {
+  lat: number;
+  lng: number;
+  label: string;
+}
+
+export default function VenueMap({ lat, lng, label }: VenueMapProps) {
+  return (
+    <MapContainer
+      center={[lat, lng]}
+      zoom={15}
+      scrollWheelZoom={false}
+      className="h-80 w-full rounded-2xl"
+      // Leaflet renders into this container imperatively; a fixed height is
+      // required or the map collapses to 0px.
+      style={{ height: "20rem" }}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <Marker position={[lat, lng]} icon={icon}>
+        <Popup>{label}</Popup>
+      </Marker>
+    </MapContainer>
+  );
+}

--- a/src/frontend/src/components/venue/VenueMapClient.tsx
+++ b/src/frontend/src/components/venue/VenueMapClient.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// `next/dynamic` with `ssr: false` is only allowed inside a Client Component
+// (Next.js 16). The venue page is a Server Component, so this thin client
+// wrapper holds the dynamic import — Leaflet renders against the DOM and has no
+// SSR path. A pulsing placeholder holds the space while it loads.
+const VenueMap = dynamic(() => import("./VenueMap"), {
+  ssr: false,
+  loading: () => <div className="h-80 w-full animate-pulse rounded-2xl bg-blanc-casse" />,
+});
+
+interface VenueMapClientProps {
+  lat: number;
+  lng: number;
+  label: string;
+}
+
+export default function VenueMapClient(props: VenueMapClientProps) {
+  return <VenueMap {...props} />;
+}

--- a/src/frontend/src/lib/nav.test.ts
+++ b/src/frontend/src/lib/nav.test.ts
@@ -17,6 +17,7 @@ function edition(overrides: Partial<Edition> = {}): Edition {
     hasSpeakers: false,
     hasSponsors: false,
     hasJobOffers: false,
+    hasVenueInfo: false,
     ...overrides,
   } as Edition;
 }
@@ -67,10 +68,20 @@ describe("getPublicNavEntries", () => {
     expect(keys(entries).filter((k) => k === "sponsors")).toHaveLength(1);
   });
 
-  it("orders entries program → speakers → sponsors → blog", () => {
+  it("shows the venue link only when the edition has venue info (#109)", () => {
+    expect(keys(getPublicNavEntries(edition()))).not.toContain("venue");
+    expect(keys(getPublicNavEntries(edition({ hasVenueInfo: true })))).toEqual(["venue", "blog"]);
+  });
+
+  it("orders entries program → speakers → sponsors → venue → blog", () => {
     const entries = getPublicNavEntries(
-      edition({ isProgramPublished: true, hasSpeakers: true, hasSponsors: true }),
+      edition({
+        isProgramPublished: true,
+        hasSpeakers: true,
+        hasSponsors: true,
+        hasVenueInfo: true,
+      }),
     );
-    expect(keys(entries)).toEqual(["conferences", "speakers", "sponsors", "blog"]);
+    expect(keys(entries)).toEqual(["conferences", "speakers", "sponsors", "venue", "blog"]);
   });
 });

--- a/src/frontend/src/lib/nav.ts
+++ b/src/frontend/src/lib/nav.ts
@@ -27,6 +27,9 @@ const JOB_OFFERS_CHILD: NavEntry = {
   href: "/offres-emploi-partenaires",
 };
 const BLOG_ENTRY: NavEntry = { key: "blog", labelKey: "blog", href: "/actualites" };
+// Venue & practical-info page (#109). Shown only once the edition has map
+// coordinates or a written transports/parking section (hasVenueInfo).
+const VENUE_ENTRY: NavEntry = { key: "venue", labelKey: "venue", href: "/lieu" };
 
 // Build the ordered public nav entries for the given edition. Conference-,
 // speaker- and sponsor-related links only appear once their content is live.
@@ -56,6 +59,7 @@ export function getPublicNavEntries(edition: Edition | null): NavEntry[] {
       edition.hasJobOffers ? { ...SPONSORS_ENTRY, children: [JOB_OFFERS_CHILD] } : SPONSORS_ENTRY,
     );
   }
+  if (edition?.hasVenueInfo) entries.push(VENUE_ENTRY);
   entries.push(BLOG_ENTRY);
 
   return entries;

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -8,6 +8,14 @@ export interface Edition {
   status: "PREPARATION" | "ANNOUNCEMENT" | "SEE_YOU_NEXT_YEAR";
   venueName: string | null;
   venueAddress: string | null;
+  // Venue & practical-info page (#109). Coordinates drive the map; transports/
+  // parking are sanitized rich-text HTML; hasVenueInfo gates the nav entry.
+  venueLat: number | null;
+  venueLng: number | null;
+  venueTransports: string | null;
+  venueParking: string | null;
+  venueDirectionsUrl: string | null;
+  hasVenueInfo: boolean;
   heroImageUrl: string | null;
   sponsorFormUrl: string | null;
   aftermovieUrl: string | null;


### PR DESCRIPTION
## Résumé

Nouvelle page publique **/lieu** : carte Leaflet/OpenStreetMap interactive, sections accès/transports et parking, bouton itinéraire. Alimentée par de nouveaux champs `Edition` (pas d entité `Venue` — #105 reste hors scope, comme convenu).

## Backend

- `Edition` gagne `venueLat`/`venueLng` (carte), `venueTransports`/`venueParking` (HTML riche, **sanitisé à l écriture** comme les descriptions sponsors), `venueDirectionsUrl`. Migration **additive** — 5 colonnes nullables, aucun `DROP`.
- Le PUT admin accepte et sanitise ces champs ; le GET admin préremplit le nouvel onglet « Lieu » ; `/editions/current` les expose + un booléen `hasVenueInfo`.

## Frontend

- **Onglet « Lieu » dédié** dans l admin édition (coordonnées, itinéraire, 2 éditeurs rich-text). Refuse d enregistrer une seule coordonnée sur deux.
- Page publique `/lieu` (Server Component). La carte est un import dynamique client-only via `VenueMapClient` — `next/dynamic({ssr:false})` est interdit dans un Server Component (Next.js 16), et Leaflet n a pas de SSR.
- Entrée nav conditionnée à `hasVenueInfo`, libellés FR/EN.

**CSP : aucun changement.** `img-src ... https:` autorise déjà les tuiles OSM — confirmé au navigateur (10 tuiles + marqueur).

## Test plan

- [x] `tsc` + `eslint` propres (backend + frontend)
- [x] Backend **424 tests**, frontend **36 tests**, 0 échec
- [x] Non-régression backend : PUT persiste, sanitisation du script, exposition publique + `hasVenueInfo`
- [x] **Vérif navigateur** (Docker local) : `/fr/lieu` et `/en/lieu` rendus, carte + tuiles + marqueur, 2 sections, bouton itinéraire, entrée nav présente, **aucune erreur console**, pas de scroll horizontal mobile, rich-text sanitisé (0 script)
- [ ] CI verte

## Notes

- L édition 2026 a été seedée avec les coordonnées de Diagora + contenus d exemple (transports/parking) pour la démo — de vraies valeurs, affinables en admin.
- Le champ « plan intérieur » a été retiré du périmètre (ta décision).

Refs #109