### PR TITLE
test(public): couverture des routes publiques speakers/categories/brochure (#308)

### DIFF
--- a/src/backend/src/__tests__/public-brochure.test.ts
+++ b/src/backend/src/__tests__/public-brochure.test.ts
@@ -1,0 +1,81 @@
+// Set the token secret before importing anything that reads it.
+process.env.BROCHURE_TOKEN_SECRET = process.env.BROCHURE_TOKEN_SECRET || "test-brochure-secret-32-chars-min-aa";
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import Fastify from "fastify";
+import brochureRoutes from "../routes/brochure.js";
+import { makeToken } from "../lib/brochure-token.js";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+
+// #308 — the brochure redirector had no coverage. Locks: bad token → 404,
+// valid token → 302 to the edition's brochure URL AND increments the counter,
+// and the best-effort nature (a valid token for a missing message still 302s).
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(brochureRoutes, { prefix: "/api" });
+  return app;
+}
+
+let editionId: number;
+let previousUrl: string | null;
+let messageId: number;
+const BROCHURE_URL = "https://example.org/brochure-test.pdf";
+
+beforeAll(async () => {
+  const edition = await getSeededEdition();
+  editionId = edition.id;
+  previousUrl = edition.sponsorBrochureUrl;
+  await prisma.edition.update({ where: { id: editionId }, data: { sponsorBrochureUrl: BROCHURE_URL } });
+
+  const msg = await prisma.contactMessage.create({
+    data: { firstName: "Bro", lastName: "Chure", email: "bro@example.org", message: "brochure please" },
+  });
+  messageId = msg.id;
+});
+
+afterAll(async () => {
+  await prisma.contactMessage.deleteMany({ where: { id: messageId } });
+  await prisma.edition.update({ where: { id: editionId }, data: { sponsorBrochureUrl: previousUrl } });
+});
+
+describe("Public brochure redirector (#308)", () => {
+  it("404s on an invalid token", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/brochure/not-a-valid-token" });
+    await app.close();
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("302s to the brochure URL and increments the download counter", async () => {
+    const token = makeToken(messageId)!;
+    const before = (await prisma.contactMessage.findUnique({ where: { id: messageId } }))!.brochureDownloadCount;
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/brochure/${token}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe(BROCHURE_URL);
+
+    const after = (await prisma.contactMessage.findUnique({ where: { id: messageId } }))!;
+    expect(after.brochureDownloadCount).toBe(before + 1);
+    expect(after.brochureDownloadedAt).not.toBeNull();
+  });
+
+  it("still 302s for a valid token whose message no longer exists (best effort)", async () => {
+    // A signed token for an id that has no row: the redirect must still work.
+    const ghost = await prisma.contactMessage.create({
+      data: { firstName: "Ghost", lastName: "Msg", email: "ghost@example.org", message: "x" },
+    });
+    const token = makeToken(ghost.id)!;
+    await prisma.contactMessage.delete({ where: { id: ghost.id } });
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/brochure/${token}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe(BROCHURE_URL);
+  });
+});

--- a/src/backend/src/__tests__/public-categories.test.ts
+++ b/src/backend/src/__tests__/public-categories.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach } from "vitest";
+import Fastify from "fastify";
+import categoryRoutes from "../routes/categories.js";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+
+// #308 — the public /api/categories route had no coverage. Locks the filtering
+// (featured edition, not trashed), ordering, and that only public fields ship.
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(categoryRoutes, { prefix: "/api" });
+  return app;
+}
+
+const createdIds: number[] = [];
+
+afterEach(async () => {
+  if (createdIds.length) {
+    await prisma.category.deleteMany({ where: { id: { in: createdIds } } });
+    createdIds.length = 0;
+  }
+});
+
+async function makeCategory(editionId: number, overrides: Record<string, unknown> = {}) {
+  const c = await prisma.category.create({
+    data: { nameFr: "Cat FR", nameEn: "Cat EN", editionId, ...overrides },
+  });
+  createdIds.push(c.id);
+  return c;
+}
+
+describe("Public categories (#308)", () => {
+  it("lists the featured edition's live categories, ordered by sortOrder", async () => {
+    const edition = await getSeededEdition();
+    const second = await makeCategory(edition.id, { nameFr: "Deuxième", sortOrder: 900 });
+    const first = await makeCategory(edition.id, { nameFr: "Première", sortOrder: 800 });
+    const trashed = await makeCategory(edition.id, { nameFr: "Corbeille", sortOrder: 950, deletedAt: new Date() });
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/categories" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const mine = res.json().filter((c: { id: number }) => [first.id, second.id, trashed.id].includes(c.id));
+    // Trashed category is excluded.
+    expect(mine.map((c: { id: number }) => c.id)).not.toContain(trashed.id);
+    // The two live ones appear in sortOrder order.
+    const firstIdx = res.json().findIndex((c: { id: number }) => c.id === first.id);
+    const secondIdx = res.json().findIndex((c: { id: number }) => c.id === second.id);
+    expect(firstIdx).toBeLessThan(secondIdx);
+    // Only public fields ship.
+    const item = res.json().find((c: { id: number }) => c.id === first.id);
+    expect(Object.keys(item).sort()).toEqual(["color", "id", "nameEn", "nameFr"]);
+  });
+});

--- a/src/backend/src/__tests__/public-speakers.test.ts
+++ b/src/backend/src/__tests__/public-speakers.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach } from "vitest";
+import Fastify from "fastify";
+import speakerRoutes from "../routes/speakers.js";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+
+// #308 — the public speaker routes had no coverage. These lock the filtering
+// (published + not trashed, featured edition) and that private fields never
+// leak. Read-mostly, teardown scoped to the ids this file creates.
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(speakerRoutes, { prefix: "/api" });
+  return app;
+}
+
+const createdIds: number[] = [];
+
+afterEach(async () => {
+  if (createdIds.length) {
+    await prisma.talk.deleteMany({ where: { speakers: { some: { id: { in: createdIds } } } } });
+    await prisma.speaker.deleteMany({ where: { id: { in: createdIds } } });
+    createdIds.length = 0;
+  }
+});
+
+async function makeSpeaker(editionId: number, overrides: Record<string, unknown> = {}) {
+  const s = await prisma.speaker.create({
+    data: {
+      name: "Test Speaker",
+      slug: `test-speaker-${Date.now()}-${Math.round(performance.now())}`,
+      editionId,
+      publicationStatus: "PUBLISHED",
+      ...overrides,
+    },
+  });
+  createdIds.push(s.id);
+  return s;
+}
+
+describe("Public speakers (#308)", () => {
+  it("lists only published, non-trashed speakers of the featured edition", async () => {
+    const edition = await getSeededEdition();
+    const published = await makeSpeaker(edition.id, { name: "Zeta Published" });
+    const draft = await makeSpeaker(edition.id, { name: "Alpha Draft", publicationStatus: "DRAFT" });
+    const trashed = await makeSpeaker(edition.id, { name: "Beta Trashed", deletedAt: new Date() });
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/speakers" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const ids = res.json().map((s: { id: number }) => s.id);
+    expect(ids).toContain(published.id);
+    expect(ids).not.toContain(draft.id);
+    expect(ids).not.toContain(trashed.id);
+    // Private fields never leak on the list.
+    const item = res.json().find((s: { id: number }) => s.id === published.id);
+    expect(item).not.toHaveProperty("contactEmail");
+    expect(item).not.toHaveProperty("editToken");
+    expect(item).not.toHaveProperty("bioFr");
+  });
+
+  it("returns only featured speakers, capped at 8", async () => {
+    const edition = await getSeededEdition();
+    const featured = await makeSpeaker(edition.id, { name: "Featured One", isFeatured: true });
+    const notFeatured = await makeSpeaker(edition.id, { name: "Not Featured", isFeatured: false });
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/speakers/featured" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const ids = res.json().map((s: { id: number }) => s.id);
+    expect(ids).toContain(featured.id);
+    expect(ids).not.toContain(notFeatured.id);
+    expect(res.json().length).toBeLessThanOrEqual(8);
+  });
+
+  it("returns a published speaker's detail with only its published talks", async () => {
+    const edition = await getSeededEdition();
+    const speaker = await makeSpeaker(edition.id, {
+      name: "Detailed Speaker",
+      bioFr: "Bio FR",
+      contactEmail: "secret@example.org",
+      talks: {
+        create: [
+          { title: "Live Talk", description: "", format: "CONFERENCE", language: "fr", publicationStatus: "PUBLISHED", editionId: edition.id, slug: `live-${Date.now()}` },
+          { title: "Draft Talk", description: "", format: "CONFERENCE", language: "fr", publicationStatus: "DRAFT", editionId: edition.id, slug: `draft-${Date.now()}` },
+        ],
+      },
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/speakers/${speaker.slug}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.name).toBe("Detailed Speaker");
+    expect(body.bioFr).toBe("Bio FR");
+    // Private field never leaks even on the detail route.
+    expect(body).not.toHaveProperty("contactEmail");
+    // Only the published talk shows up.
+    const titles = body.talks.map((t: { title: string }) => t.title);
+    expect(titles).toContain("Live Talk");
+    expect(titles).not.toContain("Draft Talk");
+  });
+
+  it("404s for an unknown or unpublished slug", async () => {
+    const edition = await getSeededEdition();
+    const draft = await makeSpeaker(edition.id, { name: "Hidden", slug: `hidden-${Date.now()}`, publicationStatus: "DRAFT" });
+
+    const app = await buildApp();
+    const missing = await app.inject({ method: "GET", url: "/api/speakers/does-not-exist-xyz" });
+    const unpublished = await app.inject({ method: "GET", url: `/api/speakers/${draft.slug}` });
+    await app.close();
+
+    expect(missing.statusCode).toBe(404);
+    expect(unpublished.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
Poursuite de #308 (couverture de tests). Comble le manque restant le plus net : les **routes publiques de lecture** signalées comme **non couvertes** dans l'issue.

## Contenu

Tests d'intégration via le harnais Fastify `inject` existant — pas d'e2e, pas de nouvel outillage.

- **`public-speakers`** : `/speakers` ne liste que les speakers **PUBLISHED, non supprimés** de l'édition featured et **ne fuit aucun champ privé** (`contactEmail`, `editToken`, `bio`) ; `/speakers/featured` ne renvoie que les featured, plafonné à 8 ; `/speakers/:slug` renvoie le détail avec **seulement ses talks publiés**, et **404** sur slug inconnu/brouillon.
- **`public-categories`** : `/categories` liste les catégories vivantes de l'édition featured triées par `sortOrder`, exclut les corbeille, ne ship que les champs publics.
- **`public-brochure`** : token invalide → **404** ; token valide → **302** vers l'URL de plaquette de l'édition **+ incrément du compteur** de téléchargement ; un token valide dont le message a été supprimé **302 quand même** (bookkeeping best-effort).

## Notes

- Chaque test a un teardown scopé à ses propres ids (pas d'interférence parallèle façon #292).
- Le filtre published/non-corbeille de speakers a été **vérifié contre le bug** (le désactiver fait échouer le test).
- `sponsor-plans` (cité dans le « reste » de l'issue) **n'existe plus** (supprimé en #317) — sans objet.

## Reste (suivi #308, hors de ce lot, par choix)

- Tests de composants React supplémentaires (`ContactForm`, `SponsorForm`, `TalkForm`, `RichTextEditor`).
- Routes admin encore non couvertes : `admin/users`, `admin/files` (au-delà du smoke), `admin/import`, `admin/translate`.
- **E2e Playwright** des parcours critiques — chantier d'infra délibérément séparé.

## Test plan

- [x] `pnpm test` backend — **446/446** (69 fichiers, +3 fichiers, +8 tests)
- [x] Garde-fou anti-régression vérifié sur le filtre published des speakers

Refs #308
