### PR TITLE
feat(admin): écran de gestion du catalogue d'offres de sponsoring (316c / #319)

### DIFF
--- a/src/frontend/src/app/admin/sponsor-tiers/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsor-tiers/[id]/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { AdminSponsorTier } from "@/lib/types";
+import SponsorTierForm, { emptySponsorTierForm, type SponsorTierFormValue } from "@/components/admin/sponsor-tiers/SponsorTierForm";
+
+export default function SponsorTierEditorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const isNew = params.id === "new";
+  const tierId = isNew ? null : Number(params.id);
+
+  const [form, setForm] = useState<SponsorTierFormValue>(emptySponsorTierForm);
+  const [isLoading, setIsLoading] = useState(!isNew);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isNew || !tierId) return;
+    adminFetch<AdminSponsorTier>(`/sponsor-tiers/${tierId}`).then(({ data, status }) => {
+      if (status === 404 || !data) {
+        router.push("/admin/sponsor-tiers");
+        return;
+      }
+      setForm({
+        key: data.key,
+        nameFr: data.nameFr,
+        nameEn: data.nameEn,
+        subtitleFr: data.subtitleFr || "",
+        subtitleEn: data.subtitleEn || "",
+        descriptionFr: data.descriptionFr || "",
+        descriptionEn: data.descriptionEn || "",
+        advantages: data.advantages || [],
+        standSize: data.standSize || "",
+        color: data.color,
+        logoScale: String(data.logoScale),
+        rank: String(data.rank),
+        jobOfferQuota: String(data.jobOfferQuota),
+        allowsPromoIdeas: data.allowsPromoIdeas,
+      });
+      setIsLoading(false);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tierId, isNew]);
+
+  async function handleSave() {
+    if (!form.nameFr.trim() || !form.nameEn.trim() || (isNew && !form.key.trim())) return;
+    setIsSaving(true);
+    setError(null);
+
+    // Numeric fields are coerced from their string form state. `key` is only
+    // sent on create — it is a locked technical identifier afterwards.
+    const payload = {
+      ...(isNew && { key: form.key.trim() }),
+      nameFr: form.nameFr.trim(),
+      nameEn: form.nameEn.trim(),
+      subtitleFr: form.subtitleFr || undefined,
+      subtitleEn: form.subtitleEn || undefined,
+      descriptionFr: form.descriptionFr || undefined,
+      descriptionEn: form.descriptionEn || undefined,
+      advantages: form.advantages.filter((a) => a.fr.trim() || a.en.trim()),
+      standSize: form.standSize || undefined,
+      color: form.color,
+      logoScale: Number(form.logoScale) || 1,
+      rank: Number(form.rank) || 0,
+      jobOfferQuota: Number(form.jobOfferQuota) || 1,
+      allowsPromoIdeas: form.allowsPromoIdeas,
+    };
+
+    if (isNew) {
+      const { data, status } = await adminFetch<{ id: number }>("/sponsor-tiers", { method: "POST", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status === 409) {
+        setError("Cette clé est déjà utilisée par une autre offre.");
+        return;
+      }
+      if (status >= 400 || !data) {
+        setError("Échec de la création.");
+        return;
+      }
+      router.push("/admin/sponsor-tiers");
+    } else {
+      const { status } = await adminFetch(`/sponsor-tiers/${tierId}`, { method: "PUT", body: JSON.stringify(payload) });
+      setIsSaving(false);
+      if (status >= 400) {
+        setError("Échec de l'enregistrement.");
+        return;
+      }
+      router.push("/admin/sponsor-tiers");
+    }
+  }
+
+  if (isLoading) return <p className="text-gris">Chargement...</p>;
+
+  const canSave = form.nameFr.trim() && form.nameEn.trim() && (!isNew || form.key.trim());
+
+  return (
+    <div className="max-w-3xl">
+      <div className="mb-8 flex items-center gap-4">
+        <button onClick={() => router.push("/admin/sponsor-tiers")} className="text-gris hover:text-noir" title="Retour">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+        </button>
+        <h1 className="text-3xl font-bold text-noir">{isNew ? "Nouvelle offre" : "Modifier l'offre"}</h1>
+      </div>
+
+      <div className="bg-blanc rounded-xl shadow-card p-6 space-y-4">
+        <SponsorTierForm value={form} onChange={setForm} isNew={isNew} />
+
+        {error && <p className="text-sm text-terre-cuite">{error}</p>}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            onClick={handleSave}
+            disabled={isSaving || !canSave}
+            className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+          >
+            {isSaving ? "Enregistrement…" : "Enregistrer"}
+          </button>
+          <button
+            onClick={() => router.push("/admin/sponsor-tiers")}
+            className="px-4 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc-casse"
+          >
+            Annuler
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/sponsor-tiers/page.tsx
+++ b/src/frontend/src/app/admin/sponsor-tiers/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { AdminSponsorTier } from "@/lib/types";
+import DataTable from "@/components/admin/DataTable";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+
+export default function SponsorTiersPage() {
+  const router = useRouter();
+  const [tiers, setTiers] = useState<AdminSponsorTier[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [deleteTarget, setDeleteTarget] = useState<AdminSponsorTier | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    adminFetch<AdminSponsorTier[]>("/sponsor-tiers").then(({ data }) => {
+      if (data) setTiers(data);
+      setIsLoading(false);
+    });
+  }, []);
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setError(null);
+    const { status, error: apiError } = await adminFetch(`/sponsor-tiers/${deleteTarget.id}`, { method: "DELETE" });
+    const deletedId = deleteTarget.id;
+    setDeleteTarget(null);
+
+    if (status === 204) {
+      setTiers((prev) => prev.filter((t) => t.id !== deletedId));
+      return;
+    }
+    // The API refuses (409) while sponsors or editions still point at the offer.
+    if (status === 409) {
+      setError("Cette offre est encore utilisée par des sponsors ou des éditions : détachez-la avant de la supprimer.");
+      return;
+    }
+    setError(apiError ?? "Suppression impossible.");
+  }
+
+  const columns = [
+    {
+      key: "color",
+      label: "Couleur",
+      render: (t: AdminSponsorTier) => (
+        <span className="inline-block h-5 w-5 rounded-full" style={{ backgroundColor: t.color }} />
+      ),
+    },
+    { key: "name", label: "Offre", render: (t: AdminSponsorTier) => <span className="font-medium text-noir">{t.nameFr}</span> },
+    { key: "rank", label: "Rang", render: (t: AdminSponsorTier) => t.rank },
+    { key: "quota", label: "Quota offres", render: (t: AdminSponsorTier) => t.jobOfferQuota },
+    { key: "promo", label: "Idées promo", render: (t: AdminSponsorTier) => (t.allowsPromoIdeas ? "✓" : "—") },
+  ];
+
+  return (
+    <div>
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-noir">Offres de sponsoring</h1>
+          <p className="mt-1 text-sm text-gris">Catalogue partagé entre toutes les éditions.</p>
+        </div>
+        <button
+          onClick={() => router.push("/admin/sponsor-tiers/new")}
+          className="shrink-0 px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90"
+        >
+          + Ajouter
+        </button>
+      </div>
+
+      {error && (
+        <div role="alert" className="mb-4 rounded-lg bg-terre-cuite/10 px-4 py-3 text-sm text-terre-cuite">
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <p className="text-gris">Chargement...</p>
+      ) : (
+        <DataTable<AdminSponsorTier>
+          columns={columns}
+          data={tiers}
+          emptyMessage="Aucune offre dans le catalogue"
+          onEdit={(t) => router.push(`/admin/sponsor-tiers/${t.id}`)}
+          onDelete={(t) => setDeleteTarget(t)}
+        />
+      )}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="Supprimer l'offre"
+        message={`Supprimer « ${deleteTarget?.nameFr} » du catalogue ? Vous pourrez la restaurer depuis la corbeille.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -27,6 +27,7 @@ export const adminNavGroups: AdminNavGroup[] = [
       { label: "Speakers", path: "/admin/speakers", icon: "user", roles: ["ADMIN", "EDITOR"] },
       { label: "Conférences", path: "/admin/talks", icon: "microphone", roles: ["ADMIN", "EDITOR"] },
       { label: "Sponsors", path: "/admin/sponsors", icon: "handshake", roles: ["ADMIN", "EDITOR"] },
+      { label: "Offres de sponsoring", path: "/admin/sponsor-tiers", icon: "star", roles: ["ADMIN", "EDITOR"] },
       { label: "Catégories", path: "/admin/categories", icon: "tag", roles: ["ADMIN", "EDITOR"] },
     ],
   },

--- a/src/frontend/src/components/admin/sponsor-tiers/SponsorTierForm.tsx
+++ b/src/frontend/src/components/admin/sponsor-tiers/SponsorTierForm.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import BilingualInput from "@/components/admin/BilingualInput";
+import FormField from "@/components/admin/FormField";
+
+// The global catalogue offer form (#319). Every label is in French: the admin
+// UI has no next-intl. Numeric fields are kept as strings in the form value and
+// coerced on save, mirroring the other admin forms.
+export interface SponsorTierFormValue {
+  key: string;
+  nameFr: string;
+  nameEn: string;
+  subtitleFr: string;
+  subtitleEn: string;
+  descriptionFr: string;
+  descriptionEn: string;
+  advantages: { fr: string; en: string }[];
+  standSize: string;
+  color: string;
+  logoScale: string;
+  rank: string;
+  jobOfferQuota: string;
+  allowsPromoIdeas: boolean;
+}
+
+export const emptySponsorTierForm: SponsorTierFormValue = {
+  key: "",
+  nameFr: "",
+  nameEn: "",
+  subtitleFr: "",
+  subtitleEn: "",
+  descriptionFr: "",
+  descriptionEn: "",
+  advantages: [],
+  standSize: "",
+  color: "#109E6E",
+  logoScale: "1",
+  rank: "0",
+  jobOfferQuota: "1",
+  allowsPromoIdeas: false,
+};
+
+const DEFAULT_COLORS = [
+  { label: "Malachite", value: "#109E6E" },
+  { label: "Jaune (Gold)", value: "#FFD428" },
+  { label: "Rose (Discovery)", value: "#EE7CAD" },
+  { label: "Bleu", value: "#507BBD" },
+  { label: "Terre cuite", value: "#EC6839" },
+  { label: "Émeraude", value: "#41B38E" },
+];
+
+interface SponsorTierFormProps {
+  value: SponsorTierFormValue;
+  onChange: (value: SponsorTierFormValue) => void;
+  // The key is a technical identifier: editable on create, locked afterwards.
+  isNew: boolean;
+}
+
+export default function SponsorTierForm({ value, onChange, isNew }: SponsorTierFormProps) {
+  const logoScale = Number(value.logoScale) || 1;
+
+  function addAdvantage() {
+    onChange({ ...value, advantages: [...value.advantages, { fr: "", en: "" }] });
+  }
+  function updateAdvantage(index: number, lang: "fr" | "en", v: string) {
+    const updated = [...value.advantages];
+    updated[index] = { ...updated[index], [lang]: v };
+    onChange({ ...value, advantages: updated });
+  }
+  function removeAdvantage(index: number) {
+    onChange({ ...value, advantages: value.advantages.filter((_, i) => i !== index) });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <FormField
+          label="Clé (identifiant technique)"
+          name="key"
+          value={value.key}
+          onChange={(v) => onChange({ ...value, key: v })}
+          required={isNew}
+          disabled={!isNew}
+          placeholder="platinum"
+          helpText={isNew ? "Minuscules et tirets, unique. Non modifiable ensuite." : "Non modifiable."}
+        />
+        <FormField
+          label="Taille du stand"
+          name="standSize"
+          value={value.standSize}
+          onChange={(v) => onChange({ ...value, standSize: v })}
+          placeholder="12m²"
+        />
+      </div>
+
+      <BilingualInput
+        label="Nom"
+        nameFr="nameFr"
+        nameEn="nameEn"
+        valueFr={value.nameFr}
+        valueEn={value.nameEn}
+        onChangeFr={(v) => onChange({ ...value, nameFr: v })}
+        onChangeEn={(v) => onChange({ ...value, nameEn: v })}
+        required
+      />
+
+      <BilingualInput
+        label="Sous-titre"
+        nameFr="subtitleFr"
+        nameEn="subtitleEn"
+        valueFr={value.subtitleFr}
+        valueEn={value.subtitleEn}
+        onChangeFr={(v) => onChange({ ...value, subtitleFr: v })}
+        onChangeEn={(v) => onChange({ ...value, subtitleEn: v })}
+      />
+
+      <BilingualInput
+        label="Description"
+        nameFr="descriptionFr"
+        nameEn="descriptionEn"
+        valueFr={value.descriptionFr}
+        valueEn={value.descriptionEn}
+        onChangeFr={(v) => onChange({ ...value, descriptionFr: v })}
+        onChangeEn={(v) => onChange({ ...value, descriptionEn: v })}
+        multiline
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <FormField
+          label="Rang (importance décroissante)"
+          name="rank"
+          type="number"
+          value={value.rank}
+          onChange={(v) => onChange({ ...value, rank: v })}
+          min={0}
+          helpText="Plus élevé = plus en avant."
+        />
+        <FormField
+          label="Quota d'offres d'emploi"
+          name="jobOfferQuota"
+          type="number"
+          value={value.jobOfferQuota}
+          onChange={(v) => onChange({ ...value, jobOfferQuota: v })}
+          min={0}
+        />
+        <FormField
+          label="Taille du logo (échelle)"
+          name="logoScale"
+          type="number"
+          value={value.logoScale}
+          onChange={(v) => onChange({ ...value, logoScale: v })}
+          min={0.1}
+          max={2}
+          step={0.1}
+          helpText="1 = pleine taille, 0.5 = moitié."
+        />
+      </div>
+
+      {/* logoScale preview: a reference box (scale 1) next to the offer's scale,
+          so the admin can visualise the decreasing logo size between offers.
+          The public wall does not consume logoScale yet (#321). */}
+      <div>
+        <span className="block text-sm font-medium text-noir mb-2">Aperçu de la taille du logo</span>
+        <div className="flex items-end gap-6">
+          <div className="text-center">
+            <div className="flex h-20 w-40 items-center justify-center rounded-lg border border-dashed border-gris/40 bg-blanc-casse/50">
+              <div className="rounded bg-gris/30" style={{ width: `${64}px`, height: `${24}px` }} />
+            </div>
+            <span className="mt-1 block text-xs text-gris">Référence (1.0)</span>
+          </div>
+          <div className="text-center">
+            <div className="flex h-20 w-40 items-center justify-center rounded-lg border border-dashed border-gris/40 bg-blanc-casse/50">
+              <div className="rounded" style={{ width: `${64 * logoScale}px`, height: `${24 * logoScale}px`, backgroundColor: value.color }} />
+            </div>
+            <span className="mt-1 block text-xs text-gris">Cette offre ({logoScale})</span>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-noir mb-1">Couleur</label>
+        <div className="flex flex-wrap gap-2">
+          {DEFAULT_COLORS.map((c) => (
+            <button
+              key={c.value}
+              type="button"
+              onClick={() => onChange({ ...value, color: c.value })}
+              className={`w-8 h-8 rounded-full border-2 transition-all ${
+                value.color === c.value ? "border-noir scale-110" : "border-transparent"
+              }`}
+              style={{ backgroundColor: c.value }}
+              title={c.label}
+            />
+          ))}
+          <input
+            type="color"
+            value={value.color}
+            onChange={(e) => onChange({ ...value, color: e.target.value })}
+            className="w-8 h-8 rounded-full cursor-pointer border-0"
+            title="Couleur personnalisée"
+          />
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={value.allowsPromoIdeas}
+          onChange={(e) => onChange({ ...value, allowsPromoIdeas: e.target.checked })}
+          className="rounded border-gris/30 text-malachite focus:ring-malachite"
+        />
+        <span className="text-sm text-noir">Autorise les idées promo réservées (contenu premium)</span>
+      </label>
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="text-sm font-medium text-noir">Avantages ({value.advantages.length})</label>
+          <button type="button" onClick={addAdvantage} className="text-sm text-bleu hover:underline">
+            + Ajouter
+          </button>
+        </div>
+        {value.advantages.map((adv, i) => (
+          <div key={i} className="flex flex-col gap-2 mb-3 sm:flex-row sm:items-start">
+            <label className="flex-1 block">
+              <span className="mb-1 block text-xs text-gris sm:hidden">FR</span>
+              <input
+                type="text"
+                placeholder="FR"
+                value={adv.fr}
+                onChange={(e) => updateAdvantage(i, "fr", e.target.value)}
+                className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              />
+            </label>
+            <label className="flex-1 block">
+              <span className="mb-1 block text-xs text-gris sm:hidden">EN</span>
+              <input
+                type="text"
+                placeholder="EN"
+                value={adv.en}
+                onChange={(e) => updateAdvantage(i, "en", e.target.value)}
+                className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => removeAdvantage(i)}
+              className="text-terre-cuite hover:underline text-sm px-2 py-2 text-left sm:pt-2"
+            >
+              Supprimer
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Sous-tâche **316c** de l'épic #316. Ajoute l'**écran d'administration** du catalogue global d'offres de sponsoring — c'est ici qu'on **ajoute une offre sans toucher au code**.

## Contexte

#318 a livré l'API CRUD `SponsorTier` mais sans écran : on pouvait *sélectionner* une offre, pas en *créer/éditer/supprimer* depuis le back-office. Cette PR comble ce manque. **Purement front** (l'API et ses tests sont dans #318).

## Contenu

- **Entrée sidebar** « Offres de sponsoring » (groupe Données, ADMIN+EDITOR).
- **Liste** `/admin/sponsor-tiers` : le catalogue (couleur, nom, rang, quota d'offres, idées promo), via `GET /api/admin/sponsor-tiers`.
- **Éditeur** `/admin/sponsor-tiers/[id]` (`id="new"` pour la création) + composant `SponsorTierForm` couvrant tous les champs : `key`, nom/sous-titre/description bilingues, avantages (FR/EN add/remove), taille de stand, couleur (palette + sélecteur libre), rang, quota, drapeau promo, et **`logoScale` avec aperçu de taille en direct**.
- **`key`** : identifiant technique éditable à la création (409 si doublon), **verrouillé en lecture seule** ensuite.
- **Suppression** : soft-delete (corbeille, `key` parkée) ; un **409** est affiché en message clair quand un sponsor ou une édition référence encore l'offre.

## Reporté

- **#320** : écran de sélection par édition ergonomique (déjà largement couvert par le SponsoringTab de #318).
- **#321** : rendu réel de `logoScale` sur le mur public (l'aperçu ici est une anticipation) + retrait du shim `level` + i18n.

## Test plan

- [x] `tsc --noEmit` + `lint` frontend — **0 erreur**
- [x] Pas de backend → pas de test backend (API testée en #318)
- [x] Navigateur (env local Docker) :
  - Entrée sidebar présente ; liste des 4 offres seedées.
  - **Créer** une offre (key `bronze-test`, libellés FR/EN, `logoScale` 0.5 → aperçu réactif) → apparaît dans la liste **et dans le `<select>` du formulaire sponsor**.
  - **Éditer** (key verrouillée, rang modifié → persiste en base).
  - **Supprimer** non utilisée → 204 (soft-delete, key parkée) ; **utilisée** (Platinum) → 409 + message clair, reste en place.
  - Données de test nettoyées.

Refs #319
