### PR TITLE
feat(admin): boutons Supprimer sur les listes speakers, talks, sponsors

### DIFF
--- a/src/frontend/src/app/admin/speakers/page.test.tsx
+++ b/src/frontend/src/app/admin/speakers/page.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock the router and query params — the page reads both at module load.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// adminFetch is the seam: the list load and the DELETE both go through it.
+const adminFetch = vi.fn();
+vi.mock("@/lib/admin-api", () => ({
+  adminFetch: (...args: unknown[]) => adminFetch(...args),
+}));
+
+const { default: SpeakersDataPage } = await import("./page");
+
+const speaker = {
+  id: 7,
+  name: "Ada Lovelace",
+  company: "Analytical Engine",
+  publicationStatus: "PUBLISHED",
+  isFeatured: false,
+  edition: { id: 1, year: 2026 },
+};
+
+beforeEach(() => {
+  adminFetch.mockReset();
+  // Default: the initial list load returns our one speaker.
+  adminFetch.mockResolvedValue({ data: [speaker], status: 200 });
+});
+
+// #300: the speakers list had no delete button — DataTable only got onEdit.
+// These lock the wiring: the button opens a danger dialog, confirming issues a
+// DELETE and drops the row; cancelling does neither.
+describe("SpeakersDataPage delete (#300)", () => {
+  it("deletes a speaker through a confirm dialog", async () => {
+    const user = userEvent.setup();
+    render(<SpeakersDataPage />);
+
+    // Wait for the row to appear (list loaded).
+    await screen.findByText("Ada Lovelace");
+
+    // The delete button exists (the bug was that it did not).
+    await user.click(screen.getByRole("button", { name: "Supprimer" }));
+
+    // A danger confirm dialog names the speaker.
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("Ada Lovelace");
+
+    // The backend soft-deletes and answers 204 — the handler must accept 204.
+    // Confirm from inside the dialog: the row's own "Supprimer" is still in the
+    // DOM, so scope the click to the dialog to avoid an ambiguous match.
+    adminFetch.mockResolvedValueOnce({ status: 204 });
+    await user.click(within(dialog).getByRole("button", { name: "Supprimer" }));
+
+    await waitFor(() => {
+      expect(adminFetch).toHaveBeenCalledWith("/speakers/7", { method: "DELETE" });
+    });
+    // Row is gone from the list.
+    await waitFor(() => {
+      expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not call DELETE when the dialog is cancelled", async () => {
+    const user = userEvent.setup();
+    render(<SpeakersDataPage />);
+    await screen.findByText("Ada Lovelace");
+
+    await user.click(screen.getByRole("button", { name: "Supprimer" }));
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: "Annuler" }));
+
+    // Only the initial list load happened — no DELETE.
+    expect(adminFetch).not.toHaveBeenCalledWith("/speakers/7", { method: "DELETE" });
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+  });
+
+  it("surfaces a backend error instead of dropping the row silently", async () => {
+    const user = userEvent.setup();
+    render(<SpeakersDataPage />);
+    await screen.findByText("Ada Lovelace");
+
+    await user.click(screen.getByRole("button", { name: "Supprimer" }));
+    const dialog = await screen.findByRole("dialog");
+
+    // A 409 (or any non-204) must show a message and keep the row.
+    adminFetch.mockResolvedValueOnce({ status: 409, error: "Conflit." });
+    await user.click(within(dialog).getByRole("button", { name: "Supprimer" }));
+
+    await screen.findByRole("alert");
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/app/admin/speakers/page.tsx
+++ b/src/frontend/src/app/admin/speakers/page.tsx
@@ -8,6 +8,7 @@ import type { Speaker } from "@/lib/types";
 import DataTable from "@/components/admin/DataTable";
 import BulkActionBar from "@/components/admin/BulkActionBar";
 import StatusBadge from "@/components/admin/StatusBadge";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 
 interface SpeakerRow extends Speaker {
   edition?: { id: number; year: number };
@@ -21,6 +22,8 @@ export default function SpeakersDataPage() {
   const [year, setYear] = useState<string>(searchParams.get("year") ?? "");
   const [search, setSearch] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [deleteTarget, setDeleteTarget] = useState<SpeakerRow | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     adminFetch<SpeakerRow[]>("/speakers").then(({ data }) => {
@@ -46,6 +49,24 @@ export default function SpeakersDataPage() {
       ),
     );
     setSelectedIds(new Set());
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setError(null);
+    // Soft-delete since #147: the backend answers 204 and the row moves to the
+    // trash. adminFetch returns 204 explicitly — test the status, not 200.
+    const { status, error: apiError } = await adminFetch(`/speakers/${deleteTarget.id}`, {
+      method: "DELETE",
+    });
+    const deletedId = deleteTarget.id;
+    setDeleteTarget(null);
+
+    if (status === 204) {
+      setSpeakers((prev) => prev.filter((s) => s.id !== deletedId));
+      return;
+    }
+    setError(apiError ?? "Suppression impossible.");
   }
 
   const years = useMemo(
@@ -142,16 +163,33 @@ export default function SpeakersDataPage() {
             />
           )}
 
+          {error && (
+            <div role="alert" className="mb-4 rounded-lg bg-terre-cuite/10 px-4 py-3 text-sm text-terre-cuite">
+              {error}
+            </div>
+          )}
+
           <DataTable<SpeakerRow>
             columns={columns}
             data={filtered}
             emptyMessage="Aucun speaker"
             onEdit={(s) => router.push(`/admin/speakers/${s.id}`)}
+            onDelete={(s) => setDeleteTarget(s)}
             selectedIds={selectedIds}
             onSelectionChange={setSelectedIds}
           />
         </>
       )}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="Supprimer le speaker"
+        message={`Supprimer « ${deleteTarget?.name} » ? Il disparaîtra des pages publiques. Vous pourrez le restaurer depuis la corbeille.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/src/frontend/src/app/admin/sponsors/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/page.tsx
@@ -8,6 +8,7 @@ import type { Sponsor, SponsorLevel } from "@/lib/types";
 import DataTable from "@/components/admin/DataTable";
 import BulkActionBar from "@/components/admin/BulkActionBar";
 import StatusBadge from "@/components/admin/StatusBadge";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 
 interface SponsorRow extends Sponsor {
   edition?: { id: number; year: number };
@@ -30,6 +31,8 @@ export default function SponsorsDataPage() {
   const [level, setLevel] = useState<string>("");
   const [search, setSearch] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [deleteTarget, setDeleteTarget] = useState<SponsorRow | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     adminFetch<SponsorRow[]>("/sponsors").then(({ data }) => {
@@ -49,6 +52,24 @@ export default function SponsorsDataPage() {
       prev.map((s) => (selectedIds.has(s.id) ? { ...s, publicationStatus: value } : s)),
     );
     setSelectedIds(new Set());
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setError(null);
+    // Soft-delete since #147: 204, the sponsor moves to the trash. Its contacts
+    // and job offers go with it on the public side; the row itself is restorable.
+    const { status, error: apiError } = await adminFetch(`/sponsors/${deleteTarget.id}`, {
+      method: "DELETE",
+    });
+    const deletedId = deleteTarget.id;
+    setDeleteTarget(null);
+
+    if (status === 204) {
+      setSponsors((prev) => prev.filter((s) => s.id !== deletedId));
+      return;
+    }
+    setError(apiError ?? "Suppression impossible.");
   }
 
   const years = useMemo(
@@ -146,16 +167,33 @@ export default function SponsorsDataPage() {
             />
           )}
 
+          {error && (
+            <div role="alert" className="mb-4 rounded-lg bg-terre-cuite/10 px-4 py-3 text-sm text-terre-cuite">
+              {error}
+            </div>
+          )}
+
           <DataTable<SponsorRow>
             columns={columns}
             data={filtered}
             emptyMessage="Aucun sponsor"
             onEdit={(s) => router.push(`/admin/sponsors/${s.id}`)}
+            onDelete={(s) => setDeleteTarget(s)}
             selectedIds={selectedIds}
             onSelectionChange={setSelectedIds}
           />
         </>
       )}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="Supprimer le sponsor"
+        message={`Supprimer « ${deleteTarget?.name} » ? Il disparaîtra des pages publiques. Vous pourrez le restaurer depuis la corbeille.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/src/frontend/src/app/admin/talks/page.tsx
+++ b/src/frontend/src/app/admin/talks/page.tsx
@@ -8,6 +8,7 @@ import type { Talk, TalkFormat } from "@/lib/types";
 import DataTable from "@/components/admin/DataTable";
 import BulkActionBar from "@/components/admin/BulkActionBar";
 import StatusBadge from "@/components/admin/StatusBadge";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 
 interface TalkRow extends Talk {
   edition?: { id: number; year: number };
@@ -29,6 +30,8 @@ export default function TalksDataPage() {
   const [format, setFormat] = useState<string>("");
   const [search, setSearch] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [deleteTarget, setDeleteTarget] = useState<TalkRow | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     adminFetch<TalkRow[]>("/talks").then(({ data }) => {
@@ -48,6 +51,23 @@ export default function TalksDataPage() {
       prev.map((t) => (selectedIds.has(t.id) ? { ...t, publicationStatus: value } : t)),
     );
     setSelectedIds(new Set());
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setError(null);
+    // Soft-delete since #147: 204, the talk moves to the trash.
+    const { status, error: apiError } = await adminFetch(`/talks/${deleteTarget.id}`, {
+      method: "DELETE",
+    });
+    const deletedId = deleteTarget.id;
+    setDeleteTarget(null);
+
+    if (status === 204) {
+      setTalks((prev) => prev.filter((t) => t.id !== deletedId));
+      return;
+    }
+    setError(apiError ?? "Suppression impossible.");
   }
 
   const years = useMemo(
@@ -163,16 +183,33 @@ export default function TalksDataPage() {
             />
           )}
 
+          {error && (
+            <div role="alert" className="mb-4 rounded-lg bg-terre-cuite/10 px-4 py-3 text-sm text-terre-cuite">
+              {error}
+            </div>
+          )}
+
           <DataTable<TalkRow>
             columns={columns}
             data={filtered}
             emptyMessage="Aucune conférence"
             onEdit={(t) => router.push(`/admin/talks/${t.id}`)}
+            onDelete={(t) => setDeleteTarget(t)}
             selectedIds={selectedIds}
             onSelectionChange={setSelectedIds}
           />
         </>
       )}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="Supprimer la conférence"
+        message={`Supprimer « ${deleteTarget?.title} » ? Elle disparaîtra des pages publiques. Vous pourrez la restaurer depuis la corbeille.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Résumé

- Ajoute une action **Supprimer** sur chaque ligne des listes admin *Speakers*, *Conférences* et *Sponsors* — jusqu'ici seul *Modifier* était exposé (le `DataTable` ne recevait pas de `onDelete`).
- Le clic ouvre un `ConfirmDialog` (variant `danger`) qui **nomme l'élément** et précise qu'il **disparaît des pages publiques** mais reste **restaurable depuis la corbeille** — pas de mention « irréversible », car #147 a transformé les suppressions en *soft-delete*.
- La confirmation appelle le `DELETE` (réponse **204**) puis retire la ligne de la liste ; une réponse non-204 affiche une bannière d'erreur au lieu de retirer la ligne silencieusement.

## Détails techniques

- Même patron sur les 3 pages : état `deleteTarget` + `error`, `handleDelete` qui teste `status === 204` (jamais 200 — `adminFetch` renvoie 204 explicitement), bannière `role="alert"`.
- `page.test.tsx` (liste speakers, représentatif des 3) : le bouton ouvre le dialog, confirmer émet `DELETE /speakers/:id` et retire la ligne, annuler ne fait ni l'un ni l'autre, un 409 affiche l'erreur et garde la ligne. Test validé contre le bug (sans `onDelete`, les 3 cas échouent).

## Test plan

- [x] `pnpm exec tsc --noEmit` (frontend) — OK
- [x] `pnpm run lint` (frontend) — 0 erreur sur les fichiers touchés
- [x] `pnpm test` frontend — **39/39** (dont les 3 nouveaux)
- [x] `pnpm test` backend — **426/426** (endpoints DELETE / soft-delete déjà couverts)
- [x] Vérif navigateur (Chrome DevTools MCP, env local Docker) pour les **3** entités :
  - bouton **Supprimer** présent, dialog nommant l'élément, mention corbeille ;
  - la ligne disparaît de la liste après confirmation ;
  - `deletedAt` renseigné en base + slug parké (`__trash_<id>__…`) ;
  - élément absent de l'API et des pages publiques (404) ;
  - élément présent dans la **corbeille** (restaurable) — puis purgé pour nettoyer la DB de dev.

Refs #300
