### PR TITLE
feat(sponsor): API catalogue d'offres + réparation des surfaces cassées (316b / #318)

### DIFF
--- a/src/backend/src/__tests__/admin-edition-sponsor-tiers.test.ts
+++ b/src/backend/src/__tests__/admin-edition-sponsor-tiers.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { buildAdminApp } from "./test-admin-app.js";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+import { tierIdByKey } from "./sponsor-test-helpers.js";
+
+// #318 — per-edition tier bindings (visibility, price, order). Mutations run on
+// an ad-hoc edition so they never disturb the seeded links that other parallel
+// files read. Read-only assertions use the seeded edition.
+let testEditionId: number;
+
+beforeAll(async () => {
+  // A year well below the seeded range so getSeededEdition never picks it (#292).
+  const edition = await prisma.edition.create({ data: { year: 1990 } });
+  testEditionId = edition.id;
+});
+
+afterAll(async () => {
+  await prisma.editionSponsorTier.deleteMany({ where: { editionId: testEditionId } });
+  await prisma.edition.delete({ where: { id: testEditionId } });
+});
+
+describe("Admin Edition Sponsor Tiers API (#318)", () => {
+  it("lists the seeded edition's bindings joined to the tier, sorted by sortOrder", async () => {
+    const edition = await getSeededEdition();
+    const app = await buildAdminApp();
+    const res = await app.inject({ method: "GET", url: `/api/admin/editions/${edition.id}/sponsor-tiers` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.length).toBeGreaterThanOrEqual(4);
+    // Joined tier is present, sortOrder is ascending.
+    expect(body[0].tier).toBeDefined();
+    expect(body[0].tier.nameFr).toBeDefined();
+    const orders = body.map((l: { sortOrder: number }) => l.sortOrder);
+    expect([...orders]).toEqual([...orders].sort((a, b) => a - b));
+  });
+
+  it("upserts a binding: creates then applies isVisible/price/sortOrder", async () => {
+    const tierId = await tierIdByKey("platinum");
+
+    const app = await buildAdminApp();
+    const create = await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${testEditionId}/sponsor-tiers/${tierId}`,
+      payload: { isVisible: false, price: "5000 EUR", sortOrder: 3 },
+    });
+    await app.close();
+    expect(create.statusCode).toBe(200);
+
+    const stored = await prisma.editionSponsorTier.findUnique({
+      where: { editionId_tierId: { editionId: testEditionId, tierId } },
+    });
+    expect(stored?.isVisible).toBe(false);
+    expect(stored?.price).toBe("5000 EUR");
+    expect(stored?.sortOrder).toBe(3);
+
+    // A second PUT updates the same row rather than duplicating it.
+    const upd = await buildAdminApp();
+    const update = await upd.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${testEditionId}/sponsor-tiers/${tierId}`,
+      payload: { isVisible: true },
+    });
+    await upd.close();
+    expect(update.statusCode).toBe(200);
+    const after = await prisma.editionSponsorTier.findUnique({
+      where: { editionId_tierId: { editionId: testEditionId, tierId } },
+    });
+    expect(after?.isVisible).toBe(true);
+    expect(after?.price).toBe("5000 EUR"); // untouched by the partial update
+  });
+
+  it("rejects a binding to a non-existent tier with 422", async () => {
+    const app = await buildAdminApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${testEditionId}/sponsor-tiers/999999`,
+      payload: { isVisible: true },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(422);
+  });
+
+  it("removes a binding and is idempotent", async () => {
+    const tierId = await tierIdByKey("gold");
+    // Ensure it exists first.
+    const setup = await buildAdminApp();
+    await setup.inject({
+      method: "PUT",
+      url: `/api/admin/editions/${testEditionId}/sponsor-tiers/${tierId}`,
+      payload: { isVisible: true },
+    });
+    await setup.close();
+
+    const app = await buildAdminApp();
+    const del = await app.inject({ method: "DELETE", url: `/api/admin/editions/${testEditionId}/sponsor-tiers/${tierId}` });
+    await app.close();
+    expect(del.statusCode).toBe(204);
+
+    const count = await prisma.editionSponsorTier.count({ where: { editionId: testEditionId, tierId } });
+    expect(count).toBe(0);
+
+    // Deleting again is a no-op, still 204.
+    const again = await buildAdminApp();
+    const del2 = await again.inject({ method: "DELETE", url: `/api/admin/editions/${testEditionId}/sponsor-tiers/${tierId}` });
+    await again.close();
+    expect(del2.statusCode).toBe(204);
+  });
+});

--- a/src/backend/src/__tests__/admin-sponsor-tiers.test.ts
+++ b/src/backend/src/__tests__/admin-sponsor-tiers.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { buildAdminApp } from "./test-admin-app.js";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+import { tierIdByKey } from "./sponsor-test-helpers.js";
+
+// #318 — CRUD of the global sponsoring-tier catalogue. Teardown is scoped to the
+// rows this file created (its keys are prefixed so they never clash with the
+// seeded catalogue read by other parallel files).
+const createdTierIds: number[] = [];
+
+afterEach(async () => {
+  if (createdTierIds.length) {
+    await prisma.sponsorTier.deleteMany({ where: { id: { in: createdTierIds } } });
+    createdTierIds.length = 0;
+  }
+});
+
+async function createTier(overrides: Record<string, unknown> = {}) {
+  const app = await buildAdminApp();
+  const res = await app.inject({
+    method: "POST",
+    url: "/api/admin/sponsor-tiers",
+    payload: { key: `test-tier-${Date.now()}-${Math.round(performance.now())}`, nameFr: "Test", nameEn: "Test", ...overrides },
+  });
+  await app.close();
+  if (res.statusCode === 201) createdTierIds.push(res.json().id);
+  return res;
+}
+
+describe("Admin Sponsor Tiers API (#318)", () => {
+  it("lists tiers sorted by rank desc with advantages as an array", async () => {
+    const app = await buildAdminApp();
+    const res = await app.inject({ method: "GET", url: "/api/admin/sponsor-tiers" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    // The seeded catalogue leads with platinum (rank 40).
+    expect(body[0].key).toBe("platinum");
+    const ranks = body.map((t: { rank: number }) => t.rank);
+    expect([...ranks]).toEqual([...ranks].sort((a, b) => b - a));
+    // advantages is deserialized, never the raw JSON string.
+    expect(Array.isArray(body[0].advantages)).toBe(true);
+  });
+
+  it("creates a tier and reads it back with advantages re-parsed", async () => {
+    const create = await createTier({
+      nameFr: "Créé", nameEn: "Created", rank: 5, jobOfferQuota: 3, allowsPromoIdeas: true,
+      advantages: [{ fr: "Un", en: "One" }],
+    });
+    expect(create.statusCode).toBe(201);
+    const { id } = create.json();
+
+    const stored = await prisma.sponsorTier.findUnique({ where: { id } });
+    expect(stored?.nameFr).toBe("Créé");
+    expect(stored?.rank).toBe(5);
+    expect(stored?.jobOfferQuota).toBe(3);
+    expect(stored?.allowsPromoIdeas).toBe(true);
+    // Stored as a JSON string; the create response returns it parsed.
+    expect(JSON.parse(stored?.advantages ?? "[]")).toEqual([{ fr: "Un", en: "One" }]);
+    expect(create.json().advantages).toEqual([{ fr: "Un", en: "One" }]);
+  });
+
+  it("rejects a duplicate key with 409", async () => {
+    const key = `dup-${Date.now()}`;
+    const first = await createTier({ key });
+    expect(first.statusCode).toBe(201);
+
+    const app = await buildAdminApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/admin/sponsor-tiers",
+      payload: { key, nameFr: "X", nameEn: "X" },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("rejects a create missing key/nameFr/nameEn with 400", async () => {
+    const app = await buildAdminApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/admin/sponsor-tiers",
+      payload: { nameFr: "Sans clé" },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("applies a PUT to the stored row", async () => {
+    const { id } = (await createTier({ nameFr: "Avant" })).json();
+    const app = await buildAdminApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/sponsor-tiers/${id}`,
+      payload: { nameFr: "Après", color: "#123456", rank: 99 },
+    });
+    await app.close();
+    expect(res.statusCode).toBe(200);
+
+    const stored = await prisma.sponsorTier.findUnique({ where: { id } });
+    expect(stored?.nameFr).toBe("Après");
+    expect(stored?.color).toBe("#123456");
+    expect(stored?.rank).toBe(99);
+  });
+
+  it("soft-deletes a tier and parks its key", async () => {
+    const key = `del-${Date.now()}`;
+    const { id } = (await createTier({ key })).json();
+
+    const app = await buildAdminApp();
+    const del = await app.inject({ method: "DELETE", url: `/api/admin/sponsor-tiers/${id}` });
+    await app.close();
+    expect(del.statusCode).toBe(204);
+
+    const stored = await prisma.sponsorTier.findUnique({ where: { id } });
+    expect(stored?.deletedAt).not.toBeNull();
+    // key is parked so a new tier could reuse the readable value.
+    expect(stored?.key).not.toBe(key);
+    expect(stored?.key.startsWith("__trash_")).toBe(true);
+
+    // No longer in the live listing.
+    const listApp = await buildAdminApp();
+    const list = await listApp.inject({ method: "GET", url: "/api/admin/sponsor-tiers" });
+    await listApp.close();
+    expect(list.json().some((t: { id: number }) => t.id === id)).toBe(false);
+  });
+
+  it("refuses to delete a tier still bound to an edition (409)", async () => {
+    // The seeded platinum tier has an EditionSponsorTier link → cannot be trashed.
+    const platinumId = await tierIdByKey("platinum");
+    const app = await buildAdminApp();
+    const del = await app.inject({ method: "DELETE", url: `/api/admin/sponsor-tiers/${platinumId}` });
+    await app.close();
+    expect(del.statusCode).toBe(409);
+
+    // And it stays live.
+    const stored = await prisma.sponsorTier.findUnique({ where: { id: platinumId } });
+    expect(stored?.deletedAt).toBeNull();
+  });
+
+  it("refuses to delete a tier still used by a live sponsor (409)", async () => {
+    const edition = await getSeededEdition();
+    const { id } = (await createTier({ key: `used-${Date.now()}` })).json();
+    const sponsor = await prisma.sponsor.create({
+      data: { name: "Tier User", slug: `tier-user-${Date.now()}`, editionId: edition.id, tierId: id },
+    });
+
+    const app = await buildAdminApp();
+    const del = await app.inject({ method: "DELETE", url: `/api/admin/sponsor-tiers/${id}` });
+    await app.close();
+    expect(del.statusCode).toBe(409);
+
+    await prisma.sponsor.delete({ where: { id: sponsor.id } });
+  });
+});

--- a/src/backend/src/__tests__/public-sponsor-tiers.test.ts
+++ b/src/backend/src/__tests__/public-sponsor-tiers.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import Fastify from "fastify";
+import editionRoutes from "../routes/editions.js";
+
+// #318 — public catalogue for /devenir-sponsor. Asserts against the seeded
+// featured edition (2026), which has four visible bindings. Read-only, so it is
+// safe under Vitest's parallel file execution.
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(editionRoutes, { prefix: "/api" });
+  return app;
+}
+
+describe("Public sponsor tiers (#318)", () => {
+  it("returns the featured edition's visible tiers, sorted, with parsed advantages", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/editions/current/sponsor-tiers" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThanOrEqual(4);
+
+    // Shape: advantages parsed to an array, no isFeatured field (dropped in #317).
+    const platinum = body.find((t: { nameFr: string }) => t.nameFr === "Platinum");
+    expect(platinum).toBeDefined();
+    expect(Array.isArray(platinum.advantages)).toBe(true);
+    expect("isFeatured" in platinum).toBe(false);
+    expect(platinum).toHaveProperty("color");
+    expect(platinum).toHaveProperty("logoScale");
+    expect(platinum).toHaveProperty("standSize");
+    // price is the per-edition override (null in the seed).
+    expect("price" in platinum).toBe(true);
+  });
+});

--- a/src/backend/src/__tests__/public-sponsors.test.ts
+++ b/src/backend/src/__tests__/public-sponsors.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { buildPublicApp } from "./test-public-app.js";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+import { tierIdByKey } from "./sponsor-test-helpers.js";
+
+// #318 — the public /api/sponsors response now carries the real tier object
+// (nameFr, nameEn, logoScale, color) alongside the legacy `level` shim (#317),
+// and stays ordered by tier rank (RG-221).
+const createdSponsorIds: number[] = [];
+
+afterEach(async () => {
+  if (createdSponsorIds.length) {
+    await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
+    createdSponsorIds.length = 0;
+  }
+});
+
+describe("Public sponsors carry tier + level (#318)", () => {
+  it("exposes tier and level, ranked by tier", async () => {
+    const edition = await getSeededEdition();
+    const goldId = await tierIdByKey("gold");
+    const platinumId = await tierIdByKey("platinum");
+
+    // Create a gold sponsor whose name sorts before the platinum one, to prove
+    // the ordering is by rank (platinum first), not by name.
+    const gold = await prisma.sponsor.create({
+      data: { name: "AAAA Gold Co", slug: `pub-gold-${Date.now()}`, editionId: edition.id, tierId: goldId, publicationStatus: "PUBLISHED" },
+    });
+    const platinum = await prisma.sponsor.create({
+      data: { name: "ZZZZ Platinum Co", slug: `pub-plat-${Date.now()}`, editionId: edition.id, tierId: platinumId, publicationStatus: "PUBLISHED" },
+    });
+    createdSponsorIds.push(gold.id, platinum.id);
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: "/api/sponsors" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    const mine = body.filter((s: { id: number }) => s.id === gold.id || s.id === platinum.id);
+    expect(mine).toHaveLength(2);
+
+    // Every item carries the tier object AND the legacy level string.
+    for (const s of mine) {
+      expect(s.tier).toMatchObject({ nameFr: expect.any(String), nameEn: expect.any(String), color: expect.any(String) });
+      expect(typeof s.tier.logoScale).toBe("number");
+      expect(typeof s.level).toBe("string");
+    }
+
+    // Platinum (higher rank) comes before gold despite the name order.
+    const platIdx = body.findIndex((s: { id: number }) => s.id === platinum.id);
+    const goldIdx = body.findIndex((s: { id: number }) => s.id === gold.id);
+    expect(platIdx).toBeLessThan(goldIdx);
+    expect(body[platIdx].level).toBe("PLATINUM");
+    expect(body[goldIdx].level).toBe("GOLD");
+  });
+});

--- a/src/backend/src/__tests__/test-admin-app.ts
+++ b/src/backend/src/__tests__/test-admin-app.ts
@@ -8,6 +8,7 @@ import adminTicketRoutes from "../routes/admin/tickets.js";
 import adminSettingsRoutes from "../routes/admin/settings.js";
 import adminPageRoutes from "../routes/admin/pages.js";
 import adminContactRoutes from "../routes/admin/contact.js";
+import adminSponsorTierRoutes from "../routes/admin/sponsor-tiers.js";
 
 export async function buildAdminApp() {
   const app = Fastify({ logger: false });
@@ -19,6 +20,7 @@ export async function buildAdminApp() {
   await app.register(adminSettingsRoutes, { prefix: "/api/admin" });
   await app.register(adminPageRoutes, { prefix: "/api/admin" });
   await app.register(adminContactRoutes, { prefix: "/api/admin" });
+  await app.register(adminSponsorTierRoutes, { prefix: "/api/admin" });
 
   return app;
 }

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -368,6 +368,80 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
     return { success: true, count: figures.length };
   });
 
+  // --- Sponsor tiers offered by an edition (#318) ---
+  // Which catalogue tiers this edition proposes, with a per-edition price
+  // override, visibility and display order. Pure join rows (no soft delete).
+
+  // GET /api/admin/editions/:id/sponsor-tiers — the edition's tier bindings,
+  // joined to the catalogue. Trashed tiers are defended against here too.
+  app.get<{ Params: { id: string } }>("/editions/:id/sponsor-tiers", async (request, reply) => {
+    const id = Number(request.params.id);
+    if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
+
+    const links = await prisma.editionSponsorTier.findMany({
+      where: { editionId: id },
+      include: {
+        tier: { select: { id: true, key: true, nameFr: true, nameEn: true, color: true, standSize: true, rank: true, deletedAt: true } },
+      },
+      orderBy: { sortOrder: "asc" },
+    });
+
+    return links
+      .filter((l) => l.tier.deletedAt === null)
+      .map((l) => {
+        const { deletedAt: _deletedAt, ...tier } = l.tier;
+        return { id: l.id, tierId: l.tierId, isVisible: l.isVisible, price: l.price, sortOrder: l.sortOrder, tier };
+      });
+  });
+
+  // PUT /api/admin/editions/:id/sponsor-tiers/:tierId — offer a tier for this
+  // edition (upsert). Creating the row means "proposed"; the body tunes it.
+  app.put<{
+    Params: { id: string; tierId: string };
+    Body: { isVisible?: boolean; price?: string | null; sortOrder?: number };
+  }>("/editions/:id/sponsor-tiers/:tierId", async (request, reply) => {
+    const editionId = Number(request.params.id);
+    const tierId = Number(request.params.tierId);
+    if (isNaN(editionId) || isNaN(tierId)) return reply.status(400).send({ error: "Invalid ID" });
+
+    const edition = await prisma.edition.findFirst({ where: { id: editionId, ...notDeleted }, select: { id: true } });
+    if (!edition) return reply.status(404).send({ error: "Edition not found" });
+    const tier = await prisma.sponsorTier.findFirst({ where: { id: tierId, ...notDeleted }, select: { id: true } });
+    if (!tier) return reply.code(422).send({ error: "Invalid tierId: no such sponsor tier" });
+
+    const body = request.body;
+    const link = await prisma.editionSponsorTier.upsert({
+      where: { editionId_tierId: { editionId, tierId } },
+      update: {
+        ...(body.isVisible !== undefined && { isVisible: body.isVisible }),
+        ...(body.price !== undefined && { price: body.price || null }),
+        ...(body.sortOrder !== undefined && { sortOrder: body.sortOrder }),
+      },
+      create: {
+        editionId,
+        tierId,
+        isVisible: body.isVisible ?? true,
+        price: body.price || null,
+        sortOrder: body.sortOrder ?? 0,
+      },
+    });
+
+    revalidateSponsors();
+    return { id: link.id, tierId: link.tierId, isVisible: link.isVisible, price: link.price, sortOrder: link.sortOrder };
+  });
+
+  // DELETE /api/admin/editions/:id/sponsor-tiers/:tierId — stop offering a tier
+  // for this edition. Hard delete of the join row; idempotent.
+  app.delete<{ Params: { id: string; tierId: string } }>("/editions/:id/sponsor-tiers/:tierId", async (request, reply) => {
+    const editionId = Number(request.params.id);
+    const tierId = Number(request.params.tierId);
+    if (isNaN(editionId) || isNaN(tierId)) return reply.status(400).send({ error: "Invalid ID" });
+
+    await prisma.editionSponsorTier.deleteMany({ where: { editionId, tierId } });
+    revalidateSponsors();
+    return reply.code(204).send();
+  });
+
   // --- Featured Edition ---
 
   // PUT /api/admin/editions/featured — set the featured edition

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -11,6 +11,7 @@ import adminContactRoutes from "./contact.js";
 import adminFileRoutes from "./files.js";
 import adminUserRoutes from "./users.js";
 import adminSponsorRoutes from "./sponsors.js";
+import adminSponsorTierRoutes from "./sponsor-tiers.js";
 import adminSpeakerRoutes from "./speakers.js";
 import adminCategoryRoutes from "./categories.js";
 import adminTalkRoutes from "./talks.js";
@@ -32,6 +33,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminFileRoutes);
     await editorApp.register(adminTranslateRoutes);
     await editorApp.register(adminSponsorRoutes);
+    await editorApp.register(adminSponsorTierRoutes);
     await editorApp.register(adminSpeakerRoutes);
     await editorApp.register(adminCategoryRoutes);
     await editorApp.register(adminTalkRoutes);

--- a/src/backend/src/routes/admin/sponsor-tiers.ts
+++ b/src/backend/src/routes/admin/sponsor-tiers.ts
@@ -1,0 +1,163 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../lib/prisma.js";
+import { revalidateSponsors } from "../../lib/revalidate.js";
+import { notDeleted, notFound, softDeleteData, parkUniqueValue } from "../../lib/admin-helpers.js";
+
+// CRUD for the global sponsoring-tier catalogue (#318). A tier is shared across
+// editions; its per-edition binding (price, visibility, order) lives in
+// EditionSponsorTier and is managed under /admin/editions/:id/sponsor-tiers.
+
+interface SponsorTierCreateBody {
+  key: string;
+  nameFr: string;
+  nameEn: string;
+  subtitleFr?: string;
+  subtitleEn?: string;
+  descriptionFr?: string;
+  descriptionEn?: string;
+  advantages?: { fr: string; en: string }[];
+  standSize?: string;
+  color?: string;
+  logoScale?: number;
+  rank?: number;
+  jobOfferQuota?: number;
+  allowsPromoIdeas?: boolean;
+}
+
+type SponsorTierUpdateBody = Partial<SponsorTierCreateBody>;
+
+interface SponsorTierIdParams {
+  id: string;
+}
+
+function serialize(t: { advantages: string | null; [k: string]: unknown }) {
+  return { ...t, advantages: t.advantages ? JSON.parse(t.advantages) : [] };
+}
+
+export default async function adminSponsorTierRoutes(app: FastifyInstance) {
+  // GET /api/admin/sponsor-tiers — the whole catalogue, most important first.
+  app.get("/sponsor-tiers", async () => {
+    const tiers = await prisma.sponsorTier.findMany({
+      where: notDeleted,
+      orderBy: { rank: "desc" },
+    });
+    return tiers.map(serialize);
+  });
+
+  // GET /api/admin/sponsor-tiers/:id
+  app.get<{ Params: SponsorTierIdParams }>("/sponsor-tiers/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const tier = await prisma.sponsorTier.findFirst({
+      where: { id: Number(request.params.id), ...notDeleted },
+    });
+    if (!tier) return notFound(reply, "Sponsor tier");
+    return serialize(tier);
+  });
+
+  // POST /api/admin/sponsor-tiers
+  app.post<{ Body: SponsorTierCreateBody }>("/sponsor-tiers", async (request, reply) => {
+    const body = request.body;
+
+    if (!body.key?.trim() || !body.nameFr?.trim() || !body.nameEn?.trim()) {
+      return reply.code(400).send({ error: "key, nameFr and nameEn are required" });
+    }
+    // `key` is @unique across the whole table, trash included — a parked key
+    // still owns its slot. Check without the notDeleted filter.
+    const clash = await prisma.sponsorTier.findFirst({ where: { key: body.key.trim() }, select: { id: true } });
+    if (clash) return reply.code(409).send({ error: "key already used" });
+
+    const tier = await prisma.sponsorTier.create({
+      data: {
+        key: body.key.trim(),
+        nameFr: body.nameFr.trim(),
+        nameEn: body.nameEn.trim(),
+        subtitleFr: body.subtitleFr || null,
+        subtitleEn: body.subtitleEn || null,
+        descriptionFr: body.descriptionFr || null,
+        descriptionEn: body.descriptionEn || null,
+        advantages: body.advantages ? JSON.stringify(body.advantages) : null,
+        standSize: body.standSize || null,
+        ...(body.color !== undefined && { color: body.color }),
+        ...(body.logoScale !== undefined && { logoScale: body.logoScale }),
+        ...(body.rank !== undefined && { rank: body.rank }),
+        ...(body.jobOfferQuota !== undefined && { jobOfferQuota: body.jobOfferQuota }),
+        ...(body.allowsPromoIdeas !== undefined && { allowsPromoIdeas: body.allowsPromoIdeas }),
+      },
+    });
+
+    revalidateSponsors();
+    return reply.code(201).send(serialize(tier));
+  });
+
+  // PUT /api/admin/sponsor-tiers/:id
+  app.put<{ Params: SponsorTierIdParams; Body: SponsorTierUpdateBody }>("/sponsor-tiers/:id", {
+    schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } },
+  }, async (request, reply) => {
+    const id = Number(request.params.id);
+    const body = request.body;
+
+    const existing = await prisma.sponsorTier.findFirst({ where: { id, ...notDeleted } });
+    if (!existing) return notFound(reply, "Sponsor tier");
+
+    if (body.key !== undefined && body.key.trim() !== existing.key) {
+      const clash = await prisma.sponsorTier.findFirst({ where: { key: body.key.trim() }, select: { id: true } });
+      if (clash) return reply.code(409).send({ error: "key already used" });
+    }
+
+    const tier = await prisma.sponsorTier.update({
+      where: { id },
+      data: {
+        ...(body.key !== undefined && { key: body.key.trim() }),
+        ...(body.nameFr !== undefined && { nameFr: body.nameFr.trim() }),
+        ...(body.nameEn !== undefined && { nameEn: body.nameEn.trim() }),
+        ...(body.subtitleFr !== undefined && { subtitleFr: body.subtitleFr || null }),
+        ...(body.subtitleEn !== undefined && { subtitleEn: body.subtitleEn || null }),
+        ...(body.descriptionFr !== undefined && { descriptionFr: body.descriptionFr || null }),
+        ...(body.descriptionEn !== undefined && { descriptionEn: body.descriptionEn || null }),
+        ...(body.advantages !== undefined && { advantages: body.advantages ? JSON.stringify(body.advantages) : null }),
+        ...(body.standSize !== undefined && { standSize: body.standSize || null }),
+        ...(body.color !== undefined && { color: body.color }),
+        ...(body.logoScale !== undefined && { logoScale: body.logoScale }),
+        ...(body.rank !== undefined && { rank: body.rank }),
+        ...(body.jobOfferQuota !== undefined && { jobOfferQuota: body.jobOfferQuota }),
+        ...(body.allowsPromoIdeas !== undefined && { allowsPromoIdeas: body.allowsPromoIdeas }),
+      },
+    });
+
+    revalidateSponsors();
+    return serialize(tier);
+  });
+
+  // DELETE /api/admin/sponsor-tiers/:id — moves the tier to the trash (#147).
+  // Refused while any live sponsor or edition binding still points at it, so a
+  // sponsor can never end up attached to a trashed tier.
+  app.delete<{ Params: SponsorTierIdParams }>("/sponsor-tiers/:id", async (request, reply) => {
+    const id = Number(request.params.id);
+    if (isNaN(id)) return reply.status(400).send({ error: "Invalid ID" });
+
+    const existing = await prisma.sponsorTier.findFirst({ where: { id, ...notDeleted } });
+    if (!existing) return notFound(reply, "Sponsor tier");
+
+    const [sponsorCount, linkCount] = await Promise.all([
+      prisma.sponsor.count({ where: { tierId: id, ...notDeleted } }),
+      prisma.editionSponsorTier.count({ where: { tierId: id } }),
+    ]);
+    if (sponsorCount > 0 || linkCount > 0) {
+      return reply.code(409).send({
+        error: "Tier still in use",
+        sponsors: sponsorCount,
+        editions: linkCount,
+      });
+    }
+
+    // `key` is @unique — park it so a new tier can reuse the readable value.
+    await prisma.sponsorTier.update({
+      where: { id },
+      data: { ...softDeleteData(), key: parkUniqueValue(existing.key, id) },
+    });
+
+    revalidateSponsors();
+    return reply.code(204).send();
+  });
+}

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -284,6 +284,37 @@ export default async function editionRoutes(app: FastifyInstance) {
     };
   });
 
+  // GET /api/editions/current/sponsor-tiers — visible sponsoring offers for the
+  // featured edition (#318). Replaces the removed sponsor-plans route: reads the
+  // catalogue through the per-edition binding, ordered by the edition's sortOrder,
+  // with its price override.
+  app.get("/editions/current/sponsor-tiers", async (_request, reply) => {
+    const edition = await getFeaturedEdition();
+    if (!edition) return reply.status(404).send({ error: "No edition found" });
+
+    const links = await prisma.editionSponsorTier.findMany({
+      where: { editionId: edition.id, isVisible: true, tier: { ...notDeleted } },
+      include: { tier: true },
+      orderBy: { sortOrder: "asc" },
+    });
+
+    return links.map((l) => ({
+      id: l.tier.id,
+      nameFr: l.tier.nameFr,
+      nameEn: l.tier.nameEn,
+      subtitleFr: l.tier.subtitleFr,
+      subtitleEn: l.tier.subtitleEn,
+      descriptionFr: l.tier.descriptionFr,
+      descriptionEn: l.tier.descriptionEn,
+      standSize: l.tier.standSize,
+      color: l.tier.color,
+      logoScale: l.tier.logoScale,
+      advantages: l.tier.advantages ? JSON.parse(l.tier.advantages) : [],
+      // Per-edition price override (may be null).
+      price: l.price,
+    }));
+  });
+
   // GET /api/editions/current/ticket-tiers — returns visible tiers for the featured edition
   app.get("/editions/current/ticket-tiers", async (_request, reply) => {
     const edition = await getFeaturedEdition();

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -23,7 +23,7 @@ export default async function sponsorRoutes(app: FastifyInstance) {
 
     const sponsors = await prisma.sponsor.findMany({
       where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
-      include: { tier: { select: { key: true, rank: true } } },
+      include: { tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } } },
     });
 
     return sponsors
@@ -34,6 +34,8 @@ export default async function sponsorRoutes(app: FastifyInstance) {
         logoUrl: s.logoUrl,
         // Legacy `level` string kept for the untouched front (#317 shim).
         level: tierKeyToLegacyLevel(s.tier.key),
+        // Real tier model for the front to move onto (#318 → #321).
+        tier: { nameFr: s.tier.nameFr, nameEn: s.tier.nameEn, logoScale: s.tier.logoScale, color: s.tier.color },
         rank: s.tier.rank,
         websiteUrl: s.websiteUrl,
       }))
@@ -59,7 +61,7 @@ export default async function sponsorRoutes(app: FastifyInstance) {
         ...notDeleted,
       },
       include: {
-        tier: { select: { key: true } },
+        tier: { select: { key: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
         // Nested reads need their own filter: a query extension would not reach
         // them (Prisma applies those to the top-level operation only), and a
         // trashed speaker would otherwise still show up on a live sponsor page.
@@ -87,6 +89,8 @@ export default async function sponsorRoutes(app: FastifyInstance) {
       logoUrl: sponsor.logoUrl,
       // Legacy `level` string kept for the untouched front (#317 shim).
       level: tierKeyToLegacyLevel(sponsor.tier.key),
+      // Real tier model for the front to move onto (#318 → #321).
+      tier: { nameFr: sponsor.tier.nameFr, nameEn: sponsor.tier.nameEn, logoScale: sponsor.tier.logoScale, color: sponsor.tier.color },
       websiteUrl: sponsor.websiteUrl,
       descriptionFr: sponsor.descriptionFr,
       descriptionEn: sponsor.descriptionEn,

--- a/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
+++ b/src/frontend/src/app/[locale]/devenir-sponsor/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
-import { getCurrentEdition, getSponsorPlans, getContactCategories } from "@/lib/api";
+import { getCurrentEdition, getSponsorTiers, getContactCategories } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
 import ContactForm from "@/components/ContactForm";
 import { Link } from "@/i18n/navigation";
@@ -32,9 +32,9 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function SponsorPage() {
   const locale = await getLocale();
   const t = await getTranslations("sponsor");
-  const [edition, plans, categories] = await Promise.all([
+  const [edition, tiers, categories] = await Promise.all([
     getCurrentEdition(),
-    getSponsorPlans(),
+    getSponsorTiers(),
     getContactCategories(),
   ]);
 
@@ -176,38 +176,27 @@ export default async function SponsorPage() {
                 {t("plansTitle")}
               </h2>
 
-              {plans.length === 0 ? (
+              {tiers.length === 0 ? (
                 <p className="mt-6 text-gris">{t("noPlans")}</p>
               ) : (
                 <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0">
-                  {plans.map((plan) => {
-                    const name = localizedField(plan as unknown as Record<string, unknown>, "name", locale);
-                    const subtitle = localizedField(plan as unknown as Record<string, unknown>, "subtitle", locale);
-                    const advantages = plan.advantages || [];
+                  {tiers.map((tier) => {
+                    const name = localizedField(tier as unknown as Record<string, unknown>, "name", locale);
+                    const subtitle = localizedField(tier as unknown as Record<string, unknown>, "subtitle", locale);
+                    const advantages = tier.advantages || [];
 
                     // CTA target depends on the page mode
-                    const planCtaHref = status === "OPEN" ? "#contact" : (tempUrl || "#contact");
-                    const planCtaExternal = status !== "OPEN" && Boolean(tempUrl);
+                    const tierCtaHref = status === "OPEN" ? "#contact" : (tempUrl || "#contact");
+                    const tierCtaExternal = status !== "OPEN" && Boolean(tempUrl);
 
                     return (
                       <div
-                        key={plan.id}
-                        className={`relative flex flex-col border border-gris/20 bg-blanc rounded-2xl ${
-                          plan.isFeatured
-                            ? "lg:-my-4 lg:shadow-xl lg:z-10 lg:scale-[1.03]"
-                            : ""
-                        }`}
+                        key={tier.id}
+                        className="relative flex flex-col border border-gris/20 bg-blanc rounded-2xl"
                       >
                         {/* Color header */}
-                        <div
-                          className={`px-6 py-4 text-center rounded-t-2xl ${
-                            plan.isFeatured ? "py-5" : ""
-                          }`}
-                          style={{ backgroundColor: plan.color }}
-                        >
-                          <p className={`font-bold text-blanc ${plan.isFeatured ? "text-2xl" : "text-xl"}`}>
-                            {name}
-                          </p>
+                        <div className="px-6 py-4 text-center rounded-t-2xl" style={{ backgroundColor: tier.color }}>
+                          <p className="font-bold text-blanc text-xl">{name}</p>
                         </div>
 
                         {/* Subtitle */}
@@ -218,13 +207,13 @@ export default async function SponsorPage() {
                         )}
 
                         {/* Stand size */}
-                        {plan.standSize && (
-                          <p className="text-center text-3xl lg:text-4xl font-bold px-4 pt-4" style={{ color: plan.color }}>
-                            {plan.standSize}
+                        {tier.standSize && (
+                          <p className="text-center text-3xl lg:text-4xl font-bold px-4 pt-4" style={{ color: tier.color }}>
+                            {tier.standSize}
                           </p>
                         )}
 
-                        {!plan.standSize && (
+                        {!tier.standSize && (
                           <p className="text-center text-lg font-bold text-gris/50 px-4 pt-6">
                             —
                           </p>
@@ -249,10 +238,10 @@ export default async function SponsorPage() {
                         {/* CTA button */}
                         <div className="px-6 pb-6">
                           <a
-                            href={planCtaHref}
-                            {...(planCtaExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                            href={tierCtaHref}
+                            {...(tierCtaExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                             className="block w-full text-center py-3 rounded-lg font-bold text-blanc transition-opacity hover:opacity-90"
-                            style={{ backgroundColor: plan.color }}
+                            style={{ backgroundColor: tier.color }}
                           >
                             {t("ctaContact")}
                           </a>

--- a/src/frontend/src/app/admin/sponsors/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { adminFetch } from "@/lib/admin-api";
-import type { Sponsor } from "@/lib/types";
+import type { Sponsor, AdminSponsorTier } from "@/lib/types";
 import SponsorContacts from "@/components/admin/sponsors/SponsorContacts";
 import SponsorForm, { emptySponsorForm, type SponsorFormValue } from "@/components/admin/sponsors/SponsorForm";
 
@@ -21,12 +21,25 @@ export default function SponsorEditorPage() {
 
   const [form, setForm] = useState<SponsorFormValue>(emptySponsorForm);
   const [current, setCurrent] = useState<SponsorData | null>(null);
+  const [tiers, setTiers] = useState<AdminSponsorTier[]>([]);
   const [editions, setEditions] = useState<{ id: number; year: number }[]>([]);
   const [editionId, setEditionId] = useState<number | null>(null);
   const [editionYear, setEditionYear] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(!isNew);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // The tier catalogue drives the "Niveau" <select> and the promo-idea gating.
+  useEffect(() => {
+    adminFetch<AdminSponsorTier[]>("/sponsor-tiers").then(({ data }) => {
+      if (!data) return;
+      setTiers(data);
+      // A brand-new sponsor needs a tier picked up front (tierId is required):
+      // default to the most important one (list is sorted by rank desc).
+      if (isNew && data[0]) setForm((f) => (f.tierId === null ? { ...f, tierId: data[0].id } : f));
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (isNew) {
@@ -47,7 +60,7 @@ export default function SponsorEditorPage() {
         setCurrent(data);
         setForm({
           name: data.name,
-          level: data.level,
+          tierId: data.tierId,
           logoUrl: data.logoUrl || "",
           websiteUrl: data.websiteUrl || "",
           descriptionFr: data.descriptionFr || "",
@@ -74,7 +87,7 @@ export default function SponsorEditorPage() {
   }, [sponsorId, isNew]);
 
   async function handleSave() {
-    if (!form.name.trim() || !editionId) return;
+    if (!form.name.trim() || !editionId || !form.tierId) return;
     setIsSaving(true);
     setError(null);
     const socialLinks: Record<string, string> = {};
@@ -85,7 +98,7 @@ export default function SponsorEditorPage() {
     const payload = {
       editionId,
       name: form.name.trim(),
-      level: form.level,
+      tierId: form.tierId,
       logoUrl: form.logoUrl || undefined,
       websiteUrl: form.websiteUrl || undefined,
       descriptionFr: form.descriptionFr || undefined,
@@ -150,7 +163,7 @@ export default function SponsorEditorPage() {
           <p className="text-sm text-gris">Édition : <span className="font-medium text-noir">{editionYear ?? "—"}</span></p>
         )}
 
-        <SponsorForm value={form} onChange={setForm} />
+        <SponsorForm value={form} onChange={setForm} tiers={tiers} />
 
         {!isNew && current && <SponsorContacts sponsorId={current.id} />}
 
@@ -159,7 +172,7 @@ export default function SponsorEditorPage() {
         <div className="flex items-center gap-3 pt-2">
           <button
             onClick={handleSave}
-            disabled={isSaving || !form.name.trim() || !editionId}
+            disabled={isSaving || !form.name.trim() || !editionId || !form.tierId}
             className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
           >
             {isSaving ? "Enregistrement…" : "Enregistrer"}

--- a/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
@@ -1,23 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { adminFetch } from "@/lib/admin-api";
+import type { AdminSponsorTier } from "@/lib/types";
 import FormField from "@/components/admin/FormField";
-import BilingualInput from "@/components/admin/BilingualInput";
-import ConfirmDialog from "@/components/admin/ConfirmDialog";
 import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
 import FilePickerDialog from "@/components/admin/FilePickerDialog";
 
 type SponsorPageStatus = "PRE_ANNOUNCEMENT" | "TEMPORARY" | "OPEN" | "SOLD_OUT";
-type SponsorLevel = "PLATINUM" | "GOLD" | "SILVER" | "SOUTIEN" | "COMMUNAUTE";
-
-const SPONSOR_LEVELS: { value: SponsorLevel; label: string }[] = [
-  { value: "PLATINUM", label: "Platinum" },
-  { value: "GOLD", label: "Gold" },
-  { value: "SILVER", label: "Silver" },
-  { value: "SOUTIEN", label: "Soutien" },
-  { value: "COMMUNAUTE", label: "Communauté" },
-];
 
 interface EditionSettings {
   sponsorPageStatus: SponsorPageStatus;
@@ -28,68 +18,37 @@ interface EditionSettings {
 
 const STATUS_OPTIONS: { value: SponsorPageStatus; label: string; hint: string }[] = [
   { value: "PRE_ANNOUNCEMENT", label: "Avant annonce", hint: "Affiche un message + CTA vers le formulaire temporaire (formulaire externe)." },
-  { value: "TEMPORARY", label: "Annoncé (formulaire temporaire)", hint: "Affiche les plans + CTA vers le formulaire externe (la plaquette n'est pas encore prête)." },
-  { value: "OPEN", label: "Ouvert (formulaire intégré)", hint: "Affiche tout : plans, plaquette téléchargeable, formulaire intégré." },
+  { value: "TEMPORARY", label: "Annoncé (formulaire temporaire)", hint: "Affiche les offres + CTA vers le formulaire externe (la plaquette n'est pas encore prête)." },
+  { value: "OPEN", label: "Ouvert (formulaire intégré)", hint: "Affiche tout : offres, plaquette téléchargeable, formulaire intégré." },
   { value: "SOLD_OUT", label: "Sponsoring complet", hint: "Affiche un message « tout est vendu » avec un lien vers /contact." },
 ];
 
-interface SponsorPlan {
-  id: number;
-  nameFr: string;
-  nameEn: string;
-  subtitleFr: string | null;
-  subtitleEn: string | null;
-  descriptionFr: string | null;
-  descriptionEn: string | null;
-  price: string | null;
-  standSize: string | null;
-  advantages: { fr: string; en: string }[];
-  color: string;
-  isFeatured: boolean;
+// A catalogue tier merged with its (optional) binding to this edition (#318).
+interface EditionTierRow {
+  tier: AdminSponsorTier;
+  offered: boolean; // a join row exists
   isVisible: boolean;
-  sortOrder: number;
+  price: string;
+  sortOrder: string;
 }
 
-const DEFAULT_COLORS = [
-  { label: "Platinum (Emeraude)", value: "#41B38E" },
-  { label: "Gold (Jaune)", value: "#FFD428" },
-  { label: "Silver (Rose)", value: "#EE7CAD" },
-  { label: "Malachite", value: "#109E6E" },
-  { label: "Bleu", value: "#507BBD" },
-  { label: "Terre cuite", value: "#EC6839" },
-];
-
-const emptyForm = {
-  nameFr: "",
-  nameEn: "",
-  subtitleFr: "",
-  subtitleEn: "",
-  descriptionFr: "",
-  descriptionEn: "",
-  price: "",
-  standSize: "",
-  advantages: [] as { fr: string; en: string }[],
-  color: "#41B38E",
-  isFeatured: false,
-  isVisible: true,
-  sortOrder: "0",
-};
+interface EditionTierLink {
+  tierId: number;
+  isVisible: boolean;
+  price: string | null;
+  sortOrder: number;
+}
 
 interface SponsoringTabProps {
   editionId: number;
 }
 
 export default function SponsoringTab({ editionId }: SponsoringTabProps) {
-  const [plans, setPlans] = useState<SponsorPlan[]>([]);
+  const [rows, setRows] = useState<EditionTierRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [showForm, setShowForm] = useState(false);
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [form, setForm] = useState(emptyForm);
-  const [isSaving, setIsSaving] = useState(false);
-  const [deleteTarget, setDeleteTarget] = useState<SponsorPlan | null>(null);
+  const [savingTierId, setSavingTierId] = useState<number | null>(null);
 
-  // Page settings (status, temporary form URL, brochure URL) — separate
-  // from the plans list because they live on Edition, not on SponsorPlan.
+  // Page settings (status, temporary form URL, brochure/hero) — live on Edition.
   const [settings, setSettings] = useState<EditionSettings>({
     sponsorPageStatus: "PRE_ANNOUNCEMENT",
     sponsorTemporaryFormUrl: null,
@@ -101,12 +60,8 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
   const [isBrochurePickerOpen, setIsBrochurePickerOpen] = useState(false);
   const [isHeroPickerOpen, setIsHeroPickerOpen] = useState(false);
 
-  // Open sponsoring levels — which levels are offered when creating a sponsor.
-  const [openLevels, setOpenLevels] = useState<SponsorLevel[]>([]);
-  const [levelsSaved, setLevelsSaved] = useState(false);
-
   async function loadSettings() {
-    const { data } = await adminFetch<EditionSettings & { openSponsorLevels?: SponsorLevel[] }>(`/editions/${editionId}`);
+    const { data } = await adminFetch<EditionSettings>(`/editions/${editionId}`);
     if (data) {
       setSettings({
         sponsorPageStatus: data.sponsorPageStatus ?? "PRE_ANNOUNCEMENT",
@@ -114,21 +69,68 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
         sponsorBrochureUrl: data.sponsorBrochureUrl ?? null,
         sponsorHeroImageUrl: data.sponsorHeroImageUrl ?? null,
       });
-      setOpenLevels(data.openSponsorLevels ?? []);
     }
   }
 
-  function toggleOpenLevel(level: SponsorLevel) {
-    setOpenLevels((prev) => (prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level]));
+  // Merge the whole catalogue with the edition's existing bindings: the
+  // catalogue is the universe of tiers to offer, a binding carries the state.
+  const loadTiers = useCallback(async () => {
+    setIsLoading(true);
+    const [catalogue, links] = await Promise.all([
+      adminFetch<AdminSponsorTier[]>("/sponsor-tiers"),
+      adminFetch<EditionTierLink[]>(`/editions/${editionId}/sponsor-tiers`),
+    ]);
+    const byTierId = new Map((links.data ?? []).map((l) => [l.tierId, l]));
+    setRows(
+      (catalogue.data ?? []).map((tier) => {
+        const link = byTierId.get(tier.id);
+        return {
+          tier,
+          offered: !!link,
+          isVisible: link?.isVisible ?? true,
+          price: link?.price ?? "",
+          sortOrder: String(link?.sortOrder ?? 0),
+        };
+      }),
+    );
+    setIsLoading(false);
+  }, [editionId]);
+
+  useEffect(() => {
+    loadTiers();
+    loadSettings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editionId]);
+
+  function patchRow(tierId: number, patch: Partial<EditionTierRow>) {
+    setRows((prev) => prev.map((r) => (r.tier.id === tierId ? { ...r, ...patch } : r)));
   }
 
-  async function saveOpenLevels() {
-    await adminFetch(`/editions/${editionId}`, {
+  // Offering a tier upserts the join row; un-offering deletes it.
+  async function toggleOffered(row: EditionTierRow) {
+    setSavingTierId(row.tier.id);
+    if (row.offered) {
+      await adminFetch(`/editions/${editionId}/sponsor-tiers/${row.tier.id}`, { method: "DELETE" });
+      patchRow(row.tier.id, { offered: false });
+    } else {
+      await adminFetch(`/editions/${editionId}/sponsor-tiers/${row.tier.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ isVisible: row.isVisible, price: row.price || null, sortOrder: Number(row.sortOrder) || 0 }),
+      });
+      patchRow(row.tier.id, { offered: true });
+    }
+    setSavingTierId(null);
+  }
+
+  // Persist visibility/price/order for an already-offered tier.
+  async function saveRow(row: EditionTierRow) {
+    if (!row.offered) return;
+    setSavingTierId(row.tier.id);
+    await adminFetch(`/editions/${editionId}/sponsor-tiers/${row.tier.id}`, {
       method: "PUT",
-      body: JSON.stringify({ openSponsorLevels: openLevels }),
+      body: JSON.stringify({ isVisible: row.isVisible, price: row.price || null, sortOrder: Number(row.sortOrder) || 0 }),
     });
-    setLevelsSaved(true);
-    setTimeout(() => setLevelsSaved(false), 3000);
+    setSavingTierId(null);
   }
 
   async function saveSettings() {
@@ -148,151 +150,13 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
     setTimeout(() => setSettingsSaved(false), 3000);
   }
 
-  async function loadPlans() {
-    setIsLoading(true);
-    const { data } = await adminFetch<SponsorPlan[]>(
-      `/sponsor-plans?editionId=${editionId}`,
-    );
-    if (data) setPlans(data);
-    setIsLoading(false);
-  }
-
-  useEffect(() => {
-    loadPlans();
-    loadSettings();
-  }, [editionId]);
-
-  function startNew() {
-    setEditingId(null);
-    setForm({ ...emptyForm });
-    setShowForm(true);
-  }
-
-  function startEdit(plan: SponsorPlan) {
-    setEditingId(plan.id);
-    setForm({
-      nameFr: plan.nameFr,
-      nameEn: plan.nameEn,
-      subtitleFr: plan.subtitleFr || "",
-      subtitleEn: plan.subtitleEn || "",
-      descriptionFr: plan.descriptionFr || "",
-      descriptionEn: plan.descriptionEn || "",
-      price: plan.price || "",
-      standSize: plan.standSize || "",
-      advantages: plan.advantages || [],
-      color: plan.color,
-      isFeatured: plan.isFeatured,
-      isVisible: plan.isVisible,
-      sortOrder: String(plan.sortOrder),
-    });
-    setShowForm(true);
-  }
-
-  async function handleSave() {
-    setIsSaving(true);
-    const payload = {
-      nameFr: form.nameFr,
-      nameEn: form.nameEn,
-      subtitleFr: form.subtitleFr || undefined,
-      subtitleEn: form.subtitleEn || undefined,
-      descriptionFr: form.descriptionFr || undefined,
-      descriptionEn: form.descriptionEn || undefined,
-      price: form.price || undefined,
-      standSize: form.standSize || undefined,
-      advantages: form.advantages,
-      color: form.color,
-      isFeatured: form.isFeatured,
-      isVisible: form.isVisible,
-      sortOrder: Number(form.sortOrder) || 0,
-      editionId,
-    };
-
-    if (editingId) {
-      await adminFetch(`/sponsor-plans/${editingId}`, {
-        method: "PUT",
-        body: JSON.stringify(payload),
-      });
-    } else {
-      await adminFetch("/sponsor-plans", {
-        method: "POST",
-        body: JSON.stringify(payload),
-      });
-    }
-
-    setIsSaving(false);
-    setShowForm(false);
-    loadPlans();
-  }
-
-  async function handleDelete() {
-    if (!deleteTarget) return;
-    await adminFetch(`/sponsor-plans/${deleteTarget.id}`, { method: "DELETE" });
-    setDeleteTarget(null);
-    loadPlans();
-  }
-
-  function addAdvantage() {
-    setForm({
-      ...form,
-      advantages: [...form.advantages, { fr: "", en: "" }],
-    });
-  }
-
-  function updateAdvantage(
-    index: number,
-    lang: "fr" | "en",
-    value: string,
-  ) {
-    const updated = [...form.advantages];
-    updated[index] = { ...updated[index], [lang]: value };
-    setForm({ ...form, advantages: updated });
-  }
-
-  function removeAdvantage(index: number) {
-    setForm({
-      ...form,
-      advantages: form.advantages.filter((_, i) => i !== index),
-    });
-  }
-
   if (isLoading) return <p className="text-gris text-sm">Chargement...</p>;
 
   const currentStatusOption = STATUS_OPTIONS.find((o) => o.value === settings.sponsorPageStatus);
   const showTempUrl = settings.sponsorPageStatus === "PRE_ANNOUNCEMENT" || settings.sponsorPageStatus === "TEMPORARY";
-  // Brochure is always editable — admins typically upload it before flipping
-  // the page to OPEN, and the sponsor-brochure email template needs it
-  // available regardless of the public page status.
 
   return (
     <div>
-      {/* Open sponsoring levels — which levels are offered when creating a sponsor */}
-      <div className="bg-blanc-casse/50 rounded-xl p-6 mb-6">
-        <h3 className="text-lg font-bold text-noir mb-1">Niveaux de sponsoring ouverts</h3>
-        <p className="text-sm text-gris mb-4">Seuls les niveaux cochés sont proposés à la création d&apos;un sponsor.</p>
-        <div className="flex flex-wrap gap-3">
-          {SPONSOR_LEVELS.map((l) => (
-            <label key={l.value} className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={openLevels.includes(l.value)}
-                onChange={() => toggleOpenLevel(l.value)}
-                className="rounded border-gris/30 text-malachite focus:ring-malachite"
-              />
-              <span className="text-sm text-noir">{l.label}</span>
-            </label>
-          ))}
-        </div>
-        <div className="mt-4 flex items-center gap-3">
-          <button
-            onClick={saveOpenLevels}
-            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
-          >
-            Enregistrer les niveaux
-          </button>
-          {levelsSaved && <span className="text-sm text-malachite">Enregistré !</span>}
-        </div>
-      </div>
-
       {/* Page settings */}
       <div className="bg-blanc-casse/50 rounded-xl p-6 mb-6 space-y-4">
         <h3 className="text-lg font-bold text-noir">Statut de la page « Devenir sponsor »</h3>
@@ -307,9 +171,7 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
               <option key={o.value} value={o.value}>{o.label}</option>
             ))}
           </select>
-          {currentStatusOption && (
-            <p className="mt-1 text-xs text-gris">{currentStatusOption.hint}</p>
-          )}
+          {currentStatusOption && <p className="mt-1 text-xs text-gris">{currentStatusOption.hint}</p>}
         </div>
 
         {showTempUrl && (
@@ -323,8 +185,8 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
           />
         )}
 
-        {/* Custom hero image (optional). Falls back to the edition main hero
-            on the public /devenir-sponsor page when empty. */}
+        {/* Custom hero image (optional). Falls back to the edition main hero on
+            the public /devenir-sponsor page when empty. */}
         <div>
           <label className="block text-sm font-medium text-noir mb-1">
             Image d&apos;en-tête « Devenir sponsor » (optionnel)
@@ -350,11 +212,7 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
           {settings.sponsorHeroImageUrl ? (
             <div className="mt-2">
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={settings.sponsorHeroImageUrl}
-                alt="Aperçu hero sponsor"
-                className="h-24 rounded-lg object-cover"
-              />
+              <img src={settings.sponsorHeroImageUrl} alt="Aperçu hero sponsor" className="h-24 rounded-lg object-cover" />
               <p className="text-xs text-gris mt-1">{settings.sponsorHeroImageUrl}</p>
             </div>
           ) : (
@@ -389,9 +247,7 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
               </button>
             )}
           </div>
-          {settings.sponsorBrochureUrl && (
-            <p className="mt-1 text-xs text-gris">{settings.sponsorBrochureUrl}</p>
-          )}
+          {settings.sponsorBrochureUrl && <p className="mt-1 text-xs text-gris">{settings.sponsorBrochureUrl}</p>}
           <FilePickerDialog
             open={isBrochurePickerOpen}
             onClose={() => setIsBrochurePickerOpen(false)}
@@ -413,273 +269,84 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
         </div>
       </div>
 
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-bold text-noir">Formules de sponsoring</h3>
-        <button
-          onClick={startNew}
-          className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
-        >
-          Nouvelle formule
-        </button>
+      {/* Offers proposed for this edition — pick from the shared catalogue (#318).
+          Editing a tier's name/colour/advantages is done in the catalogue (#319). */}
+      <div className="mb-2">
+        <h3 className="text-lg font-bold text-noir">Offres proposées pour cette édition</h3>
+        <p className="text-sm text-gris">
+          Cochez les offres du catalogue à proposer, définissez leur tarif et leur ordre d&apos;affichage sur
+          « Devenir sponsor ». Le catalogue lui-même se gère à part.
+        </p>
       </div>
 
-      {showForm && (
-        <div className="bg-blanc-casse/50 rounded-xl p-6 mb-6 space-y-4">
-          <h4 className="text-sm font-bold text-noir">
-            {editingId ? "Modifier la formule" : "Nouvelle formule"}
-          </h4>
-
-          <BilingualInput
-            label="Nom"
-            nameFr="nameFr"
-            nameEn="nameEn"
-            valueFr={form.nameFr}
-            valueEn={form.nameEn}
-            onChangeFr={(v) => setForm({ ...form, nameFr: v })}
-            onChangeEn={(v) => setForm({ ...form, nameEn: v })}
-            required
-          />
-
-          <BilingualInput
-            label="Sous-titre"
-            nameFr="subtitleFr"
-            nameEn="subtitleEn"
-            valueFr={form.subtitleFr}
-            valueEn={form.subtitleEn}
-            onChangeFr={(v) => setForm({ ...form, subtitleFr: v })}
-            onChangeEn={(v) => setForm({ ...form, subtitleEn: v })}
-          />
-
-          <BilingualInput
-            label="Description"
-            nameFr="descriptionFr"
-            nameEn="descriptionEn"
-            valueFr={form.descriptionFr}
-            valueEn={form.descriptionEn}
-            onChangeFr={(v) => setForm({ ...form, descriptionFr: v })}
-            onChangeEn={(v) => setForm({ ...form, descriptionEn: v })}
-          />
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <FormField
-              label="Prix (ex: 5 000 EUR HT)"
-              name="price"
-              value={form.price}
-              onChange={(v) => setForm({ ...form, price: v })}
-            />
-            <FormField
-              label="Taille du stand (ex: 12m\u00B2)"
-              name="standSize"
-              value={form.standSize}
-              onChange={(v) => setForm({ ...form, standSize: v })}
-            />
-            <FormField
-              label="Ordre"
-              name="sortOrder"
-              type="number"
-              value={form.sortOrder}
-              onChange={(v) => setForm({ ...form, sortOrder: v })}
-            />
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-noir mb-1">
-                Couleur
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {DEFAULT_COLORS.map((c) => (
-                  <button
-                    key={c.value}
-                    type="button"
-                    onClick={() => setForm({ ...form, color: c.value })}
-                    className={`w-8 h-8 rounded-full border-2 transition-all ${
-                      form.color === c.value
-                        ? "border-noir scale-110"
-                        : "border-transparent"
-                    }`}
-                    style={{ backgroundColor: c.value }}
-                    title={c.label}
-                  />
-                ))}
-                <input
-                  type="color"
-                  value={form.color}
-                  onChange={(e) => setForm({ ...form, color: e.target.value })}
-                  className="w-8 h-8 rounded-full cursor-pointer border-0"
-                  title="Couleur personnalisée"
-                />
-              </div>
-            </div>
-
-            <div className="flex items-center gap-6 pt-6">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={form.isVisible}
-                  onChange={(e) =>
-                    setForm({ ...form, isVisible: e.target.checked })
-                  }
-                  className="rounded border-gris/30 text-malachite focus:ring-malachite"
-                />
-                <span className="text-sm text-noir">Visible sur le site</span>
-              </label>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={form.isFeatured}
-                  onChange={(e) =>
-                    setForm({ ...form, isFeatured: e.target.checked })
-                  }
-                  className="rounded border-gris/30 text-malachite focus:ring-malachite"
-                />
-                <span className="text-sm text-noir">Formule à la une</span>
-              </label>
-            </div>
-          </div>
-
-          {/* Advantages */}
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <label className="text-sm font-medium text-noir">
-                Avantages ({form.advantages.length})
-              </label>
-              <button
-                type="button"
-                onClick={addAdvantage}
-                className="text-sm text-bleu hover:underline"
-              >
-                + Ajouter
-              </button>
-            </div>
-            {form.advantages.map((adv, i) => (
-              // Stack FR/EN on mobile so neither column runs off-screen (#243);
-              // side-by-side from sm up. The delete button sits at the end of
-              // the row on desktop, and full-width under the fields on mobile.
-              <div key={i} className="flex flex-col gap-2 mb-3 sm:flex-row sm:items-start">
-                <label className="flex-1 block">
-                  <span className="mb-1 block text-xs text-gris sm:hidden">FR</span>
-                  <input
-                    type="text"
-                    placeholder="FR"
-                    value={adv.fr}
-                    onChange={(e) => updateAdvantage(i, "fr", e.target.value)}
-                    className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
-                  />
-                </label>
-                <label className="flex-1 block">
-                  <span className="mb-1 block text-xs text-gris sm:hidden">EN</span>
-                  <input
-                    type="text"
-                    placeholder="EN"
-                    value={adv.en}
-                    onChange={(e) => updateAdvantage(i, "en", e.target.value)}
-                    className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
-                  />
-                </label>
-                <button
-                  type="button"
-                  onClick={() => removeAdvantage(i)}
-                  className="text-terre-cuite hover:underline text-sm px-2 py-2 text-left sm:pt-2"
-                >
-                  Supprimer
-                </button>
-              </div>
-            ))}
-          </div>
-
-          <div className="flex gap-3 justify-end">
-            <button
-              onClick={() => setShowForm(false)}
-              className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
-            >
-              Annuler
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={isSaving}
-              className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
-            >
-              {isSaving ? "Sauvegarde..." : "Sauvegarder"}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {plans.length === 0 ? (
-        <p className="text-gris text-sm">
-          Aucune formule de sponsoring pour cette édition.
-        </p>
+      {rows.length === 0 ? (
+        <p className="text-gris text-sm">Aucune offre dans le catalogue.</p>
       ) : (
         <div className="overflow-x-auto rounded-xl border border-gris/20">
           <table className="w-full text-sm">
             <thead>
               <tr className="bg-blanc-casse/60 border-b border-gris/20">
-                <th className="text-left px-4 py-3 font-medium text-gris">
-                  Couleur
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gris">
-                  Nom
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gris">
-                  Prix
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gris">
-                  Stand
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gris">
-                  Visible
-                </th>
-                <th className="text-right px-4 py-3 font-medium text-gris">
-                  Actions
-                </th>
+                <th className="text-left px-4 py-3 font-medium text-gris">Proposée</th>
+                <th className="text-left px-4 py-3 font-medium text-gris">Offre</th>
+                <th className="text-left px-4 py-3 font-medium text-gris">Visible</th>
+                <th className="text-left px-4 py-3 font-medium text-gris">Tarif (édition)</th>
+                <th className="text-left px-4 py-3 font-medium text-gris">Ordre</th>
+                <th className="text-right px-4 py-3 font-medium text-gris">Actions</th>
               </tr>
             </thead>
             <tbody>
-              {plans.map((plan) => (
-                <tr
-                  key={plan.id}
-                  className="border-b border-gris/10 hover:bg-blanc-casse/50"
-                >
+              {rows.map((row) => (
+                <tr key={row.tier.id} className="border-b border-gris/10 hover:bg-blanc-casse/50">
                   <td className="px-4 py-3">
-                    <span
-                      className="inline-block w-5 h-5 rounded-full"
-                      style={{ backgroundColor: plan.color }}
+                    <input
+                      type="checkbox"
+                      checked={row.offered}
+                      disabled={savingTierId === row.tier.id}
+                      onChange={() => toggleOffered(row)}
+                      className="rounded border-gris/30 text-malachite focus:ring-malachite"
+                      aria-label={`Proposer ${row.tier.nameFr}`}
                     />
                   </td>
                   <td className="px-4 py-3 text-noir font-medium">
-                    {plan.nameFr}
-                    {plan.subtitleFr && (
-                      <span className="text-gris text-xs ml-2">
-                        — {plan.subtitleFr}
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-noir">{plan.price || "—"}</td>
-                  <td className="px-4 py-3 text-noir">
-                    {plan.standSize || "—"}
+                    <span className="inline-block w-4 h-4 rounded-full mr-2 align-middle" style={{ backgroundColor: row.tier.color }} />
+                    {row.tier.nameFr}
                   </td>
                   <td className="px-4 py-3">
-                    {plan.isVisible ? (
-                      <span className="text-malachite text-xs font-medium">
-                        Oui
-                      </span>
-                    ) : (
-                      <span className="text-gris text-xs">Non</span>
-                    )}
+                    <input
+                      type="checkbox"
+                      checked={row.isVisible}
+                      disabled={!row.offered}
+                      onChange={(e) => patchRow(row.tier.id, { isVisible: e.target.checked })}
+                      className="rounded border-gris/30 text-malachite focus:ring-malachite disabled:opacity-40"
+                      aria-label={`Visible : ${row.tier.nameFr}`}
+                    />
                   </td>
-                  <td className="px-4 py-3 text-right space-x-2">
+                  <td className="px-4 py-3">
+                    <input
+                      type="text"
+                      value={row.price}
+                      disabled={!row.offered}
+                      placeholder="—"
+                      onChange={(e) => patchRow(row.tier.id, { price: e.target.value })}
+                      className="w-32 rounded-lg border border-gris/30 px-2 py-1 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50 disabled:opacity-40"
+                    />
+                  </td>
+                  <td className="px-4 py-3">
+                    <input
+                      type="number"
+                      value={row.sortOrder}
+                      disabled={!row.offered}
+                      onChange={(e) => patchRow(row.tier.id, { sortOrder: e.target.value })}
+                      className="w-16 rounded-lg border border-gris/30 px-2 py-1 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50 disabled:opacity-40"
+                    />
+                  </td>
+                  <td className="px-4 py-3 text-right">
                     <button
-                      onClick={() => startEdit(plan)}
-                      className="text-bleu hover:underline text-sm"
+                      onClick={() => saveRow(row)}
+                      disabled={!row.offered || savingTierId === row.tier.id}
+                      className="text-bleu hover:underline text-sm disabled:opacity-40 disabled:no-underline"
                     >
-                      Modifier
-                    </button>
-                    <button
-                      onClick={() => setDeleteTarget(plan)}
-                      className="text-terre-cuite hover:underline text-sm"
-                    >
-                      Supprimer
+                      {savingTierId === row.tier.id ? "…" : "Enregistrer"}
                     </button>
                   </td>
                 </tr>
@@ -688,16 +355,6 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
           </table>
         </div>
       )}
-
-      <ConfirmDialog
-        isOpen={!!deleteTarget}
-        title="Supprimer la formule"
-        message={`Supprimer "${deleteTarget?.nameFr}" ?`}
-        confirmLabel="Supprimer"
-        variant="danger"
-        onConfirm={handleDelete}
-        onCancel={() => setDeleteTarget(null)}
-      />
     </div>
   );
 }

--- a/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
+++ b/src/frontend/src/components/admin/sponsors/SponsorForm.tsx
@@ -2,22 +2,14 @@
 
 import { useState } from "react";
 
-import type { SponsorLevel } from "@/lib/types";
+import type { AdminSponsorTier } from "@/lib/types";
 import ImagePickerDialog from "@/components/admin/ImagePickerDialog";
 import BilingualTabs from "@/components/admin/BilingualTabs";
 import RichTextEditor from "@/components/admin/RichTextEditor";
 
-const LEVELS: { value: SponsorLevel; label: string }[] = [
-  { value: "PLATINUM", label: "Platinum" },
-  { value: "GOLD", label: "Gold" },
-  { value: "SILVER", label: "Silver" },
-  { value: "SOUTIEN", label: "Soutien" },
-  { value: "COMMUNAUTE", label: "Communauté" },
-];
-
 export interface SponsorFormValue {
   name: string;
-  level: SponsorLevel;
+  tierId: number | null;
   logoUrl: string;
   websiteUrl: string;
   descriptionFr: string;
@@ -39,7 +31,7 @@ export interface SponsorFormValue {
 
 export const emptySponsorForm: SponsorFormValue = {
   name: "",
-  level: "PLATINUM",
+  tierId: null,
   logoUrl: "",
   websiteUrl: "",
   descriptionFr: "",
@@ -64,10 +56,16 @@ const inputClass =
 interface SponsorFormProps {
   value: SponsorFormValue;
   onChange: (value: SponsorFormValue) => void;
+  tiers: AdminSponsorTier[];
 }
 
-export default function SponsorForm({ value, onChange }: SponsorFormProps) {
+export default function SponsorForm({ value, onChange, tiers }: SponsorFormProps) {
   const [isImagePickerOpen, setIsImagePickerOpen] = useState(false);
+
+  // The promo-idea fields (#252) are gated on the selected tier, not on a
+  // hard-coded Platinum level (#318).
+  const selectedTier = tiers.find((t) => t.id === value.tierId);
+  const allowsPromoIdeas = selectedTier?.allowsPromoIdeas ?? false;
 
   return (
     <div className="space-y-4">
@@ -78,9 +76,14 @@ export default function SponsorForm({ value, onChange }: SponsorFormProps) {
         </label>
         <label className="block">
           <span className="block text-sm font-medium text-noir mb-1">Niveau *</span>
-          <select value={value.level} onChange={(e) => onChange({ ...value, level: e.target.value as SponsorLevel })} className={inputClass}>
-            {LEVELS.map((l) => (
-              <option key={l.value} value={l.value}>{l.label}</option>
+          <select
+            value={value.tierId ?? ""}
+            onChange={(e) => onChange({ ...value, tierId: e.target.value ? Number(e.target.value) : null })}
+            className={inputClass}
+          >
+            <option value="" disabled>Choisir un niveau…</option>
+            {tiers.map((t) => (
+              <option key={t.id} value={t.id}>{t.nameFr}</option>
             ))}
           </select>
         </label>
@@ -217,10 +220,10 @@ export default function SponsorForm({ value, onChange }: SponsorFormProps) {
           <textarea value={value.comKitNotes} onChange={(e) => onChange({ ...value, comKitNotes: e.target.value })} rows={3} className={inputClass} />
         </label>
 
-        {/* Platinum-only ideas (#252) — shown only when level is Platinum. */}
-        {value.level === "PLATINUM" && (
+        {/* Promo ideas (#252) — shown only for tiers that allow them (#318). */}
+        {allowsPromoIdeas && (
           <div className="mt-4 rounded-lg border border-jaune/40 bg-jaune/5 p-4">
-            <p className="text-sm font-semibold text-noir mb-3">💎 Réservé aux partenaires Platinum</p>
+            <p className="text-sm font-semibold text-noir mb-3">💎 Réservé aux partenaires premium</p>
             <label className="block">
               <span className="block text-sm font-medium text-noir mb-1">Contenu promotionnel à mettre en avant</span>
               <textarea value={value.platinumPromoIdea} onChange={(e) => onChange({ ...value, platinumPromoIdea: e.target.value })} rows={3} className={inputClass} />

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -12,7 +12,7 @@ import type {
   CfpSettings,
   ContactCategory,
   PaginatedArticles,
-  SponsorPlan,
+  SponsorTierPublic,
   SponsorPublic,
   SponsorDetail,
   SponsorWithOffers,
@@ -141,8 +141,8 @@ export async function getAboutCarousel(): Promise<CarouselSlide[]> {
   return (await fetchAPI<CarouselSlide[]>("/api/settings/carousel")) || [];
 }
 
-export async function getSponsorPlans(): Promise<SponsorPlan[]> {
-  return (await fetchAPI<SponsorPlan[]>("/api/editions/current/sponsor-plans")) || [];
+export async function getSponsorTiers(): Promise<SponsorTierPublic[]> {
+  return (await fetchAPI<SponsorTierPublic[]>("/api/editions/current/sponsor-tiers")) || [];
 }
 
 export async function getSponsors(): Promise<SponsorPublic[]> {

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -122,7 +122,10 @@ export interface ContentPage {
   updatedAt: string;
 }
 
-export interface SponsorPlan {
+// A sponsoring offer shown on /devenir-sponsor (#318). One row of the shared
+// SponsorTier catalogue, joined to the current edition (price is the edition
+// override). Replaces the former SponsorPlan.
+export interface SponsorTierPublic {
   id: number;
   nameFr: string;
   nameEn: string;
@@ -130,14 +133,42 @@ export interface SponsorPlan {
   subtitleEn: string | null;
   descriptionFr: string | null;
   descriptionEn: string | null;
-  price: string | null;
   standSize: string | null;
-  advantages: { fr: string; en: string }[];
   color: string;
-  isFeatured: boolean;
+  logoScale: number;
+  advantages: { fr: string; en: string }[];
+  price: string | null;
 }
 
+// The catalogue tier as seen by the admin (#318 select, #319 CRUD).
+export interface AdminSponsorTier {
+  id: number;
+  key: string;
+  nameFr: string;
+  nameEn: string;
+  subtitleFr: string | null;
+  subtitleEn: string | null;
+  descriptionFr: string | null;
+  descriptionEn: string | null;
+  advantages: { fr: string; en: string }[];
+  standSize: string | null;
+  color: string;
+  logoScale: number;
+  rank: number;
+  jobOfferQuota: number;
+  allowsPromoIdeas: boolean;
+}
+
+// Legacy level kept alive by the #317 shim until #321 rebinds the public wall.
 export type SponsorLevel = "PLATINUM" | "GOLD" | "SILVER" | "SOUTIEN" | "COMMUNAUTE";
+
+// The tier summary the public sponsor routes expose alongside `level` (#318).
+export interface SponsorTierRef {
+  nameFr: string;
+  nameEn: string;
+  logoScale: number;
+  color: string;
+}
 
 export interface Sponsor {
   id: number;
@@ -145,6 +176,7 @@ export interface Sponsor {
   name: string;
   logoUrl: string | null;
   level: SponsorLevel;
+  tierId: number;
   websiteUrl: string | null;
   descriptionFr: string | null;
   descriptionEn: string | null;
@@ -171,6 +203,7 @@ export interface SponsorPublic {
   name: string;
   logoUrl: string | null;
   level: SponsorLevel;
+  tier: SponsorTierRef;
   websiteUrl: string | null;
 }
 
@@ -197,6 +230,7 @@ export interface SponsorDetail {
   name: string;
   logoUrl: string | null;
   level: SponsorLevel;
+  tier: SponsorTierRef;
   websiteUrl: string | null;
   descriptionFr: string | null;
   descriptionEn: string | null;


### PR DESCRIPTION
Sous-tâche **316b** de l'épic #316. Livre l'**API du catalogue** de sponsoring **et répare les 3 surfaces cassées par #317**.

## Contexte

#317 a posé la fondation données (`SponsorTier`/`EditionSponsorTier`, `Sponsor.tierId`) mais, le shim ne couvrant que la *lecture* de `level`, 3 surfaces sont restées cassées sur dev-j : création de sponsor en admin (POST 400), onglet Sponsoring (routes `/sponsor-plans` en 404), page `/devenir-sponsor` (grille vide). Cette PR ajoute l'API manquante et corrige les 3.

## API (backend)

- **CRUD catalogue** `/api/admin/sponsor-tiers` (list/get/create/update/soft-delete) — `key` unique (409), suppression refusée (409) tant qu'un sponsor vivant ou un lien d'édition pointe le tier, `key` parkée au trash. Monté sous `requireAdmin` (les éditeurs doivent charger le `<select>` de tiers).
- **Liens par édition** nestés sous `/api/admin/editions/:id/sponsor-tiers` (list, upsert, remove) — quelles offres une édition propose, avec tarif override, visibilité, ordre. Jointures pures (suppression dure).
- **Route publique** `/api/editions/current/sponsor-tiers` — remplace `sponsor-plans` : offres visibles de l'édition featured, triées par `sortOrder`, avec le tarif override. `isFeatured` retiré (disparu du modèle).
- `/api/sponsors` et `/:slug` exposent désormais l'objet `tier` (nameFr, nameEn, logoScale, color) **à côté** de `level`, toujours triés par `rank`.

## Réparations front

- **SponsorForm / [id]** pilotent `tierId` (un `<select>` de tiers chargé du catalogue) au lieu du `level` supprimé ; le gating des champs promo repose sur `allowsPromoIdeas` du tier sélectionné. → **création de sponsor réparée**.
- **SponsoringTab** remplace le CRUD `SponsorPlan` mort et le bloc `openSponsorLevels` par un sélecteur de tiers par édition (proposé / visible / tarif / ordre) ; le bloc *Page settings* est inchangé.
- **/devenir-sponsor** lit le catalogue via `getSponsorTiers` ; la grille se remplit.
- `types.ts` : `SponsorPlan` → `SponsorTierPublic` + `AdminSponsorTier`, `Sponsor.tierId`, types publics enrichis du `tier`.

## Reporté (à signaler)

- **#319** : UI de CRUD du catalogue (créer/éditer un tier). Ici seulement l'API + le `<select>`.
- **#320** : écran de sélection par édition ergonomique.
- **#321** : retrait du shim `level` + rebranchement du mur public (`SponsorCard`, couleurs, i18n `sponsors.level.*`) et de la liste admin (filtre par niveau). ⚠️ Le filtre admin par niveau reste legacy en attendant (le shim mappe `discovery→SILVER`, `soutien-communautes→SOUTIEN`) — bancal mais non bloquant.

## Test plan

- [x] `tsc --noEmit` backend & frontend — **0 erreur**
- [x] Tests backend — **438/438** (4 nouveaux fichiers, +14 tests) : CRUD catalogue (unicité key 409, delete bloqué 409, park), liens par édition (upsert, 422 tier inexistant, delete idempotent), route publique (tri, advantages array, pas d'isFeatured), `/api/sponsors` (tier + level, tri rank)
- [x] Pas de changement de schéma → pas de migration
- [x] Navigateur (env local Docker) :
  - **Surface A** — création sponsor : `<select>` de tiers (Platinum/Gold/Discovery/Soutien et Communautés), gating premium réactif au tier, POST OK, `tierId` correct en base.
  - **Surface B** — onglet Sponsoring : tableau des 4 tiers, tarif override persisté, plus aucun 404, Page settings intacts.
  - **Surface C** — `/devenir-sponsor` (statut Ouvert) : 4 cartes affichées.
  - Données de test nettoyées, état dev-j restauré.

Refs #318
