### PR TITLE
Accueil — deux paragraphes dans le bloc « Derrière le DevFest » (#322)

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -48,7 +48,8 @@
     },
     "about": {
       "behindTitle": "Behind #DevFestToulouse",
-      "gdgDescription": "DevFest Toulouse is organized by GDG Toulouse, a passionate developer community. Since 2016, we bring together the Toulouse tech community every year around talks, workshops, and networking.",
+      "gdgDescription": "DevFest Toulouse is organized by GDG Toulouse, a passionate developer community.",
+      "gdgHistory": "Since 2016, we bring together the Toulouse tech community every year around talks, workshops, and networking.",
       "ecosystemTitle": "Dive into our ecosystem",
       "carouselPrev": "Previous photo",
       "carouselNext": "Next photo"

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -48,7 +48,8 @@
     },
     "about": {
       "behindTitle": "Derrière le #DevFestToulouse",
-      "gdgDescription": "Le DevFest Toulouse est organisé par le GDG Toulouse, une communauté de développeurs passionnés. Depuis 2016, nous rassemblons chaque année les acteurs de la tech toulousaine autour de conférences, de workshops et de moments de partage.",
+      "gdgDescription": "Le DevFest Toulouse est organisé par le GDG Toulouse, une communauté de développeurs passionnés.",
+      "gdgHistory": "Depuis 2016, nous rassemblons chaque année les acteurs de la tech toulousaine autour de conférences, de workshops et de moments de partage.",
       "ecosystemTitle": "Plongez dans notre écosystème",
       "carouselPrev": "Photo précédente",
       "carouselNext": "Photo suivante"

--- a/src/frontend/src/components/home/AboutSection.tsx
+++ b/src/frontend/src/components/home/AboutSection.tsx
@@ -36,9 +36,12 @@ export default async function AboutSection({ surface = "blanc" }: AboutSectionPr
               <h2 className="text-3xl lg:text-5xl font-bold text-blanc mb-6">
                 {t("behindTitle")}
               </h2>
-              <div className="bg-blanc/90 rounded-m p-6 lg:p-8">
+              <div className="bg-blanc/90 rounded-m p-6 lg:p-8 space-y-4">
                 <p className="text-base lg:text-lg text-noir leading-relaxed">
                   {t("gdgDescription")}
+                </p>
+                <p className="text-base lg:text-lg text-noir leading-relaxed">
+                  {t("gdgHistory")}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Corrige **#322**. Le texte du GDG et l historique « Depuis 2016… » s affichaient d un seul tenant.

- `home.about.gdgDescription` scindé en deux clés (`gdgDescription` + `gdgHistory`), coupure avant « Depuis 2016 » / « Since 2016 », en FR **et** EN.
- `AboutSection` rend deux `<p>` avec `space-y-4`. Aucun texte perdu ni dupliqué.

## Test plan

- [x] `tsc` + lint frontend propres
- [x] Cohérence des clés vérifiée fr/en (fin du 1er = « passionnés. » / « community. », début du 2e = « Depuis 2016 » / « Since 2016 »)
- [ ] Vérif navigateur — **non faite** (serveur MCP Chrome DevTools déconnecté). Changement statique (i18n + JSX), visible sur beta après merge.

Refs #322