### PR TITLE
feat(sponsor): refonte visuelle du mur de sponsors — en-têtes de niveau + logos dégressifs (#323)

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -312,6 +312,7 @@
     "title": "Sponsors",
     "description": "Discover the sponsors of DevFest Toulouse 2026: tech companies from Toulouse and beyond who support the developer ecosystem.",
     "heading": "DevFest Toulouse {year} sponsors",
+    "intro": "DevFest Toulouse exists thanks to its partners. Thank you to the companies that support the Toulouse tech ecosystem and make the event possible.",
     "comingSoonTitle": "Sponsors will be announced soon",
     "comingSoonBody": "The DevFest Toulouse {year} sponsor list will be published here. Does your company want to support the Toulouse tech ecosystem?",
     "becomeSponsorCta": "Become a sponsor",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -312,6 +312,7 @@
     "title": "Sponsors",
     "description": "Découvrez les sponsors du DevFest Toulouse 2026 : entreprises tech de Toulouse et d'ailleurs qui soutiennent l'écosystème développeur.",
     "heading": "Sponsors du DevFest Toulouse {year}",
+    "intro": "Le DevFest Toulouse existe grâce à ses partenaires. Merci aux entreprises qui soutiennent l'écosystème tech toulousain et rendent l'événement possible.",
     "comingSoonTitle": "Les sponsors seront annoncés prochainement",
     "comingSoonBody": "La liste des sponsors du DevFest Toulouse {year} sera publiée ici. Votre entreprise souhaite soutenir l'écosystème tech toulousain ?",
     "becomeSponsorCta": "Devenir sponsor",

--- a/src/frontend/src/app/[locale]/sponsors/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/page.tsx
@@ -4,7 +4,8 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { getCurrentEdition, getSponsors } from "@/lib/api";
 import type { SponsorPublic } from "@/lib/types";
 import Breadcrumb from "@/components/Breadcrumb";
-import SponsorCard, { sizeForLogoScale } from "@/components/sponsors/SponsorCard";
+import SponsorCard, { bandForLogoScale } from "@/components/sponsors/SponsorCard";
+import TierHeader from "@/components/sponsors/TierHeader";
 import { Link } from "@/i18n/navigation";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -64,23 +65,19 @@ export default async function SponsorsPage() {
           </Link>
         </div>
 
+        <p className="mx-auto mt-4 max-w-[640px] text-center text-gris">{t("intro")}</p>
+
         {byTier.length === 0 ? (
-          <p className="mt-12 text-lg text-gris">{t("empty")}</p>
+          <p className="mt-12 text-center text-lg text-gris">{t("empty")}</p>
         ) : (
-          <div className="mt-10 space-y-12">
+          <div className="mt-4">
             {byTier.map(({ key, tier, items }) => {
-              const size = sizeForLogoScale(tier.logoScale);
+              const size = bandForLogoScale(tier.logoScale);
               const title = locale === "en" ? tier.nameEn : tier.nameFr;
               return (
-                <section key={key}>
-                  <h2 className="mb-6 text-2xl font-bold text-noir">{title}</h2>
-                  <div
-                    className={
-                      size === "lg"
-                        ? "grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
-                        : "grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4"
-                    }
-                  >
+                <section key={key} className="mt-[52px] first:mt-10">
+                  <TierHeader title={title} color={tier.color} size={size} />
+                  <div className="mt-6 flex flex-wrap items-stretch justify-center gap-[18px]">
                     {items.map((s) => (
                       <SponsorCard key={s.id} sponsor={s} size={size} />
                     ))}

--- a/src/frontend/src/components/home/SponsorsSection.tsx
+++ b/src/frontend/src/components/home/SponsorsSection.tsx
@@ -1,8 +1,9 @@
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import type { SponsorPublic } from "@/lib/types";
 import { Link } from "@/i18n/navigation";
-import SponsorCard, { sizeForLogoScale } from "@/components/sponsors/SponsorCard";
+import SponsorCard, { bandForLogoScale } from "@/components/sponsors/SponsorCard";
+import TierHeader from "@/components/sponsors/TierHeader";
 import { surfaceBgClass, type SectionSurface } from "./section-surface";
 
 interface SponsorsSectionProps {
@@ -14,6 +15,7 @@ interface SponsorsSectionProps {
 // over the visible sections (#135).
 export default async function SponsorsSection({ sponsors, surface = "blanc" }: SponsorsSectionProps) {
   const t = await getTranslations("home.sponsors");
+  const locale = await getLocale();
 
   // Hidden when no sponsor is published (US-212).
   if (sponsors.length === 0) return null;
@@ -53,21 +55,18 @@ export default async function SponsorsSection({ sponsors, surface = "blanc" }: S
           </Link>
         </div>
 
-        <div className="space-y-8">
+        <div className="mt-6 space-y-10">
           {byTier.map(({ key, tier, items }) => {
-            const size = sizeForLogoScale(tier.logoScale);
+            const size = bandForLogoScale(tier.logoScale);
+            const title = locale === "en" ? tier.nameEn : tier.nameFr;
             return (
-              <div
-                key={key}
-                className={
-                  size === "lg"
-                    ? "grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
-                    : "grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4"
-                }
-              >
-                {items.map((s) => (
-                  <SponsorCard key={s.id} sponsor={s} size={size} logoOnly />
-                ))}
+              <div key={key}>
+                <TierHeader title={title} color={tier.color} size={size} />
+                <div className="mt-5 flex flex-wrap items-stretch justify-center gap-[18px]">
+                  {items.map((s) => (
+                    <SponsorCard key={s.id} sponsor={s} size={size} logoOnly />
+                  ))}
+                </div>
               </div>
             );
           })}

--- a/src/frontend/src/components/sponsors/SponsorCard.tsx
+++ b/src/frontend/src/components/sponsors/SponsorCard.tsx
@@ -2,27 +2,31 @@ import Image from "next/image";
 import { Link } from "@/i18n/navigation";
 import type { SponsorPublic } from "@/lib/types";
 
-// Card size tier, derived from the offer's logoScale (#321). Higher offers get
-// bigger logos, so the wall reads Platinum > Gold > Discovery > Soutien.
-export type SponsorCardSize = "lg" | "md" | "sm";
+// Size band derived from the offer's logoScale (#323). The catalogue seeds four
+// distinct scales (1.0 / 0.8 / 0.6 / 0.5), so the wall reads Platinum > Gold >
+// Discovery > Soutien as strictly decreasing cards. Nothing is hard-coded per
+// level — everything flows from the tier.
+export type SponsorCardSize = "xl" | "lg" | "md" | "sm";
 
-// Map a tier's logoScale to a card size band. Tailwind can't take arbitrary
-// heights cleanly, so we snap to three bands rather than a continuous scale.
-export function sizeForLogoScale(logoScale: number): SponsorCardSize {
-  if (logoScale >= 1) return "lg";
-  if (logoScale >= 0.7) return "md";
+export function bandForLogoScale(logoScale: number): SponsorCardSize {
+  if (logoScale >= 1) return "xl";
+  if (logoScale >= 0.75) return "lg";
+  if (logoScale >= 0.55) return "md";
   return "sm";
 }
 
-const SIZE_CLASSES: Record<SponsorCardSize, { pad: string; box: string; sizes: string; name: string; fallback: string }> = {
-  lg: { pad: "p-8", box: "h-32", sizes: "267px", name: "text-2xl", fallback: "text-3xl" },
-  md: { pad: "p-6", box: "h-24", sizes: "220px", name: "text-xl", fallback: "text-2xl" },
-  sm: { pad: "p-6", box: "h-20", sizes: "200px", name: "text-lg", fallback: "text-xl" },
+// Per-band presentation. `card` is a fixed width so a flex-wrap row stays
+// centred (incomplete rows included). The top band is a wide single card.
+const BAND: Record<SponsorCardSize, { card: string; radius: string; box: string; sizes: string; name: string }> = {
+  xl: { card: "w-full max-w-[440px]", radius: "rounded-[24px]", box: "h-28", sizes: "360px", name: "text-2xl" },
+  lg: { card: "w-[250px]", radius: "rounded-[16px]", box: "h-24", sizes: "230px", name: "text-xl" },
+  md: { card: "w-[230px]", radius: "rounded-[16px]", box: "h-20", sizes: "210px", name: "text-lg" },
+  sm: { card: "w-[210px]", radius: "rounded-[16px]", box: "h-16", sizes: "190px", name: "text-base" },
 };
 
 interface SponsorCardProps {
   sponsor: SponsorPublic;
-  /** Logo size band, derived from the tier's logoScale (#321). */
+  /** Size band, derived from the tier's logoScale (#323). */
   size?: SponsorCardSize;
   /** On the homepage only the logo is shown, without the name (RG-223). */
   logoOnly?: boolean;
@@ -30,34 +34,25 @@ interface SponsorCardProps {
 
 export default function SponsorCard({ sponsor, size = "sm", logoOnly = false }: SponsorCardProps) {
   const showName = !logoOnly || !sponsor.logoUrl;
-  const s = SIZE_CLASSES[size];
+  const b = BAND[size];
   return (
     <Link
       href={`/sponsors/${sponsor.slug}`}
-      className="group block overflow-hidden rounded-2xl bg-blanc shadow-card transition-transform hover:-translate-y-1"
+      // Soft hover: shadow deepens, no bounce (#323).
+      className={`group block overflow-hidden bg-blanc shadow-card border border-[rgba(29,29,27,0.08)] transition-shadow duration-200 hover:shadow-lg ${b.card} ${b.radius}`}
     >
       {/* Banner colour comes from the tier (#321) — a hex value, not a class. */}
       <div className="h-2" style={{ backgroundColor: sponsor.tier.color }} />
-      <div className={`flex flex-col items-center justify-center gap-3 ${s.pad}`}>
-        <div className={`relative flex items-center justify-center w-full ${s.box}`}>
+      <div className="flex flex-col items-center justify-center gap-3 p-6">
+        <div className={`relative flex w-full items-center justify-center ${b.box}`}>
           {sponsor.logoUrl ? (
-            <Image
-              src={sponsor.logoUrl}
-              alt={sponsor.name}
-              fill
-              className="object-contain"
-              sizes={s.sizes}
-            />
+            <Image src={sponsor.logoUrl} alt={sponsor.name} fill className="object-contain" sizes={b.sizes} />
           ) : (
-            <span className={`font-bold text-noir ${s.fallback}`}>
-              {sponsor.name}
-            </span>
+            <span className={`font-bold text-noir ${b.name}`}>{sponsor.name}</span>
           )}
         </div>
         {sponsor.logoUrl && showName && (
-          <span className={`font-bold text-noir ${s.name}`}>
-            {sponsor.name}
-          </span>
+          <span className={`font-bold text-noir ${b.name}`}>{sponsor.name}</span>
         )}
       </div>
     </Link>

--- a/src/frontend/src/components/sponsors/TierHeader.tsx
+++ b/src/frontend/src/components/sponsors/TierHeader.tsx
@@ -1,0 +1,35 @@
+import type { SponsorCardSize } from "./SponsorCard";
+
+// Centred level header (#323): the offer name framed by two symmetric gradient
+// rules in the offer's own colour. No vertical bar. The name size follows the
+// offer's band, so higher tiers read larger — all derived from the tier.
+const NAME_SIZE: Record<SponsorCardSize, string> = {
+  xl: "text-[34px] leading-tight",
+  lg: "text-[28px] leading-tight",
+  md: "text-2xl",
+  sm: "text-xl",
+};
+
+interface TierHeaderProps {
+  title: string;
+  color: string;
+  size: SponsorCardSize;
+}
+
+export default function TierHeader({ title, color, size }: TierHeaderProps) {
+  return (
+    <div className="flex items-center justify-center gap-5">
+      <span
+        aria-hidden="true"
+        className="h-[2px] flex-[0_1_200px] rounded-[2px]"
+        style={{ background: `linear-gradient(90deg, transparent, ${color})` }}
+      />
+      <h2 className={`whitespace-nowrap text-center font-bold text-noir ${NAME_SIZE[size]}`}>{title}</h2>
+      <span
+        aria-hidden="true"
+        className="h-[2px] flex-[0_1_200px] rounded-[2px]"
+        style={{ background: `linear-gradient(90deg, ${color}, transparent)` }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Applique le design hi-fi du handoff sur la page publique `/sponsors` **et** la section accueil. **Aucune couleur ni taille de niveau codée en dur** : tout dérive du catalogue (`tier.color` / `logoScale` / `rank`).

## Contenu

- **Nouveau `TierHeader`** : nom de l'offre centré, encadré de **deux liserés dégradés symétriques à la couleur de l'offre** (pas de barre verticale). Taille du nom selon le rang.
- **`SponsorCard`** : 4 bandes de taille dérivées de `logoScale` (`xl/lg/md/sm`) — le rang le plus haut a de grandes cartes, les rangs suivants décroissent ; largeur de carte fixe par bande pour que le **flex-wrap reste centré** ; **hover doux** (ombre en fondu, sans rebond).
- **`/sponsors`** : **paragraphe d'intro centré** (nouvelle clé i18n `sponsors.intro`, FR + EN) sous le H1, puis en-têtes par offre + rangées `flex-wrap justify-center` (**une rangée incomplète reste centrée**). Breadcrumb, H1 et CTA « Devenir sponsor » conservés.
- **Accueil `SponsorsSection`** : même système, condensé, `logoOnly` conservé.

## Test plan

- [x] `tsc` + `lint` frontend — **0 erreur** ; JSON i18n valides
- [x] Navigateur (env local Docker), captures desktop + 600px :
  - `/fr/sponsors` & `/en/sponsors` : en-têtes centrés (liserés à la couleur du tier), **tailles de logo strictement dégressives** (Platinum > Gold > Soutien), rangée incomplète centrée, intro traduite.
  - Responsive 600px : Platinum pleine largeur, Gold/Soutien 2 colonnes centrées.
  - Accueil `/fr` : section au nouveau design (en-têtes + dégressivité, `logoOnly`).
  - Console sans erreur.

## Note

Le rendu utilise les logos placeholder (monogrammes) du seed ; avec de vrais logos, il sera encore plus proche du proto. La structure (dégressivité, en-têtes, centrage, responsive) est conforme au handoff, tout dérivé du catalogue.

Refs #323
