### PR TITLE
feat(sponsor): shared multi-edition sponsor model

### DIFF
--- a/docs/superpowers/plans/2026-07-29-sponsor-backend.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-backend.md
@@ -222,12 +222,29 @@ const sponsor = await prisma.sponsor.findFirst({
   where: {
     slug: request.params.slug,
     ...notDeleted,
-    editions: { some: { publicationStatus: "PUBLISHED" } },
+    // `edition: notDeleted` is required in BOTH positions, exactly as
+    // speakers.ts does since #352: the route used to resolve
+    // getFeaturedEdition(), which filtered the trash for free. Now that it
+    // spans every year, a trashed edition would resurface — as a dead year tag
+    // linking to a 404, or as a live page for a sponsor whose only
+    // participations are in withdrawn editions.
+    editions: { some: { publicationStatus: "PUBLISHED", edition: notDeleted } },
   },
   include: {
+    // One query, not two: tier and jobOffers are read here rather than by a
+    // second findUnique on the participation. The row is already being touched,
+    // and a second read would open a skew window for no gain.
     editions: {
-      where: { publicationStatus: "PUBLISHED" },
-      select: { editionId: true, edition: { select: { year: true } } },
+      where: { publicationStatus: "PUBLISHED", edition: notDeleted },
+      select: {
+        editionId: true,
+        edition: { select: { year: true } },
+        tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+        jobOffers: {
+          select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
+          orderBy: { createdAt: "asc" },
+        },
+      },
       orderBy: { edition: { year: "desc" } },
     },
     // Nested reads need their own filter: a query extension would not reach
@@ -248,33 +265,24 @@ if (!sponsor) return reply.status(404).send({ error: "Sponsor not found" });
 const edition = await getFeaturedEdition();
 const current = edition ? sponsor.editions.find((e) => e.editionId === edition.id) : undefined;
 
-let tier = null;
-let jobOffers: Array<{ id: number; title: string; descriptionFr: string; descriptionEn: string; url: string }> = [];
+// `current` already carries the tier and the offers — no second query. Do NOT
+// re-fetch the participation with findUnique: it reads a row the query above
+// already touched, and a guard on its result would be unreachable (current is
+// non-undefined only when that exact participation exists).
+const tier = current
+  ? {
+      key: current.tier.key,
+      rank: current.tier.rank,
+      nameFr: current.tier.nameFr,
+      nameEn: current.tier.nameEn,
+      logoScale: current.tier.logoScale,
+      color: current.tier.color,
+    }
+  : null;
 
-if (edition && current) {
-  const live = await prisma.editionSponsor.findUnique({
-    where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: edition.id } },
-    include: {
-      tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
-      jobOffers: {
-        select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
-        orderBy: { createdAt: "asc" },
-      },
-    },
-  });
-  if (live) {
-    tier = {
-      key: live.tier.key,
-      rank: live.tier.rank,
-      nameFr: live.tier.nameFr,
-      nameEn: live.tier.nameEn,
-      logoScale: live.tier.logoScale,
-      color: live.tier.color,
-    };
-    // Offers disappear one month after the event (#251).
-    jobOffers = areOffersVisible(edition) ? live.jobOffers : [];
-  }
-}
+// Offers disappear one month after the event (#251). `edition` is the featured
+// one, the only edition whose offers may ever be shown.
+const jobOffers = current && edition && areOffersVisible(edition) ? current.jobOffers : [];
 
 return {
   id: sponsor.id,
@@ -341,18 +349,37 @@ Append to `src/backend/src/__tests__/public-sponsors.test.ts`. These are new beh
 
 ```ts
 describe("Sponsor detail spans editions (#129)", () => {
-  it("serves a sponsor of a past edition with no tier and no offers", async () => {
-    const past = await prisma.edition.create({ data: { year: 1760 } });
+  it("serves a past-edition sponsor with no tier, and hides its offers", async () => {
+    // Two past editions, newest first in the response: pins the sort order.
+    // 176x is this file's block — every year stays below getSeededEdition()'s
+    // 2016 floor so no parallel file can pick these up (#292).
+    const older = await prisma.edition.create({ data: { year: 1760 } });
+    const newer = await prisma.edition.create({ data: { year: 1761 } });
     const tierId = await tierIdByKey("gold");
     const sponsor = await createSponsorFixture({
       name: "Past Only Co",
       slug: `past-only-${Date.now()}`,
-      editionId: past.id,
+      editionId: older.id,
       tierId,
       publicationStatus: "PUBLISHED",
     });
     createdSponsorIds.push(sponsor.id);
-    createdEditionIds.push(past.id);
+    createdEditionIds.push(older.id, newer.id);
+
+    await prisma.editionSponsor.create({
+      data: { sponsorId: sponsor.id, editionId: newer.id, tierId, publicationStatus: "PUBLISHED" },
+    });
+
+    // An offer on a PAST participation. The governing rule is "no past offer is
+    // ever shown", so this must not surface — asserting [] on a sponsor with no
+    // offers at all would hold even with the filter removed.
+    const pastParticipation = await prisma.editionSponsor.findUniqueOrThrow({
+      where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: newer.id } },
+      select: { id: true },
+    });
+    await prisma.sponsorJobOffer.create({
+      data: { editionSponsorId: pastParticipation.id, title: "Stale Job", url: "https://example.org/stale" },
+    });
 
     const app = await buildPublicApp();
     const res = await app.inject({ method: "GET", url: `/api/sponsors/${sponsor.slug}` });
@@ -363,7 +390,8 @@ describe("Sponsor detail spans editions (#129)", () => {
     // Not sponsoring the featured edition: highlight is empty, history remains.
     expect(body.tier).toBeNull();
     expect(body.jobOffers).toEqual([]);
-    expect(body.editions).toEqual([1760]);
+    // Newest first, exact — `toContain` would let a reversed sort pass.
+    expect(body.editions).toEqual([1761, 1760]);
   });
 
   it("highlights the tier of the featured edition", async () => {
@@ -384,13 +412,22 @@ describe("Sponsor detail spans editions (#129)", () => {
 
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    expect(body.tier.key).toBe("platinum");
+    // The WHOLE tier object, not just its key: rank, logoScale and color drive
+    // the banner colour and logo size, so dropping one must fail the test.
+    expect(body.tier).toMatchObject({
+      key: "platinum",
+      nameFr: expect.any(String),
+      nameEn: expect.any(String),
+      color: expect.any(String),
+    });
+    expect(typeof body.tier.rank).toBe("number");
+    expect(typeof body.tier.logoScale).toBe("number");
     expect(body.editions).toContain(edition.year);
   });
 });
 ```
 
-Add `createdEditionIds` tracking and an `afterEach` edition cleanup to this file if it has none, following `sponsor-identity.test.ts`: delete sponsors first, then editions, both unconditionally. Year 1760 sits in this plan's 17xx block, below `getSeededEdition()`'s 2016 floor, so parallel files cannot pick it up (#292).
+Add `createdEditionIds` tracking and an `afterEach` edition cleanup to this file if it has none, following `sponsor-identity.test.ts`: delete sponsors first, then editions, both unconditionally. Years 1760 and 1761 sit in this file's 176x block, below `getSeededEdition()`'s 2016 floor, so parallel files cannot pick them up (#292).
 
 - [ ] **Step 5: Port the existing fixtures in both test files**
 

--- a/docs/superpowers/plans/2026-07-29-sponsor-backend.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-backend.md
@@ -684,6 +684,8 @@ const sponsors = await prisma.sponsor.findMany({
 
 Read what the current handler emits and keep the admin frontend's field names working. Where it emitted a flat `tier`/`publicationStatus`/`edition`, emit them from the participation the admin is looking at — the most recent one when no `editionId` filter is given.
 
+**On the ordering:** the old handler sorted by tier rank descending, then name (RG-221). Sorting by name alone is the accepted behaviour here — a deliberate call, not an oversight: RG-221 governs how sponsors are *displayed to visitors*, and the public wall in `routes/sponsors.ts` still applies it. The admin list is a working list; filters and sort controls can come later if the need appears. Do not reintroduce the rank ordering.
+
 - [ ] **Step 3: `GET /sponsors/:id` — identity plus its participations**
 
 `include: { edition, tier, jobOffers }` no longer resolves. Replace with:
@@ -780,7 +782,9 @@ const target = body.editionId
     });
 ```
 
-Then update each side only with the fields the body actually carries, preserving the existing "only touch what was sent" behaviour. If a per-year field is sent and `target` is null, answer `422` — there is no year to write it to.
+Then update each side only with the fields the body actually carries, preserving the existing "only touch what was sent" behaviour.
+
+**Resolve `target` only when the body actually carries a per-year field.** An identity-only edit — renaming a company, swapping its logo — must succeed even on a sponsor with no participation at all; refusing it because no edition is attached yet would be nonsense. The `422` then fires exactly where it should: a per-year value was sent and there is no year to write it to.
 
 - [ ] **Step 6: `POST /sponsors/bulk` — target participations**
 
@@ -800,10 +804,15 @@ if (!body.editionId) {
   return reply.code(400).send({ error: "editionId is required: status is per edition" });
 }
 const { count } = await prisma.editionSponsor.updateMany({
-  where: { sponsorId: { in: body.ids }, editionId: body.editionId },
+  // `sponsor: notDeleted` matters: without it a trashed company caught in a
+  // bulk selection gets published. The sibling endpoint already guards this —
+  // see admin/speakers.ts, `speaker: notDeleted` on its own bulk updateMany.
+  where: { sponsorId: { in: body.ids }, editionId: body.editionId, sponsor: notDeleted },
   data: { publicationStatus: body.value },
 });
 ```
+
+Cover it with a test that bites: two sponsors on one edition, one trashed, bulk-publish both ids, assert the live one is `PUBLISHED` and the trashed one still `DRAFT`. Removing the guard must fail that test.
 
 - [ ] **Step 7: Add attach / detach endpoints**
 

--- a/docs/superpowers/plans/2026-07-29-sponsor-backend.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-backend.md
@@ -546,6 +546,24 @@ editionSponsors: { where: { sponsor: notDeleted } },
 
 And at each readback site, `edition._count.sponsors` becomes `edition._count.editionSponsors`. **Keep the emitted field name `sponsorsCount`** — that is the admin API contract and the frontend reads it.
 
+**The relation name also reaches an admin-facing string.** The DELETE handler builds its 409 message straight from the `_count` keys:
+
+```ts
+const blocking = Object.entries(existing._count)
+  .filter(([, count]) => count > 0)
+  .map(([relation, count]) => `${relation} (${count})`);
+```
+
+So renaming the relation silently changes what an organiser reads from "sponsors (12)" to "editionSponsors (12)" — a Prisma internal leaking into the UI. Map it back, scoped to this handler:
+
+```ts
+// The 409 message is built from relation keys, so a renamed relation would
+// surface as "editionSponsors (12)". Label it for humans.
+const RELATION_LABELS: Record<string, string> = { editionSponsors: "sponsors" };
+```
+
+and use `RELATION_LABELS[relation] ?? relation` in the `.map()`. Add a test asserting the 409 body says "sponsors" — nothing pinned this string before, which is exactly why the regression would have shipped silently.
+
 - [ ] **Step 4: `admin/sponsor-tiers.ts` — the tier-in-use check**
 
 Line ~143 asks whether any sponsor uses a tier, via `where: { tierId }` on `Sponsor`. The tier is on the participation now:

--- a/docs/superpowers/plans/2026-07-29-sponsor-backend.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-backend.md
@@ -1,0 +1,1015 @@
+# Sponsor Backend on the Identity/Participation Model (#130) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite every consumer of the `Sponsor` model onto the identity/participation split delivered by #129, so the app compiles and the test suite passes again.
+
+**Architecture:** One temporal rule governs the public shape — the sponsor page highlights the featured edition, past years are only tags. Queries move to `EditionSponsor`; API response shapes stay byte-identical **except** `/api/sponsors/:slug`, where `tier` becomes nullable and `editions: number[]` appears.
+
+**Tech Stack:** Fastify, Prisma 7 (client generated to `src/backend/src/generated/prisma/`), Vitest against a live Postgres, TypeScript ESM (`.js` import specifiers), Next.js 16 App Router for the one frontend file.
+
+**Spec:** [2026-07-29-sponsor-backend-design.md](../specs/2026-07-29-sponsor-backend-design.md)
+**Predecessor:** [2026-07-29-sponsor-identity-schema.md](2026-07-29-sponsor-identity-schema.md) (#129 — schema + migration, already merged into this branch)
+
+## Global Constraints
+
+- **Branch:** `feature/us-129-sponsor-identity` (already holds #129). Never checkout another branch.
+- **Language:** code, comments and commit messages in **English**. Communication with the user in French.
+- **Commits:** Conventional Commits, subject under 72 chars. Stage named files only — never `git add .` / `git add -A`. One git command per Bash call, never chained with `&&`, never `git -C`.
+- **Shell cwd persists between commands.** Backend commands run from `src/backend`; `cd /c/dev/devfesttoulouse/Site-Devfest-Toulouse-2026` to get back to the repo root.
+- **DATABASE_URL must point at localhost** or ~44 tests fail with 500s. The repo `.env` targets the Docker-internal host and may be unreadable (blocked as a secret). Prefix commands: `DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest"`. Never write to `.env`, never print secrets into a report.
+- **Docker compose must name the file** — this repo has no default `docker-compose.yml`: `docker compose -f docker-compose.local.yml exec -T db psql -U devfest -d devfest -c "..."` from the repo root. Postgres user/password/db are all `devfest`, already running on localhost:5432.
+- **Do NOT touch** `src/backend/prisma/schema.prisma`, any file under `src/backend/prisma/migrations/`, or `src/backend/prisma/seed-dev.ts`. #129 owns them and they are correct.
+- **No backwards-compatibility shims.** No renaming to `_unused`, no re-exporting dead types, no keeping a field alive "for now". If something is unused, delete it.
+- **API shapes are the contract.** `/api/sponsors` and `/api/job-offers` must not change by one byte. The existing tests prove it — if a test demands a changed assertion in those areas, you broke something. The single exception is `/api/sponsors/:slug` (Task 2).
+- **Definition of done for the whole plan:** `pnpm typecheck` clean, `pnpm test` green (backend), `pnpm lint` + `pnpm build` clean (frontend).
+
+## The temporal rule (memorise this — it decides most questions)
+
+| Data | Featured edition | Past editions |
+|---|---|---|
+| `tier` | highlighted on the sponsor page | absent from the page — lives on the edition's recap page |
+| `jobOffers` | shown | **never** |
+| participation | — | year tag, linking to `/editions/<year>` |
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/backend/src/__tests__/sponsor-test-helpers.ts` | Fixture factory — port once, unblocks many test files | 1 |
+| `src/backend/src/routes/sponsors.ts` | Public list / detail / job-offers | 2 |
+| `src/backend/src/routes/speakers.ts` | A speaker's employer per year | 3 |
+| `src/backend/src/routes/editions.ts` | Public per-year sponsor counts | 3 |
+| `src/backend/src/routes/admin/editions.ts` | Admin per-edition sponsor count | 3 |
+| `src/backend/src/routes/admin/sponsor-tiers.ts` | Tier-in-use check | 3 |
+| `src/backend/src/routes/admin/sponsors.ts` | 12 admin endpoints (412 lines) | 4 |
+| `src/backend/src/routes/edit.ts` | Magic-link sponsor editing | 5 |
+| `src/frontend/src/lib/types.ts` + `src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx` | `SponsorDetail` contract + the page reading it | 6 |
+| 13 remaining `src/backend/src/__tests__/*.test.ts` | Fixtures on the new model | spread across 2–5 |
+
+---
+
+## Task 1: Port the sponsor test helpers
+
+The highest-leverage change in the plan: several test files build sponsors through this factory, so porting it once clears their fixtures.
+
+**Files:**
+- Modify: `src/backend/src/__tests__/sponsor-test-helpers.ts`
+
+**Interfaces:**
+- Produces: `createSponsorWithToken(data, token, contact?)` — `data` becomes `SponsorFixture` (below), not `Prisma.SponsorUncheckedCreateInput`. Callers pass identity fields plus `editionId`/`tierId`/`publicationStatus`, and the helper routes the last three into the nested participation. Also produces `tierIdByKey(key: string): Promise<number>` (unchanged).
+
+- [ ] **Step 1: Read the current helper**
+
+```bash
+cat src/backend/src/__tests__/sponsor-test-helpers.ts
+```
+
+Note that `createSponsorWithToken` takes `Prisma.SponsorUncheckedCreateInput` and that the `Prisma` type import exists for that reason.
+
+- [ ] **Step 2: Introduce the fixture type and route the participation fields**
+
+Replace the `createSponsorWithToken` signature and body. Keep `tierIdByKey` exactly as it is.
+
+```ts
+// A sponsor fixture on the identity/participation model (#129). Callers still
+// pass editionId/tierId/publicationStatus flat — those are what a test cares
+// about — and this factory files them into the participation.
+export interface SponsorFixture {
+  name: string;
+  slug: string;
+  editionId: number;
+  tierId: number;
+  publicationStatus?: "DRAFT" | "PUBLISHED";
+  logoUrl?: string | null;
+  websiteUrl?: string | null;
+  descriptionFr?: string | null;
+  descriptionEn?: string | null;
+  socialLinks?: string | null;
+  contactEmail?: string | null;
+  standContacts?: string | null;
+  locale?: string;
+}
+
+export async function createSponsorWithToken(
+  data: SponsorFixture,
+  token: string,
+  contact?: { email?: string; sentAt?: Date; locked?: boolean },
+) {
+  const { editionId, tierId, publicationStatus, ...identity } = data;
+  const sponsor = await prisma.sponsor.create({
+    data: {
+      ...identity,
+      editions: {
+        create: [{ editionId, tierId, publicationStatus: publicationStatus ?? "DRAFT" }],
+      },
+    },
+  });
+  await prisma.sponsorContact.create({
+    data: {
+      sponsorId: sponsor.id,
+      email: contact?.email ?? sponsor.contactEmail ?? "contact@example.org",
+      editToken: token,
+      editTokenSentAt: contact?.sentAt ?? new Date(),
+      editLinkLocked: contact?.locked ?? false,
+    },
+  });
+  return sponsor;
+}
+```
+
+- [ ] **Step 3: Add a participation-aware fixture for tests that need no token**
+
+Several files create a sponsor directly with `prisma.sponsor.create` and a flat `editionId`. Give them one factory instead of each inventing the nesting:
+
+```ts
+// Same shape as createSponsorWithToken, without the modification-link contact.
+export async function createSponsorFixture(data: SponsorFixture) {
+  const { editionId, tierId, publicationStatus, ...identity } = data;
+  return prisma.sponsor.create({
+    data: {
+      ...identity,
+      editions: {
+        create: [{ editionId, tierId, publicationStatus: publicationStatus ?? "DRAFT" }],
+      },
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Fix the stale comment at the top of the file**
+
+The header says "Sponsors carry a tierId FK now, not a level enum" — true of the participation now, not of the sponsor. Correct it to name where the tier lives:
+
+```ts
+// Resolve a seeded SponsorTier id from its stable key (#317). The tier is bought
+// per edition since #129, so it is set on the participation, not the company.
+```
+
+- [ ] **Step 5: Typecheck the helper file**
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm typecheck 2>&1 | grep "sponsor-test-helpers"
+```
+
+Expected: empty. Errors elsewhere are expected at this stage — later tasks own them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backend/src/__tests__/sponsor-test-helpers.ts
+git commit -m "test(sponsor): fixtures build identity plus participation"
+```
+
+---
+
+## Task 2: Public sponsor endpoints
+
+**Files:**
+- Modify: `src/backend/src/routes/sponsors.ts`
+- Modify: `src/backend/src/__tests__/public-sponsors.test.ts`
+- Modify: `src/backend/src/__tests__/sponsor-job-offers.test.ts`
+
+**Interfaces:**
+- Consumes: `tierIdByKey`, `createSponsorFixture` from Task 1.
+- Produces: the `/api/sponsors/:slug` response shape that Task 6 consumes — `tier: SponsorTierRef | null`, `editions: number[]` (years, descending), everything else unchanged.
+
+- [ ] **Step 1: Port `GET /api/sponsors` — contract unchanged**
+
+The query moves to the join; the response must stay identical. Replace the `prisma.sponsor.findMany` call with:
+
+```ts
+const links = await prisma.editionSponsor.findMany({
+  where: { editionId: edition.id, publicationStatus: "PUBLISHED", sponsor: notDeleted },
+  include: {
+    sponsor: { select: { id: true, slug: true, name: true, logoUrl: true, websiteUrl: true } },
+    tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+  },
+});
+
+return links
+  .map((link) => ({
+    id: link.sponsor.id,
+    slug: link.sponsor.slug,
+    name: link.sponsor.name,
+    logoUrl: link.sponsor.logoUrl,
+    tier: {
+      key: link.tier.key,
+      rank: link.tier.rank,
+      nameFr: link.tier.nameFr,
+      nameEn: link.tier.nameEn,
+      logoScale: link.tier.logoScale,
+      color: link.tier.color,
+    },
+    websiteUrl: link.sponsor.websiteUrl,
+  }))
+  // Higher rank = more prominent (RG-221), so sort descending.
+  .sort((a, b) => (b.tier.rank - a.tier.rank) || a.name.localeCompare(b.name));
+```
+
+Note `id` is the **sponsor's** id, as before — not the participation's. The existing test asserts on sponsor ids.
+
+- [ ] **Step 2: Port `GET /api/sponsors/:slug` — two independent resolutions**
+
+This is the one deliberate shape change. Replace the whole handler body:
+
+```ts
+// The company, by global slug (#129). No featured-edition scope: a company
+// page exists independently of whether it sponsors the current year.
+const sponsor = await prisma.sponsor.findFirst({
+  where: {
+    slug: request.params.slug,
+    ...notDeleted,
+    editions: { some: { publicationStatus: "PUBLISHED" } },
+  },
+  include: {
+    editions: {
+      where: { publicationStatus: "PUBLISHED" },
+      select: { editionId: true, edition: { select: { year: true } } },
+      orderBy: { edition: { year: "desc" } },
+    },
+    // Nested reads need their own filter: a query extension would not reach
+    // them (Prisma applies those to the top-level operation only).
+    speakers: {
+      where: { publicationStatus: "PUBLISHED", speaker: notDeleted },
+      select: { speaker: { select: { slug: true, name: true, photoUrl: true, company: true } } },
+      orderBy: { speaker: { name: "asc" } },
+    },
+  },
+});
+
+if (!sponsor) return reply.status(404).send({ error: "Sponsor not found" });
+
+// The featured edition is resolved separately and drives the highlight only.
+// Past years are tags: no tier, no offers (spec — "no past offer is ever
+// shown", so there is no edition to choose when filtering).
+const edition = await getFeaturedEdition();
+const current = edition ? sponsor.editions.find((e) => e.editionId === edition.id) : undefined;
+
+let tier = null;
+let jobOffers: Array<{ id: number; title: string; descriptionFr: string; descriptionEn: string; url: string }> = [];
+
+if (edition && current) {
+  const live = await prisma.editionSponsor.findUnique({
+    where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: edition.id } },
+    include: {
+      tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+      jobOffers: {
+        select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+  if (live) {
+    tier = {
+      key: live.tier.key,
+      rank: live.tier.rank,
+      nameFr: live.tier.nameFr,
+      nameEn: live.tier.nameEn,
+      logoScale: live.tier.logoScale,
+      color: live.tier.color,
+    };
+    // Offers disappear one month after the event (#251).
+    jobOffers = areOffersVisible(edition) ? live.jobOffers : [];
+  }
+}
+
+return {
+  id: sponsor.id,
+  slug: sponsor.slug,
+  name: sponsor.name,
+  logoUrl: sponsor.logoUrl,
+  tier,
+  websiteUrl: sponsor.websiteUrl,
+  descriptionFr: sponsor.descriptionFr,
+  descriptionEn: sponsor.descriptionEn,
+  socialLinks: parseSocial(sponsor.socialLinks),
+  // Projected back to the pre-#353 shape: the payload must not change.
+  speakers: sponsor.speakers.map((link) => link.speaker),
+  jobOffers,
+  // Year tags (#129), newest first. The frontend links them to /editions/<year>.
+  editions: sponsor.editions.map((e) => e.edition.year),
+};
+```
+
+- [ ] **Step 3: Port `GET /api/job-offers` — contract unchanged**
+
+Only the query path changes. The `where` on `prisma.sponsor.findMany` moves onto the participation:
+
+```ts
+const sponsors = await prisma.sponsor.findMany({
+  where: {
+    ...notDeleted,
+    editions: { some: { editionId: edition.id, publicationStatus: "PUBLISHED", jobOffers: { some: {} } } },
+  },
+  select: {
+    slug: true,
+    name: true,
+    logoUrl: true,
+    editions: {
+      where: { editionId: edition.id },
+      select: {
+        jobOffers: {
+          select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    },
+  },
+  orderBy: { name: "asc" },
+});
+```
+
+Then flatten so the emitted shape is unchanged — each item still carries a flat `jobOffers` array:
+
+```ts
+return sponsors.map((s) => ({
+  slug: s.slug,
+  name: s.name,
+  logoUrl: s.logoUrl,
+  jobOffers: s.editions.flatMap((e) => e.jobOffers),
+}));
+```
+
+Read the existing handler before editing and preserve whatever ordering and filtering it already applies — this snippet shows the shape of the change, not a licence to drop existing behaviour.
+
+- [ ] **Step 4: Write the new tests for the changed shape**
+
+Append to `src/backend/src/__tests__/public-sponsors.test.ts`. These are new behaviour, so they must fail before Step 1–3 land — if you have already implemented, verify they pass and that mutating the expectation makes them fail.
+
+```ts
+describe("Sponsor detail spans editions (#129)", () => {
+  it("serves a sponsor of a past edition with no tier and no offers", async () => {
+    const past = await prisma.edition.create({ data: { year: 1760 } });
+    const tierId = await tierIdByKey("gold");
+    const sponsor = await createSponsorFixture({
+      name: "Past Only Co",
+      slug: `past-only-${Date.now()}`,
+      editionId: past.id,
+      tierId,
+      publicationStatus: "PUBLISHED",
+    });
+    createdSponsorIds.push(sponsor.id);
+    createdEditionIds.push(past.id);
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: `/api/sponsors/${sponsor.slug}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // Not sponsoring the featured edition: highlight is empty, history remains.
+    expect(body.tier).toBeNull();
+    expect(body.jobOffers).toEqual([]);
+    expect(body.editions).toEqual([1760]);
+  });
+
+  it("highlights the tier of the featured edition", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("platinum");
+    const sponsor = await createSponsorFixture({
+      name: "Current Co",
+      slug: `current-${Date.now()}`,
+      editionId: edition.id,
+      tierId,
+      publicationStatus: "PUBLISHED",
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: `/api/sponsors/${sponsor.slug}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.tier.key).toBe("platinum");
+    expect(body.editions).toContain(edition.year);
+  });
+});
+```
+
+Add `createdEditionIds` tracking and an `afterEach` edition cleanup to this file if it has none, following `sponsor-identity.test.ts`: delete sponsors first, then editions, both unconditionally. Year 1760 sits in this plan's 17xx block, below `getSeededEdition()`'s 2016 floor, so parallel files cannot pick it up (#292).
+
+- [ ] **Step 5: Port the existing fixtures in both test files**
+
+In `public-sponsors.test.ts` and `sponsor-job-offers.test.ts`, replace every `prisma.sponsor.create({ data: { ..., editionId, tierId, publicationStatus } })` with `createSponsorFixture({ ... })` from Task 1. Job-offer creates move from `sponsorId` to `editionSponsorId` — resolve the participation first:
+
+```ts
+const participation = await prisma.editionSponsor.findUniqueOrThrow({
+  where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: edition.id } },
+  select: { id: true },
+});
+await prisma.sponsorJobOffer.create({
+  data: { editionSponsorId: participation.id, title: "Dev", url: "https://example.org/job" },
+});
+```
+
+**Do not change any existing assertion** in these files except where the sponsor-detail shape genuinely changed (`tier`, `editions`). An assertion on `/api/sponsors` or `/api/job-offers` that stops passing means the port is wrong.
+
+- [ ] **Step 6: Run both test files**
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm exec vitest run src/__tests__/public-sponsors.test.ts src/__tests__/sponsor-job-offers.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Search for tests encoding the old 404**
+
+The 404 changed meaning: it no longer fires when there is no featured edition. Check nothing asserts the old behaviour:
+
+```bash
+grep -rn "Sponsor not found\|No edition found" src/__tests__/
+```
+
+For each hit, read the test and confirm it still describes reality. Report any that do not — do **not** silently rewrite an assertion to match new behaviour without saying so in your report.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/backend/src/routes/sponsors.ts src/backend/src/__tests__/public-sponsors.test.ts src/backend/src/__tests__/sponsor-job-offers.test.ts
+git commit -m "feat(sponsor): serve any edition's sponsor, highlight the current"
+```
+
+---
+
+## Task 3: The four peripheral route files
+
+Small, mechanical, and each independently verifiable. Grouped because no one of them is worth its own review gate.
+
+**Files:**
+- Modify: `src/backend/src/routes/speakers.ts`
+- Modify: `src/backend/src/routes/editions.ts`
+- Modify: `src/backend/src/routes/admin/editions.ts`
+- Modify: `src/backend/src/routes/admin/sponsor-tiers.ts`
+- Modify: `src/backend/src/__tests__/editions.test.ts`
+- Modify: `src/backend/src/__tests__/speaker-edition-sponsor.test.ts`
+- Modify: `src/backend/src/__tests__/admin-sponsor-tiers.test.ts`
+
+- [ ] **Step 1: `speakers.ts` — publication of the employer, per year**
+
+`GET /api/speakers/:slug` shows each participation's employer and hides it unless the sponsor is published. `publicationStatus` left the identity, so the question became "published for which year?" — **the year of that participation** (decided with the user). A sponsor in draft for 2019 must not surface on a 2019 card because it is published in 2026.
+
+In the `editions` select, replace the `sponsor` select with one that carries that year's participation:
+
+```ts
+sponsor: {
+  select: {
+    slug: true,
+    name: true,
+    deletedAt: true,
+    // Published for THIS year, not any year: the employer statement is dated
+    // (#353), so its visibility must be too. A to-one relation takes no
+    // `where` in a select, hence the filtered nested list.
+    editions: { select: { editionId: true, publicationStatus: true } },
+  },
+},
+```
+
+Then rewrite the `sponsor:` projection in the returned `participations`:
+
+```ts
+sponsor: (() => {
+  if (!link.sponsor || link.sponsor.deletedAt) return null;
+  const thatYear = link.sponsor.editions.find((e) => e.editionId === link.editionId);
+  return thatYear?.publicationStatus === "PUBLISHED"
+    ? { slug: link.sponsor.slug, name: link.sponsor.name }
+    : null;
+})(),
+```
+
+This needs `editionId` in the outer `editions` select — add it next to `isFeatured` if absent.
+
+- [ ] **Step 2: `editions.ts` — the public per-year sponsor query**
+
+Around line 302 a `prisma.sponsor` query filters on `editionId`, and a `SponsorJobOffer` query filters on `sponsor`. Route both through the participation:
+
+```ts
+// sponsor count / list for the year
+where: { ...notDeleted, editions: { some: { editionId: edition.id, publicationStatus: "PUBLISHED" } } }
+
+// job offers of that year's participations
+where: { editionSponsor: { editionId: edition.id, publicationStatus: "PUBLISHED", sponsor: notDeleted } }
+```
+
+Read the surrounding code and preserve its existing intent — these are the two `where` clauses to fix, not a rewrite of the handler.
+
+- [ ] **Step 3: `admin/editions.ts` — the sponsor counter**
+
+Two `_count` selects name `sponsors`, a relation `Edition` no longer has, and the readback uses `edition._count.sponsors`. The join is `editionSponsors`, and the trash now lives on the identity — so the filter matches the speakers/categories lines directly above:
+
+```ts
+// `editionSponsors` is the EditionSponsor join since #129, same as `speakers`
+// and `categories`: the join row has no deletedAt, so the filter targets the
+// company.
+editionSponsors: { where: { sponsor: notDeleted } },
+```
+
+And at each readback site, `edition._count.sponsors` becomes `edition._count.editionSponsors`. **Keep the emitted field name `sponsorsCount`** — that is the admin API contract and the frontend reads it.
+
+- [ ] **Step 4: `admin/sponsor-tiers.ts` — the tier-in-use check**
+
+Line ~143 asks whether any sponsor uses a tier, via `where: { tierId }` on `Sponsor`. The tier is on the participation now:
+
+```ts
+const inUse = await prisma.editionSponsor.count({ where: { tierId: Number(id) } });
+```
+
+Read the surrounding block: if it also filters on `notDeleted`, express it as `sponsor: notDeleted`.
+
+- [ ] **Step 5: Port the three test files' fixtures**
+
+`editions.test.ts`, `speaker-edition-sponsor.test.ts` and `admin-sponsor-tiers.test.ts` each build a sponsor with a flat `editionId`. Replace with `createSponsorFixture({ ... })` from Task 1. Change no assertion.
+
+- [ ] **Step 6: Typecheck these four route files**
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm typecheck 2>&1 | grep -E "routes/(speakers|editions)\.ts|routes/admin/(editions|sponsor-tiers)\.ts"
+```
+
+Expected: empty.
+
+- [ ] **Step 7: Run the affected tests**
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm exec vitest run src/__tests__/editions.test.ts src/__tests__/speaker-edition-sponsor.test.ts src/__tests__/admin-sponsor-tiers.test.ts src/__tests__/public-speaker-detail.test.ts
+```
+
+Expected: all pass. `public-speaker-detail.test.ts` is included deliberately — it covers the employer projection you changed in Step 1.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/backend/src/routes/speakers.ts src/backend/src/routes/editions.ts src/backend/src/routes/admin/editions.ts src/backend/src/routes/admin/sponsor-tiers.ts src/backend/src/__tests__/editions.test.ts src/backend/src/__tests__/speaker-edition-sponsor.test.ts src/backend/src/__tests__/admin-sponsor-tiers.test.ts
+git commit -m "fix(sponsor): date the employer and tier lookups per edition"
+```
+
+---
+
+## Task 4: Admin sponsor endpoints
+
+The largest task: 412 lines, 12 endpoints. Read the whole file before editing.
+
+**Files:**
+- Modify: `src/backend/src/routes/admin/sponsors.ts`
+- Modify: `src/backend/src/__tests__/admin-sponsor-contacts.test.ts`
+- Modify: `src/backend/src/__tests__/sponsor-contacts.test.ts`
+
+**Interfaces:**
+- Consumes: `createSponsorFixture` from Task 1.
+- Produces: `POST /sponsors` answers **409** `{ error: "sponsor_exists", id: number }` when the slug is taken; `POST /sponsors/:id/editions` and `DELETE /sponsors/:id/editions/:editionId` attach/detach a participation.
+
+- [ ] **Step 1: Split the request body types**
+
+`SponsorCreateBody` mixes identity and participation. Make the split explicit so the handlers cannot confuse them:
+
+```ts
+// Identity — shared across every edition the company sponsors.
+interface SponsorIdentityFields {
+  name: string;
+  logoUrl?: string;
+  websiteUrl?: string;
+  descriptionFr?: string;
+  descriptionEn?: string;
+  socialLinks?: Record<string, string>;
+  contactEmail?: string;
+  locale?: string;
+  standContacts?: StandContact[];
+}
+
+// Participation — bought or tracked for one edition (#129).
+interface SponsorParticipationFields {
+  tierId: number;
+  publicationStatus?: "DRAFT" | "PUBLISHED";
+  comKitReceived?: boolean;
+  comKitLogoWebUrl?: string;
+  comKitLogoPrintUrl?: string;
+  comKitCharterUrl?: string;
+  comKitNotes?: string;
+  platinumPromoIdea?: string;
+  platinumCoBuildIdea?: string;
+}
+
+interface SponsorCreateBody extends SponsorIdentityFields, SponsorParticipationFields {
+  editionId: number;
+}
+
+type SponsorUpdateBody = Partial<Omit<SponsorCreateBody, "editionId">> & { editionId?: number };
+```
+
+`SponsorUpdateBody` keeps an optional `editionId` so a `PUT` can say which participation its per-year fields target.
+
+- [ ] **Step 2: `GET /sponsors` — one row per company**
+
+The list currently filters `editionId` on `Sponsor` and orders by tier. Route it through the join and carry the participations, mirroring the admin speakers list:
+
+```ts
+const sponsors = await prisma.sponsor.findMany({
+  where: {
+    ...notDeleted,
+    ...(editionId ? { editions: { some: { editionId: Number(editionId) } } } : {}),
+  },
+  include: {
+    editions: {
+      ...(editionId ? { where: { editionId: Number(editionId) } } : {}),
+      select: {
+        id: true,
+        publicationStatus: true,
+        edition: { select: { id: true, year: true } },
+        tier: { select: { key: true, nameFr: true, nameEn: true, rank: true } },
+      },
+      orderBy: { edition: { year: "desc" } },
+    },
+  },
+  orderBy: { name: "asc" },
+});
+```
+
+Read what the current handler emits and keep the admin frontend's field names working. Where it emitted a flat `tier`/`publicationStatus`/`edition`, emit them from the participation the admin is looking at — the most recent one when no `editionId` filter is given.
+
+- [ ] **Step 3: `GET /sponsors/:id` — identity plus its participations**
+
+`include: { edition, tier, jobOffers }` no longer resolves. Replace with:
+
+```ts
+include: {
+  editions: {
+    select: {
+      id: true,
+      publicationStatus: true,
+      comKitReceived: true,
+      comKitLogoWebUrl: true,
+      comKitLogoPrintUrl: true,
+      comKitCharterUrl: true,
+      comKitNotes: true,
+      platinumPromoIdea: true,
+      platinumCoBuildIdea: true,
+      edition: { select: { id: true, year: true } },
+      tier: { select: { key: true, nameFr: true, nameEn: true, rank: true } },
+      jobOffers: { orderBy: { createdAt: "asc" } },
+    },
+    orderBy: { edition: { year: "desc" } },
+  },
+},
+```
+
+- [ ] **Step 4: `POST /sponsors` — create identity + participation, 409 on a taken slug**
+
+The slug is globally unique now, so `uniqueSlug` against a per-edition set is wrong: silently minting `acme-2` would recreate the duplicates #129 removed. Answer 409 and let the admin attach instead.
+
+```ts
+const slug = slugify(body.name);
+
+// Globally unique since #129. A taken slug means the company already exists:
+// offer to attach a participation rather than minting acme-2 and recreating
+// the duplicates the model was changed to remove. Deliberately NOT filtered on
+// deletedAt — a trashed company still owns its slug until purged.
+const clash = await prisma.sponsor.findUnique({ where: { slug }, select: { id: true } });
+if (clash) {
+  return reply.code(409).send({ error: "sponsor_exists", id: clash.id });
+}
+
+const sponsor = await prisma.sponsor.create({
+  include: {
+    editions: {
+      select: { id: true, edition: { select: { id: true, year: true } }, tier: { select: { key: true, nameFr: true, nameEn: true, rank: true } } },
+    },
+  },
+  data: {
+    slug,
+    name: body.name.trim(),
+    logoUrl: body.logoUrl || null,
+    websiteUrl: body.websiteUrl || null,
+    descriptionFr: sanitizeRichHtml(body.descriptionFr) || null,
+    descriptionEn: sanitizeRichHtml(body.descriptionEn) || null,
+    socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
+    contactEmail: body.contactEmail || null,
+    locale: normalizeLocale(body.locale),
+    standContacts: body.standContacts?.length ? JSON.stringify(body.standContacts) : null,
+    editions: {
+      create: [{
+        editionId: body.editionId,
+        tierId: body.tierId,
+        publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
+        comKitReceived: body.comKitReceived ?? false,
+        comKitLogoWebUrl: body.comKitLogoWebUrl || null,
+        comKitLogoPrintUrl: body.comKitLogoPrintUrl || null,
+        comKitCharterUrl: body.comKitCharterUrl || null,
+        comKitNotes: body.comKitNotes || null,
+        platinumPromoIdea: body.platinumPromoIdea || null,
+        platinumCoBuildIdea: body.platinumCoBuildIdea || null,
+      }],
+    },
+  },
+});
+```
+
+Keep the existing `400` on missing `editionId`/`name`/`tierId` and the `422` on an invalid `tierId`, both unchanged.
+
+- [ ] **Step 5: `PUT /sponsors/:id` — identity fields vs participation fields**
+
+Write identity fields on `Sponsor`, per-year fields on the participation. Resolve which participation from `body.editionId`, falling back to the most recent:
+
+```ts
+const target = body.editionId
+  ? await prisma.editionSponsor.findUnique({
+      where: { sponsorId_editionId: { sponsorId: id, editionId: body.editionId } },
+      select: { id: true },
+    })
+  : await prisma.editionSponsor.findFirst({
+      where: { sponsorId: id },
+      orderBy: { edition: { year: "desc" } },
+      select: { id: true },
+    });
+```
+
+Then update each side only with the fields the body actually carries, preserving the existing "only touch what was sent" behaviour. If a per-year field is sent and `target` is null, answer `422` — there is no year to write it to.
+
+- [ ] **Step 6: `POST /sponsors/bulk` — target participations**
+
+The bulk status action sets `publicationStatus`, now on the participation. Require an `editionId` in the body so the action cannot silently touch editions the admin is not looking at (the guard #351 established for speakers):
+
+```ts
+interface SponsorBulkBody {
+  ids: number[];
+  action: "setStatus";
+  value: "DRAFT" | "PUBLISHED";
+  editionId: number;
+}
+```
+
+```ts
+if (!body.editionId) {
+  return reply.code(400).send({ error: "editionId is required: status is per edition" });
+}
+const { count } = await prisma.editionSponsor.updateMany({
+  where: { sponsorId: { in: body.ids }, editionId: body.editionId },
+  data: { publicationStatus: body.value },
+});
+```
+
+- [ ] **Step 7: Add attach / detach endpoints**
+
+```ts
+// POST /api/admin/sponsors/:id/editions — attach a participation (#129).
+app.post<{ Params: SponsorIdParams; Body: { editionId: number; tierId: number } }>(
+  "/sponsors/:id/editions",
+  { schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } } },
+  async (request, reply) => {
+    const sponsorId = Number(request.params.id);
+    const { editionId, tierId } = request.body;
+    if (!editionId || !tierId) {
+      return reply.code(400).send({ error: "editionId and tierId are required" });
+    }
+    const participation = await prisma.editionSponsor.upsert({
+      where: { sponsorId_editionId: { sponsorId, editionId } },
+      create: { sponsorId, editionId, tierId, publicationStatus: "DRAFT" },
+      update: { tierId },
+      select: { id: true, editionId: true, tierId: true, publicationStatus: true },
+    });
+    revalidateSponsors();
+    return participation;
+  },
+);
+
+// DELETE /api/admin/sponsors/:id/editions/:editionId — detach a participation.
+// The company itself survives: the trash operates on the identity.
+app.delete<{ Params: SponsorIdParams & { editionId: string } }>(
+  "/sponsors/:id/editions/:editionId",
+  {
+    schema: {
+      params: {
+        type: "object",
+        required: ["id", "editionId"],
+        properties: { id: { type: "string" }, editionId: { type: "string" } },
+      },
+    },
+  },
+  async (request, reply) => {
+    const { count } = await prisma.editionSponsor.deleteMany({
+      where: { sponsorId: Number(request.params.id), editionId: Number(request.params.editionId) },
+    });
+    if (!count) return notFound(reply, "Participation not found");
+    revalidateSponsors();
+    return reply.code(204).send();
+  },
+);
+```
+
+- [ ] **Step 8: Leave the contact endpoints alone**
+
+`/contacts`, `/contacts/:contactId/resend`, `/lock`, and the contact `DELETE` operate on `SponsorContact`, which stayed on the identity. If one of them fails to typecheck, it is because of a shared helper — fix that, not the endpoint's logic.
+
+- [ ] **Step 9: Port the two contact test files**
+
+`admin-sponsor-contacts.test.ts` and `sponsor-contacts.test.ts` build sponsors with a flat `editionId`. Use `createSponsorFixture`. Change no assertion — contact behaviour did not change.
+
+- [ ] **Step 10: Typecheck and run the admin tests**
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm typecheck 2>&1 | grep "admin/sponsors"
+```
+Expected: empty.
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm exec vitest run src/__tests__/admin-sponsor-contacts.test.ts src/__tests__/sponsor-contacts.test.ts
+```
+Expected: all pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/backend/src/routes/admin/sponsors.ts src/backend/src/__tests__/admin-sponsor-contacts.test.ts src/backend/src/__tests__/sponsor-contacts.test.ts
+git commit -m "feat(admin): edit a sponsor identity and its participations"
+```
+
+---
+
+## Task 5: Magic-link sponsor editing
+
+**Files:**
+- Modify: `src/backend/src/routes/edit.ts`
+- Modify: `src/backend/src/__tests__/edit-sponsor-platinum.test.ts`
+- Modify: `src/backend/src/__tests__/edit-sponsor-private.test.ts`
+- Modify: `src/backend/src/__tests__/edit-sponsor-description.test.ts`
+- Modify: `src/backend/src/__tests__/edit-social-bluesky.test.ts`
+- Modify: `src/backend/src/__tests__/edit-upload.test.ts`
+- Modify: `src/backend/src/__tests__/edit-talk-update.test.ts`
+
+**Interfaces:**
+- Consumes: `createSponsorWithToken` from Task 1.
+
+- [ ] **Step 1: Understand what does and does not change**
+
+The token still resolves on `SponsorContact` → `Sponsor` (identity), untouched since #250. What breaks is the **fields** the handler reads and writes: `platinumPromoIdea`, `comKit*` and `publicationStatus` moved to the participation, while `logoUrl`, descriptions, `socialLinks` and `standContacts` stayed on the identity.
+
+Read the sponsor branch of `edit.ts` (around lines 310 and 561) and classify every field it touches against that split before editing.
+
+- [ ] **Step 2: Resolve the editable participation**
+
+A sponsor editing its page edits the **current** edition — that is what the link is for. Resolve the featured edition's participation once, next to where the contact is resolved:
+
+```ts
+// Per-year fields live on the participation since #129. A modification link
+// edits the current edition: that is the year the sponsor was contacted about.
+const edition = await getFeaturedEdition();
+const participation = edition
+  ? await prisma.editionSponsor.findUnique({
+      where: { sponsorId_editionId: { sponsorId: entity.id, editionId: edition.id } },
+      select: { id: true, platinumPromoIdea: true, platinumCoBuildIdea: true, comKitReceived: true, comKitLogoWebUrl: true, comKitLogoPrintUrl: true, comKitCharterUrl: true, comKitNotes: true, tier: { select: { key: true } } },
+    })
+  : null;
+```
+
+- [ ] **Step 3: Read and write the per-year fields through the participation**
+
+Where the GET projected `sponsor.platinumPromoIdea` / `comKit*`, read them from `participation`. Where the PUT wrote them via `prisma.sponsor.update`, write them with `prisma.editionSponsor.update({ where: { id: participation.id }, data: { ... } })`. Identity fields keep using `prisma.sponsor.update`.
+
+The Platinum block is conditional on the tier (#252): read the tier from `participation.tier.key`, not from the sponsor.
+
+If `participation` is null — no featured edition, or the company does not sponsor it — the per-year fields read as empty and a write to them answers `422`. There is no year to write to, and silently writing to last year's participation would be worse.
+
+- [ ] **Step 4: Port the six test files' fixtures**
+
+All six call `createSponsorWithToken` with a flat `editionId`/`tierId`, which Task 1's `SponsorFixture` already accepts — most will need no change beyond removing an explicit `Prisma.SponsorUncheckedCreateInput` annotation if one is present. Where a test asserts on a per-year field, it must now create the participation on the **featured** edition for the handler to find it.
+
+Change assertions only where the per-year/identity split genuinely moved the behaviour, and say so in your report.
+
+- [ ] **Step 5: Typecheck and run the edit tests**
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm typecheck 2>&1 | grep "routes/edit.ts"
+```
+Expected: empty.
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm exec vitest run src/__tests__/edit-sponsor-platinum.test.ts src/__tests__/edit-sponsor-private.test.ts src/__tests__/edit-sponsor-description.test.ts src/__tests__/edit-social-bluesky.test.ts src/__tests__/edit-upload.test.ts src/__tests__/edit-talk-update.test.ts
+```
+Expected: all pass.
+
+- [ ] **Step 6: Full backend suite**
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm typecheck
+```
+Expected: **clean, zero errors.** This is the moment the backend is whole again.
+
+```bash
+DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest" pnpm test
+```
+Expected: every test passes. If a test outside the sponsor area fails, stop and report — it means the port reached further than intended.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/backend/src/routes/edit.ts src/backend/src/__tests__/edit-sponsor-platinum.test.ts src/backend/src/__tests__/edit-sponsor-private.test.ts src/backend/src/__tests__/edit-sponsor-description.test.ts src/backend/src/__tests__/edit-social-bluesky.test.ts src/backend/src/__tests__/edit-upload.test.ts src/backend/src/__tests__/edit-talk-update.test.ts
+git commit -m "feat(edit): sponsor per-year fields live on the participation"
+```
+
+---
+
+## Task 6: The public sponsor page
+
+Pulled into #130 rather than left to #132: the contract changes here, so the consumer changes with it.
+
+**A correction to the spec's premise, verified before writing this task:** the page **never reads `sponsor.tier`**. It renders `name`, `logoUrl`, the descriptions, `speakers` and `jobOffers` — no tier block exists today. So making `tier` nullable breaks nothing, and the "broken in-between state" the spec worried about does not arise. The real work here is the type change plus the new year tags.
+
+That also means the tier is currently shown **only** on the sponsor wall (`/api/sponsors`), which is exactly where the spec's temporal rule says it belongs. No tier UI needs adding or guarding.
+
+**Files:**
+- Modify: `src/frontend/src/lib/types.ts`
+- Modify: `src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx`
+
+**Interfaces:**
+- Consumes: the `/api/sponsors/:slug` shape from Task 2 — `tier: SponsorTierRef | null`, `editions: number[]`.
+
+- [ ] **Step 1: Update the contract**
+
+In `src/frontend/src/lib/types.ts`, `interface SponsorDetail`:
+
+```ts
+  // Null unless the company sponsors the featured edition (#129): the tier is
+  // a per-year fact. Shown on the sponsor wall, not on this page.
+  tier: SponsorTierRef | null;
+  // Years the company sponsored, newest first. Rendered as tags linking to
+  // each edition's page.
+  editions: number[];
+```
+
+- [ ] **Step 2: Confirm the page needs no tier guard**
+
+```bash
+grep -n "tier" "src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx"
+```
+
+Expected: **no output.** If this prints anything, the file changed since this plan was written — guard each use with the file's existing `{cond && (...)}` style, and say so in your report. Do not invent a placeholder like "Ancien sponsor": absence of a tier means absence of a tier block.
+
+- [ ] **Step 3: Render the year tags**
+
+Add a tag list for `sponsor.editions`, each linking to that edition. Use the localized `Link` from `@/i18n/navigation` (not `next/link`) — the routes are locale-prefixed:
+
+```tsx
+{sponsor.editions.length > 0 && (
+  <ul className="mt-6 flex flex-wrap gap-2">
+    {sponsor.editions.map((year) => (
+      <li key={year}>
+        <Link
+          href={`/editions/${year}`}
+          className="rounded-[12px] bg-blanc-casse px-3 py-1 text-sm text-gris hover:text-noir transition-colors"
+        >
+          {year}
+        </Link>
+      </li>
+    ))}
+  </ul>
+)}
+```
+
+Match the surrounding file's Tailwind vocabulary — reuse its existing colour and radius tokens rather than the ones above if they differ. The project uses `rounded-[12px]` for all-corner radius (`rounded-s` is logical/start-side only in Tailwind v4).
+
+- [ ] **Step 4: Typecheck, lint and build the frontend**
+
+From `src/frontend`:
+
+```bash
+pnpm exec tsc --noEmit
+pnpm lint
+pnpm build
+```
+
+Expected: all clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/lib/types.ts "src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx"
+git commit -m "feat(sponsors): show the current tier, past years as tags"
+```
+
+---
+
+## Verification Before Opening the PR
+
+Run these and paste the real output into the PR description. Do not claim a step passed without having run it.
+
+- [ ] Backend `pnpm typecheck` — **zero errors**
+- [ ] Backend `pnpm test` — every test passes
+- [ ] Frontend `pnpm exec tsc --noEmit`, `pnpm lint`, `pnpm build` — clean
+- [ ] `pnpm exec tsx prisma/seed-dev.ts` twice in a row — both clean, sponsor counts stable
+- [ ] Browser check on the local Docker stack (`.claude/rules/testing.md` step 3), via Chrome DevTools MCP:
+  - `/fr/sponsors` — the wall renders, grouped by tier, unchanged from before
+  - `/fr/sponsors/<slug>` for a **current** sponsor — tier highlighted, offers listed if any
+  - `/fr/sponsors/<slug>` for a **past-only** sponsor — no tier block, year tags present and clickable
+  - `/fr/offres-emploi-partenaires` — unchanged
+  - `/fr/admin/sponsors` — list renders, one row per company
+  - console clean on each
+
+The browser pass is not optional: three of these behaviours (nullable tier, year tags, admin list) have no automated coverage of their rendering.
+
+---
+
+## Status
+
+_Filled in during execution._

--- a/docs/superpowers/plans/2026-07-29-sponsor-backend.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-backend.md
@@ -901,6 +901,10 @@ git commit -m "feat(admin): edit a sponsor identity and its participations"
 - Modify: `src/backend/src/__tests__/edit-social-bluesky.test.ts`
 - Modify: `src/backend/src/__tests__/edit-upload.test.ts`
 - Modify: `src/backend/src/__tests__/edit-talk-update.test.ts`
+- Modify: `src/frontend/src/app/edit/[token]/SponsorPrivateSection.tsx` — **the consumer of the contract this task changes**
+- Modify: `src/frontend/src/app/edit/[token]/page.tsx` — handles the new 422
+
+> **This task changes a public API contract, so its consumer moves with it.** Making `private.tier` nullable while the frontend still declares it non-nullable does not fail `typecheck` — the two sides are compiled separately, so the stale frontend type hides the mismatch until a real sponsor hits it at runtime. That is why these two frontend files are in scope here and not left to Task 6: a contract change and its consumer belong in the same commit.
 
 **Interfaces:**
 - Consumes: `createSponsorWithToken` from Task 1.
@@ -927,6 +931,8 @@ const participation = edition
   : null;
 ```
 
+> **The job-offer routes (`POST`/`PUT`/`DELETE /edit/:token/job-offers*`) need the same rework** — they read `entity.tier` and `entity.jobOffers` too. Load the offers through the resolved participation, so the list a handler searches is already scoped to this sponsor AND this year. That scoping IS the authorization check: `find(o => o.id === offerId)` over a pre-filtered list makes both cross-sponsor and cross-year writes impossible, and no unvalidated `offerId` ever reaches Prisma. **Keep that `select` narrow.** Widening it later — say, hoisting `jobOffers` up to a `sponsor.editions` include — silently reopens cross-year writes, and no current test would catch it.
+
 - [ ] **Step 3: Read and write the per-year fields through the participation**
 
 Where the GET projected `sponsor.platinumPromoIdea` / `comKit*`, read them from `participation`. Where the PUT wrote them via `prisma.sponsor.update`, write them with `prisma.editionSponsor.update({ where: { id: participation.id }, data: { ... } })`. Identity fields keep using `prisma.sponsor.update`.
@@ -934,6 +940,13 @@ Where the GET projected `sponsor.platinumPromoIdea` / `comKit*`, read them from 
 The Platinum block is conditional on the tier (#252): read the tier from `participation.tier.key`, not from the sponsor.
 
 If `participation` is null — no featured edition, or the company does not sponsor it — the per-year fields read as empty and a write to them answers `422`. There is no year to write to, and silently writing to last year's participation would be worse.
+
+**Both halves of that null case need a frontend counterpart**, and neither is optional:
+
+- **`tier` becomes nullable.** `SponsorPrivateSection.tsx` declares it non-nullable and dereferences it bare (`initial.tier.allowsPromoIdeas`). Widen the type and use `initial.tier?.allowsPromoIdeas ?? false`. Without this, a sponsor of a past edition clicking a still-valid link gets a `TypeError` that kills the entire page — including the identity fields the route would have served and saved perfectly well.
+- **The `422` needs a handler.** `page.tsx` maps unknown error codes to `"blocked"`, which replaces the form with "les modifications sont clôturées" and discards whatever was typed. Handle `no_current_participation` explicitly, with a message saying the per-year fields are unavailable because the company does not sponsor the current edition — and **do not destroy the form or the entered values**.
+
+Only write per-year fields when the body actually carries one. An identity-only save with a non-null participation would otherwise run `editionSponsor.update` with `data: {}`, bumping `@updatedAt` and costing a round-trip for nothing.
 
 - [ ] **Step 4: Port the six test files' fixtures**
 

--- a/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
@@ -1,0 +1,694 @@
+# Sponsor Identity — Schema & Migration (#129) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `Sponsor` into a global identity plus an `EditionSponsor` participation row, so one company sponsoring N editions is one row plus N participations.
+
+**Architecture:** Mirrors the `Speaker`/`SpeakerEdition` split delivered by #351, but **without any deduplication step** — no sponsor exists on more than one edition today, so the migration is a mechanical 1-for-1 transform. `SponsorJobOffer` moves to the participation; `SponsorContact` stays on the identity.
+
+**Tech Stack:** Prisma 7 (config-first, `prisma.config.ts`), PostgreSQL, Fastify, Vitest, TypeScript ESM (`.js` import specifiers).
+
+**Spec:** [2026-07-29-sponsor-identity-design.md](../specs/2026-07-29-sponsor-identity-design.md)
+
+## Global Constraints
+
+- **Scope is PR 1 of 4.** This plan delivers the schema and migration only. Rewriting the API consumers is #130, admin front #131, public front #132. At the end of this plan the app must still build and all existing tests must pass.
+- **Language:** code, comments and commit messages in **English**. Communication with the user in French.
+- **Commits:** Conventional Commits, subject under 72 chars. Stage named files only — never `git add .` or `git add -A`. One git command per Bash call, never chained with `&&`, never `git -C`.
+- **Branch:** work on `feature/us-129-sponsor-identity` (already created, holds the design doc commit).
+- **Prisma 7:** the generated client lives in `src/backend/src/generated/prisma/` and is gitignored. Always `pnpm db:generate` after editing the schema. Migration commands read `prisma.config.ts`.
+- **Backend commands run from `src/backend/`.** Tests against a live Postgres. From the host, prefix `DATABASE_URL` pointing at `localhost:5432`, otherwise ~44 tests fail with 500s.
+- **Do not add backwards-compatibility shims.** No renaming to `_unused`, no re-exporting dead types. If something is unused, delete it.
+- **Migration must never silently lose rows.** Every destructive step is preceded by an explicit guard that fails loudly.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/backend/prisma/schema.prisma` | Modify: `Sponsor` loses its per-edition fields, gains `slug @unique`; new `EditionSponsor` model; `SponsorJobOffer` repointed |
+| `src/backend/prisma/migrations/20260729xxxxxx_sponsor_identity/migration.sql` | Create: the hand-written migration with its guard and invariants |
+| `src/backend/src/__tests__/sponsor-identity.test.ts` | Create: locks the new model's invariants |
+| `src/backend/prisma/seed-dev.ts` | Modify: create identity + participation |
+
+`src/backend/src/routes/**` is **deliberately untouched** in this PR — see Task 5.
+
+---
+
+## Task 1: Add EditionSponsor to the Prisma schema
+
+**Files:**
+- Modify: `src/backend/prisma/schema.prisma` (models `Sponsor`, `SponsorJobOffer`)
+
+**Interfaces:**
+- Produces: model `EditionSponsor` with fields `id`, `editionId`, `sponsorId`, `tierId`, `publicationStatus`, `comKitReceived`, `comKitLogoWebUrl`, `comKitLogoPrintUrl`, `comKitCharterUrl`, `comKitNotes`, `platinumPromoIdea`, `platinumCoBuildIdea`, `createdAt`, `updatedAt`; unique on `(sponsorId, editionId)`. `Sponsor.slug` becomes `@unique`. `SponsorJobOffer.editionSponsorId` replaces `sponsorId`.
+
+- [ ] **Step 1: Read the current models before editing**
+
+Read `src/backend/prisma/schema.prisma` and locate `model Sponsor`, `model SponsorContact`, `model SponsorJobOffer`. Note the exact field list — the migration in Task 2 must match it.
+
+- [ ] **Step 2: Edit `model Sponsor`**
+
+Remove these lines from `model Sponsor`:
+
+```prisma
+  publicationStatus   PublicationStatus @default(DRAFT)
+  editionId Int
+  edition   Edition @relation(fields: [editionId], references: [id], onDelete: Cascade)
+  tierId Int
+  tier   SponsorTier @relation(fields: [tierId], references: [id])
+  comKitReceived      Boolean           @default(false)
+  comKitLogoWebUrl    String?
+  comKitLogoPrintUrl  String?
+  comKitCharterUrl    String?
+  comKitNotes         String?
+  platinumPromoIdea   String?
+  platinumCoBuildIdea String?
+  jobOffers SponsorJobOffer[]
+  @@unique([editionId, slug])
+  @@index([editionId])
+  @@index([tierId])
+```
+
+Change the slug line to:
+
+```prisma
+  // Globally unique since #129: a slug identifies a company, not a
+  // participation. Same rule as Speaker.slug (#351).
+  slug          String       @unique
+```
+
+Add to `model Sponsor`:
+
+```prisma
+  editions EditionSponsor[]
+```
+
+Keep on `Sponsor`: `name`, `logoUrl`, `websiteUrl`, `descriptionFr`, `descriptionEn`, `socialLinks`, `contactEmail`, `standContacts`, `locale`, `createdAt`, `updatedAt`, `deletedAt`, `speakers`, `contacts`, `@@index([deletedAt])`.
+
+- [ ] **Step 3: Add the EditionSponsor model**
+
+Insert after `model Sponsor`:
+
+```prisma
+// Which editions a company sponsored (#129), and on what terms that year.
+// The identity/participation split of SpeakerEdition (#351), EditionCategory
+// (#338) and EditionSponsorTier (#316).
+//
+// The tier is bought per edition, and so is everything the organisers track
+// while preparing it: the communication kit and the Platinum promo ideas.
+// standContacts deliberately stays on Sponsor — the booth team only matters
+// for scanning during the event, so its history has no value.
+// Pure join row: the trash operates on the Sponsor identity, so no soft delete.
+model EditionSponsor {
+  id                Int               @id @default(autoincrement())
+  publicationStatus PublicationStatus @default(DRAFT)
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+
+  sponsorId Int
+  sponsor   Sponsor @relation(fields: [sponsorId], references: [id], onDelete: Cascade)
+  editionId Int
+  edition   Edition @relation(fields: [editionId], references: [id], onDelete: Cascade)
+
+  // Sponsoring tier from the shared catalogue (#317), bought for this edition.
+  tierId Int
+  tier   SponsorTier @relation(fields: [tierId], references: [id])
+
+  // --- Private fields (#249) — organizers only, NEVER exposed publicly ---
+  comKitReceived      Boolean @default(false)
+  comKitLogoWebUrl    String?
+  comKitLogoPrintUrl  String?
+  comKitCharterUrl    String?
+  comKitNotes         String?
+  // Platinum-only promotional content ideas (#252).
+  platinumPromoIdea   String?
+  platinumCoBuildIdea String?
+
+  // Job offers are dated by nature and their quota depends on this year's
+  // tier (#251), so they hang off the participation, not the company.
+  jobOffers SponsorJobOffer[]
+
+  @@unique([sponsorId, editionId])
+  @@index([sponsorId])
+  @@index([editionId])
+  @@index([tierId])
+}
+```
+
+- [ ] **Step 4: Repoint SponsorJobOffer**
+
+In `model SponsorJobOffer`, replace:
+
+```prisma
+  sponsorId Int
+  sponsor   Sponsor @relation(fields: [sponsorId], references: [id], onDelete: Cascade)
+
+  @@index([sponsorId])
+```
+
+with:
+
+```prisma
+  editionSponsorId Int
+  editionSponsor   EditionSponsor @relation(fields: [editionSponsorId], references: [id], onDelete: Cascade)
+
+  @@index([editionSponsorId])
+```
+
+- [ ] **Step 5: Add the back-relations**
+
+In `model Edition`, add next to the other participation lists:
+
+```prisma
+  editionSponsors EditionSponsor[]
+```
+
+In `model SponsorTier`, add:
+
+```prisma
+  editionSponsors EditionSponsor[]
+```
+
+- [ ] **Step 6: Verify the schema is valid**
+
+Run from `src/backend`:
+
+```bash
+pnpm exec prisma validate
+```
+
+Expected: `The schema at prisma/schema.prisma is valid 🚀`
+
+If it reports a missing back-relation, add the corresponding array field to the named model — do not silence it by making a relation optional.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/backend/prisma/schema.prisma
+git commit -m "feat(sponsor): split identity from per-edition participation"
+```
+
+---
+
+## Task 2: Write the migration
+
+**Files:**
+- Create: `src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql`
+
+**Interfaces:**
+- Consumes: the schema from Task 1.
+- Produces: a migration that creates `EditionSponsor`, backfills one row per sponsor, repoints `SponsorJobOffer`, and drops the moved columns.
+
+- [ ] **Step 1: Create the migration directory and file**
+
+Create `src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql` with this exact content:
+
+```sql
+-- Sponsor becomes a global identity (#129).
+--
+-- Sponsor carried a mandatory editionId and a per-edition unique slug, so a
+-- company sponsoring several editions would exist as several unlinked rows.
+-- Sponsor becomes the company, EditionSponsor carries the participation and
+-- everything bought or tracked for that year -- the same split as
+-- SpeakerEdition (#351), EditionCategory (#338) and EditionSponsorTier (#316).
+--
+-- NOT destructive in the #351 sense: no sponsor exists on more than one
+-- edition today, so there is nothing to fold and no row is deleted. Every
+-- Sponsor produces exactly one EditionSponsor.
+--
+-- Invariants to check on both sides:
+--   SELECT count(*) FROM "Sponsor";           -- unchanged
+--   SELECT count(*) FROM "EditionSponsor";    -- equals the above
+--   SELECT count(*) FROM "SponsorJobOffer";   -- unchanged
+--   SELECT count(*) FROM "SponsorContact";    -- unchanged
+
+-- ---------------------------------------------------------------------------
+-- 0. GUARD. Step 5 creates a global unique index on Sponsor.slug. If two
+--    editions ever shared a slug, that index would fail with a violation that
+--    says nothing useful. Fail here instead, naming the problem.
+--
+--    This cannot happen with today's data (every sponsor is on one edition).
+--    It is checked rather than assumed: the #351 migration's hardest bug came
+--    from a cascade nobody had verified.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  dup_count INTEGER;
+  dup_list  TEXT;
+BEGIN
+  SELECT count(*), string_agg(slug, ', ')
+  INTO dup_count, dup_list
+  FROM (SELECT "slug" FROM "Sponsor" GROUP BY "slug" HAVING count(*) > 1) d;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION
+      'Cannot make Sponsor.slug globally unique: % slug(s) used by more than one sponsor (%). Merge them before migrating.',
+      dup_count, dup_list;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 1. The join table.
+-- ---------------------------------------------------------------------------
+CREATE TABLE "EditionSponsor" (
+  "id" SERIAL PRIMARY KEY,
+  "publicationStatus" "PublicationStatus" NOT NULL DEFAULT 'DRAFT',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "sponsorId" INTEGER NOT NULL,
+  "editionId" INTEGER NOT NULL,
+  "tierId" INTEGER NOT NULL,
+  "comKitReceived" BOOLEAN NOT NULL DEFAULT false,
+  "comKitLogoWebUrl" TEXT,
+  "comKitLogoPrintUrl" TEXT,
+  "comKitCharterUrl" TEXT,
+  "comKitNotes" TEXT,
+  "platinumPromoIdea" TEXT,
+  "platinumCoBuildIdea" TEXT
+);
+
+CREATE UNIQUE INDEX "EditionSponsor_sponsorId_editionId_key" ON "EditionSponsor"("sponsorId", "editionId");
+CREATE INDEX "EditionSponsor_sponsorId_idx" ON "EditionSponsor"("sponsorId");
+CREATE INDEX "EditionSponsor_editionId_idx" ON "EditionSponsor"("editionId");
+CREATE INDEX "EditionSponsor_tierId_idx" ON "EditionSponsor"("tierId");
+
+ALTER TABLE "EditionSponsor"
+  ADD CONSTRAINT "EditionSponsor_sponsorId_fkey" FOREIGN KEY ("sponsorId") REFERENCES "Sponsor"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "EditionSponsor"
+  ADD CONSTRAINT "EditionSponsor_editionId_fkey" FOREIGN KEY ("editionId") REFERENCES "Edition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "EditionSponsor"
+  ADD CONSTRAINT "EditionSponsor_tierId_fkey" FOREIGN KEY ("tierId") REFERENCES "SponsorTier"("id") ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 2. One participation per existing sponsor, carrying the per-edition state.
+--    Trashed sponsors included: the trash lives on the identity, and restoring
+--    one must restore a company that still belongs to its edition.
+-- ---------------------------------------------------------------------------
+INSERT INTO "EditionSponsor" (
+  "sponsorId", "editionId", "tierId", "publicationStatus",
+  "comKitReceived", "comKitLogoWebUrl", "comKitLogoPrintUrl",
+  "comKitCharterUrl", "comKitNotes", "platinumPromoIdea",
+  "platinumCoBuildIdea", "updatedAt"
+)
+SELECT
+  s."id", s."editionId", s."tierId", s."publicationStatus",
+  s."comKitReceived", s."comKitLogoWebUrl", s."comKitLogoPrintUrl",
+  s."comKitCharterUrl", s."comKitNotes", s."platinumPromoIdea",
+  s."platinumCoBuildIdea", CURRENT_TIMESTAMP
+FROM "Sponsor" s;
+
+-- ---------------------------------------------------------------------------
+-- 3. Job offers hang off the participation. The column is added nullable,
+--    backfilled, then made NOT NULL -- an offer with no participation would
+--    mean step 2 missed a sponsor, so the SET NOT NULL is the check.
+-- ---------------------------------------------------------------------------
+ALTER TABLE "SponsorJobOffer" ADD COLUMN "editionSponsorId" INTEGER;
+
+UPDATE "SponsorJobOffer" o
+SET "editionSponsorId" = es."id"
+FROM "EditionSponsor" es
+WHERE es."sponsorId" = o."sponsorId";
+
+ALTER TABLE "SponsorJobOffer" ALTER COLUMN "editionSponsorId" SET NOT NULL;
+
+ALTER TABLE "SponsorJobOffer" DROP CONSTRAINT IF EXISTS "SponsorJobOffer_sponsorId_fkey";
+DROP INDEX IF EXISTS "SponsorJobOffer_sponsorId_idx";
+ALTER TABLE "SponsorJobOffer" DROP COLUMN "sponsorId";
+
+CREATE INDEX "SponsorJobOffer_editionSponsorId_idx" ON "SponsorJobOffer"("editionSponsorId");
+ALTER TABLE "SponsorJobOffer"
+  ADD CONSTRAINT "SponsorJobOffer_editionSponsorId_fkey" FOREIGN KEY ("editionSponsorId") REFERENCES "EditionSponsor"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 4. The edition link and the per-edition fields now live on the join.
+--    Index names taken from the live schema, not guessed.
+-- ---------------------------------------------------------------------------
+DROP INDEX IF EXISTS "Sponsor_editionId_idx";
+DROP INDEX IF EXISTS "Sponsor_tierId_idx";
+DROP INDEX IF EXISTS "Sponsor_editionId_slug_key";
+ALTER TABLE "Sponsor" DROP CONSTRAINT IF EXISTS "Sponsor_editionId_fkey";
+ALTER TABLE "Sponsor" DROP CONSTRAINT IF EXISTS "Sponsor_tierId_fkey";
+ALTER TABLE "Sponsor" DROP COLUMN "editionId";
+ALTER TABLE "Sponsor" DROP COLUMN "tierId";
+ALTER TABLE "Sponsor" DROP COLUMN "publicationStatus";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitReceived";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitLogoWebUrl";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitLogoPrintUrl";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitCharterUrl";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitNotes";
+ALTER TABLE "Sponsor" DROP COLUMN "platinumPromoIdea";
+ALTER TABLE "Sponsor" DROP COLUMN "platinumCoBuildIdea";
+
+-- ---------------------------------------------------------------------------
+-- 5. A slug now identifies a company globally.
+-- ---------------------------------------------------------------------------
+CREATE UNIQUE INDEX "Sponsor_slug_key" ON "Sponsor"("slug");
+```
+
+- [ ] **Step 2: Record the row counts BEFORE applying**
+
+Run against the dev database and write the four numbers down — they are the invariants:
+
+```bash
+docker compose exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"SponsorJobOffer\") AS offers, (SELECT count(*) FROM \"SponsorContact\") AS contacts;"
+```
+
+If the container or credentials differ, read `docker-compose.yml` for the service name and `POSTGRES_USER`/`POSTGRES_DB` rather than guessing.
+
+- [ ] **Step 3: Apply the migration**
+
+From `src/backend`:
+
+```bash
+pnpm exec prisma migrate deploy
+```
+
+Expected: `1 migration found` then `Applying migration '20260729120000_sponsor_identity'` and no error.
+
+If it fails on the step-0 guard, that is the guard doing its job: two sponsors share a slug and must be merged by hand before retrying. Do not weaken the guard.
+
+- [ ] **Step 4: Verify the invariants**
+
+```bash
+docker compose exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"EditionSponsor\") AS participations, (SELECT count(*) FROM \"SponsorJobOffer\") AS offers, (SELECT count(*) FROM \"SponsorContact\") AS contacts;"
+```
+
+Expected: `sponsors` = `participations` = the pre-migration sponsor count; `offers` and `contacts` unchanged from Step 2.
+
+If `participations` is lower than `sponsors`, step 2 of the SQL skipped rows — stop and investigate before going further. Do not "fix" it by re-running the INSERT.
+
+- [ ] **Step 5: Regenerate the Prisma client**
+
+```bash
+pnpm db:generate
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql
+git commit -m "feat(sponsor): migrate to identity plus edition participation"
+```
+
+---
+
+## Task 3: Lock the model with tests
+
+**Files:**
+- Create: `src/backend/src/__tests__/sponsor-identity.test.ts`
+
+**Interfaces:**
+- Consumes: `prisma` from `../lib/prisma.js`, `getSeededEdition()` from `./edition-test-helpers.js`, `tierIdByKey(key: string): Promise<number>` from `./sponsor-test-helpers.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/backend/src/__tests__/sponsor-identity.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from "vitest";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+import { tierIdByKey } from "./sponsor-test-helpers.js";
+
+// #129 — a sponsor is a company, not a per-edition row. The slug is global and
+// participation lives on EditionSponsor. These are the invariants the rest of
+// the sponsor work (#130, #131, #132) is allowed to assume.
+
+const createdSponsorIds: number[] = [];
+
+afterEach(async () => {
+  if (createdSponsorIds.length) {
+    // EditionSponsor and SponsorJobOffer cascade from Sponsor.
+    await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
+    createdSponsorIds.length = 0;
+  }
+});
+
+describe("Sponsor identity (#129)", () => {
+  it("rejects a second sponsor with the same slug, whatever the edition", async () => {
+    const slug = `identity-dup-${Date.now()}`;
+    const first = await prisma.sponsor.create({ data: { name: "Acme", slug } });
+    createdSponsorIds.push(first.id);
+
+    await expect(
+      prisma.sponsor.create({ data: { name: "Acme Again", slug } }),
+    ).rejects.toThrow();
+  });
+
+  it("carries one company across two editions as two participations", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("gold");
+
+    // year is the only required field on Edition, and it is @unique.
+    //
+    // 1900, NOT a future year: getSeededEdition() picks the most recent edition
+    // at or after 2016, so a 2999 row would be handed to whichever parallel
+    // test file asked for an edition while this one still existed — exactly the
+    // #292 race that helper was written to close. Below 2016 it is invisible.
+    const other = await prisma.edition.create({ data: { year: 1900 } });
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Multi Year Co",
+        slug: `identity-multi-${Date.now()}`,
+        editions: {
+          create: [
+            { editionId: edition.id, tierId, publicationStatus: "PUBLISHED" },
+            { editionId: other.id, tierId, publicationStatus: "DRAFT" },
+          ],
+        },
+      },
+      include: { editions: true },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    expect(sponsor.editions).toHaveLength(2);
+
+    const years = await prisma.editionSponsor.findMany({
+      where: { sponsorId: sponsor.id },
+      select: { edition: { select: { year: true } }, publicationStatus: true },
+    });
+    expect(years.map((p) => p.edition.year).sort()).toEqual([edition.year, 1900].sort());
+
+    await prisma.edition.delete({ where: { id: other.id } });
+  });
+
+  it("refuses two participations of one company on the same edition", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("gold");
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Once Per Year Co",
+        slug: `identity-once-${Date.now()}`,
+        editions: { create: [{ editionId: edition.id, tierId }] },
+      },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    await expect(
+      prisma.editionSponsor.create({ data: { sponsorId: sponsor.id, editionId: edition.id, tierId } }),
+    ).rejects.toThrow();
+  });
+
+  it("hangs job offers off the participation, not the company", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("gold");
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Hiring Co",
+        slug: `identity-offers-${Date.now()}`,
+        editions: {
+          create: [{
+            editionId: edition.id,
+            tierId,
+            jobOffers: { create: [{ title: "Dev", url: "https://example.org/job" }] },
+          }],
+        },
+      },
+      include: { editions: { include: { jobOffers: true } } },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    expect(sponsor.editions[0].jobOffers).toHaveLength(1);
+    expect(sponsor.editions[0].jobOffers[0].title).toBe("Dev");
+  });
+
+  it("keeps contacts on the company, shared across its editions", async () => {
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Contactable Co",
+        slug: `identity-contact-${Date.now()}`,
+        contacts: { create: [{ email: "boss@example.org" }] },
+      },
+      include: { contacts: true },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    expect(sponsor.contacts).toHaveLength(1);
+    expect(sponsor.contacts[0].email).toBe("boss@example.org");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+From `src/backend`, with `DATABASE_URL` pointing at the running Postgres:
+
+```bash
+pnpm exec vitest run src/__tests__/sponsor-identity.test.ts
+```
+
+Expected: 5 passed.
+
+These tests describe the schema built in Tasks 1–2, so they pass on first run. If any fails, the schema or migration is wrong — fix that, not the test.
+
+If several tests fail with 500s or connection errors, `DATABASE_URL` is pointing at the Docker-internal host. Prefix it with the `localhost:5432` form.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/src/__tests__/sponsor-identity.test.ts
+git commit -m "test(sponsor): lock the identity and participation invariants"
+```
+
+---
+
+## Task 4: Update seed-dev to the new model
+
+**Files:**
+- Modify: `src/backend/prisma/seed-dev.ts`
+
+**Interfaces:**
+- Consumes: `EditionSponsor` from Task 1.
+
+- [ ] **Step 1: Read the sponsor block**
+
+Read `src/backend/prisma/seed-dev.ts` around the `DEMO_SPONSORS` loop (the `prisma.sponsor.create` call near line 487) and the teardown (`prisma.sponsor.deleteMany({ where: { editionId: edition.id } })` near line 324).
+
+- [ ] **Step 2: Rewrite the creation to nest the participation**
+
+The `prisma.sponsor.create` call currently passes `editionId`, `tierId` and `publicationStatus` at the top level. Move those three into a nested `editions.create`, keeping every identity field where it is:
+
+```ts
+await prisma.sponsor.create({
+  data: {
+    // ...identity fields unchanged: name, slug, logoUrl, websiteUrl,
+    // descriptionFr, descriptionEn, socialLinks, contactEmail...
+    editions: {
+      create: [{
+        editionId: edition.id,
+        tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id,
+        publicationStatus: "PUBLISHED",
+      }],
+    },
+  },
+});
+```
+
+- [ ] **Step 3: Fix the teardown**
+
+`prisma.sponsor.deleteMany({ where: { editionId: edition.id } })` no longer compiles — `editionId` is not a field of `Sponsor`. Replace with:
+
+```ts
+await prisma.sponsor.deleteMany({ where: { editions: { some: { editionId: edition.id } } } });
+```
+
+- [ ] **Step 4: Fix any remaining sponsor lookups**
+
+Search the file for other sponsor queries keyed on the edition:
+
+```bash
+grep -n "sponsor" src/backend/prisma/seed-dev.ts
+```
+
+The lookup `where: { editionId: edition.id, slug: "garonne-digital" }` (near line 520) becomes `where: { slug: "garonne-digital" }` — the slug is globally unique now.
+
+- [ ] **Step 5: Typecheck**
+
+From `src/backend`:
+
+```bash
+pnpm typecheck
+```
+
+Expected: errors in `src/routes/**` about `editionId`, `tierId` and `publicationStatus` on `Sponsor` — **those are expected and belong to #130**. There must be no error in `prisma/seed-dev.ts`.
+
+- [ ] **Step 6: Run the seed against a clean database**
+
+```bash
+pnpm exec tsx prisma/seed-dev.ts
+```
+
+Expected: completes without error, logging the sponsor count as before.
+
+- [ ] **Step 7: Verify the seeded shape**
+
+```bash
+docker compose exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"EditionSponsor\") AS participations;"
+```
+
+Expected: both counts equal and non-zero.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/backend/prisma/seed-dev.ts
+git commit -m "chore(seed): create sponsors as identity plus participation"
+```
+
+---
+
+## Task 5: Record the handoff to #130
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md` (this file — the Status section below)
+
+At this point the schema, migration, tests and seed are done, and `pnpm typecheck` **still fails inside `src/routes/**`**. That is the intended end state of this PR: the socle lands first, the consumers are rewritten in #130.
+
+- [ ] **Step 1: Capture the exact compile errors**
+
+From `src/backend`:
+
+```bash
+pnpm typecheck 2>&1 | tee /tmp/sponsor-typecheck.txt
+```
+
+- [ ] **Step 2: Turn them into the #130 worklist**
+
+Append to the Status section at the bottom of this plan: the file list and, per file, the failing symbol. This is the checklist #130 works through — it is cheaper to record it now, while the errors are in front of you, than to rediscover it later.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
+git commit -m "docs(sponsor): record the #130 consumer worklist"
+```
+
+---
+
+## Verification Before Opening the PR
+
+Run these and paste the real output into the PR description. Do not claim a step passed without having run it.
+
+- [ ] `pnpm exec prisma validate` — schema valid
+- [ ] `pnpm exec prisma migrate deploy` on a **fresh** database — applies cleanly from zero
+- [ ] Invariants: `count(Sponsor) == count(EditionSponsor)`, offers and contacts unchanged
+- [ ] `pnpm exec vitest run src/__tests__/sponsor-identity.test.ts` — 5 passed
+- [ ] `pnpm exec tsx prisma/seed-dev.ts` — completes clean
+- [ ] `pnpm typecheck` — fails **only** in `src/routes/**`, per Task 5
+
+The fresh-database run matters: CI applies migrations from zero on every push, so a migration that only works against the dev database breaks the pipeline.
+
+---
+
+## Status
+
+_Filled in by Task 5._
+
+### #130 consumer worklist
+
+_To be captured from the typecheck output._

--- a/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
@@ -579,15 +579,30 @@ git commit -m "test(sponsor): lock the identity and participation invariants"
 
 Read `src/backend/prisma/seed-dev.ts` around the `DEMO_SPONSORS` loop (the `prisma.sponsor.create` call near line 487) and the teardown (`prisma.sponsor.deleteMany({ where: { editionId: edition.id } })` near line 324).
 
-- [ ] **Step 2: Rewrite the creation to nest the participation**
+- [ ] **Step 2: Rewrite the creation as an upsert keyed on slug**
 
-The `prisma.sponsor.create` call currently passes `editionId`, `tierId` and `publicationStatus` at the top level. Move those three into a nested `editions.create`, keeping every identity field where it is:
+Steps 2 and 3 are one change in two halves — read both before editing either.
+
+The identity must now SURVIVE a re-seed, exactly like speakers (#351) and categories (#338) already do in this same file. That means the teardown drops only the participation (Step 3), which in turn means the creation can no longer be a `create`: `Sponsor.slug` is globally `@unique` since Task 1, so the second run would throw on a duplicate slug.
+
+Convert `prisma.sponsor.create` to an `upsert` keyed on `slug`, identity fields in both branches, participation nested. Follow the shape the speaker seeding further down this same file already uses (upsert the identity by slug, then upsert the participation on `speakerId_editionId`):
 
 ```ts
-await prisma.sponsor.create({
-  data: {
-    // ...identity fields unchanged: name, slug, logoUrl, websiteUrl,
-    // descriptionFr, descriptionEn, socialLinks, contactEmail...
+await prisma.sponsor.upsert({
+  where: { slug: s.slug },
+  // ...identity fields unchanged in BOTH create and update: name, logoUrl,
+  // websiteUrl, descriptionFr, descriptionEn, socialLinks, contactEmail...
+  create: {
+    slug: s.slug,
+    editions: {
+      create: [{
+        editionId: edition.id,
+        tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id,
+        publicationStatus: "PUBLISHED",
+      }],
+    },
+  },
+  update: {
     editions: {
       create: [{
         editionId: edition.id,
@@ -599,12 +614,17 @@ await prisma.sponsor.create({
 });
 ```
 
-- [ ] **Step 3: Fix the teardown**
+- [ ] **Step 3: Fix the teardown — participation only, never the identity**
 
-`prisma.sponsor.deleteMany({ where: { editionId: edition.id } })` no longer compiles — `editionId` is not a field of `Sponsor`. Replace with:
+`prisma.sponsor.deleteMany({ where: { editionId: edition.id } })` no longer compiles — `editionId` is not a field of `Sponsor`.
+
+Do **not** replace it with `sponsor.deleteMany({ where: { editions: { some: { editionId } } } })`. That compiles, but it deletes the company identity, and `EditionSponsor.sponsor` is `onDelete: Cascade` — so it would silently destroy that company's participations in every OTHER edition. The two lines around it in the same block (speakers at ~line 320, categories at ~line 325) both carry comments explaining why identities must survive; this line must follow the same rule.
 
 ```ts
-await prisma.sponsor.deleteMany({ where: { editions: { some: { editionId: edition.id } } } });
+// Sponsors are companies since #129, shared across editions like speakers and
+// categories: deleting them would wipe identities other editions still point
+// at. Only this edition's participations go; the identities are upserted by slug.
+await prisma.editionSponsor.deleteMany({ where: { editionId: edition.id } });
 ```
 
 - [ ] **Step 4: Fix any remaining sponsor lookups**
@@ -627,13 +647,16 @@ pnpm typecheck
 
 Expected: errors in `src/routes/**` about `editionId`, `tierId` and `publicationStatus` on `Sponsor` — **those are expected and belong to #130**. There must be no error in `prisma/seed-dev.ts`.
 
-- [ ] **Step 6: Run the seed against a clean database**
+- [ ] **Step 6: Run the seed TWICE in a row**
 
 ```bash
 pnpm exec tsx prisma/seed-dev.ts
+pnpm exec tsx prisma/seed-dev.ts
 ```
 
-Expected: completes without error, logging the sponsor count as before.
+Both runs must complete without error, logging the sponsor count as before.
+
+Twice, not once: the seed is re-run routinely and in CI, and the identity/participation split moved where the idempotency comes from. A single green run does not prove it — an upsert bug or a teardown that leaves the identity behind only shows up on the second pass, as a unique-constraint violation on `slug`.
 
 - [ ] **Step 7: Verify the seeded shape**
 
@@ -641,7 +664,7 @@ Expected: completes without error, logging the sponsor count as before.
 docker compose -f docker-compose.local.yml exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"EditionSponsor\") AS participations;"
 ```
 
-Expected: both counts equal and non-zero.
+Expected: both counts equal and non-zero, and **identical after the first and second run** — a climbing participation count means the teardown is not clearing what the upsert re-creates.
 
 - [ ] **Step 8: Commit**
 

--- a/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
@@ -419,12 +419,21 @@ import { tierIdByKey } from "./sponsor-test-helpers.js";
 // the sponsor work (#130, #131, #132) is allowed to assume.
 
 const createdSponsorIds: number[] = [];
+const createdEditionIds: number[] = [];
 
 afterEach(async () => {
   if (createdSponsorIds.length) {
     // EditionSponsor and SponsorJobOffer cascade from Sponsor.
     await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
     createdSponsorIds.length = 0;
+  }
+  // Editions go after sponsors, so participations cascade away first and no FK
+  // blocks the delete. Cleaned up here rather than inline at the end of a test:
+  // an assertion failure would skip an inline delete, and Edition.year is
+  // @unique, so the leaked row would break every later run of the file.
+  if (createdEditionIds.length) {
+    await prisma.edition.deleteMany({ where: { id: { in: createdEditionIds } } });
+    createdEditionIds.length = 0;
   }
 });
 
@@ -450,6 +459,7 @@ describe("Sponsor identity (#129)", () => {
     // test file asked for an edition while this one still existed — exactly the
     // #292 race that helper was written to close. Below 2016 it is invisible.
     const other = await prisma.edition.create({ data: { year: 1900 } });
+    createdEditionIds.push(other.id);
 
     const sponsor = await prisma.sponsor.create({
       data: {
@@ -473,8 +483,6 @@ describe("Sponsor identity (#129)", () => {
       select: { edition: { select: { year: true } }, publicationStatus: true },
     });
     expect(years.map((p) => p.edition.year).sort()).toEqual([edition.year, 1900].sort());
-
-    await prisma.edition.delete({ where: { id: other.id } });
   });
 
   it("refuses two participations of one company on the same edition", async () => {

--- a/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
@@ -12,7 +12,9 @@
 
 ## Global Constraints
 
-- **Scope is PR 1 of 4.** This plan delivers the schema and migration only. Rewriting the API consumers is #130, admin front #131, public front #132. At the end of this plan the app must still build and all existing tests must pass.
+- **Scope is PR 1 of 4.** This plan delivers the schema and migration only. Rewriting the API consumers is #130, admin front #131, public front #132.
+- **This PR does NOT compile on its own, by design.** Dropping `Sponsor.editionId` breaks `src/backend/src/routes/sponsors.ts` and `routes/admin/sponsors.ts`, and the existing tests that build sponsors with `editionId`. That breakage is #130's worklist, captured in Task 5. What MUST hold at the end of this plan: the migration applies cleanly, the invariants hold, `sponsor-identity.test.ts` passes, `seed-dev.ts` runs, and `prisma/**` typechecks. Do **not** "fix" `src/routes/**` to make the build green — that is out of scope and belongs to #130.
+- **CI will be red on this branch until #130 lands.** Expected. Do not merge this branch to `dev` alone.
 - **Language:** code, comments and commit messages in **English**. Communication with the user in French.
 - **Commits:** Conventional Commits, subject under 72 chars. Stage named files only — never `git add .` or `git add -A`. One git command per Bash call, never chained with `&&`, never `git -C`.
 - **Branch:** work on `feature/us-129-sponsor-identity` (already created, holds the design doc commit).
@@ -352,7 +354,7 @@ CREATE UNIQUE INDEX "Sponsor_slug_key" ON "Sponsor"("slug");
 Run against the dev database and write the four numbers down — they are the invariants:
 
 ```bash
-docker compose exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"SponsorJobOffer\") AS offers, (SELECT count(*) FROM \"SponsorContact\") AS contacts;"
+docker compose -f docker-compose.local.yml exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"SponsorJobOffer\") AS offers, (SELECT count(*) FROM \"SponsorContact\") AS contacts;"
 ```
 
 If the container or credentials differ, read `docker-compose.yml` for the service name and `POSTGRES_USER`/`POSTGRES_DB` rather than guessing.
@@ -372,7 +374,7 @@ If it fails on the step-0 guard, that is the guard doing its job: two sponsors s
 - [ ] **Step 4: Verify the invariants**
 
 ```bash
-docker compose exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"EditionSponsor\") AS participations, (SELECT count(*) FROM \"SponsorJobOffer\") AS offers, (SELECT count(*) FROM \"SponsorContact\") AS contacts;"
+docker compose -f docker-compose.local.yml exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"EditionSponsor\") AS participations, (SELECT count(*) FROM \"SponsorJobOffer\") AS offers, (SELECT count(*) FROM \"SponsorContact\") AS contacts;"
 ```
 
 Expected: `sponsors` = `participations` = the pre-migration sponsor count; `offers` and `contacts` unchanged from Step 2.
@@ -628,7 +630,7 @@ Expected: completes without error, logging the sponsor count as before.
 - [ ] **Step 7: Verify the seeded shape**
 
 ```bash
-docker compose exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"EditionSponsor\") AS participations;"
+docker compose -f docker-compose.local.yml exec -T db psql -U devfest -d devfest -c "SELECT (SELECT count(*) FROM \"Sponsor\") AS sponsors, (SELECT count(*) FROM \"EditionSponsor\") AS participations;"
 ```
 
 Expected: both counts equal and non-zero.

--- a/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
+++ b/docs/superpowers/plans/2026-07-29-sponsor-identity-schema.md
@@ -712,7 +712,7 @@ Run these and paste the real output into the PR description. Do not claim a step
 - [ ] Invariants: `count(Sponsor) == count(EditionSponsor)`, offers and contacts unchanged
 - [ ] `pnpm exec vitest run src/__tests__/sponsor-identity.test.ts` — 5 passed
 - [ ] `pnpm exec tsx prisma/seed-dev.ts` — completes clean
-- [ ] `pnpm typecheck` — fails **only** in `src/routes/**`, per Task 5
+- [ ] `pnpm typecheck` — no error in `prisma/**`; the remaining errors are the #130 worklist below
 
 The fresh-database run matters: CI applies migrations from zero on every push, so a migration that only works against the dev database breaks the pipeline.
 
@@ -720,8 +720,50 @@ The fresh-database run matters: CI applies migrations from zero on every push, s
 
 ## Status
 
-_Filled in by Task 5._
+**PR 1 (#129) complete.** Schema split, migration applied, invariants locked, seed ported. Verified on the local Docker stack (`docker-compose.local.yml`, Postgres on `localhost:5432`):
+
+| Check | Result |
+|---|---|
+| `prisma validate` | valid |
+| `prisma migrate deploy` | applied `20260729120000_sponsor_identity` |
+| `prisma migrate status` | "Database schema is up to date!" — no drift |
+| Invariants | Sponsor 28 → EditionSponsor 28; offers 0, contacts 0 unchanged; all participations on year 2026 |
+| Step-0 guard | passed without firing (0 duplicate slugs) |
+| `sponsor-identity.test.ts` | 5 passed, twice consecutively |
+| `seed-dev.ts` | runs twice consecutively, counts stable at 28/28 |
+| `prisma/**` typecheck | clean |
+
+Two defects came out of the reviews, **both traced to this plan's own text**, both fixed here and in the shipped code:
+
+1. Task 3 deleted its throwaway `Edition` inline at the end of a test, so a failing assertion would leak a row that `Edition.year @unique` then made permanent. Now cleaned in `afterEach`.
+2. Task 4's teardown deleted the sponsor **identity**, which cascades away other editions' participations. Now deletes only the participation — which forced the creation to become an `upsert`, since the surviving identity would collide on the globally-unique slug.
 
 ### #130 consumer worklist
 
-_To be captured from the typecheck output._
+`pnpm typecheck` reports ~90 errors across 20 files. This is the expected end state of PR 1 — the API consumers are #130's scope. The errors fall into five families:
+
+| Family | What to do |
+|---|---|
+| `'editionId' does not exist on Sponsor…` (21×) — creates, wheres, updates | Route through `editions` (`editions: { some: { editionId } }` to filter, nested create to write) |
+| `Property 'tier' does not exist on Sponsor` (12×) + `'tier' not in SponsorInclude` (5×) | The tier now hangs off the participation: include `editions: { include: { tier: true } }` |
+| `platinumPromoIdea` / `comKit*` / `publicationStatus` not on `Sponsor` | Read and write them on `EditionSponsor` |
+| `'sponsorId' does not exist on SponsorJobOfferCreateInput` (3×) | Offers attach to `editionSponsorId` |
+| `Property '_count' does not exist on Edition` (7×), implicit `any` on `o` / `link` params | Fallout of the above — the shapes change once the includes are fixed |
+
+**Backend routes** (the substance of #130):
+
+| File | Errors |
+|---|---|
+| `src/routes/sponsors.ts` | 21 |
+| `src/routes/speakers.ts` | 10 |
+| `src/routes/admin/sponsors.ts` | 10 |
+| `src/routes/admin/editions.ts` | 10 |
+| `src/routes/edit.ts` | 7 |
+| `src/routes/editions.ts` | 2 |
+| `src/routes/admin/sponsor-tiers.ts` | 1 |
+
+**Test files** — 15 files, ~22 errors, mostly fixtures building a sponsor with `editionId`/`tierId` at the top level. Chief among them: `edit-sponsor-platinum.test.ts` (5), `sponsor-job-offers.test.ts` (4), `edit-sponsor-private.test.ts` (3), plus `public-sponsors`, `editions`, `admin-sponsor-contacts` (2 each) and 9 files with one apiece.
+
+`sponsor-test-helpers.ts` is the highest-leverage fix: `createSponsorWithToken()` takes a `Prisma.SponsorUncheckedCreateInput`, so porting it once should clear several call sites at a stroke.
+
+**Do not** port these by making the types happy field-by-field. The point of #130 is that the API response shapes stay identical while the queries move to the participation — the existing tests are the contract that proves it.

--- a/docs/superpowers/specs/2026-07-29-sponsor-backend-design.md
+++ b/docs/superpowers/specs/2026-07-29-sponsor-backend-design.md
@@ -1,0 +1,116 @@
+# Sponsor backend on the identity/participation model — design
+
+**Date** : 2026-07-29
+**Issue** : #130 (123b), sous-étape 2/4 de #123
+**Prérequis** : #129 livré — `Sponsor` est une identité à slug global, `EditionSponsor` porte la participation.
+**Spec parente** : [2026-07-29-sponsor-identity-design.md](2026-07-29-sponsor-identity-design.md)
+
+## Problème
+
+#129 a changé le modèle sans toucher aux consommateurs. `pnpm typecheck` échoue avec ~90 erreurs sur 20 fichiers, la CI est rouge, et la branche n'est pas mergeable. #130 réécrit la couche backend pour que l'application fonctionne à nouveau.
+
+## La règle qui gouverne tout le design
+
+**La fiche sponsor met en avant l'édition en cours ; les autres années ne sont que des tags.**
+
+C'est une règle **temporelle**, pas structurelle. Elle décide de trois choses d'un coup, au lieu de trois logiques distinctes à retenir :
+
+| Donnée | Édition à la une | Éditions passées |
+|---|---|---|
+| Niveau de sponsoring (`tier`) | mis en avant | absent de la fiche — visible sur la page récap de l'édition |
+| Offres d'emploi | affichées | jamais |
+| Participation | — | tag « année », cliquable vers `/editions/<year>` |
+
+Corollaire retenu explicitement : **aucune offre passée ne s'affiche jamais.** Il n'y a donc pas d'édition à « choisir » pour filtrer — seule celle à la une peut porter des offres vivantes.
+
+## Endpoints publics
+
+### `GET /api/sponsors` — contrat inchangé
+
+La requête part de `EditionSponsor` (`where: { editionId, publicationStatus: "PUBLISHED", sponsor: notDeleted }`) et projette `sponsor` + `tier`. Tri par rang de tier conservé (RG-221). **Zéro impact frontend.**
+
+C'est cette page — le mur de sponsors d'une édition — qui porte le niveau de sponsoring.
+
+### `GET /api/sponsors/:slug` — le vrai changement
+
+Deux résolutions désormais **indépendantes** :
+
+1. **L'entreprise**, par slug global. Plus de `getFeaturedEdition()` dans cette requête.
+2. **L'édition à la une**, résolue séparément, pour la mise en avant uniquement.
+
+Le `404` change de sens : il ne survient plus que si l'entreprise n'existe pas, est en corbeille, ou n'a aucune participation publiée. **Il ne dépend plus de l'édition à la une** — c'est l'objet du chantier, une fiche d'entreprise reste consultable hors édition.
+
+Deux évolutions du contrat :
+
+```ts
+tier: SponsorTierRef | null   // était: SponsorTierRef
+editions: number[]            // nouveau — années de participation, tri desc
+```
+
+`tier` et `jobOffers` sont renseignés **si et seulement si** l'entreprise participe à l'édition à la une **et** que `areOffersVisible()` passe pour celle-ci. Sinon `tier: null`, `jobOffers: []`. Pas d'édition à la une du tout → même résultat, sans erreur.
+
+`speakers` reste inchangé : la relation passe déjà par `SpeakerEdition` depuis #353.
+
+### `GET /api/job-offers` — contrat inchangé
+
+La page récap reste entièrement scopée à l'édition à la une. Elle ne liste que des offres vivantes par construction. Seul le chemin de requête change (via la participation).
+
+## Endpoints admin
+
+Les 7 endpoints de [admin/sponsors.ts](src/backend/src/routes/admin/sponsors.ts) (412 lignes) suivent le découpage appliqué aux speakers dans #351 :
+
+- **liste** — une ligne par entreprise avec ses participations ; filtre `editionId` optionnel via `editions: { some: { editionId } }`
+- **create** — crée l'identité **et** sa participation. Slug déjà pris → **409 avec l'id existant**, proposant de rattacher plutôt que dupliquer. C'est ce qui empêche les doublons de se reformer.
+- **update** — sépare champs d'identité (touchent toutes les années) et champs de participation (locaux à l'année)
+- **delete** — corbeille sur l'identité (`deletedAt`), inchangé ; la revue de #129 a confirmé que le mécanisme générique continue de fonctionner
+- **bulk** — cible des participations, pas des identités. Même garde-fou que côté speakers : sans année explicite, une action de masse toucherait des éditions que l'admin ne regarde pas.
+- **rattacher / détacher une édition** — deux endpoints nouveaux, calqués sur `speakerEdition.upsert` / `deleteMany`
+
+**Les endpoints de contacts ne bougent pas** (`/contacts`, `/resend`, `/lock`) : les contacts restent sur l'identité.
+
+**Le magic-link est hors sujet côté sponsor.** Depuis #250 les tokens vivent sur `SponsorContact`, qui n'a pas bougé. L'objectif « token porté par la participation » écrit dans #129 ne concerne plus que les speakers.
+
+## Imports et seed
+
+`sessionize-import.ts` ne touche pas aux sponsors — rien à faire. `seed-dev.ts` a été porté en #129.
+
+## Tests
+
+La moitié invisible du travail : **15 fichiers, ~22 erreurs**, presque toutes des fixtures construisant un sponsor avec `editionId`/`tierId` au premier niveau.
+
+`sponsor-test-helpers.ts` est le point le plus rentable : `createSponsorWithToken()` prend un `Prisma.SponsorUncheckedCreateInput`, donc le porter une fois débloque plusieurs fichiers d'un coup. **À faire en premier** — il donne un filet avant de toucher aux routes.
+
+**Règle** : les assertions existantes ne changent pas, **sauf** sur `/api/sponsors/:slug` (`tier` nullable, `editions` ajouté). Ce sont elles qui prouvent que les shapes sont préservées ailleurs. Si un test réclame de changer son assertion, c'est le signal qu'on a cassé quelque chose.
+
+Tests nouveaux : slug global servant plusieurs années ; 409 sur homonyme ; rattachement/détachement ; `tier: null` hors édition à la une ; aucune offre passée exposée.
+
+## Frontière avec #132
+
+`tier` devenant nullable et `editions` apparaissant, la page publique `/sponsors/<slug>` casse. Le découpage initial mettait tout le front dans #132.
+
+**Décision : cette page est portée dans #130.** Livrer un champ nullable en laissant un consommateur le lire comme non-nullable crée un état intermédiaire cassé qui se fait oublier — et le projet interdit les shims de compatibilité.
+
+Périmètre front de #130, strictement : la fiche sponsor publique + le type `SponsorDetail` dans `types.ts`. Le reste de #132 (non-régression, JSON-LD `Organization`, OG) reste hors périmètre.
+
+## Ordre d'exécution
+
+1. `sponsor-test-helpers.ts` — débloque plusieurs fichiers de test, donne un filet
+2. Endpoints publics — les plus simples, contrat quasi inchangé
+3. Endpoints admin — le gros du travail
+4. Page front sponsor + `SponsorDetail`
+5. Les 15 fichiers de test restants
+
+## Risques
+
+**Le 404 qui change de sens.** Aujourd'hui `/sponsors/:slug` répond 404 sans édition à la une ; après, 200 avec `tier: null`. Voulu, mais un test existant peut encoder l'ancien comportement. À vérifier, pas à supposer.
+
+**Les shapes préservées ailleurs.** `/api/sponsors` et `/api/job-offers` ne doivent pas bouger d'un octet.
+
+**Le quota d'offres par tier.** `SponsorTier.jobOfferQuota` se lit sur le tier **de la participation**. Une entreprise Gold en 2024 et Platinum en 2026 a deux quotas différents selon l'année.
+
+## Hors scope
+
+- `/editions/:year/sponsors` et la section sponsors d'une édition passée → **#370**
+- Back-office sponsor authentifié, rôles par sponsor → **#362**
+- Hall of sponsors → idée conservée, non implémentée
+- Admin front (liste dédoublonnée, fiche en deux blocs) → **#131**

--- a/docs/superpowers/specs/2026-07-29-sponsor-identity-design.md
+++ b/docs/superpowers/specs/2026-07-29-sponsor-identity-design.md
@@ -1,0 +1,126 @@
+# Sponsor en entité partagée multi-éditions — design
+
+**Date** : 2026-07-29
+**Issues** : #123 (épique) → #129 (socle), #130 (backend), #131 (admin front), #132 (public front)
+**Précédent** : #351/#352/#353 ont appliqué la même refonte aux speakers.
+
+## Problème
+
+`Sponsor` porte `editionId` et `@@unique([editionId, slug])` : une entreprise qui sponsorise N éditions existe en N lignes sans lien entre elles. C'est le modèle que #351 a supprimé côté speakers.
+
+## Pourquoi maintenant
+
+Contre-intuitivement, l'absence de données est l'argument pour agir tout de suite.
+
+Le risque de la migration speaker n'était pas dans le `ALTER TABLE` mais dans **la fusion** : 330 lignes à replier en 240 personnes, élection d'un survivant, arbitrage des quasi-doublons (`Tregan`/`Trégan`), repointage de 289 liens `_SpeakerToTalk` **avant** suppression de 90 lignes — sous peine de perte silencieuse par `ON DELETE CASCADE`.
+
+Côté sponsors, aucun de ces risques n'a de support :
+
+- `devfest-history.json` ne contient que `speakers` et `sessions` — **aucun sponsor historique en base** (vérifié en rédigeant #370).
+- Les sponsors de démo (`seed-dev.ts`) sont tous sur l'édition courante, slugs distincts.
+- Donc **zéro doublon inter-éditions** : rien à fondre.
+
+La migration se réduit à une transformation mécanique 1-pour-1. Les 22 lignes d'aujourd'hui sont le moment le moins cher de toute la vie du projet pour changer ce modèle. Chaque édition ajoutée l'alourdit, et le jour où #370 fait saisir les sponsors 2016-2025, on retombe exactement dans le scénario speaker : doublons réels, fusion à arbitrer, risque de perte.
+
+Le coût du chantier n'est donc pas la migration : c'est la **réécriture des consommateurs**. Du portage de code testable et revue-able, pas un risque de données.
+
+## Répartition des champs
+
+Le critère retenu : **l'historique de cette donnée a-t-il de la valeur ?**
+
+| | Champs |
+|---|---|
+| **Identité** `Sponsor` | `slug` (→ `@unique`), `name`, `logoUrl`, `websiteUrl`, `descriptionFr/En`, `socialLinks`, `contactEmail`, `locale`, `standContacts`, `deletedAt`, relation `SponsorContact[]` |
+| **Participation** `EditionSponsor` | `editionId`, `sponsorId`, `tierId`, `publicationStatus`, `comKitReceived`, `comKitLogoWebUrl`, `comKitLogoPrintUrl`, `comKitCharterUrl`, `comKitNotes`, `platinumPromoIdea`, `platinumCoBuildIdea`, relation `SponsorJobOffer[]` |
+
+Décisions notables :
+
+- **`logoUrl` et descriptions sur l'identité.** Une page d'édition passée affichera donc le logo et le pitch *actuels* de l'entreprise, pas ceux de l'époque. Assumé : cohérent avec `Speaker.photoUrl`, et évite de ressaisir chaque année. Un rebranding réécrit l'archive — accepté.
+- **`standContacts` sur l'identité.** C'est l'équipe qui tient le stand, utile uniquement pour scanner pendant l'événement. L'édition finie, la donnée est morte : son historique n'a aucune valeur, donc pas besoin de l'archiver par année. Écrasée à chaque édition. (Si #113 — passport QR — a besoin d'un historique, ce sera une table de scans, pas ce champ.)
+- **`SponsorJobOffer` sur la participation.** Une offre est datée par nature et son quota dépend du `tierId` de l'année ; sur l'identité, les offres de 2019 réapparaîtraient en 2026.
+- **`SponsorContact` sur l'identité.** Les personnes autorisées à éditer la fiche suivent l'entreprise, pas l'année. Plus simple, et leur code existant reste correct.
+
+## Migration
+
+Aucune fusion : chaque `Sponsor` produit exactement un `EditionSponsor`.
+
+1. `CREATE TABLE "EditionSponsor"` + index + FK, `@@unique([sponsorId, editionId])`
+2. `INSERT ... SELECT` — une participation par sponsor, portant les champs annuels
+3. Repointer `SponsorJobOffer.sponsorId` → `editionSponsorId`
+4. `DROP COLUMN` sur `Sponsor` : `editionId`, `tierId`, `publicationStatus`, les 5 `comKit*`, les 2 `platinum*`
+5. `DROP INDEX "Sponsor_editionId_slug_key"` → `CREATE UNIQUE INDEX "Sponsor_slug_key"`
+
+**Garde explicite** : l'étape 5 échouerait si deux éditions partageaient un slug. C'est impossible aujourd'hui, mais la migration le **vérifie** au lieu de le supposer — leçon du `_SpeakerToTalk` en cascade, où une hypothèse tacite pouvait détruire des données sans rien lever.
+
+**Invariants à vérifier des deux côtés** :
+
+- `count(Sponsor)` avant = `count(EditionSponsor)` après
+- `count(SponsorJobOffer)` inchangé, chacune rattachée à une participation non nulle
+- `count(SponsorContact)` inchangé
+
+Pas de suppression de lignes : une erreur SQL fait échouer la migration en transaction plutôt que de perdre des données silencieusement.
+
+## Backend
+
+**Endpoints publics** — shapes préservées, le front n'est pas touché.
+
+- `GET /api/sponsors` : contrat inchangé. La requête part de `EditionSponsor` (`where: { editionId, publicationStatus: "PUBLISHED", sponsor: notDeleted }`) et projette `sponsor` + `tier`.
+- `GET /api/sponsors/:slug` : plus de `getFeaturedEdition()`. Résolution par slug global, réponse enrichie d'un tableau `editions[]` (année + tier), comme la fiche speaker depuis #352. **Les offres d'emploi ne sont servies que pour la participation la plus récente** — afficher celles de 2019 sur une fiche multi-éditions n'aurait pas de sens. Filtrage `areOffersVisible()` conservé.
+- `GET /api/editions/:year/sponsors` : nouvel endpoint (#370), pendant exact de `/editions/:year/speakers`.
+
+**Endpoints admin** — même découpage que les speakers dans #351.
+
+- liste : une ligne par entreprise + participations, filtre `editionId` via `editions: { some: { editionId } }`
+- create : crée identité + participation ; slug déjà pris → **409 avec l'id existant**, proposant de rattacher plutôt que dupliquer. C'est ce qui empêche les doublons de se reformer.
+- update : sépare champs d'identité et champs de participation
+- delete : corbeille sur l'identité (`deletedAt`), inchangé
+- rattacher / détacher une édition : deux endpoints nouveaux, calqués sur `speakerEdition.upsert` / `deleteMany`
+- contacts (`/contacts`, `/resend`, `/lock`) : **inchangés**, les contacts restent sur l'identité
+
+**Magic-link : hors sujet côté sponsor.** Depuis #250 les tokens vivent sur `SponsorContact`. L'objectif « token porté par la participation » écrit dans #129 est **caduc** pour les sponsors — il ne concerne plus que les speakers, où `editToken` est resté sur l'identité.
+
+**Imports / seed** : `sessionize-import.ts` ne touche pas aux sponsors. `seed-dev.ts` crée identité + participation.
+
+**Tests (TDD)** : les tests existants (`public-sponsors.test.ts`, `admin-sponsor-contacts.test.ts`, `sponsor-job-offers.test.ts`) servent de filet — **leurs assertions ne changent pas**, puisque les shapes sont préservées. Nouveaux : slug global servant plusieurs années, 409 sur homonyme, rattachement/détachement, `/editions/:year/sponsors`, non-fuite d'une offre de 2019.
+
+## Admin front
+
+`/admin/sponsors` : une ligne par entreprise avec ses années. Portage direct de `admin/speakers/page.tsx`, helper `currentParticipation(entity, year)` compris.
+
+**Garde-fou repris du précédent speaker** : les actions de masse ciblent **une** participation explicite — sans année sélectionnée, on toucherait des éditions que l'admin ne regarde pas.
+
+`/admin/sponsors/[id]` : bloc **identité** (nom, logo, site, descriptions, réseaux, contacts) + bloc **participation** (tier, publication, kit com, idées Platinum, offres), avec panneau de rattachement d'éditions.
+
+Vigilance :
+
+- La consigne d'upload de logo (#340) est attachée à `logoUrl` → bloc identité. À ne pas perdre en restructurant.
+- Le quota d'offres se calcule sur le `tierId` **de la participation**, pas sur un tier « courant ».
+
+## Public front
+
+Le plus léger, par construction : les shapes étant préservées, `/sponsors` et les composants de la home ne changent pas.
+
+`/sponsors/<slug>` gagne la liste des années de sponsoring avec le tier de chaque année. JSON-LD `Organization` conservé, via `jsonLdScript()` qui échappe la sortie (durcissement XSS de `f68541b`).
+
+Réponse au risque nommé par #132 (régression silencieuse) : tests backend verrouillant les shapes + vérification navigateur (Chrome DevTools MCP) sur édition courante **et** passée, FR et EN, console propre.
+
+## Hors scope
+
+- **Hall of sponsors** (liste de tous les sponsors, toutes éditions) : idée conservée, **non implémentée**.
+- **Saisie des sponsors historiques** : c'est #370. Ce design la rend possible sans la supposer.
+
+## Découpage
+
+Une PR par sous-issue, dans l'ordre, chacune laissant l'application fonctionnelle :
+
+| PR | Issue | Contenu |
+|---|---|---|
+| 1 | #129 | Schéma + migration + invariants |
+| 2 | #130 | Endpoints publics et admin, seed, tests |
+| 3 | #131 | Admin front : liste dédoublonnée, fiche en deux blocs |
+| 4 | #132 | Public front + vérification de non-régression |
+
+## Effets sur les autres issues
+
+- **#370 devient plus simple** : le slug étant global, son point ouvert (« quelle fiche servir quand le slug est ambigu ») disparaît. Reste la section sponsors sur la page d'édition passée et la saisie des données. À commenter une fois #129 mergée.
+- **#362 (vrai back-office sponsor) n'est pas affecté** : il s'appuie sur `SponsorContact`, qui ne bouge pas. Chantiers indépendants.

--- a/src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql
+++ b/src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql
@@ -24,6 +24,14 @@
 --    This cannot happen with today's data (every sponsor is on one edition).
 --    It is checked rather than assumed: the #351 migration's hardest bug came
 --    from a cascade nobody had verified.
+--
+--    Scope: the guard reads the stored slug, so trashed rows are invisible to
+--    it — the trash parks them as "__trash_<id>__<slug>" (#146). That is
+--    deliberate, not an oversight: a parked slug cannot collide with the new
+--    index either, and if two trashed sponsors from different editions did
+--    share an original slug, restoring the second already answers 409
+--    restore_conflict (routes/admin/trash.ts). Nothing is lost, and the admin
+--    is told. There are 0 trashed sponsors at migration time.
 -- ---------------------------------------------------------------------------
 DO $$
 DECLARE

--- a/src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql
+++ b/src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql
@@ -66,7 +66,14 @@ CREATE TABLE "EditionSponsor" (
   "comKitCharterUrl" TEXT,
   "comKitNotes" TEXT,
   "platinumPromoIdea" TEXT,
-  "platinumCoBuildIdea" TEXT
+  "platinumCoBuildIdea" TEXT,
+  -- What the edition displayed, frozen so later edits never rewrite an
+  -- archive (#375). Nullable: null reads through to the live tier / identity.
+  "logoUrl" TEXT,
+  "tierNameFr" TEXT,
+  "tierNameEn" TEXT,
+  "tierColor" TEXT,
+  "tierLogoScale" DOUBLE PRECISION
 );
 
 CREATE UNIQUE INDEX "EditionSponsor_sponsorId_editionId_key" ON "EditionSponsor"("sponsorId", "editionId");
@@ -86,18 +93,29 @@ ALTER TABLE "EditionSponsor"
 --    Trashed sponsors included: the trash lives on the identity, and restoring
 --    one must restore a company that still belongs to its edition.
 -- ---------------------------------------------------------------------------
+--    The logo and the tier's appearance are frozen here (#375): the split
+--    moves logoUrl onto the identity, which would otherwise let a 2027 logo
+--    change repaint 2026's wall. Sponsor.logoUrl stays as the company's
+--    current logo and the fallback for a participation that has none.
+--
+--    The JOIN cannot drop a sponsor: Sponsor.tierId is NOT NULL behind
+--    Sponsor_tierId_fkey (ON DELETE RESTRICT, 20260723084347), so every row
+--    has a live tier. Step 3's SET NOT NULL would catch it anyway.
 INSERT INTO "EditionSponsor" (
   "sponsorId", "editionId", "tierId", "publicationStatus",
   "comKitReceived", "comKitLogoWebUrl", "comKitLogoPrintUrl",
   "comKitCharterUrl", "comKitNotes", "platinumPromoIdea",
-  "platinumCoBuildIdea", "updatedAt"
+  "platinumCoBuildIdea", "updatedAt",
+  "logoUrl", "tierNameFr", "tierNameEn", "tierColor", "tierLogoScale"
 )
 SELECT
   s."id", s."editionId", s."tierId", s."publicationStatus",
   s."comKitReceived", s."comKitLogoWebUrl", s."comKitLogoPrintUrl",
   s."comKitCharterUrl", s."comKitNotes", s."platinumPromoIdea",
-  s."platinumCoBuildIdea", CURRENT_TIMESTAMP
-FROM "Sponsor" s;
+  s."platinumCoBuildIdea", CURRENT_TIMESTAMP,
+  s."logoUrl", t."nameFr", t."nameEn", t."color", t."logoScale"
+FROM "Sponsor" s
+JOIN "SponsorTier" t ON t."id" = s."tierId";
 
 -- ---------------------------------------------------------------------------
 -- 3. Job offers hang off the participation. The column is added nullable,

--- a/src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql
+++ b/src/backend/prisma/migrations/20260729120000_sponsor_identity/migration.sql
@@ -1,0 +1,139 @@
+-- Sponsor becomes a global identity (#129).
+--
+-- Sponsor carried a mandatory editionId and a per-edition unique slug, so a
+-- company sponsoring several editions would exist as several unlinked rows.
+-- Sponsor becomes the company, EditionSponsor carries the participation and
+-- everything bought or tracked for that year -- the same split as
+-- SpeakerEdition (#351), EditionCategory (#338) and EditionSponsorTier (#316).
+--
+-- NOT destructive in the #351 sense: no sponsor exists on more than one
+-- edition today, so there is nothing to fold and no row is deleted. Every
+-- Sponsor produces exactly one EditionSponsor.
+--
+-- Invariants to check on both sides:
+--   SELECT count(*) FROM "Sponsor";           -- unchanged
+--   SELECT count(*) FROM "EditionSponsor";    -- equals the above
+--   SELECT count(*) FROM "SponsorJobOffer";   -- unchanged
+--   SELECT count(*) FROM "SponsorContact";    -- unchanged
+
+-- ---------------------------------------------------------------------------
+-- 0. GUARD. Step 5 creates a global unique index on Sponsor.slug. If two
+--    editions ever shared a slug, that index would fail with a violation that
+--    says nothing useful. Fail here instead, naming the problem.
+--
+--    This cannot happen with today's data (every sponsor is on one edition).
+--    It is checked rather than assumed: the #351 migration's hardest bug came
+--    from a cascade nobody had verified.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  dup_count INTEGER;
+  dup_list  TEXT;
+BEGIN
+  SELECT count(*), string_agg(slug, ', ')
+  INTO dup_count, dup_list
+  FROM (SELECT "slug" FROM "Sponsor" GROUP BY "slug" HAVING count(*) > 1) d;
+
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION
+      'Cannot make Sponsor.slug globally unique: % slug(s) used by more than one sponsor (%). Merge them before migrating.',
+      dup_count, dup_list;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 1. The join table.
+-- ---------------------------------------------------------------------------
+CREATE TABLE "EditionSponsor" (
+  "id" SERIAL PRIMARY KEY,
+  "publicationStatus" "PublicationStatus" NOT NULL DEFAULT 'DRAFT',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "sponsorId" INTEGER NOT NULL,
+  "editionId" INTEGER NOT NULL,
+  "tierId" INTEGER NOT NULL,
+  "comKitReceived" BOOLEAN NOT NULL DEFAULT false,
+  "comKitLogoWebUrl" TEXT,
+  "comKitLogoPrintUrl" TEXT,
+  "comKitCharterUrl" TEXT,
+  "comKitNotes" TEXT,
+  "platinumPromoIdea" TEXT,
+  "platinumCoBuildIdea" TEXT
+);
+
+CREATE UNIQUE INDEX "EditionSponsor_sponsorId_editionId_key" ON "EditionSponsor"("sponsorId", "editionId");
+CREATE INDEX "EditionSponsor_sponsorId_idx" ON "EditionSponsor"("sponsorId");
+CREATE INDEX "EditionSponsor_editionId_idx" ON "EditionSponsor"("editionId");
+CREATE INDEX "EditionSponsor_tierId_idx" ON "EditionSponsor"("tierId");
+
+ALTER TABLE "EditionSponsor"
+  ADD CONSTRAINT "EditionSponsor_sponsorId_fkey" FOREIGN KEY ("sponsorId") REFERENCES "Sponsor"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "EditionSponsor"
+  ADD CONSTRAINT "EditionSponsor_editionId_fkey" FOREIGN KEY ("editionId") REFERENCES "Edition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "EditionSponsor"
+  ADD CONSTRAINT "EditionSponsor_tierId_fkey" FOREIGN KEY ("tierId") REFERENCES "SponsorTier"("id") ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 2. One participation per existing sponsor, carrying the per-edition state.
+--    Trashed sponsors included: the trash lives on the identity, and restoring
+--    one must restore a company that still belongs to its edition.
+-- ---------------------------------------------------------------------------
+INSERT INTO "EditionSponsor" (
+  "sponsorId", "editionId", "tierId", "publicationStatus",
+  "comKitReceived", "comKitLogoWebUrl", "comKitLogoPrintUrl",
+  "comKitCharterUrl", "comKitNotes", "platinumPromoIdea",
+  "platinumCoBuildIdea", "updatedAt"
+)
+SELECT
+  s."id", s."editionId", s."tierId", s."publicationStatus",
+  s."comKitReceived", s."comKitLogoWebUrl", s."comKitLogoPrintUrl",
+  s."comKitCharterUrl", s."comKitNotes", s."platinumPromoIdea",
+  s."platinumCoBuildIdea", CURRENT_TIMESTAMP
+FROM "Sponsor" s;
+
+-- ---------------------------------------------------------------------------
+-- 3. Job offers hang off the participation. The column is added nullable,
+--    backfilled, then made NOT NULL -- an offer with no participation would
+--    mean step 2 missed a sponsor, so the SET NOT NULL is the check.
+-- ---------------------------------------------------------------------------
+ALTER TABLE "SponsorJobOffer" ADD COLUMN "editionSponsorId" INTEGER;
+
+UPDATE "SponsorJobOffer" o
+SET "editionSponsorId" = es."id"
+FROM "EditionSponsor" es
+WHERE es."sponsorId" = o."sponsorId";
+
+ALTER TABLE "SponsorJobOffer" ALTER COLUMN "editionSponsorId" SET NOT NULL;
+
+ALTER TABLE "SponsorJobOffer" DROP CONSTRAINT IF EXISTS "SponsorJobOffer_sponsorId_fkey";
+DROP INDEX IF EXISTS "SponsorJobOffer_sponsorId_idx";
+ALTER TABLE "SponsorJobOffer" DROP COLUMN "sponsorId";
+
+CREATE INDEX "SponsorJobOffer_editionSponsorId_idx" ON "SponsorJobOffer"("editionSponsorId");
+ALTER TABLE "SponsorJobOffer"
+  ADD CONSTRAINT "SponsorJobOffer_editionSponsorId_fkey" FOREIGN KEY ("editionSponsorId") REFERENCES "EditionSponsor"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 4. The edition link and the per-edition fields now live on the join.
+--    Index names taken from the live schema, not guessed.
+-- ---------------------------------------------------------------------------
+DROP INDEX IF EXISTS "Sponsor_editionId_idx";
+DROP INDEX IF EXISTS "Sponsor_tierId_idx";
+DROP INDEX IF EXISTS "Sponsor_editionId_slug_key";
+ALTER TABLE "Sponsor" DROP CONSTRAINT IF EXISTS "Sponsor_editionId_fkey";
+ALTER TABLE "Sponsor" DROP CONSTRAINT IF EXISTS "Sponsor_tierId_fkey";
+ALTER TABLE "Sponsor" DROP COLUMN "editionId";
+ALTER TABLE "Sponsor" DROP COLUMN "tierId";
+ALTER TABLE "Sponsor" DROP COLUMN "publicationStatus";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitReceived";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitLogoWebUrl";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitLogoPrintUrl";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitCharterUrl";
+ALTER TABLE "Sponsor" DROP COLUMN "comKitNotes";
+ALTER TABLE "Sponsor" DROP COLUMN "platinumPromoIdea";
+ALTER TABLE "Sponsor" DROP COLUMN "platinumCoBuildIdea";
+
+-- ---------------------------------------------------------------------------
+-- 5. A slug now identifies a company globally.
+-- ---------------------------------------------------------------------------
+CREATE UNIQUE INDEX "Sponsor_slug_key" ON "Sponsor"("slug");

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -544,7 +544,9 @@ model Speaker {
   deletedAt DateTime?
 
   // The sponsor association moved to SpeakerEdition (#353): working for a
-  // sponsor is true of a given year, and Sponsor is itself edition-scoped.
+  // sponsor is true of a given year, so the link is dated on the speaker's
+  // side. Sponsor itself is a company identity since #129 — the year lives
+  // on EditionSponsor, not on Sponsor.
 
   editions SpeakerEdition[]
   talks    Talk[]

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -97,16 +97,16 @@ model Edition {
   // Soft delete (#146): non-null means the row sits in the trash.
   deletedAt               DateTime?
 
-  ticketTiers  TicketTier[]
-  articles     Article[]
-  keyFigures   KeyFigure[]
-  sponsorTiers EditionSponsorTier[]
+  ticketTiers     TicketTier[]
+  articles        Article[]
+  keyFigures      KeyFigure[]
+  sponsorTiers    EditionSponsorTier[]
   // The join since #351, like `categories` above: an edition's speakers are
   // participations, not identities.
-  speakers     SpeakerEdition[]
-  talks        Talk[]
-  sponsors     Sponsor[]
-  categories   EditionCategory[]
+  speakers        SpeakerEdition[]
+  talks           Talk[]
+  editionSponsors EditionSponsor[]
+  categories      EditionCategory[]
 
   @@index([deletedAt])
 }
@@ -175,36 +175,36 @@ model Tag {
 // a signed sponsor) and the SponsorPlan model (offer shown on /devenir-sponsor).
 // The per-edition binding (price, visibility, order) lives in EditionSponsorTier.
 model SponsorTier {
-  id            Int       @id @default(autoincrement())
+  id               Int       @id @default(autoincrement())
   // Stable key used in code/imports and to park the row when trashed
   // (e.g. "platinum", "gold", "discovery", "soutien-communautes").
-  key           String    @unique
-  nameFr        String
-  nameEn        String
-  subtitleFr    String?
-  subtitleEn    String?
-  descriptionFr String?
-  descriptionEn String?
+  key              String    @unique
+  nameFr           String
+  nameEn           String
+  subtitleFr       String?
+  subtitleEn       String?
+  descriptionFr    String?
+  descriptionEn    String?
   // JSON array of { fr: string, en: string }.
-  advantages    String?
-  standSize     String?
-  color         String    @default("#109E6E")
+  advantages       String?
+  standSize        String?
+  color            String    @default("#109E6E")
   // Logo display scale on the sponsor wall (#315): higher tier, larger logo.
-  logoScale     Float     @default(1)
+  logoScale        Float     @default(1)
   // Importance rank — higher means more prominent (Platinum). Sorted descending.
-  rank          Int       @default(0)
+  rank             Int       @default(0)
   // How many job offers a sponsor of this tier may publish (#251, ex-OFFER_QUOTA).
-  jobOfferQuota Int       @default(1)
+  jobOfferQuota    Int       @default(1)
   // Whether sponsors of this tier may fill the promo/co-build ideas (#252,
   // ex-condition level === PLATINUM).
-  allowsPromoIdeas Boolean @default(false)
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  allowsPromoIdeas Boolean   @default(false)
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
   // Soft delete (#146): non-null means the row sits in the trash.
-  deletedAt     DateTime?
+  deletedAt        DateTime?
 
-  sponsors     Sponsor[]
-  editionLinks EditionSponsorTier[]
+  editionSponsors EditionSponsor[]
+  editionLinks    EditionSponsorTier[]
 
   @@index([deletedAt])
 }
@@ -639,9 +639,10 @@ model Talk {
 // --- Sponsors (RG-220 to RG-231) ---
 
 model Sponsor {
-  id            Int          @id @default(autoincrement())
-  // Slug derived from the name (RG-227). Unique per edition.
-  slug          String
+  id            Int     @id @default(autoincrement())
+  // Globally unique since #129: a slug identifies a company, not a
+  // participation. Same rule as Speaker.slug (#351).
+  slug          String  @unique
   name          String
   logoUrl       String?
   websiteUrl    String?
@@ -655,35 +656,15 @@ model Sponsor {
   // --- Private fields (#249) — organizers only, NEVER exposed publicly ---
   // Social handles of the people staffing the booth, for day-of relaying.
   // JSON array of { name, linkedin, twitter, bluesky }.
-  standContacts       String?
-  // Communication kit: whether the sponsor confirmed receiving it, plus the
-  // assets they can drop as links (web/print logo, brand charter) and free notes.
-  comKitReceived      Boolean           @default(false)
-  comKitLogoWebUrl    String?
-  comKitLogoPrintUrl  String?
-  comKitCharterUrl    String?
-  comKitNotes         String?
-  // Platinum-only promotional content ideas (#252) — private, shown in the
-  // edit form only when level == PLATINUM.
-  platinumPromoIdea   String?
-  platinumCoBuildIdea String?
+  standContacts String?
   // Language we write to this sponsor in — "fr" | "en" (#224). Same rule as
   // Speaker.locale: set in the admin, defaults to French.
-  locale              String            @default("fr")
-  publicationStatus   PublicationStatus @default(DRAFT)
+  locale        String  @default("fr")
 
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   // Soft delete (#146): non-null means the row sits in the trash.
   deletedAt DateTime?
-
-  editionId Int
-  edition   Edition @relation(fields: [editionId], references: [id], onDelete: Cascade)
-
-  // Sponsoring tier from the shared catalogue (#317). Replaces the SponsorLevel
-  // enum: the level assigned to a sponsor IS an entry of the SponsorTier catalogue.
-  tierId Int
-  tier   SponsorTier @relation(fields: [tierId], references: [id])
 
   // Speakers working for this sponsor's company (RG-226). Through the
   // participation since #353 — the association is per-edition on both ends.
@@ -693,13 +674,53 @@ model Sponsor {
   // modification link (#250). Replaces the single editToken on Sponsor.
   contacts SponsorContact[]
 
-  // Job offers the sponsor wants relayed (#251). Count capped by tier.
+  editions EditionSponsor[]
+
+  @@index([deletedAt])
+}
+
+// Which editions a company sponsored (#129), and on what terms that year.
+// The identity/participation split of SpeakerEdition (#351), EditionCategory
+// (#338) and EditionSponsorTier (#316).
+//
+// The tier is bought per edition, and so is everything the organisers track
+// while preparing it: the communication kit and the Platinum promo ideas.
+// standContacts deliberately stays on Sponsor — the booth team only matters
+// for scanning during the event, so its history has no value.
+// Pure join row: the trash operates on the Sponsor identity, so no soft delete.
+model EditionSponsor {
+  id                Int               @id @default(autoincrement())
+  publicationStatus PublicationStatus @default(DRAFT)
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+
+  sponsorId Int
+  sponsor   Sponsor @relation(fields: [sponsorId], references: [id], onDelete: Cascade)
+  editionId Int
+  edition   Edition @relation(fields: [editionId], references: [id], onDelete: Cascade)
+
+  // Sponsoring tier from the shared catalogue (#317), bought for this edition.
+  tierId Int
+  tier   SponsorTier @relation(fields: [tierId], references: [id])
+
+  // --- Private fields (#249) — organizers only, NEVER exposed publicly ---
+  comKitReceived      Boolean @default(false)
+  comKitLogoWebUrl    String?
+  comKitLogoPrintUrl  String?
+  comKitCharterUrl    String?
+  comKitNotes         String?
+  // Platinum-only promotional content ideas (#252).
+  platinumPromoIdea   String?
+  platinumCoBuildIdea String?
+
+  // Job offers are dated by nature and their quota depends on this year's
+  // tier (#251), so they hang off the participation, not the company.
   jobOffers SponsorJobOffer[]
 
-  @@unique([editionId, slug])
+  @@unique([sponsorId, editionId])
+  @@index([sponsorId])
   @@index([editionId])
   @@index([tierId])
-  @@index([deletedAt])
 }
 
 // A person who can edit a sponsor's page via their own modification link
@@ -743,10 +764,10 @@ model SponsorJobOffer {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  sponsorId Int
-  sponsor   Sponsor @relation(fields: [sponsorId], references: [id], onDelete: Cascade)
+  editionSponsorId Int
+  editionSponsor   EditionSponsor @relation(fields: [editionSponsorId], references: [id], onDelete: Cascade)
 
-  @@index([sponsorId])
+  @@index([editionSponsorId])
 }
 
 // --- Categories / Tracks (RG-213, US-246) ---

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -646,6 +646,9 @@ model Sponsor {
   // participation. Same rule as Speaker.slug (#351).
   slug          String  @unique
   name          String
+  // The company's current logo. Falls back for an edition that has none of its
+  // own (#375) — a new participation starts from it instead of being resaisi.
+  // What a past edition shows is EditionSponsor.logoUrl, never this one.
   logoUrl       String?
   websiteUrl    String?
   descriptionFr String?
@@ -687,6 +690,8 @@ model Sponsor {
 //
 // The tier is bought per edition, and so is everything the organisers track
 // while preparing it: the communication kit and the Platinum promo ideas.
+// It also carries what the edition displayed — logo and tier appearance —
+// frozen so an archive stays true to its year (#375).
 // standContacts deliberately stays on Sponsor — the booth team only matters
 // for scanning during the event, so its history has no value.
 // Pure join row: the trash operates on the Sponsor identity, so no soft delete.
@@ -704,6 +709,16 @@ model EditionSponsor {
   // Sponsoring tier from the shared catalogue (#317), bought for this edition.
   tierId Int
   tier   SponsorTier @relation(fields: [tierId], references: [id])
+
+  // What this edition displayed, frozen so later edits never rewrite an
+  // archive (#375). The catalogue is shared and mutable: renaming "Gold" or
+  // recolouring it would otherwise repaint every past edition's sponsor wall.
+  // Null means "not frozen yet" — read through to the live tier / identity.
+  logoUrl       String?
+  tierNameFr    String?
+  tierNameEn    String?
+  tierColor     String?
+  tierLogoScale Float?
 
   // --- Private fields (#249) — organizers only, NEVER exposed publicly ---
   comKitReceived      Boolean @default(false)

--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -321,7 +321,11 @@ async function seedDev() {
   // below: deleting them would wipe identities other editions still point at.
   // Only this edition's participations go; the identities are upserted by slug.
   await prisma.speakerEdition.deleteMany({ where: { editionId: edition.id } });
-  await prisma.sponsor.deleteMany({ where: { editions: { some: { editionId: edition.id } } } });
+  // Sponsors are companies since #129, shared across editions like speakers
+  // above: deleting the identity would cascade-delete its participations in
+  // OTHER editions too. Only this edition's participation goes; the identity
+  // is upserted by slug.
+  await prisma.editionSponsor.deleteMany({ where: { editionId: edition.id } });
   // Categories are shared across editions since #338, so they are upserted by
   // name and merely re-bound to this edition rather than wiped and recreated —
   // deleting them would take other editions' bindings down with them.
@@ -484,8 +488,25 @@ async function seedDev() {
   };
 
   for (const s of DEMO_SPONSORS) {
-    await prisma.sponsor.create({
-      data: {
+    // Upserted by slug, with the participation upserted separately (#129): the
+    // identity may already exist from another edition, only the participation
+    // is this year's — mirrors the speaker identity/participation split above.
+    const sponsor = await prisma.sponsor.upsert({
+      where: { slug: s.slug },
+      update: {
+        name: s.name,
+        logoUrl: `/images/sponsors/${s.slug}.svg`,
+        websiteUrl: s.websiteUrl,
+        descriptionFr: s.descriptionFr,
+        descriptionEn: s.descriptionEn,
+        socialLinks: JSON.stringify({
+          linkedin: `https://www.linkedin.com/company/${s.slug}`,
+          twitter: `https://x.com/${s.slug.replace(/-/g, "")}`,
+          github: `https://github.com/${s.slug}`,
+        }),
+        contactEmail: `contact@${s.slug}.example.com`,
+      },
+      create: {
         slug: s.slug,
         name: s.name,
         logoUrl: `/images/sponsors/${s.slug}.svg`,
@@ -498,13 +519,17 @@ async function seedDev() {
           github: `https://github.com/${s.slug}`,
         }),
         contactEmail: `contact@${s.slug}.example.com`,
-        editions: {
-          create: [{
-            editionId: edition.id,
-            tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id,
-            publicationStatus: "PUBLISHED",
-          }],
-        },
+      },
+    });
+
+    await prisma.editionSponsor.upsert({
+      where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: edition.id } },
+      update: { tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id, publicationStatus: "PUBLISHED" },
+      create: {
+        sponsorId: sponsor.id,
+        editionId: edition.id,
+        tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id,
+        publicationStatus: "PUBLISHED",
       },
     });
   }

--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -321,7 +321,7 @@ async function seedDev() {
   // below: deleting them would wipe identities other editions still point at.
   // Only this edition's participations go; the identities are upserted by slug.
   await prisma.speakerEdition.deleteMany({ where: { editionId: edition.id } });
-  await prisma.sponsor.deleteMany({ where: { editionId: edition.id } });
+  await prisma.sponsor.deleteMany({ where: { editions: { some: { editionId: edition.id } } } });
   // Categories are shared across editions since #338, so they are upserted by
   // name and merely re-bound to this edition rather than wiped and recreated —
   // deleting them would take other editions' bindings down with them.
@@ -488,7 +488,6 @@ async function seedDev() {
       data: {
         slug: s.slug,
         name: s.name,
-        tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id,
         logoUrl: `/images/sponsors/${s.slug}.svg`,
         websiteUrl: s.websiteUrl,
         descriptionFr: s.descriptionFr,
@@ -499,8 +498,13 @@ async function seedDev() {
           github: `https://github.com/${s.slug}`,
         }),
         contactEmail: `contact@${s.slug}.example.com`,
-        publicationStatus: "PUBLISHED",
-        editionId: edition.id,
+        editions: {
+          create: [{
+            editionId: edition.id,
+            tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id,
+            publicationStatus: "PUBLISHED",
+          }],
+        },
       },
     });
   }
@@ -517,7 +521,7 @@ async function seedDev() {
   // The featured speaker below works for a sponsor, which exercises the
   // speaker↔sponsor link (RG-204/RG-226) — her company must match its name.
   const sponsorOfMarie = await prisma.sponsor.findFirstOrThrow({
-    where: { editionId: edition.id, slug: "garonne-digital" },
+    where: { slug: "garonne-digital" },
   });
 
   // Upserted by slug, with the participation nested (#351): the identity may

--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -288,7 +288,11 @@ async function seedDev() {
       color: "#507BBD", logoScale: 0.5, rank: 10, jobOfferQuota: 1, allowsPromoIdeas: false,
     },
   ];
-  const sponsorTiers: Record<string, { id: number }> = {};
+  // Display attributes kept alongside the id: participations freeze them (#375).
+  const sponsorTiers: Record<
+    string,
+    { id: number; nameFr: string; nameEn: string; color: string; logoScale: number }
+  > = {};
   for (const t of TIER_CATALOG) {
     sponsorTiers[t.key] = await prisma.sponsorTier.upsert({
       where: { key: t.key },
@@ -522,15 +526,22 @@ async function seedDev() {
       },
     });
 
+    // Freeze what this edition displays (#375), like the admin does on create:
+    // the demo data then exercises the archive path rather than the fallback.
+    const tier = sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]];
+    const frozen = {
+      logoUrl: `/images/sponsors/${s.slug}.svg`,
+      tierId: tier.id,
+      tierNameFr: tier.nameFr,
+      tierNameEn: tier.nameEn,
+      tierColor: tier.color,
+      tierLogoScale: tier.logoScale,
+      publicationStatus: "PUBLISHED" as const,
+    };
     await prisma.editionSponsor.upsert({
       where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: edition.id } },
-      update: { tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id, publicationStatus: "PUBLISHED" },
-      create: {
-        sponsorId: sponsor.id,
-        editionId: edition.id,
-        tierId: sponsorTiers[DEMO_LEVEL_TO_TIER[s.level]].id,
-        publicationStatus: "PUBLISHED",
-      },
+      update: frozen,
+      create: { sponsorId: sponsor.id, editionId: edition.id, ...frozen },
     });
   }
 

--- a/src/backend/src/__tests__/admin-editions.test.ts
+++ b/src/backend/src/__tests__/admin-editions.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { buildAdminApp } from "./test-admin-app.js";
+import { prisma } from "../lib/prisma.js";
+import { createSponsorFixture, tierIdByKey } from "./sponsor-test-helpers.js";
+
+// Below the seeded range (2016+, #292) so a parallel file can never pick this
+// edition up as "the most recent one" mid-test.
+const createdEditionIds: number[] = [];
+
+afterEach(async () => {
+  if (createdEditionIds.length) {
+    await prisma.edition.deleteMany({ where: { id: { in: createdEditionIds } } });
+    createdEditionIds.length = 0;
+  }
+});
 
 describe("Admin Editions API", () => {
   it("GET /api/admin/editions should list editions", async () => {
@@ -101,5 +114,27 @@ describe("Admin Editions API", () => {
       })),
     });
     await app.close();
+  });
+
+  // The 409 body is admin-facing text, not a Prisma internal: `editionSponsors`
+  // is the join's relation name since #129, but an organiser reading the
+  // refusal should see "sponsors", not the schema's own vocabulary.
+  it("DELETE refuses with a human label, not the Prisma relation name", async () => {
+    const edition = await prisma.edition.create({ data: { year: 1850, status: "SEE_YOU_NEXT_YEAR" } });
+    createdEditionIds.push(edition.id);
+    await createSponsorFixture({
+      name: "Blocking Sponsor",
+      slug: `blocking-sponsor-${Date.now()}`,
+      editionId: edition.id,
+      tierId: await tierIdByKey("gold"),
+    });
+
+    const app = await buildAdminApp();
+    const res = await app.inject({ method: "DELETE", url: `/api/admin/editions/${edition.id}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain("sponsors (1)");
+    expect(res.json().error).not.toContain("editionSponsors");
   });
 });

--- a/src/backend/src/__tests__/admin-sponsor-contacts.test.ts
+++ b/src/backend/src/__tests__/admin-sponsor-contacts.test.ts
@@ -10,7 +10,7 @@ import Fastify, { type FastifyInstance } from "fastify";
 import adminSponsorRoutes from "../routes/admin/sponsors.js";
 import { prisma } from "../lib/prisma.js";
 import { getSeededEdition } from "./edition-test-helpers.js";
-import { tierIdByKey } from "./sponsor-test-helpers.js";
+import { createSponsorFixture, tierIdByKey } from "./sponsor-test-helpers.js";
 
 // Admin management of sponsor contacts (#250): add, list, lock, resend, delete.
 
@@ -26,8 +26,8 @@ describe("Admin sponsor contacts (#250)", () => {
     const edition = await getSeededEdition();
     editionId = edition.id;
 
-    const sponsor = await prisma.sponsor.create({
-      data: { name: "Admin Contacts Sponsor", slug: `admin-contacts-${Date.now()}`, editionId, tierId: await tierIdByKey("gold") },
+    const sponsor = await createSponsorFixture({
+      name: "Admin Contacts Sponsor", slug: `admin-contacts-${Date.now()}`, editionId, tierId: await tierIdByKey("gold"),
     });
     sponsorId = sponsor.id;
   });
@@ -85,8 +85,8 @@ describe("Admin sponsor contacts (#250)", () => {
   });
 
   it("rejects a contact that belongs to another sponsor (404)", async () => {
-    const other = await prisma.sponsor.create({
-      data: { name: "Other Sponsor", slug: `other-${Date.now()}`, editionId, tierId: await tierIdByKey("gold") },
+    const other = await createSponsorFixture({
+      name: "Other Sponsor", slug: `other-${Date.now()}`, editionId, tierId: await tierIdByKey("gold"),
     });
     const otherContact = await prisma.sponsorContact.create({
       data: { sponsorId: other.id, email: "x@example.org" },

--- a/src/backend/src/__tests__/admin-sponsor-tiers.test.ts
+++ b/src/backend/src/__tests__/admin-sponsor-tiers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { buildAdminApp } from "./test-admin-app.js";
 import { prisma } from "../lib/prisma.js";
 import { getSeededEdition } from "./edition-test-helpers.js";
-import { tierIdByKey } from "./sponsor-test-helpers.js";
+import { createSponsorFixture, tierIdByKey } from "./sponsor-test-helpers.js";
 
 // #318 — CRUD of the global sponsoring-tier catalogue. Teardown is scoped to the
 // rows this file created (its keys are prefixed so they never clash with the
@@ -144,8 +144,8 @@ describe("Admin Sponsor Tiers API (#318)", () => {
   it("refuses to delete a tier still used by a live sponsor (409)", async () => {
     const edition = await getSeededEdition();
     const { id } = (await createTier({ key: `used-${Date.now()}` })).json();
-    const sponsor = await prisma.sponsor.create({
-      data: { name: "Tier User", slug: `tier-user-${Date.now()}`, editionId: edition.id, tierId: id },
+    const sponsor = await createSponsorFixture({
+      name: "Tier User", slug: `tier-user-${Date.now()}`, editionId: edition.id, tierId: id,
     });
 
     const app = await buildAdminApp();

--- a/src/backend/src/__tests__/admin-sponsors-bulk.test.ts
+++ b/src/backend/src/__tests__/admin-sponsors-bulk.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterAll } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import adminSponsorRoutes from "../routes/admin/sponsors.js";
+import { prisma } from "../lib/prisma.js";
+import { getSeededEdition } from "./edition-test-helpers.js";
+import { createSponsorFixture, tierIdByKey } from "./sponsor-test-helpers.js";
+
+// Minimal app for the route under test, same pattern as admin-speakers.test.ts.
+async function buildSponsorsApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(adminSponsorRoutes, { prefix: "/api/admin" });
+  return app;
+}
+
+const createdSponsorIds: number[] = [];
+
+afterAll(async () => {
+  if (createdSponsorIds.length > 0) {
+    await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
+  }
+});
+
+describe("POST /api/admin/sponsors/bulk — trash boundary", () => {
+  it("skips a trashed sponsor caught in the selection, and still updates the live one", async () => {
+    const app = await buildSponsorsApp();
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("gold");
+
+    const live = await createSponsorFixture({
+      name: `Bulk Live ${Date.now()}`,
+      slug: `bulk-live-${Date.now()}`,
+      editionId: edition.id,
+      tierId,
+      publicationStatus: "DRAFT",
+    });
+    const trashed = await createSponsorFixture({
+      name: `Bulk Trashed ${Date.now()}`,
+      slug: `bulk-trashed-${Date.now()}`,
+      editionId: edition.id,
+      tierId,
+      publicationStatus: "DRAFT",
+    });
+    createdSponsorIds.push(live.id, trashed.id);
+
+    // Trash one of the two before the bulk action runs.
+    await prisma.sponsor.update({ where: { id: trashed.id }, data: { deletedAt: new Date() } });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/admin/sponsors/bulk",
+      payload: { ids: [live.id, trashed.id], action: "setStatus", value: "PUBLISHED", editionId: edition.id },
+    });
+    expect(res.statusCode).toBe(200);
+    // Only the live sponsor's participation was touched — the trashed one is
+    // excluded from the count entirely.
+    expect(res.json().count).toBe(1);
+
+    const liveParticipation = await prisma.editionSponsor.findUnique({
+      where: { sponsorId_editionId: { sponsorId: live.id, editionId: edition.id } },
+    });
+    const trashedParticipation = await prisma.editionSponsor.findUnique({
+      where: { sponsorId_editionId: { sponsorId: trashed.id, editionId: edition.id } },
+    });
+    expect(liveParticipation!.publicationStatus).toBe("PUBLISHED");
+    // The trash is a real boundary: a trashed sponsor's participation must not
+    // be silently published by a bulk action run over a selection that
+    // happens to include it.
+    expect(trashedParticipation!.publicationStatus).toBe("DRAFT");
+
+    await app.close();
+  });
+});

--- a/src/backend/src/__tests__/edit-sponsor-platinum.test.ts
+++ b/src/backend/src/__tests__/edit-sponsor-platinum.test.ts
@@ -45,9 +45,11 @@ describe("Sponsor Platinum promo content (#252)", () => {
     });
     expect(res.statusCode).toBe(200);
 
-    const sponsor = await prisma.sponsor.findUnique({ where: { id: platinumId } });
-    expect(sponsor?.platinumPromoIdea).toBe("Une vidéo produit");
-    expect(sponsor?.platinumCoBuildIdea).toBe("Un live technique");
+    const participation = await prisma.editionSponsor.findUnique({
+      where: { sponsorId_editionId: { sponsorId: platinumId, editionId } },
+    });
+    expect(participation?.platinumPromoIdea).toBe("Une vidéo produit");
+    expect(participation?.platinumCoBuildIdea).toBe("Un live technique");
     await app.close();
   });
 
@@ -61,8 +63,10 @@ describe("Sponsor Platinum promo content (#252)", () => {
     // The request itself is valid (field is allowlisted); it's just not written.
     expect(res.statusCode).toBe(200);
 
-    const sponsor = await prisma.sponsor.findUnique({ where: { id: goldId } });
-    expect(sponsor?.platinumPromoIdea).toBeNull();
+    const participation = await prisma.editionSponsor.findUnique({
+      where: { sponsorId_editionId: { sponsorId: goldId, editionId } },
+    });
+    expect(participation?.platinumPromoIdea).toBeNull();
     await app.close();
   });
 

--- a/src/backend/src/__tests__/edit-sponsor-private.test.ts
+++ b/src/backend/src/__tests__/edit-sponsor-private.test.ts
@@ -46,8 +46,11 @@ describe("Sponsor private section (#249)", () => {
     expect(res.statusCode).toBe(200);
 
     const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
-    expect(sponsor?.comKitReceived).toBe(true);
-    expect(sponsor?.comKitLogoWebUrl).toBe("https://example.org/logo-web.png");
+    const participation = await prisma.editionSponsor.findUnique({
+      where: { sponsorId_editionId: { sponsorId, editionId } },
+    });
+    expect(participation?.comKitReceived).toBe(true);
+    expect(participation?.comKitLogoWebUrl).toBe("https://example.org/logo-web.png");
     // The empty contact row is dropped; only Alice remains.
     const stand = JSON.parse(sponsor?.standContacts ?? "[]");
     expect(stand).toHaveLength(1);

--- a/src/backend/src/__tests__/edit-sponsor-private.test.ts
+++ b/src/backend/src/__tests__/edit-sponsor-private.test.ts
@@ -58,6 +58,26 @@ describe("Sponsor private section (#249)", () => {
     await app.close();
   });
 
+  // #375 — a new logo belongs to the edition being edited. It also refreshes
+  // the company's current logo, so a later participation starts from it.
+  it("writes the logo onto the participation and the identity", async () => {
+    const app = await buildEditApp();
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/edit/${TOKEN}`,
+      payload: { logoUrl: "https://example.org/logo-2026.png" },
+    });
+    expect(res.statusCode).toBe(200);
+    await app.close();
+
+    const participation = await prisma.editionSponsor.findUnique({
+      where: { sponsorId_editionId: { sponsorId, editionId } },
+    });
+    const sponsor = await prisma.sponsor.findUnique({ where: { id: sponsorId } });
+    expect(participation?.logoUrl).toBe("https://example.org/logo-2026.png");
+    expect(sponsor?.logoUrl).toBe("https://example.org/logo-2026.png");
+  });
+
   it("returns the private block to the token holder (GET)", async () => {
     const app = await buildEditApp();
     const res = await app.inject({ method: "GET", url: `/api/edit/${TOKEN}` });

--- a/src/backend/src/__tests__/editions.test.ts
+++ b/src/backend/src/__tests__/editions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterAll } from "vitest";
 import { buildApp } from "./test-app.js";
 import { prisma } from "../lib/prisma.js";
 import { getSeededEdition } from "./edition-test-helpers.js";
-import { tierIdByKey } from "./sponsor-test-helpers.js";
+import { createSponsorFixture, tierIdByKey } from "./sponsor-test-helpers.js";
 
 describe("GET /api/editions/current", () => {
   it("should return the current edition", async () => {
@@ -28,14 +28,15 @@ describe("GET /api/editions/current", () => {
     expect(before.json().hasJobOffers).toBe(false);
     await app.close();
 
-    const sponsor = await prisma.sponsor.create({
-      data: {
-        name: "Nav Offers", slug: `nav-offers-${Date.now()}`, editionId: edition.id,
-        tierId: await tierIdByKey("gold"), publicationStatus: "PUBLISHED",
-      },
+    const sponsor = await createSponsorFixture({
+      name: "Nav Offers", slug: `nav-offers-${Date.now()}`, editionId: edition.id,
+      tierId: await tierIdByKey("gold"), publicationStatus: "PUBLISHED",
+    });
+    const editionSponsor = await prisma.editionSponsor.findUniqueOrThrow({
+      where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: edition.id } },
     });
     await prisma.sponsorJobOffer.create({
-      data: { sponsorId: sponsor.id, title: "Dev", descriptionFr: "", descriptionEn: "", url: "https://x.org" },
+      data: { editionSponsorId: editionSponsor.id, title: "Dev", descriptionFr: "", descriptionEn: "", url: "https://x.org" },
     });
 
     const app2 = await buildApp();

--- a/src/backend/src/__tests__/public-sponsors.test.ts
+++ b/src/backend/src/__tests__/public-sponsors.test.ts
@@ -64,6 +64,69 @@ describe("Public sponsors carry the tier (#321)", () => {
   });
 });
 
+// #375 — the wall serves what the edition displayed, not what the company and
+// the shared catalogue look like today.
+describe("The sponsor wall serves the edition's frozen values (#375)", () => {
+  it("prefers the participation's logo and tier label over the live ones", async () => {
+    const edition = await getSeededEdition();
+    const goldId = await tierIdByKey("gold");
+
+    const sponsor = await createSponsorFixture({
+      name: "Frozen Wall Co",
+      slug: `pub-frozen-${Date.now()}`,
+      editionId: edition.id,
+      tierId: goldId,
+      publicationStatus: "PUBLISHED",
+      // The company's current logo — what the wall must NOT show.
+      logoUrl: "/logos/current.svg",
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    await prisma.editionSponsor.updateMany({
+      where: { sponsorId: sponsor.id, editionId: edition.id },
+      data: { logoUrl: "/logos/that-year.svg", tierNameFr: "Or de 2026", tierColor: "#d4af37" },
+    });
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: "/api/sponsors" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const mine = res.json().find((s: { id: number }) => s.id === sponsor.id);
+    expect(mine.logoUrl).toBe("/logos/that-year.svg");
+    expect(mine.tier.nameFr).toBe("Or de 2026");
+    expect(mine.tier.color).toBe("#d4af37");
+    // Not frozen: key and rank drive grouping and ordering, so they stay live.
+    expect(mine.tier.key).toBe("gold");
+  });
+
+  it("falls back to the company's logo when the edition froze none", async () => {
+    const edition = await getSeededEdition();
+    const goldId = await tierIdByKey("gold");
+
+    // createSponsorFixture sets logoUrl on the identity only, so the
+    // participation carries null — a row created before #375 looks like this.
+    const sponsor = await createSponsorFixture({
+      name: "Fallback Wall Co",
+      slug: `pub-fallback-${Date.now()}`,
+      editionId: edition.id,
+      tierId: goldId,
+      publicationStatus: "PUBLISHED",
+      logoUrl: "/logos/identity.svg",
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: "/api/sponsors" });
+    await app.close();
+
+    const live = await prisma.sponsorTier.findUniqueOrThrow({ where: { id: goldId } });
+    const mine = res.json().find((s: { id: number }) => s.id === sponsor.id);
+    expect(mine.logoUrl).toBe("/logos/identity.svg");
+    expect(mine.tier.nameFr).toBe(live.nameFr);
+  });
+});
+
 // Years 1760 and 1761 are reserved for this file's past-edition fixtures.
 // Both sit below getSeededEdition()'s 2016 floor, so parallel test files
 // cannot pick them up as "the current edition" (#292).

--- a/src/backend/src/__tests__/public-sponsors.test.ts
+++ b/src/backend/src/__tests__/public-sponsors.test.ts
@@ -2,17 +2,22 @@ import { describe, it, expect, afterEach } from "vitest";
 import { buildPublicApp } from "./test-public-app.js";
 import { prisma } from "../lib/prisma.js";
 import { getSeededEdition } from "./edition-test-helpers.js";
-import { tierIdByKey } from "./sponsor-test-helpers.js";
+import { tierIdByKey, createSponsorFixture } from "./sponsor-test-helpers.js";
 
 // #321 — the public /api/sponsors response carries the tier object
 // (key, rank, nameFr, nameEn, logoScale, color) and no longer any legacy
 // `level` string; it stays ordered by tier rank (RG-221).
 const createdSponsorIds: number[] = [];
+const createdEditionIds: number[] = [];
 
 afterEach(async () => {
   if (createdSponsorIds.length) {
     await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
     createdSponsorIds.length = 0;
+  }
+  if (createdEditionIds.length) {
+    await prisma.edition.deleteMany({ where: { id: { in: createdEditionIds } } });
+    createdEditionIds.length = 0;
   }
 });
 
@@ -24,11 +29,11 @@ describe("Public sponsors carry the tier (#321)", () => {
 
     // Create a gold sponsor whose name sorts before the platinum one, to prove
     // the ordering is by rank (platinum first), not by name.
-    const gold = await prisma.sponsor.create({
-      data: { name: "AAAA Gold Co", slug: `pub-gold-${Date.now()}`, editionId: edition.id, tierId: goldId, publicationStatus: "PUBLISHED" },
+    const gold = await createSponsorFixture({
+      name: "AAAA Gold Co", slug: `pub-gold-${Date.now()}`, editionId: edition.id, tierId: goldId, publicationStatus: "PUBLISHED",
     });
-    const platinum = await prisma.sponsor.create({
-      data: { name: "ZZZZ Platinum Co", slug: `pub-plat-${Date.now()}`, editionId: edition.id, tierId: platinumId, publicationStatus: "PUBLISHED" },
+    const platinum = await createSponsorFixture({
+      name: "ZZZZ Platinum Co", slug: `pub-plat-${Date.now()}`, editionId: edition.id, tierId: platinumId, publicationStatus: "PUBLISHED",
     });
     createdSponsorIds.push(gold.id, platinum.id);
 
@@ -56,5 +61,54 @@ describe("Public sponsors carry the tier (#321)", () => {
     expect(platIdx).toBeLessThan(goldIdx);
     expect(body[platIdx].tier.key).toBe("platinum");
     expect(body[goldIdx].tier.key).toBe("gold");
+  });
+});
+
+describe("Sponsor detail spans editions (#129)", () => {
+  it("serves a sponsor of a past edition with no tier and no offers", async () => {
+    const past = await prisma.edition.create({ data: { year: 1760 } });
+    const tierId = await tierIdByKey("gold");
+    const sponsor = await createSponsorFixture({
+      name: "Past Only Co",
+      slug: `past-only-${Date.now()}`,
+      editionId: past.id,
+      tierId,
+      publicationStatus: "PUBLISHED",
+    });
+    createdSponsorIds.push(sponsor.id);
+    createdEditionIds.push(past.id);
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: `/api/sponsors/${sponsor.slug}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // Not sponsoring the featured edition: highlight is empty, history remains.
+    expect(body.tier).toBeNull();
+    expect(body.jobOffers).toEqual([]);
+    expect(body.editions).toEqual([1760]);
+  });
+
+  it("highlights the tier of the featured edition", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("platinum");
+    const sponsor = await createSponsorFixture({
+      name: "Current Co",
+      slug: `current-${Date.now()}`,
+      editionId: edition.id,
+      tierId,
+      publicationStatus: "PUBLISHED",
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: `/api/sponsors/${sponsor.slug}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.tier.key).toBe("platinum");
+    expect(body.editions).toContain(edition.year);
   });
 });

--- a/src/backend/src/__tests__/public-sponsors.test.ts
+++ b/src/backend/src/__tests__/public-sponsors.test.ts
@@ -64,9 +64,13 @@ describe("Public sponsors carry the tier (#321)", () => {
   });
 });
 
+// Years 1760 and 1761 are reserved for this file's past-edition fixtures.
+// Both sit below getSeededEdition()'s 2016 floor, so parallel test files
+// cannot pick them up as "the current edition" (#292).
 describe("Sponsor detail spans editions (#129)", () => {
-  it("serves a sponsor of a past edition with no tier and no offers", async () => {
+  it("serves a sponsor of a past edition with no tier and no offers, even if it had one", async () => {
     const past = await prisma.edition.create({ data: { year: 1760 } });
+    const pastAgain = await prisma.edition.create({ data: { year: 1761 } });
     const tierId = await tierIdByKey("gold");
     const sponsor = await createSponsorFixture({
       name: "Past Only Co",
@@ -76,7 +80,23 @@ describe("Sponsor detail spans editions (#129)", () => {
       publicationStatus: "PUBLISHED",
     });
     createdSponsorIds.push(sponsor.id);
-    createdEditionIds.push(past.id);
+    createdEditionIds.push(past.id, pastAgain.id);
+
+    // A second past participation, ordered newest-first below.
+    await prisma.editionSponsor.create({
+      data: { sponsorId: sponsor.id, editionId: pastAgain.id, tierId, publicationStatus: "PUBLISHED" },
+    });
+
+    // Even a past edition can carry a job offer in the data (e.g. never
+    // cleaned up) — the rule is "no past offer is ever shown", not "past
+    // sponsors never had offers". Prove the filter actually holds.
+    const pastParticipation = await prisma.editionSponsor.findUniqueOrThrow({
+      where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: past.id } },
+      select: { id: true },
+    });
+    await prisma.sponsorJobOffer.create({
+      data: { editionSponsorId: pastParticipation.id, title: "Old role", url: "https://example.org/old-job" },
+    });
 
     const app = await buildPublicApp();
     const res = await app.inject({ method: "GET", url: `/api/sponsors/${sponsor.slug}` });
@@ -87,7 +107,8 @@ describe("Sponsor detail spans editions (#129)", () => {
     // Not sponsoring the featured edition: highlight is empty, history remains.
     expect(body.tier).toBeNull();
     expect(body.jobOffers).toEqual([]);
-    expect(body.editions).toEqual([1760]);
+    // Newest first, unpinned by fixture insertion order.
+    expect(body.editions).toEqual([1761, 1760]);
   });
 
   it("highlights the tier of the featured edition", async () => {
@@ -108,7 +129,15 @@ describe("Sponsor detail spans editions (#129)", () => {
 
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    expect(body.tier.key).toBe("platinum");
+    // Full tier shape (RG-221 banner colour / logo size), not just the key.
+    expect(body.tier).toMatchObject({
+      key: "platinum",
+      nameFr: expect.any(String),
+      nameEn: expect.any(String),
+      color: expect.any(String),
+    });
+    expect(typeof body.tier.logoScale).toBe("number");
+    expect(typeof body.tier.rank).toBe("number");
     expect(body.editions).toContain(edition.year);
   });
 });

--- a/src/backend/src/__tests__/speaker-edition-sponsor.test.ts
+++ b/src/backend/src/__tests__/speaker-edition-sponsor.test.ts
@@ -165,6 +165,39 @@ describe("Speaker sponsor per edition (#353)", () => {
     expect(res.json().participations[0].sponsor).toBeNull();
   });
 
+  it("publishes per participation, not per identity — one sponsor, two years", async () => {
+    // The decision this task implements: `publicationStatus` left the identity
+    // for EditionSponsor (#129), so "published" means published for THAT
+    // year's participation. A wrong reading — e.g. "published on any year" —
+    // would leak this sponsor's name onto the draft year too.
+    const older = await makeEdition(1708);
+    const newer = await makeEdition(1709);
+    const tierId = await tierIdByKey("gold");
+
+    const sponsor = await createSponsorFixture({
+      name: "Mixed Status Sponsor",
+      slug: `mixed-status-sponsor-${uniq()}`,
+      editionId: older.id,
+      tierId,
+      publicationStatus: "DRAFT",
+    });
+    createdSponsorIds.push(sponsor.id);
+    await prisma.editionSponsor.create({
+      data: { sponsorId: sponsor.id, editionId: newer.id, tierId, publicationStatus: "PUBLISHED" },
+    });
+
+    const person = await makePerson("Mixed Status Employee", [
+      { editionId: older.id, sponsorId: sponsor.id },
+      { editionId: newer.id, sponsorId: sponsor.id },
+    ]);
+
+    const res = await fetchSpeaker(person.slug);
+
+    const participations = res.json().participations;
+    expect(participations.find((p: { year: number }) => p.year === 1708).sponsor).toBeNull();
+    expect(participations.find((p: { year: number }) => p.year === 1709).sponsor.name).toBe("Mixed Status Sponsor");
+  });
+
   it("keeps the participation when the sponsor is deleted", async () => {
     const edition = await makeEdition(1707);
     const sponsor = await makeSponsor(edition.id, "Doomed Sponsor");

--- a/src/backend/src/__tests__/speaker-edition-sponsor.test.ts
+++ b/src/backend/src/__tests__/speaker-edition-sponsor.test.ts
@@ -3,6 +3,7 @@ import Fastify from "fastify";
 
 import speakerRoutes from "../routes/speakers.js";
 import { prisma } from "../lib/prisma.js";
+import { createSponsorFixture, tierIdByKey } from "./sponsor-test-helpers.js";
 
 // #353 — the sponsor association moved from Speaker to SpeakerEdition. Working
 // for a sponsor is true of a given year, and Sponsor is edition-scoped itself,
@@ -59,15 +60,12 @@ async function makeSponsor(
   { publicationStatus }: { publicationStatus?: "DRAFT" | "PUBLISHED" } = {},
 ) {
   // Sponsor needs a tier; reuse whichever the catalogue already holds.
-  const tier = await prisma.sponsorTier.findFirstOrThrow();
-  const sponsor = await prisma.sponsor.create({
-    data: {
-      editionId,
-      tierId: tier.id,
-      name,
-      slug: `sponsor-${name.toLowerCase().replace(/\W+/g, "-")}-${uniq()}`,
-      publicationStatus: publicationStatus ?? "PUBLISHED",
-    },
+  const sponsor = await createSponsorFixture({
+    editionId,
+    tierId: await tierIdByKey("gold"),
+    name,
+    slug: `sponsor-${name.toLowerCase().replace(/\W+/g, "-")}-${uniq()}`,
+    publicationStatus: publicationStatus ?? "PUBLISHED",
   });
   createdSponsorIds.push(sponsor.id);
   return sponsor;

--- a/src/backend/src/__tests__/sponsor-contacts.test.ts
+++ b/src/backend/src/__tests__/sponsor-contacts.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { buildEditApp } from "./test-edit-app.js";
 import { prisma } from "../lib/prisma.js";
 import { getSeededEdition } from "./edition-test-helpers.js";
-import { tierIdByKey } from "./sponsor-test-helpers.js";
+import { createSponsorFixture, tierIdByKey } from "./sponsor-test-helpers.js";
 
 // Secondary contacts (#250): a sponsor can have several contacts, each with its
 // own modification link, lock and expiry — all editing the same sponsor page.
@@ -17,19 +17,17 @@ describe("Sponsor secondary contacts (#250)", () => {
     const edition = await getSeededEdition();
     editionId = edition.id;
 
-    const sponsor = await prisma.sponsor.create({
-      data: {
-        name: "Multi Contact Sponsor", slug: `multi-contact-${Date.now()}`, editionId, tierId: await tierIdByKey("gold"),
-        publicationStatus: "PUBLISHED",
-        contacts: {
-          create: [
-            { email: "primary@example.org", editToken: TOKEN_A, editTokenSentAt: new Date() },
-            { email: "secondary@example.org", editToken: TOKEN_B, editTokenSentAt: new Date() },
-          ],
-        },
-      },
+    const sponsor = await createSponsorFixture({
+      name: "Multi Contact Sponsor", slug: `multi-contact-${Date.now()}`, editionId, tierId: await tierIdByKey("gold"),
+      publicationStatus: "PUBLISHED",
     });
     sponsorId = sponsor.id;
+    await prisma.sponsorContact.createMany({
+      data: [
+        { sponsorId, email: "primary@example.org", editToken: TOKEN_A, editTokenSentAt: new Date() },
+        { sponsorId, email: "secondary@example.org", editToken: TOKEN_B, editTokenSentAt: new Date() },
+      ],
+    });
   });
 
   afterAll(async () => {

--- a/src/backend/src/__tests__/sponsor-identity.test.ts
+++ b/src/backend/src/__tests__/sponsor-identity.test.ts
@@ -11,6 +11,7 @@ import { tierIdByKey } from "./sponsor-test-helpers.js";
 
 const createdSponsorIds: number[] = [];
 const createdEditionIds: number[] = [];
+const createdTierIds: number[] = [];
 
 afterEach(async () => {
   if (createdSponsorIds.length) {
@@ -22,6 +23,11 @@ afterEach(async () => {
   if (createdEditionIds.length) {
     await prisma.edition.deleteMany({ where: { id: { in: createdEditionIds } } });
     createdEditionIds.length = 0;
+  }
+  // Last: EditionSponsor.tierId holds a tier until its participations are gone.
+  if (createdTierIds.length) {
+    await prisma.sponsorTier.deleteMany({ where: { id: { in: createdTierIds } } });
+    createdTierIds.length = 0;
   }
 });
 
@@ -123,6 +129,76 @@ describe("Sponsor identity (#129)", () => {
 
     expect(sponsor.editions[0].jobOffers).toHaveLength(1);
     expect(sponsor.editions[0].jobOffers[0].title).toBe("Dev");
+  });
+
+  // #375 — the identity/participation split moved the logo off the year it
+  // belonged to. What an edition displayed is frozen on its participation, so
+  // neither the company nor the shared tier catalogue can rewrite an archive.
+
+  it("keeps a past edition's logo when the company changes its own", async () => {
+    const tierId = await tierIdByKey("gold");
+    const past = await prisma.edition.create({ data: { year: 1751 } });
+    createdEditionIds.push(past.id);
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Rebranding Co",
+        slug: `archive-logo-${Date.now()}`,
+        logoUrl: "/logos/old.svg",
+        editions: { create: [{ editionId: past.id, tierId, logoUrl: "/logos/old.svg" }] },
+      },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    await prisma.sponsor.update({
+      where: { id: sponsor.id },
+      data: { logoUrl: "/logos/new.svg" },
+    });
+
+    const participation = await prisma.editionSponsor.findFirstOrThrow({
+      where: { sponsorId: sponsor.id, editionId: past.id },
+    });
+    expect(participation.logoUrl).toBe("/logos/old.svg");
+  });
+
+  it("keeps a past edition's tier label when the catalogue is renamed", async () => {
+    const past = await prisma.edition.create({ data: { year: 1752 } });
+    createdEditionIds.push(past.id);
+
+    // A throwaway tier: renaming a seeded one would leak into other test files.
+    const tier = await prisma.sponsorTier.create({
+      data: { key: `archive-tier-${Date.now()}`, nameFr: "Or", nameEn: "Gold", color: "#d4af37" },
+    });
+    createdTierIds.push(tier.id);
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Frozen Tier Co",
+        slug: `archive-tier-${Date.now()}`,
+        editions: {
+          create: [{
+            editionId: past.id,
+            tierId: tier.id,
+            tierNameFr: tier.nameFr,
+            tierNameEn: tier.nameEn,
+            tierColor: tier.color,
+          }],
+        },
+      },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    await prisma.sponsorTier.update({
+      where: { id: tier.id },
+      data: { nameFr: "Platine", nameEn: "Platinum", color: "#e5e4e2" },
+    });
+
+    const participation = await prisma.editionSponsor.findFirstOrThrow({
+      where: { sponsorId: sponsor.id, editionId: past.id },
+    });
+    expect(participation.tierNameFr).toBe("Or");
+    expect(participation.tierNameEn).toBe("Gold");
+    expect(participation.tierColor).toBe("#d4af37");
   });
 
   it("keeps contacts on the company, shared across its editions", async () => {

--- a/src/backend/src/__tests__/sponsor-identity.test.ts
+++ b/src/backend/src/__tests__/sponsor-identity.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { prisma } from "../lib/prisma.js";
+
+import { getSeededEdition } from "./edition-test-helpers.js";
+import { tierIdByKey } from "./sponsor-test-helpers.js";
+
+// #129 — a sponsor is a company, not a per-edition row. The slug is global and
+// participation lives on EditionSponsor. These are the invariants the rest of
+// the sponsor work (#130, #131, #132) is allowed to assume.
+
+const createdSponsorIds: number[] = [];
+
+afterEach(async () => {
+  if (createdSponsorIds.length) {
+    // EditionSponsor and SponsorJobOffer cascade from Sponsor.
+    await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
+    createdSponsorIds.length = 0;
+  }
+});
+
+describe("Sponsor identity (#129)", () => {
+  it("rejects a second sponsor with the same slug, whatever the edition", async () => {
+    const slug = `identity-dup-${Date.now()}`;
+    const first = await prisma.sponsor.create({ data: { name: "Acme", slug } });
+    createdSponsorIds.push(first.id);
+
+    await expect(
+      prisma.sponsor.create({ data: { name: "Acme Again", slug } }),
+    ).rejects.toThrow();
+  });
+
+  it("carries one company across two editions as two participations", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("gold");
+
+    // year is the only required field on Edition, and it is @unique.
+    //
+    // 1900, NOT a future year: getSeededEdition() picks the most recent edition
+    // at or after 2016, so a 2999 row would be handed to whichever parallel
+    // test file asked for an edition while this one still existed — exactly the
+    // #292 race that helper was written to close. Below 2016 it is invisible.
+    const other = await prisma.edition.create({ data: { year: 1900 } });
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Multi Year Co",
+        slug: `identity-multi-${Date.now()}`,
+        editions: {
+          create: [
+            { editionId: edition.id, tierId, publicationStatus: "PUBLISHED" },
+            { editionId: other.id, tierId, publicationStatus: "DRAFT" },
+          ],
+        },
+      },
+      include: { editions: true },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    expect(sponsor.editions).toHaveLength(2);
+
+    const years = await prisma.editionSponsor.findMany({
+      where: { sponsorId: sponsor.id },
+      select: { edition: { select: { year: true } }, publicationStatus: true },
+    });
+    expect(years.map((p) => p.edition.year).sort()).toEqual([edition.year, 1900].sort());
+
+    await prisma.edition.delete({ where: { id: other.id } });
+  });
+
+  it("refuses two participations of one company on the same edition", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("gold");
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Once Per Year Co",
+        slug: `identity-once-${Date.now()}`,
+        editions: { create: [{ editionId: edition.id, tierId }] },
+      },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    await expect(
+      prisma.editionSponsor.create({ data: { sponsorId: sponsor.id, editionId: edition.id, tierId } }),
+    ).rejects.toThrow();
+  });
+
+  it("hangs job offers off the participation, not the company", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("gold");
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Hiring Co",
+        slug: `identity-offers-${Date.now()}`,
+        editions: {
+          create: [{
+            editionId: edition.id,
+            tierId,
+            jobOffers: { create: [{ title: "Dev", url: "https://example.org/job" }] },
+          }],
+        },
+      },
+      include: { editions: { include: { jobOffers: true } } },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    expect(sponsor.editions[0].jobOffers).toHaveLength(1);
+    expect(sponsor.editions[0].jobOffers[0].title).toBe("Dev");
+  });
+
+  it("keeps contacts on the company, shared across its editions", async () => {
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Contactable Co",
+        slug: `identity-contact-${Date.now()}`,
+        contacts: { create: [{ email: "boss@example.org" }] },
+      },
+      include: { contacts: true },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    expect(sponsor.contacts).toHaveLength(1);
+    expect(sponsor.contacts[0].email).toBe("boss@example.org");
+  });
+});

--- a/src/backend/src/__tests__/sponsor-identity.test.ts
+++ b/src/backend/src/__tests__/sponsor-identity.test.ts
@@ -10,12 +10,18 @@ import { tierIdByKey } from "./sponsor-test-helpers.js";
 // the sponsor work (#130, #131, #132) is allowed to assume.
 
 const createdSponsorIds: number[] = [];
+const createdEditionIds: number[] = [];
 
 afterEach(async () => {
   if (createdSponsorIds.length) {
-    // EditionSponsor and SponsorJobOffer cascade from Sponsor.
+    // EditionSponsor and SponsorJobOffer cascade from Sponsor. Delete sponsors
+    // first so their participations are gone before we delete the edition.
     await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
     createdSponsorIds.length = 0;
+  }
+  if (createdEditionIds.length) {
+    await prisma.edition.deleteMany({ where: { id: { in: createdEditionIds } } });
+    createdEditionIds.length = 0;
   }
 });
 
@@ -41,6 +47,7 @@ describe("Sponsor identity (#129)", () => {
     // test file asked for an edition while this one still existed — exactly the
     // #292 race that helper was written to close. Below 2016 it is invisible.
     const other = await prisma.edition.create({ data: { year: 1900 } });
+    createdEditionIds.push(other.id);
 
     const sponsor = await prisma.sponsor.create({
       data: {
@@ -64,8 +71,6 @@ describe("Sponsor identity (#129)", () => {
       select: { edition: { select: { year: true } }, publicationStatus: true },
     });
     expect(years.map((p) => p.edition.year).sort()).toEqual([edition.year, 1900].sort());
-
-    await prisma.edition.delete({ where: { id: other.id } });
   });
 
   it("refuses two participations of one company on the same edition", async () => {

--- a/src/backend/src/__tests__/sponsor-identity.test.ts
+++ b/src/backend/src/__tests__/sponsor-identity.test.ts
@@ -42,11 +42,15 @@ describe("Sponsor identity (#129)", () => {
 
     // year is the only required field on Edition, and it is @unique.
     //
-    // 1900, NOT a future year: getSeededEdition() picks the most recent edition
+    // 1750, NOT a future year: getSeededEdition() picks the most recent edition
     // at or after 2016, so a 2999 row would be handed to whichever parallel
     // test file asked for an edition while this one still existed — exactly the
     // #292 race that helper was written to close. Below 2016 it is invisible.
-    const other = await prisma.edition.create({ data: { year: 1900 } });
+    //
+    // Test files each own a year block so two of them never collide on the
+    // @unique year: 16xx and 1990 are taken, 19xx by the speaker files. 17xx
+    // is this file's.
+    const other = await prisma.edition.create({ data: { year: 1750 } });
     createdEditionIds.push(other.id);
 
     const sponsor = await prisma.sponsor.create({
@@ -70,7 +74,13 @@ describe("Sponsor identity (#129)", () => {
       where: { sponsorId: sponsor.id },
       select: { edition: { select: { year: true } }, publicationStatus: true },
     });
-    expect(years.map((p) => p.edition.year).sort()).toEqual([edition.year, 1900].sort());
+    expect(years.map((p) => p.edition.year).sort()).toEqual([edition.year, 1750].sort());
+
+    // Publication is per participation, not per company: the same sponsor is
+    // live on one edition and still a draft on the other.
+    const byYear = new Map(years.map((p) => [p.edition.year, p.publicationStatus]));
+    expect(byYear.get(edition.year)).toBe("PUBLISHED");
+    expect(byYear.get(1750)).toBe("DRAFT");
   });
 
   it("refuses two participations of one company on the same edition", async () => {

--- a/src/backend/src/__tests__/sponsor-job-offers.test.ts
+++ b/src/backend/src/__tests__/sponsor-job-offers.test.ts
@@ -3,7 +3,7 @@ import { buildEditApp } from "./test-edit-app.js";
 import { buildPublicApp } from "./test-public-app.js";
 import { prisma } from "../lib/prisma.js";
 import { getSeededEdition } from "./edition-test-helpers.js";
-import { createSponsorWithToken, tierIdByKey } from "./sponsor-test-helpers.js";
+import { createSponsorFixture, createSponsorWithToken, tierIdByKey } from "./sponsor-test-helpers.js";
 
 // Sponsor job offers (#251): CRUD via the magic link, quota per level, HTML
 // sanitized, exposed publicly.
@@ -78,7 +78,11 @@ describe("Sponsor job offers (#251)", () => {
   it("rejects an unsafe URL", async () => {
     const app = await buildEditApp();
     // Delete one first so quota isn't the blocker.
-    const offer = await prisma.sponsorJobOffer.findFirst({ where: { sponsorId: goldSponsorId } });
+    const participation = await prisma.editionSponsor.findUniqueOrThrow({
+      where: { sponsorId_editionId: { sponsorId: goldSponsorId, editionId } },
+      select: { id: true },
+    });
+    const offer = await prisma.sponsorJobOffer.findFirst({ where: { editionSponsorId: participation.id } });
     await prisma.sponsorJobOffer.delete({ where: { id: offer!.id } });
 
     const res = await app.inject({
@@ -91,11 +95,15 @@ describe("Sponsor job offers (#251)", () => {
   });
 
   it("only edits offers belonging to the token's sponsor", async () => {
-    const other = await prisma.sponsor.create({
-      data: { name: "Other", slug: `offers-other-${Date.now()}`, editionId, tierId: await tierIdByKey("gold") },
+    const other = await createSponsorFixture({
+      name: "Other", slug: `offers-other-${Date.now()}`, editionId, tierId: await tierIdByKey("gold"),
+    });
+    const otherParticipation = await prisma.editionSponsor.findUniqueOrThrow({
+      where: { sponsorId_editionId: { sponsorId: other.id, editionId } },
+      select: { id: true },
     });
     const foreignOffer = await prisma.sponsorJobOffer.create({
-      data: { sponsorId: other.id, title: "Foreign", descriptionFr: "", descriptionEn: "", url: "https://x.org" },
+      data: { editionSponsorId: otherParticipation.id, title: "Foreign", descriptionFr: "", descriptionEn: "", url: "https://x.org" },
     });
     const app = await buildEditApp();
     const res = await app.inject({

--- a/src/backend/src/__tests__/sponsor-test-helpers.ts
+++ b/src/backend/src/__tests__/sponsor-test-helpers.ts
@@ -1,11 +1,29 @@
 import { prisma } from "../lib/prisma.js";
-import type { Prisma } from "../generated/prisma/client.js";
 
-// Resolve a seeded SponsorTier id from its stable key (#317). Sponsors carry a
-// tierId FK now, not a level enum, so fixtures fetch the id they need here.
+// Resolve a seeded SponsorTier id from its stable key (#317). The tier is bought
+// per edition since #129, so it is set on the participation, not the company.
 export async function tierIdByKey(key: string): Promise<number> {
   const tier = await prisma.sponsorTier.findFirstOrThrow({ where: { key } });
   return tier.id;
+}
+
+// A sponsor fixture on the identity/participation model (#129). Callers still
+// pass editionId/tierId/publicationStatus flat — those are what a test cares
+// about — and this factory files them into the participation.
+export interface SponsorFixture {
+  name: string;
+  slug: string;
+  editionId: number;
+  tierId: number;
+  publicationStatus?: "DRAFT" | "PUBLISHED";
+  logoUrl?: string | null;
+  websiteUrl?: string | null;
+  descriptionFr?: string | null;
+  descriptionEn?: string | null;
+  socialLinks?: string | null;
+  contactEmail?: string | null;
+  standContacts?: string | null;
+  locale?: string;
 }
 
 // Since #250 a sponsor's modification token lives on a SponsorContact, not on
@@ -13,11 +31,19 @@ export async function tierIdByKey(key: string): Promise<number> {
 // token, so tests can resolve /api/edit/:token exactly as before.
 
 export async function createSponsorWithToken(
-  data: Prisma.SponsorUncheckedCreateInput,
+  data: SponsorFixture,
   token: string,
   contact?: { email?: string; sentAt?: Date; locked?: boolean },
 ) {
-  const sponsor = await prisma.sponsor.create({ data });
+  const { editionId, tierId, publicationStatus, ...identity } = data;
+  const sponsor = await prisma.sponsor.create({
+    data: {
+      ...identity,
+      editions: {
+        create: [{ editionId, tierId, publicationStatus: publicationStatus ?? "DRAFT" }],
+      },
+    },
+  });
   await prisma.sponsorContact.create({
     data: {
       sponsorId: sponsor.id,
@@ -28,4 +54,17 @@ export async function createSponsorWithToken(
     },
   });
   return sponsor;
+}
+
+// Same shape as createSponsorWithToken, without the modification-link contact.
+export async function createSponsorFixture(data: SponsorFixture) {
+  const { editionId, tierId, publicationStatus, ...identity } = data;
+  return prisma.sponsor.create({
+    data: {
+      ...identity,
+      editions: {
+        create: [{ editionId, tierId, publicationStatus: publicationStatus ?? "DRAFT" }],
+      },
+    },
+  });
 }

--- a/src/backend/src/lib/sponsor-archive.ts
+++ b/src/backend/src/lib/sponsor-archive.ts
@@ -1,0 +1,54 @@
+// What a sponsor looked like on a given edition (#375).
+//
+// #129 made Sponsor a company identity shared across editions, which moved the
+// logo off the year it belonged to: a 2027 logo change would repaint the 2026
+// wall. The tier had the same problem from the other side — it is bought per
+// edition, but its name, colour and logo scale live in a shared catalogue that
+// renaming "Gold" mutates for every past edition at once.
+//
+// So the participation stores what was displayed. Both readers below prefer
+// that frozen value and fall back to the live one when it is null, which is
+// what a participation created before this change looks like.
+
+interface FrozenLogo {
+  logoUrl: string | null;
+}
+
+interface LiveTier {
+  key: string;
+  rank: number;
+  nameFr: string;
+  nameEn: string;
+  logoScale: number;
+  color: string;
+}
+
+interface FrozenTier {
+  tierNameFr: string | null;
+  tierNameEn: string | null;
+  tierColor: string | null;
+  tierLogoScale: number | null;
+}
+
+// The logo this edition showed, falling back to the company's current one.
+export function archivedLogoUrl(
+  participation: FrozenLogo,
+  sponsor: { logoUrl: string | null },
+): string | null {
+  return participation.logoUrl ?? sponsor.logoUrl;
+}
+
+// The tier as this edition displayed it. `key` and `rank` are never frozen:
+// they drive grouping and ordering, not appearance, and a renamed tier is
+// still the same offer.
+export function archivedTier(participation: FrozenTier & { tier: LiveTier }) {
+  const { tier } = participation;
+  return {
+    key: tier.key,
+    rank: tier.rank,
+    nameFr: participation.tierNameFr ?? tier.nameFr,
+    nameEn: participation.tierNameEn ?? tier.nameEn,
+    logoScale: participation.tierLogoScale ?? tier.logoScale,
+    color: participation.tierColor ?? tier.color,
+  };
+}

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -113,7 +113,10 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
               // `categories` below: the join row has no deletedAt of its own.
               speakers: { where: { speaker: notDeleted } },
               talks: { where: notDeleted },
-              sponsors: { where: notDeleted },
+              // `editionSponsors` is the EditionSponsor join since #129, same as
+              // `speakers` and `categories`: the join row has no deletedAt, so
+              // the filter targets the company.
+              editionSponsors: { where: { sponsor: notDeleted } },
               // `categories` is the EditionCategory join since #338: the join
               // row carries no deletedAt, so the filter targets the track.
               categories: { where: { category: notDeleted } },
@@ -151,7 +154,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         articlesCount: edition._count.articles,
         speakersCount: edition._count.speakers,
         talksCount: edition._count.talks,
-        sponsorsCount: edition._count.sponsors,
+        sponsorsCount: edition._count.editionSponsors,
         categoriesCount: edition._count.categories,
       };
     }
@@ -274,7 +277,9 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
               talks: { where: notDeleted },
               // The SpeakerEdition join since #351 — no deletedAt of its own.
               speakers: { where: { speaker: notDeleted } },
-              sponsors: { where: notDeleted },
+              // `editionSponsors` is the EditionSponsor join since #129: the join
+              // row has no deletedAt, so the filter targets the company.
+              editionSponsors: { where: { sponsor: notDeleted } },
               // `categories` is the EditionCategory join since #338: the join
               // row carries no deletedAt, so the filter targets the track.
               categories: { where: { category: notDeleted } },

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -296,9 +296,15 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       // trashed *by* the cascade — otherwise it resurrects what should stay
       // gone. The article check below already worked this way; the other
       // children now follow the same rule.
+      //
+      // `_count` keys are Prisma relation names, not user-facing labels: since
+      // #129 the sponsor relation is `editionSponsors`, which reads as an
+      // internal implementation detail to an admin reading a 409. Map the one
+      // relation whose name diverges from what the organiser expects.
+      const RELATION_LABELS: Record<string, string> = { editionSponsors: "sponsors" };
       const blocking = Object.entries(existing._count)
         .filter(([, count]) => count > 0)
-        .map(([relation, count]) => `${relation} (${count})`);
+        .map(([relation, count]) => `${RELATION_LABELS[relation] ?? relation} (${count})`);
 
       if (blocking.length > 0) {
         return reply.status(409).send({

--- a/src/backend/src/routes/admin/sponsor-tiers.ts
+++ b/src/backend/src/routes/admin/sponsor-tiers.ts
@@ -139,8 +139,10 @@ export default async function adminSponsorTierRoutes(app: FastifyInstance) {
     const existing = await prisma.sponsorTier.findFirst({ where: { id, ...notDeleted } });
     if (!existing) return notFound(reply, "Sponsor tier");
 
+    // The tier is bought per edition since #129, so "in use" is asked of the
+    // participation, not the sponsor identity.
     const [sponsorCount, linkCount] = await Promise.all([
-      prisma.sponsor.count({ where: { tierId: id, ...notDeleted } }),
+      prisma.editionSponsor.count({ where: { tierId: id, sponsor: notDeleted } }),
       prisma.editionSponsorTier.count({ where: { tierId: id } }),
     ]);
     if (sponsorCount > 0 || linkCount > 0) {

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateJobOffers, revalidateSponsor, revalidateSponsors } from "../../lib/revalidate.js";
-import { slugify, uniqueSlug } from "../../lib/slug.js";
+import { slugify } from "../../lib/slug.js";
 import { generateEditToken } from "../../lib/edit-token.js";
 import { sendEditLinkEmail, normalizeLocale } from "../../lib/edit-link-email.js";
 import { sanitizeRichHtml } from "../../lib/sanitize.js";
@@ -14,10 +14,9 @@ interface StandContact {
   bluesky?: string;
 }
 
-interface SponsorCreateBody {
-  editionId: number;
+// Identity — shared across every edition the company sponsors.
+interface SponsorIdentityFields {
   name: string;
-  tierId: number;
   logoUrl?: string;
   websiteUrl?: string;
   descriptionFr?: string;
@@ -25,9 +24,15 @@ interface SponsorCreateBody {
   socialLinks?: Record<string, string>;
   contactEmail?: string;
   locale?: string;
-  publicationStatus?: "DRAFT" | "PUBLISHED";
   // Private fields (#249) — organizers only.
   standContacts?: StandContact[];
+}
+
+// Participation — bought or tracked for one edition (#129).
+interface SponsorParticipationFields {
+  tierId: number;
+  publicationStatus?: "DRAFT" | "PUBLISHED";
+  // Private fields (#249) — organizers only.
   comKitReceived?: boolean;
   comKitLogoWebUrl?: string;
   comKitLogoPrintUrl?: string;
@@ -37,7 +42,13 @@ interface SponsorCreateBody {
   platinumCoBuildIdea?: string;
 }
 
-type SponsorUpdateBody = Partial<Omit<SponsorCreateBody, "editionId">>;
+interface SponsorCreateBody extends SponsorIdentityFields, SponsorParticipationFields {
+  editionId: number;
+}
+
+// `editionId` says which participation the per-year fields target (defaults to
+// the most recent one when omitted).
+type SponsorUpdateBody = Partial<Omit<SponsorCreateBody, "editionId">> & { editionId?: number };
 
 interface SponsorIdParams {
   id: string;
@@ -51,17 +62,65 @@ interface SponsorBulkBody {
   ids: number[];
   action: "setStatus";
   value: "DRAFT" | "PUBLISHED";
+  editionId: number;
 }
 
+const TIER_SELECT = { id: true, key: true, nameFr: true, nameEn: true, rank: true } as const;
+
+interface ParticipationLike {
+  id: number;
+  publicationStatus: "DRAFT" | "PUBLISHED";
+  comKitReceived?: boolean;
+  comKitLogoWebUrl?: string | null;
+  comKitLogoPrintUrl?: string | null;
+  comKitCharterUrl?: string | null;
+  comKitNotes?: string | null;
+  platinumPromoIdea?: string | null;
+  platinumCoBuildIdea?: string | null;
+  editionId: number;
+  edition: { id: number; year: number };
+  tier: { id: number; key: string; nameFr: string; nameEn: string; rank: number };
+  jobOffers?: unknown[];
+}
+
+// Flatten identity + the participation the admin is looking at (the most
+// recent one, unless the list/detail query narrowed to a single edition) into
+// the shape the admin frontend already expects: flat `tier`, `tierId`,
+// `publicationStatus`, `edition`, `editionId`.
 function serialize(s: {
   socialLinks: string | null;
   standContacts?: string | null;
+  editions?: ParticipationLike[];
   [k: string]: unknown;
 }) {
+  const { editions, ...rest } = s;
+  const current = editions?.[0];
   return {
-    ...s,
+    ...rest,
     socialLinks: s.socialLinks ? JSON.parse(s.socialLinks) : {},
     standContacts: s.standContacts ? JSON.parse(s.standContacts) : [],
+    ...(current && {
+      participationId: current.id,
+      editionId: current.editionId,
+      edition: current.edition,
+      tierId: current.tier.id,
+      tier: current.tier,
+      publicationStatus: current.publicationStatus,
+      comKitReceived: current.comKitReceived,
+      comKitLogoWebUrl: current.comKitLogoWebUrl,
+      comKitLogoPrintUrl: current.comKitLogoPrintUrl,
+      comKitCharterUrl: current.comKitCharterUrl,
+      comKitNotes: current.comKitNotes,
+      platinumPromoIdea: current.platinumPromoIdea,
+      platinumCoBuildIdea: current.platinumCoBuildIdea,
+      ...(current.jobOffers && { jobOffers: current.jobOffers }),
+    }),
+    editions: editions?.map((e) => ({
+      editionId: e.editionId,
+      edition: e.edition,
+      tier: e.tier,
+      publicationStatus: e.publicationStatus,
+    })),
   };
 }
 
@@ -72,18 +131,37 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
       querystring: { type: "object", properties: { editionId: { type: "string" } } },
     },
   }, async (request) => {
-    const { editionId } = request.query;
+    const editionId = request.query.editionId ? Number(request.query.editionId) : undefined;
 
+    // One row per company (#129): the list moves onto the join, mirroring the
+    // admin speakers list. `editions` carries every participation so the row
+    // can flatten to the one the admin is looking at.
     const sponsors = await prisma.sponsor.findMany({
-      where: editionId ? { editionId: Number(editionId), ...notDeleted } : notDeleted,
-      include: {
-        tier: { select: { key: true, nameFr: true, nameEn: true, rank: true } },
-        ...(editionId ? {} : { edition: { select: { id: true, year: true } } }),
+      where: {
+        ...notDeleted,
+        ...(editionId ? { editions: { some: { editionId } } } : {}),
       },
-      // Higher tier rank first (RG-221), then name.
-      orderBy: editionId
-        ? [{ tier: { rank: "desc" } }, { name: "asc" }]
-        : [{ edition: { year: "desc" } }, { tier: { rank: "desc" } }, { name: "asc" }],
+      include: {
+        editions: {
+          where: { ...(editionId ? { editionId } : {}), edition: notDeleted },
+          select: {
+            id: true,
+            publicationStatus: true,
+            comKitReceived: true,
+            comKitLogoWebUrl: true,
+            comKitLogoPrintUrl: true,
+            comKitCharterUrl: true,
+            comKitNotes: true,
+            platinumPromoIdea: true,
+            platinumCoBuildIdea: true,
+            editionId: true,
+            edition: { select: { id: true, year: true } },
+            tier: { select: TIER_SELECT },
+          },
+          orderBy: { edition: { year: "desc" } },
+        },
+      },
+      orderBy: { name: "asc" },
     });
     return sponsors.map(serialize);
   });
@@ -97,10 +175,27 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     const sponsor = await prisma.sponsor.findFirst({
       where: { id: Number(request.params.id), ...notDeleted },
       include: {
-        edition: { select: { id: true, year: true } },
-        tier: { select: { key: true, nameFr: true, nameEn: true, rank: true } },
-        // Job offers for admin consultation/moderation (#251).
-        jobOffers: { orderBy: { createdAt: "asc" } },
+        editions: {
+          where: { edition: notDeleted },
+          select: {
+            id: true,
+            publicationStatus: true,
+            comKitReceived: true,
+            comKitLogoWebUrl: true,
+            comKitLogoPrintUrl: true,
+            comKitCharterUrl: true,
+            comKitNotes: true,
+            platinumPromoIdea: true,
+            platinumCoBuildIdea: true,
+            editionId: true,
+            edition: { select: { id: true, year: true } },
+            tier: { select: TIER_SELECT },
+            // Job offers for admin consultation/moderation (#251), now per
+            // participation since they are dated by the year's tier quota.
+            jobOffers: { orderBy: { createdAt: "asc" } },
+          },
+          orderBy: { edition: { year: "desc" } },
+        },
       },
     });
     if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
@@ -122,24 +217,40 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
       return reply.code(422).send({ error: "Invalid tierId: no such sponsor tier" });
     }
 
-    // Build a slug unique within the edition. Deliberately NOT filtered on
-    // deletedAt: uniqueness is a database-wide constraint, so a trashed sponsor
-    // still owns its slug until purged. Parking frees the readable form, but a
-    // row keeping an unparked slug (restored, or trashed before #147) must still
-    // be counted or the create would collide.
-    const existing = await prisma.sponsor.findMany({
-      where: { editionId: body.editionId },
-      select: { slug: true },
-    });
-    const slug = uniqueSlug(slugify(body.name), new Set(existing.map((e) => e.slug)));
+    const slug = slugify(body.name);
+
+    // Globally unique since #129. A taken slug means the company already
+    // exists: offer to attach a participation rather than minting acme-2 and
+    // recreating the duplicates the model was changed to remove. Deliberately
+    // NOT filtered on deletedAt — a trashed company still owns its slug until
+    // purged.
+    const clash = await prisma.sponsor.findUnique({ where: { slug }, select: { id: true } });
+    if (clash) {
+      return reply.code(409).send({ error: "sponsor_exists", id: clash.id });
+    }
 
     const sponsor = await prisma.sponsor.create({
-      include: { tier: { select: { key: true, nameFr: true, nameEn: true, rank: true } } },
+      include: {
+        editions: {
+          select: {
+            id: true,
+            publicationStatus: true,
+            comKitReceived: true,
+            comKitLogoWebUrl: true,
+            comKitLogoPrintUrl: true,
+            comKitCharterUrl: true,
+            comKitNotes: true,
+            platinumPromoIdea: true,
+            platinumCoBuildIdea: true,
+            editionId: true,
+            edition: { select: { id: true, year: true } },
+            tier: { select: TIER_SELECT },
+          },
+        },
+      },
       data: {
-        editionId: body.editionId,
         slug,
         name: body.name.trim(),
-        tierId: body.tierId,
         logoUrl: body.logoUrl || null,
         websiteUrl: body.websiteUrl || null,
         // Rich-text HTML (#270): sanitized on write, like article content.
@@ -148,16 +259,22 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         socialLinks: body.socialLinks ? JSON.stringify(body.socialLinks) : null,
         contactEmail: body.contactEmail || null,
         locale: normalizeLocale(body.locale),
-        publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
         // Private fields (#249).
         standContacts: body.standContacts?.length ? JSON.stringify(body.standContacts) : null,
-        comKitReceived: body.comKitReceived ?? false,
-        comKitLogoWebUrl: body.comKitLogoWebUrl || null,
-        comKitLogoPrintUrl: body.comKitLogoPrintUrl || null,
-        comKitCharterUrl: body.comKitCharterUrl || null,
-        comKitNotes: body.comKitNotes || null,
-        platinumPromoIdea: body.platinumPromoIdea || null,
-        platinumCoBuildIdea: body.platinumCoBuildIdea || null,
+        editions: {
+          create: [{
+            editionId: body.editionId,
+            tierId: body.tierId,
+            publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
+            comKitReceived: body.comKitReceived ?? false,
+            comKitLogoWebUrl: body.comKitLogoWebUrl || null,
+            comKitLogoPrintUrl: body.comKitLogoPrintUrl || null,
+            comKitCharterUrl: body.comKitCharterUrl || null,
+            comKitNotes: body.comKitNotes || null,
+            platinumPromoIdea: body.platinumPromoIdea || null,
+            platinumCoBuildIdea: body.platinumCoBuildIdea || null,
+          }],
+        },
       },
     });
 
@@ -172,7 +289,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
       params: { type: "object", required: ["id"], properties: { id: { type: "string" } } },
     },
   }, async (request, reply) => {
-    const { id } = request.params;
+    const id = Number(request.params.id);
     const body = request.body;
 
     if (body.tierId !== undefined) {
@@ -185,12 +302,77 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
       }
     }
 
+    // Per-year fields need a participation to land on. Resolve it from
+    // `body.editionId`, falling back to the most recent one.
+    const participationFieldsSent =
+      body.tierId !== undefined ||
+      body.publicationStatus !== undefined ||
+      body.comKitReceived !== undefined ||
+      body.comKitLogoWebUrl !== undefined ||
+      body.comKitLogoPrintUrl !== undefined ||
+      body.comKitCharterUrl !== undefined ||
+      body.comKitNotes !== undefined ||
+      body.platinumPromoIdea !== undefined ||
+      body.platinumCoBuildIdea !== undefined;
+
+    const target = participationFieldsSent
+      ? body.editionId
+        ? await prisma.editionSponsor.findUnique({
+            where: { sponsorId_editionId: { sponsorId: id, editionId: body.editionId } },
+            select: { id: true },
+          })
+        : await prisma.editionSponsor.findFirst({
+            where: { sponsorId: id },
+            orderBy: { edition: { year: "desc" } },
+            select: { id: true },
+          })
+      : null;
+
+    if (participationFieldsSent && !target) {
+      return reply.code(422).send({ error: "No participation found to update" });
+    }
+
+    if (target) {
+      await prisma.editionSponsor.update({
+        where: { id: target.id },
+        data: {
+          ...(body.tierId !== undefined && { tierId: body.tierId }),
+          ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
+          ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
+          ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
+          ...(body.comKitLogoPrintUrl !== undefined && { comKitLogoPrintUrl: body.comKitLogoPrintUrl || null }),
+          ...(body.comKitCharterUrl !== undefined && { comKitCharterUrl: body.comKitCharterUrl || null }),
+          ...(body.comKitNotes !== undefined && { comKitNotes: body.comKitNotes || null }),
+          ...(body.platinumPromoIdea !== undefined && { platinumPromoIdea: body.platinumPromoIdea || null }),
+          ...(body.platinumCoBuildIdea !== undefined && { platinumCoBuildIdea: body.platinumCoBuildIdea || null }),
+        },
+      });
+    }
+
     const sponsor = await prisma.sponsor.update({
-      where: { id: Number(id) },
-      include: { tier: { select: { key: true, nameFr: true, nameEn: true, rank: true } } },
+      where: { id },
+      include: {
+        editions: {
+          where: target ? { id: target.id } : {},
+          select: {
+            id: true,
+            publicationStatus: true,
+            comKitReceived: true,
+            comKitLogoWebUrl: true,
+            comKitLogoPrintUrl: true,
+            comKitCharterUrl: true,
+            comKitNotes: true,
+            platinumPromoIdea: true,
+            platinumCoBuildIdea: true,
+            editionId: true,
+            edition: { select: { id: true, year: true } },
+            tier: { select: TIER_SELECT },
+          },
+          orderBy: { edition: { year: "desc" } },
+        },
+      },
       data: {
         ...(body.name !== undefined && { name: body.name.trim() }),
-        ...(body.tierId !== undefined && { tierId: body.tierId }),
         ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
         ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
         // Rich-text HTML (#270): sanitized on write, like article content.
@@ -201,18 +383,10 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
         }),
         ...(body.contactEmail !== undefined && { contactEmail: body.contactEmail || null }),
         ...(body.locale !== undefined && { locale: normalizeLocale(body.locale) }),
-        ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
         // Private fields (#249).
         ...(body.standContacts !== undefined && {
           standContacts: body.standContacts?.length ? JSON.stringify(body.standContacts) : null,
         }),
-        ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
-        ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
-        ...(body.comKitLogoPrintUrl !== undefined && { comKitLogoPrintUrl: body.comKitLogoPrintUrl || null }),
-        ...(body.comKitCharterUrl !== undefined && { comKitCharterUrl: body.comKitCharterUrl || null }),
-        ...(body.comKitNotes !== undefined && { comKitNotes: body.comKitNotes || null }),
-        ...(body.platinumPromoIdea !== undefined && { platinumPromoIdea: body.platinumPromoIdea || null }),
-        ...(body.platinumCoBuildIdea !== undefined && { platinumCoBuildIdea: body.platinumCoBuildIdea || null }),
       },
     });
 
@@ -225,16 +399,22 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
 
   // POST /api/admin/sponsors/bulk — apply one action to several sponsors at once.
   app.post<{ Body: SponsorBulkBody }>("/sponsors/bulk", async (request, reply) => {
-    const { ids, action, value } = request.body;
+    const { ids, action, value, editionId } = request.body;
     if (!Array.isArray(ids) || ids.length === 0 || !ids.every((id) => Number.isInteger(id))) {
       return reply.code(400).send({ error: "ids must be a non-empty array of integers" });
     }
     if (action !== "setStatus" || (value !== "DRAFT" && value !== "PUBLISHED")) {
       return reply.code(400).send({ error: "unsupported action or value" });
     }
+    // publicationStatus now lives on the participation (#129): require the
+    // edition so the action cannot silently touch a year the admin isn't
+    // looking at (the guard #351 established for speakers).
+    if (!editionId) {
+      return reply.code(400).send({ error: "editionId is required: status is per edition" });
+    }
 
-    const { count } = await prisma.sponsor.updateMany({
-      where: { id: { in: ids }, ...notDeleted },
+    const { count } = await prisma.editionSponsor.updateMany({
+      where: { sponsorId: { in: ids }, editionId },
       data: { publicationStatus: value },
     });
     revalidateSponsors();
@@ -252,9 +432,9 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     const sponsor = await prisma.sponsor.findFirst({ where: { id: sponsorId, ...notDeleted } });
     if (!sponsor) return notFound(reply, "Sponsor");
 
-    // The slug is unique per edition and a trashed row keeps its slot, so park
-    // it out of the live namespace — otherwise re-creating a sponsor under the
-    // same name would hit the constraint (#146).
+    // The slug is globally unique (#129) and a trashed row keeps its slot, so
+    // park it out of the live namespace — otherwise re-creating a sponsor
+    // under the same name would hit the constraint (#146).
     await prisma.sponsor.update({
       where: { id: sponsorId },
       data: { ...softDeleteData(), slug: parkUniqueValue(sponsor.slug, sponsorId) },
@@ -265,6 +445,50 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     revalidateSponsor(sponsor.slug);
     return reply.code(204).send();
   });
+
+  // POST /api/admin/sponsors/:id/editions — attach a participation (#129).
+  app.post<{ Params: SponsorIdParams; Body: { editionId: number; tierId: number } }>(
+    "/sponsors/:id/editions",
+    { schema: { params: { type: "object", required: ["id"], properties: { id: { type: "string" } } } } },
+    async (request, reply) => {
+      const sponsorId = Number(request.params.id);
+      const { editionId, tierId } = request.body;
+      if (!editionId || !tierId) {
+        return reply.code(400).send({ error: "editionId and tierId are required" });
+      }
+      const participation = await prisma.editionSponsor.upsert({
+        where: { sponsorId_editionId: { sponsorId, editionId } },
+        create: { sponsorId, editionId, tierId, publicationStatus: "DRAFT" },
+        update: { tierId },
+        select: { id: true, editionId: true, tierId: true, publicationStatus: true },
+      });
+      revalidateSponsors();
+      return participation;
+    },
+  );
+
+  // DELETE /api/admin/sponsors/:id/editions/:editionId — detach a participation.
+  // The company itself survives: the trash operates on the identity.
+  app.delete<{ Params: SponsorIdParams & { editionId: string } }>(
+    "/sponsors/:id/editions/:editionId",
+    {
+      schema: {
+        params: {
+          type: "object",
+          required: ["id", "editionId"],
+          properties: { id: { type: "string" }, editionId: { type: "string" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { count } = await prisma.editionSponsor.deleteMany({
+        where: { sponsorId: Number(request.params.id), editionId: Number(request.params.editionId) },
+      });
+      if (!count) return notFound(reply, "Participation not found");
+      revalidateSponsors();
+      return reply.code(204).send();
+    },
+  );
 
   // A sponsor can have several contacts, each with its own modification link
   // (#250). The token itself is never returned to the admin — only whether a
@@ -395,12 +619,17 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
   );
 
   // DELETE /api/admin/sponsors/:id/job-offers/:offerId — moderate an offer (#251).
+  // Job offers hang off the participation now (#129), not the identity
+  // directly, so ownership is checked through `editionSponsor.sponsorId`.
   app.delete<{ Params: SponsorIdParams & { offerId: string } }>(
     "/sponsors/:id/job-offers/:offerId",
     { schema: { params: { type: "object", required: ["id", "offerId"], properties: { id: { type: "string" }, offerId: { type: "string" } } } } },
     async (request, reply) => {
-      const offer = await prisma.sponsorJobOffer.findUnique({ where: { id: Number(request.params.offerId) } });
-      if (!offer || offer.sponsorId !== Number(request.params.id)) {
+      const offer = await prisma.sponsorJobOffer.findUnique({
+        where: { id: Number(request.params.offerId) },
+        include: { editionSponsor: { select: { sponsorId: true } } },
+      });
+      if (!offer || offer.editionSponsor.sponsorId !== Number(request.params.id)) {
         return reply.code(404).send({ error: "Offer not found" });
       }
       await prisma.sponsorJobOffer.delete({ where: { id: offer.id } });

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -70,6 +70,8 @@ const TIER_SELECT = { id: true, key: true, nameFr: true, nameEn: true, rank: tru
 interface ParticipationLike {
   id: number;
   publicationStatus: "DRAFT" | "PUBLISHED";
+  // Frozen per edition (#375) — absent from the queries that don't select it.
+  logoUrl?: string | null;
   comKitReceived?: boolean;
   comKitLogoWebUrl?: string | null;
   comKitLogoPrintUrl?: string | null;
@@ -105,6 +107,9 @@ function serialize(s: {
       edition: current.edition,
       tierId: current.tier.id,
       tier: current.tier,
+      // The edition's own logo (#375) shadows the identity's, so the admin
+      // form edits the year it is looking at. Null until one is set.
+      ...(current.logoUrl !== undefined && { logoUrl: current.logoUrl ?? s.logoUrl }),
       publicationStatus: current.publicationStatus,
       comKitReceived: current.comKitReceived,
       comKitLogoWebUrl: current.comKitLogoWebUrl,
@@ -147,6 +152,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
           select: {
             id: true,
             publicationStatus: true,
+            logoUrl: true,
             comKitReceived: true,
             comKitLogoWebUrl: true,
             comKitLogoPrintUrl: true,
@@ -180,6 +186,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
           select: {
             id: true,
             publicationStatus: true,
+            logoUrl: true,
             comKitReceived: true,
             comKitLogoWebUrl: true,
             comKitLogoPrintUrl: true,
@@ -209,9 +216,12 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     if (!body.editionId || !body.name?.trim() || !body.tierId) {
       return reply.code(400).send({ error: "editionId, name and tierId are required" });
     }
+    // The display attributes come along: the participation freezes them (#375)
+    // so renaming or recolouring the shared catalogue later leaves this
+    // edition's wall untouched.
     const tier = await prisma.sponsorTier.findFirst({
       where: { id: body.tierId, ...notDeleted },
-      select: { id: true },
+      select: { id: true, nameFr: true, nameEn: true, color: true, logoScale: true },
     });
     if (!tier) {
       return reply.code(422).send({ error: "Invalid tierId: no such sponsor tier" });
@@ -235,6 +245,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
           select: {
             id: true,
             publicationStatus: true,
+            logoUrl: true,
             comKitReceived: true,
             comKitLogoWebUrl: true,
             comKitLogoPrintUrl: true,
@@ -265,6 +276,13 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
           create: [{
             editionId: body.editionId,
             tierId: body.tierId,
+            // Frozen for the archive (#375): the logo this edition shows, and
+            // the tier as it reads today.
+            logoUrl: body.logoUrl || null,
+            tierNameFr: tier.nameFr,
+            tierNameEn: tier.nameEn,
+            tierColor: tier.color,
+            tierLogoScale: tier.logoScale,
             publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
             comKitReceived: body.comKitReceived ?? false,
             comKitLogoWebUrl: body.comKitLogoWebUrl || null,
@@ -292,10 +310,13 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     const id = Number(request.params.id);
     const body = request.body;
 
+    // Changing tier re-freezes the appearance (#375): the participation must
+    // show the tier it was actually moved to, not the one it left.
+    let tier = null;
     if (body.tierId !== undefined) {
-      const tier = await prisma.sponsorTier.findFirst({
+      tier = await prisma.sponsorTier.findFirst({
         where: { id: body.tierId, ...notDeleted },
-        select: { id: true },
+        select: { id: true, nameFr: true, nameEn: true, color: true, logoScale: true },
       });
       if (!tier) {
         return reply.code(422).send({ error: "Invalid tierId: no such sponsor tier" });
@@ -306,6 +327,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     // `body.editionId`, falling back to the most recent one.
     const participationFieldsSent =
       body.tierId !== undefined ||
+      body.logoUrl !== undefined ||
       body.publicationStatus !== undefined ||
       body.comKitReceived !== undefined ||
       body.comKitLogoWebUrl !== undefined ||
@@ -336,7 +358,16 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
       await prisma.editionSponsor.update({
         where: { id: target.id },
         data: {
-          ...(body.tierId !== undefined && { tierId: body.tierId }),
+          // Re-freeze the appearance alongside the tier itself (#375).
+          ...(tier && {
+            tierId: tier.id,
+            tierNameFr: tier.nameFr,
+            tierNameEn: tier.nameEn,
+            tierColor: tier.color,
+            tierLogoScale: tier.logoScale,
+          }),
+          // The logo this edition displays, kept off the other years.
+          ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
           ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
           ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
           ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
@@ -357,6 +388,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
           select: {
             id: true,
             publicationStatus: true,
+            logoUrl: true,
             comKitReceived: true,
             comKitLogoWebUrl: true,
             comKitLogoPrintUrl: true,

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -414,7 +414,7 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     }
 
     const { count } = await prisma.editionSponsor.updateMany({
-      where: { sponsorId: { in: ids }, editionId },
+      where: { sponsorId: { in: ids }, editionId, sponsor: notDeleted },
       data: { publicationStatus: value },
     });
     revalidateSponsors();

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -3,6 +3,8 @@ import { prisma } from "../lib/prisma.js";
 import { isEditingFrozen, isEditTokenExpired } from "../lib/edit-token.js";
 import { normalizeLocale } from "../lib/edit-link-email.js";
 import { isSafeUrl } from "../lib/sanitize.js";
+import { notDeleted } from "../lib/admin-helpers.js";
+import { getFeaturedEdition } from "./editions.js";
 import {
   revalidateConferences,
   revalidateJobOffers,
@@ -303,32 +305,48 @@ async function resolveToken(token: string) {
 
   // Sponsors resolve through their contacts (#250): the token lives on a
   // SponsorContact, and the lock/send-date are per-contact. We flatten the
-  // contact's token fields onto the sponsor so the rest of the route (which
-  // reads entity.tier, entity.standContacts, entity.id, entity.editLinkLocked,
-  // …) keeps working unchanged, and expose contactId/contactEmail for the
+  // contact's token fields onto the sponsor identity so the rest of the route
+  // (which reads entity.id, entity.editLinkLocked, entity.standContacts, …)
+  // keeps working unchanged, and expose contactId/contactEmail for the
   // notification Reply-To.
   const contact = await prisma.sponsorContact.findUnique({
     where: { editToken: token },
-    include: {
-      sponsor: {
-        include: {
-          edition: { select: { startDate: true, endDate: true } },
-          // Tier drives the job-offer quota and the promo-ideas gating (#317).
-          tier: { select: { key: true, nameFr: true, nameEn: true, jobOfferQuota: true, allowsPromoIdeas: true } },
-          // Job offers the sponsor can manage from the link (#251).
-          jobOffers: { orderBy: { createdAt: "asc" } },
-        },
-      },
-    },
+    include: { sponsor: true },
   });
   if (contact) {
+    // Per-year fields live on the participation since #129 (RG-317/#252). A
+    // modification link edits the current edition: that is the year the
+    // sponsor was contacted about. No featured edition, or the company not
+    // sponsoring it, leaves `participation` null — see editingBlockedReason
+    // and the per-year field handling below.
+    const edition = await getFeaturedEdition();
+    const participation = edition
+      ? await prisma.editionSponsor.findFirst({
+          where: { sponsorId: contact.sponsor.id, editionId: edition.id, edition: notDeleted },
+          select: {
+            id: true,
+            platinumPromoIdea: true,
+            platinumCoBuildIdea: true,
+            comKitReceived: true,
+            comKitLogoWebUrl: true,
+            comKitLogoPrintUrl: true,
+            comKitCharterUrl: true,
+            comKitNotes: true,
+            tier: { select: { key: true, nameFr: true, nameEn: true, jobOfferQuota: true, allowsPromoIdeas: true } },
+            jobOffers: { orderBy: { createdAt: "asc" } },
+          },
+        })
+      : null;
+
     const entity = {
       ...contact.sponsor,
+      edition: { startDate: edition?.startDate ?? null },
       editLinkLocked: contact.editLinkLocked,
       editTokenSentAt: contact.editTokenSentAt,
       contactId: contact.id,
       // The link recipient's own address wins over the sponsor's default.
       contactEmail: contact.email || contact.sponsor.contactEmail,
+      participation,
     };
     return { kind: "sponsor" as const, entity };
   }
@@ -454,6 +472,7 @@ export default async function editRoutes(app: FastifyInstance) {
     // Where the sponsor should email complements that don't fit as links (#271):
     // the sponsoring contact address, so the client can build a mailto: link.
     const sponsorContactEmail = (await getSponsorContactRecipients())[0];
+    const { participation } = entity;
     return {
       kind,
       locale,
@@ -471,37 +490,41 @@ export default async function editRoutes(app: FastifyInstance) {
       private: {
         // The sponsoring tier: drives the promo-idea gating and the label shown
         // to the sponsor. Replaces the former legacy `level` string (#321).
-        tier: {
-          key: entity.tier.key,
-          nameFr: entity.tier.nameFr,
-          nameEn: entity.tier.nameEn,
-          allowsPromoIdeas: entity.tier.allowsPromoIdeas,
-        },
+        // No participation on the featured edition means no tier to show.
+        tier: participation
+          ? {
+              key: participation.tier.key,
+              nameFr: participation.tier.nameFr,
+              nameEn: participation.tier.nameEn,
+              allowsPromoIdeas: participation.tier.allowsPromoIdeas,
+            }
+          : null,
         standContacts: parseStandContacts(entity.standContacts),
-        comKitReceived: entity.comKitReceived,
-        comKitLogoWebUrl: entity.comKitLogoWebUrl,
-        comKitLogoPrintUrl: entity.comKitLogoPrintUrl,
-        comKitCharterUrl: entity.comKitCharterUrl,
-        comKitNotes: entity.comKitNotes,
+        comKitReceived: participation?.comKitReceived ?? false,
+        comKitLogoWebUrl: participation?.comKitLogoWebUrl ?? null,
+        comKitLogoPrintUrl: participation?.comKitLogoPrintUrl ?? null,
+        comKitCharterUrl: participation?.comKitCharterUrl ?? null,
+        comKitNotes: participation?.comKitNotes ?? null,
         // Promo-idea fields (#252). Sent for every sponsor; the UI shows them
         // only when the tier allows promo ideas.
-        platinumPromoIdea: entity.platinumPromoIdea,
-        platinumCoBuildIdea: entity.platinumCoBuildIdea,
+        platinumPromoIdea: participation?.platinumPromoIdea ?? null,
+        platinumCoBuildIdea: participation?.platinumCoBuildIdea ?? null,
         // Address the sponsor should email complements to (#271). The UI builds
         // a mailto: link from it — no server-side send for this case anymore.
         sponsorContactEmail,
       },
       // Job offers (#251): the sponsor's offers plus its tier quota, so the
-      // UI can disable "add" at the cap.
+      // UI can disable "add" at the cap. No participation this year means no
+      // offers to manage and no quota.
       jobOffers: {
-        items: entity.jobOffers.map((o) => ({
+        items: (participation?.jobOffers ?? []).map((o) => ({
           id: o.id,
           title: o.title,
           descriptionFr: o.descriptionFr,
           descriptionEn: o.descriptionEn,
           url: o.url,
         })),
-        quota: entity.tier.jobOfferQuota,
+        quota: participation?.tier.jobOfferQuota ?? 0,
       },
     };
   });
@@ -558,6 +581,25 @@ export default async function editRoutes(app: FastifyInstance) {
       revalidateSpeaker(entity.slug);
     } else {
       const body = request.body as SponsorEditBody;
+      const { participation } = entity;
+
+      // Per-year fields (#129): comKit* and platinum* live on the
+      // participation. Writing one with no participation on the featured
+      // edition has no year to land on — there is nothing sane to write to,
+      // and silently writing to last year's participation would be worse
+      // (#252, #249).
+      const writesYearField =
+        body.comKitReceived !== undefined ||
+        body.comKitLogoWebUrl !== undefined ||
+        body.comKitLogoPrintUrl !== undefined ||
+        body.comKitCharterUrl !== undefined ||
+        body.comKitNotes !== undefined ||
+        body.platinumPromoIdea !== undefined ||
+        body.platinumCoBuildIdea !== undefined;
+      if (writesYearField && !participation) {
+        return reply.code(422).send({ error: "no_current_participation" });
+      }
+
       await prisma.sponsor.update({
         where: { id: entity.id },
         data: {
@@ -567,23 +609,33 @@ export default async function editRoutes(app: FastifyInstance) {
           ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
           ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
           ...(body.socialLinks !== undefined && { socialLinks: cleanSocial(body.socialLinks) }),
-          // Private fields (#249).
+          // Private field (#249) — stand staffing isn't per-year, stays on the identity.
           ...(body.standContacts !== undefined && { standContacts: cleanStandContacts(body.standContacts) }),
-          ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
-          ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
-          ...(body.comKitLogoPrintUrl !== undefined && { comKitLogoPrintUrl: body.comKitLogoPrintUrl || null }),
-          ...(body.comKitCharterUrl !== undefined && { comKitCharterUrl: body.comKitCharterUrl || null }),
-          ...(body.comKitNotes !== undefined && { comKitNotes: body.comKitNotes || null }),
-          // Promo-idea fields (#252): silently ignored for tiers that don't
-          // allow them, so the field can't be set by tampering with the payload.
-          ...(entity.tier.allowsPromoIdeas && body.platinumPromoIdea !== undefined && {
-            platinumPromoIdea: body.platinumPromoIdea || null,
-          }),
-          ...(entity.tier.allowsPromoIdeas && body.platinumCoBuildIdea !== undefined && {
-            platinumCoBuildIdea: body.platinumCoBuildIdea || null,
-          }),
         },
       });
+
+      if (participation) {
+        await prisma.editionSponsor.update({
+          where: { id: participation.id },
+          data: {
+            // Private per-year fields (#249).
+            ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
+            ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
+            ...(body.comKitLogoPrintUrl !== undefined && { comKitLogoPrintUrl: body.comKitLogoPrintUrl || null }),
+            ...(body.comKitCharterUrl !== undefined && { comKitCharterUrl: body.comKitCharterUrl || null }),
+            ...(body.comKitNotes !== undefined && { comKitNotes: body.comKitNotes || null }),
+            // Promo-idea fields (#252): silently ignored for tiers that don't
+            // allow them, so the field can't be set by tampering with the payload.
+            ...(participation.tier.allowsPromoIdeas && body.platinumPromoIdea !== undefined && {
+              platinumPromoIdea: body.platinumPromoIdea || null,
+            }),
+            ...(participation.tier.allowsPromoIdeas && body.platinumCoBuildIdea !== undefined && {
+              platinumCoBuildIdea: body.platinumCoBuildIdea || null,
+            }),
+          },
+        });
+      }
+
       // Only public-facing changes need cache revalidation; a private-only
       // save (com kit, stand contacts) changes nothing on the public pages.
       const touchesPublic =
@@ -714,20 +766,26 @@ export default async function editRoutes(app: FastifyInstance) {
       const blocked = editingBlockedReason(entity);
       if (blocked) return reply.code(403).send({ error: blocked });
 
+      // Job offers hang off this year's participation (#251, #129). No
+      // participation on the featured edition means no year to publish an
+      // offer for.
+      const { participation } = entity;
+      if (!participation) return reply.code(422).send({ error: "no_current_participation" });
+
       const { title, url } = request.body;
       if (!title.trim()) return reply.code(400).send({ error: "empty_title" });
       if (!isSafeUrl(url)) return reply.code(400).send({ error: "invalid_url", field: "url" });
 
       // Quota is per tier (#251). Count what's already there; a lowered tier
       // keeps existing offers but blocks new ones beyond the new cap.
-      const quota = entity.tier.jobOfferQuota;
-      if (entity.jobOffers.length >= quota) {
+      const quota = participation.tier.jobOfferQuota;
+      if (participation.jobOffers.length >= quota) {
         return reply.code(409).send({ error: "quota_reached", quota });
       }
 
       const offer = await prisma.sponsorJobOffer.create({
         data: {
-          sponsorId: entity.id,
+          editionSponsorId: participation.id,
           title: title.trim(),
           descriptionFr: sanitizeRichHtml(request.body.descriptionFr),
           descriptionEn: sanitizeRichHtml(request.body.descriptionEn),
@@ -767,9 +825,9 @@ export default async function editRoutes(app: FastifyInstance) {
       const blocked = editingBlockedReason(entity);
       if (blocked) return reply.code(403).send({ error: blocked });
 
-      // Ownership: only offers already attached to this sponsor.
+      // Ownership: only offers already attached to this year's participation.
       const offerId = Number(request.params.offerId);
-      const offer = entity.jobOffers.find((o) => o.id === offerId);
+      const offer = entity.participation?.jobOffers.find((o) => o.id === offerId);
       if (!offer) return reply.code(404).send({ error: "offer_not_found" });
 
       const body = request.body;
@@ -812,7 +870,7 @@ export default async function editRoutes(app: FastifyInstance) {
       if (blocked) return reply.code(403).send({ error: blocked });
 
       const offerId = Number(request.params.offerId);
-      const offer = entity.jobOffers.find((o) => o.id === offerId);
+      const offer = entity.participation?.jobOffers.find((o) => o.id === offerId);
       if (!offer) return reply.code(404).send({ error: "offer_not_found" });
 
       await prisma.sponsorJobOffer.delete({ where: { id: offer.id } });

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -328,6 +328,8 @@ async function resolveToken(token: string) {
           where: { sponsorId: contact.sponsor.id, editionId: edition.id, edition: notDeleted },
           select: {
             id: true,
+            // The logo this edition shows (#375) — what the form must edit.
+            logoUrl: true,
             platinumPromoIdea: true,
             platinumCoBuildIdea: true,
             comKitReceived: true,
@@ -484,7 +486,9 @@ export default async function editRoutes(app: FastifyInstance) {
         descriptionFr: entity.descriptionFr,
         descriptionEn: entity.descriptionEn,
         websiteUrl: entity.websiteUrl,
-        logoUrl: entity.logoUrl,
+        // The featured edition's logo (#375), falling back to the company's
+        // current one — the sponsor edits this year, not the archive.
+        logoUrl: participation?.logoUrl ?? entity.logoUrl,
         socialLinks: parseSocial(entity.socialLinks),
       },
       // Private fields (#249) — served to the token holder so they can edit
@@ -586,12 +590,15 @@ export default async function editRoutes(app: FastifyInstance) {
       const body = request.body as SponsorEditBody;
       const { participation } = entity;
 
-      // Per-year fields (#129): comKit* and platinum* live on the
+      // Per-year fields (#129): logoUrl, comKit* and platinum* live on the
       // participation. Writing one with no participation on the featured
       // edition has no year to land on — there is nothing sane to write to,
       // and silently writing to last year's participation would be worse
       // (#252, #249).
+      // logoUrl joined them in #375: what an edition displayed is frozen on its
+      // participation, so a new logo must not rewrite the years already past.
       const writesYearField =
+        body.logoUrl !== undefined ||
         body.comKitReceived !== undefined ||
         body.comKitLogoWebUrl !== undefined ||
         body.comKitLogoPrintUrl !== undefined ||
@@ -610,6 +617,9 @@ export default async function editRoutes(app: FastifyInstance) {
           ...(body.descriptionFr !== undefined && { descriptionFr: sanitizeRichHtml(body.descriptionFr) || null }),
           ...(body.descriptionEn !== undefined && { descriptionEn: sanitizeRichHtml(body.descriptionEn) || null }),
           ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
+          // The company's current logo tracks the latest one it sent (#375),
+          // so a future participation starts from it. What each edition shows
+          // is the copy frozen on its own participation, just below.
           ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
           ...(body.socialLinks !== undefined && { socialLinks: cleanSocial(body.socialLinks) }),
           // Private field (#249) — stand staffing isn't per-year, stays on the identity.
@@ -625,6 +635,10 @@ export default async function editRoutes(app: FastifyInstance) {
         await prisma.editionSponsor.update({
           where: { id: participation.id },
           data: {
+            // The logo this edition displays (#375). Editing is already
+            // confined to the featured edition, and isEditingFrozen closes it
+            // once the event starts — so past years cannot be rewritten.
+            ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
             // Private per-year fields (#249).
             ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
             ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -614,7 +614,11 @@ export default async function editRoutes(app: FastifyInstance) {
         },
       });
 
-      if (participation) {
+      // Skip the write entirely when no per-year field was sent: EditionSponsor
+      // has @updatedAt, so an empty `data: {}` would still bump the
+      // participation's timestamp — and cost a round-trip — on every
+      // identity-only save (description, logo, socials).
+      if (participation && writesYearField) {
         await prisma.editionSponsor.update({
           where: { id: participation.id },
           data: {

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -298,15 +298,18 @@ export default async function editionRoutes(app: FastifyInstance) {
         prisma.speakerEdition.count({
           where: { editionId: edition.id, publicationStatus: "PUBLISHED", speaker: notDeleted },
         }),
+        // Since #129 the tier is bought per edition, so the count moves onto the
+        // participation join rather than the sponsor identity.
         prisma.sponsor.count({
-          where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
+          where: { ...notDeleted, editions: { some: { editionId: edition.id, publicationStatus: "PUBLISHED" } } },
         }),
         // Offers of published sponsors only — same set the recap page lists.
-        // SponsorJobOffer itself is out of the trash's scope, but its sponsor is
-        // not: offers of a trashed sponsor must stop counting.
+        // SponsorJobOffer now points at the participation (#129); the sponsor's
+        // trash status still has to be checked explicitly since the join row
+        // itself carries no deletedAt.
         prisma.sponsorJobOffer.count({
           where: {
-            sponsor: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
+            editionSponsor: { editionId: edition.id, publicationStatus: "PUBLISHED", sponsor: notDeleted },
           },
         }),
       ]);

--- a/src/backend/src/routes/speakers.ts
+++ b/src/backend/src/routes/speakers.ts
@@ -105,13 +105,21 @@ export default async function speakerRoutes(app: FastifyInstance) {
           where: { publicationStatus: "PUBLISHED", edition: notDeleted },
           select: {
             isFeatured: true,
+            editionId: true,
             edition: { select: { year: true } },
             // Per-edition since #353: the employer of that year, not the latest
-            // one. publicationStatus/deletedAt come along so a trashed or
-            // unpublished sponsor can be filtered out below — a to-one relation
-            // takes no `where` in a select.
+            // one. publicationStatus left the identity for the participation
+            // (#129), so "published" now means published for THAT year, not any
+            // year — a sponsor in draft for 2019 must not surface on a 2019 card
+            // merely because it is published in 2026. A to-one relation takes no
+            // `where` in a select, hence the nested participation list here.
             sponsor: {
-              select: { slug: true, name: true, publicationStatus: true, deletedAt: true },
+              select: {
+                slug: true,
+                name: true,
+                deletedAt: true,
+                editions: { select: { editionId: true, publicationStatus: true } },
+              },
             },
           },
           orderBy: { edition: { year: "desc" } },
@@ -159,12 +167,16 @@ export default async function speakerRoutes(app: FastifyInstance) {
       participations: speaker.editions.map((link) => ({
         year: link.edition.year,
         isFeatured: link.isFeatured,
-        // The employer of that year (#353). Hidden unless the sponsor is itself
-        // published and out of the trash, like everywhere else on public pages.
-        sponsor:
-          link.sponsor && link.sponsor.publicationStatus === "PUBLISHED" && !link.sponsor.deletedAt
+        // The employer of that year (#353). Hidden unless the sponsor is out of
+        // the trash and published for THIS year specifically — not "published on
+        // any year" (#129 moved publicationStatus off the identity).
+        sponsor: (() => {
+          if (!link.sponsor || link.sponsor.deletedAt) return null;
+          const thatYear = link.sponsor.editions.find((e) => e.editionId === link.editionId);
+          return thatYear?.publicationStatus === "PUBLISHED"
             ? { slug: link.sponsor.slug, name: link.sponsor.name }
-            : null,
+            : null;
+        })(),
         talks: (byYear.get(link.edition.year) ?? []).map(({ edition, ...talk }) => talk),
       })),
     };

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -21,88 +21,111 @@ export default async function sponsorRoutes(app: FastifyInstance) {
     const edition = await getFeaturedEdition();
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
-    const sponsors = await prisma.sponsor.findMany({
-      where: { editionId: edition.id, publicationStatus: "PUBLISHED", ...notDeleted },
-      include: { tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } } },
+    // Since #129 the tier is bought per edition, so the query moves onto the
+    // participation join rather than the sponsor identity.
+    const links = await prisma.editionSponsor.findMany({
+      where: { editionId: edition.id, publicationStatus: "PUBLISHED", sponsor: notDeleted },
+      include: {
+        sponsor: { select: { id: true, slug: true, name: true, logoUrl: true, websiteUrl: true } },
+        tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+      },
     });
 
-    return sponsors
-      .map((s) => ({
-        id: s.id,
-        slug: s.slug,
-        name: s.name,
-        logoUrl: s.logoUrl,
+    return links
+      .map((link) => ({
+        id: link.sponsor.id,
+        slug: link.sponsor.slug,
+        name: link.sponsor.name,
+        logoUrl: link.sponsor.logoUrl,
         tier: {
-          key: s.tier.key,
-          rank: s.tier.rank,
-          nameFr: s.tier.nameFr,
-          nameEn: s.tier.nameEn,
-          logoScale: s.tier.logoScale,
-          color: s.tier.color,
+          key: link.tier.key,
+          rank: link.tier.rank,
+          nameFr: link.tier.nameFr,
+          nameEn: link.tier.nameEn,
+          logoScale: link.tier.logoScale,
+          color: link.tier.color,
         },
-        websiteUrl: s.websiteUrl,
+        websiteUrl: link.sponsor.websiteUrl,
       }))
       // Higher rank = more prominent (RG-221), so sort descending.
       .sort((a, b) => (b.tier.rank - a.tier.rank) || a.name.localeCompare(b.name));
   });
 
   // GET /api/sponsors/:slug — detail of a published sponsor + its speakers (RG-226).
+  // Since #129 the company page exists independently of the featured edition:
+  // any sponsor with at least one published participation resolves, and the
+  // featured edition only drives the highlight (tier + live job offers).
   app.get<{ Params: { slug: string } }>("/sponsors/:slug", {
     schema: {
       params: { type: "object", required: ["slug"], properties: { slug: { type: "string" } } },
     },
   }, async (request, reply) => {
-    const edition = await getFeaturedEdition();
-    if (!edition) return reply.status(404).send({ error: "No edition found" });
-
+    // The company, by global slug (#129). No featured-edition scope: a company
+    // page exists independently of whether it sponsors the current year.
     const sponsor = await prisma.sponsor.findFirst({
       where: {
-        editionId: edition.id,
         slug: request.params.slug,
-        publicationStatus: "PUBLISHED",
         ...notDeleted,
+        editions: { some: { publicationStatus: "PUBLISHED" } },
       },
       include: {
-        tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+        editions: {
+          where: { publicationStatus: "PUBLISHED" },
+          select: { editionId: true, edition: { select: { year: true } } },
+          orderBy: { edition: { year: "desc" } },
+        },
         // Nested reads need their own filter: a query extension would not reach
-        // them (Prisma applies those to the top-level operation only), and a
-        // trashed speaker would otherwise still show up on a live sponsor page.
-        // Participations since #353, so the association is already dated: no
-        // need to re-scope on the edition, the join row *is* the year. Still
-        // filtered on the publication of that participation and on the person
-        // not being in the trash.
+        // them (Prisma applies those to the top-level operation only).
         speakers: {
           where: { publicationStatus: "PUBLISHED", speaker: notDeleted },
-          select: {
-            speaker: { select: { slug: true, name: true, photoUrl: true, company: true } },
-          },
+          select: { speaker: { select: { slug: true, name: true, photoUrl: true, company: true } } },
           orderBy: { speaker: { name: "asc" } },
-        },
-        jobOffers: {
-          select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
-          orderBy: { createdAt: "asc" },
         },
       },
     });
 
     if (!sponsor) return reply.status(404).send({ error: "Sponsor not found" });
 
-    // Offers disappear one month after the event (#251).
-    const jobOffers = areOffersVisible(edition) ? sponsor.jobOffers : [];
+    // The featured edition is resolved separately and drives the highlight only.
+    // Past years are tags: no tier, no offers (spec — "no past offer is ever
+    // shown", so there is no edition to choose when filtering).
+    const edition = await getFeaturedEdition();
+    const current = edition ? sponsor.editions.find((e) => e.editionId === edition.id) : undefined;
+
+    let tier = null;
+    let jobOffers: Array<{ id: number; title: string; descriptionFr: string; descriptionEn: string; url: string }> = [];
+
+    if (edition && current) {
+      const live = await prisma.editionSponsor.findUnique({
+        where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: edition.id } },
+        include: {
+          tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+          jobOffers: {
+            select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
+            orderBy: { createdAt: "asc" },
+          },
+        },
+      });
+      if (live) {
+        tier = {
+          key: live.tier.key,
+          rank: live.tier.rank,
+          nameFr: live.tier.nameFr,
+          nameEn: live.tier.nameEn,
+          logoScale: live.tier.logoScale,
+          color: live.tier.color,
+        };
+        // Offers disappear one month after the event (#251).
+        jobOffers = areOffersVisible(edition) ? live.jobOffers : [];
+      }
+    }
 
     return {
       id: sponsor.id,
       slug: sponsor.slug,
       name: sponsor.name,
       logoUrl: sponsor.logoUrl,
-      tier: {
-        key: sponsor.tier.key,
-        rank: sponsor.tier.rank,
-        nameFr: sponsor.tier.nameFr,
-        nameEn: sponsor.tier.nameEn,
-        logoScale: sponsor.tier.logoScale,
-        color: sponsor.tier.color,
-      },
+      tier,
       websiteUrl: sponsor.websiteUrl,
       descriptionFr: sponsor.descriptionFr,
       descriptionEn: sponsor.descriptionEn,
@@ -110,6 +133,8 @@ export default async function sponsorRoutes(app: FastifyInstance) {
       // Projected back to the pre-#353 shape: the payload must not change.
       speakers: sponsor.speakers.map((link) => link.speaker),
       jobOffers,
+      // Year tags (#129), newest first. The frontend links them to /editions/<year>.
+      editions: sponsor.editions.map((e) => e.edition.year),
     };
   });
 
@@ -123,23 +148,33 @@ export default async function sponsorRoutes(app: FastifyInstance) {
 
     const sponsors = await prisma.sponsor.findMany({
       where: {
-        editionId: edition.id,
-        publicationStatus: "PUBLISHED",
         ...notDeleted,
-        jobOffers: { some: {} },
+        editions: { some: { editionId: edition.id, publicationStatus: "PUBLISHED", jobOffers: { some: {} } } },
       },
       select: {
         slug: true,
         name: true,
         logoUrl: true,
-        jobOffers: {
-          select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
-          orderBy: { createdAt: "asc" },
+        editions: {
+          where: { editionId: edition.id },
+          select: {
+            jobOffers: {
+              select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
+              orderBy: { createdAt: "asc" },
+            },
+          },
         },
       },
       orderBy: { name: "asc" },
     });
 
-    return sponsors;
+    // Flatten so the emitted shape stays a flat jobOffers array per sponsor,
+    // unchanged despite the query now going through the participation join.
+    return sponsors.map((s) => ({
+      slug: s.slug,
+      name: s.name,
+      logoUrl: s.logoUrl,
+      jobOffers: s.editions.flatMap((e) => e.jobOffers),
+    }));
   });
 }

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -66,16 +66,28 @@ export default async function sponsorRoutes(app: FastifyInstance) {
       where: {
         slug: request.params.slug,
         ...notDeleted,
-        editions: { some: { publicationStatus: "PUBLISHED" } },
+        editions: { some: { publicationStatus: "PUBLISHED", edition: notDeleted } },
       },
       include: {
-        editions: {
-          where: { publicationStatus: "PUBLISHED" },
-          select: { editionId: true, edition: { select: { year: true } } },
-          orderBy: { edition: { year: "desc" } },
-        },
         // Nested reads need their own filter: a query extension would not reach
         // them (Prisma applies those to the top-level operation only).
+        //
+        // `edition: notDeleted` is required here since #352: the route used to
+        // resolve getFeaturedEdition(), which already filtered the trash. Now
+        // that it spans every year, a trashed edition would resurface.
+        editions: {
+          where: { publicationStatus: "PUBLISHED", edition: notDeleted },
+          select: {
+            editionId: true,
+            edition: { select: { year: true } },
+            tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+            jobOffers: {
+              select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
+              orderBy: { createdAt: "asc" },
+            },
+          },
+          orderBy: { edition: { year: "desc" } },
+        },
         speakers: {
           where: { publicationStatus: "PUBLISHED", speaker: notDeleted },
           select: { speaker: { select: { slug: true, name: true, photoUrl: true, company: true } } },
@@ -92,33 +104,18 @@ export default async function sponsorRoutes(app: FastifyInstance) {
     const edition = await getFeaturedEdition();
     const current = edition ? sponsor.editions.find((e) => e.editionId === edition.id) : undefined;
 
-    let tier = null;
-    let jobOffers: Array<{ id: number; title: string; descriptionFr: string; descriptionEn: string; url: string }> = [];
-
-    if (edition && current) {
-      const live = await prisma.editionSponsor.findUnique({
-        where: { sponsorId_editionId: { sponsorId: sponsor.id, editionId: edition.id } },
-        include: {
-          tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
-          jobOffers: {
-            select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
-            orderBy: { createdAt: "asc" },
-          },
-        },
-      });
-      if (live) {
-        tier = {
-          key: live.tier.key,
-          rank: live.tier.rank,
-          nameFr: live.tier.nameFr,
-          nameEn: live.tier.nameEn,
-          logoScale: live.tier.logoScale,
-          color: live.tier.color,
-        };
-        // Offers disappear one month after the event (#251).
-        jobOffers = areOffersVisible(edition) ? live.jobOffers : [];
-      }
-    }
+    const tier = current
+      ? {
+          key: current.tier.key,
+          rank: current.tier.rank,
+          nameFr: current.tier.nameFr,
+          nameEn: current.tier.nameEn,
+          logoScale: current.tier.logoScale,
+          color: current.tier.color,
+        }
+      : null;
+    // Offers disappear one month after the event (#251).
+    const jobOffers = current && edition && areOffersVisible(edition) ? current.jobOffers : [];
 
     return {
       id: sponsor.id,

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -3,6 +3,7 @@ import { prisma } from "../lib/prisma.js";
 import { getFeaturedEdition } from "./editions.js";
 import { areOffersVisible } from "../lib/job-offers.js";
 import { notDeleted } from "../lib/admin-helpers.js";
+import { archivedLogoUrl, archivedTier } from "../lib/sponsor-archive.js";
 
 function parseSocial(raw: string | null): Record<string, string> {
   if (!raw) return {};
@@ -36,15 +37,10 @@ export default async function sponsorRoutes(app: FastifyInstance) {
         id: link.sponsor.id,
         slug: link.sponsor.slug,
         name: link.sponsor.name,
-        logoUrl: link.sponsor.logoUrl,
-        tier: {
-          key: link.tier.key,
-          rank: link.tier.rank,
-          nameFr: link.tier.nameFr,
-          nameEn: link.tier.nameEn,
-          logoScale: link.tier.logoScale,
-          color: link.tier.color,
-        },
+        // Frozen per edition (#375) so the wall keeps showing what this year
+        // displayed, whatever the company or the catalogue does later.
+        logoUrl: archivedLogoUrl(link, link.sponsor),
+        tier: archivedTier(link),
         websiteUrl: link.sponsor.websiteUrl,
       }))
       // Higher rank = more prominent (RG-221), so sort descending.
@@ -81,6 +77,12 @@ export default async function sponsorRoutes(app: FastifyInstance) {
             editionId: true,
             edition: { select: { year: true } },
             tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+            // What this edition displayed (#375), preferred over the live values.
+            logoUrl: true,
+            tierNameFr: true,
+            tierNameEn: true,
+            tierColor: true,
+            tierLogoScale: true,
             jobOffers: {
               select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
               orderBy: { createdAt: "asc" },
@@ -104,16 +106,10 @@ export default async function sponsorRoutes(app: FastifyInstance) {
     const edition = await getFeaturedEdition();
     const current = edition ? sponsor.editions.find((e) => e.editionId === edition.id) : undefined;
 
-    const tier = current
-      ? {
-          key: current.tier.key,
-          rank: current.tier.rank,
-          nameFr: current.tier.nameFr,
-          nameEn: current.tier.nameEn,
-          logoScale: current.tier.logoScale,
-          color: current.tier.color,
-        }
-      : null;
+    // As the featured edition displayed it (#375), not as the catalogue reads
+    // today. The logo below stays the identity's: this is the company's page,
+    // so it shows the company as it is now — the archive lives on the wall.
+    const tier = current ? archivedTier(current) : null;
     // Offers disappear one month after the event (#251).
     const jobOffers = current && edition && areOffersVisible(edition) ? current.jobOffers : [];
 
@@ -155,6 +151,7 @@ export default async function sponsorRoutes(app: FastifyInstance) {
         editions: {
           where: { editionId: edition.id },
           select: {
+            logoUrl: true,
             jobOffers: {
               select: { id: true, title: true, descriptionFr: true, descriptionEn: true, url: true },
               orderBy: { createdAt: "asc" },
@@ -170,7 +167,8 @@ export default async function sponsorRoutes(app: FastifyInstance) {
     return sponsors.map((s) => ({
       slug: s.slug,
       name: s.name,
-      logoUrl: s.logoUrl,
+      // The where above pins editions to the featured one, so at most one row.
+      logoUrl: s.editions[0] ? archivedLogoUrl(s.editions[0], s) : s.logoUrl,
       jobOffers: s.editions.flatMap((e) => e.jobOffers),
     }));
   });

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -340,6 +340,7 @@
     "home": "Home",
     "empty": "Sponsors will be announced soon.",
     "visitWebsite": "Visit website",
+    "currentTier": "{tier} sponsor of the current edition",
     "speakersOf": "Speakers from {name}",
     "jobOffersTitle": "Job offers",
     "jobOfferCta": "View offer"

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -340,6 +340,7 @@
     "home": "Accueil",
     "empty": "Les sponsors seront annoncés prochainement.",
     "visitWebsite": "Visiter le site",
+    "currentTier": "Sponsor {tier} de l'édition en cours",
     "speakersOf": "Speakers de {name}",
     "jobOffersTitle": "Offres d'emploi",
     "jobOfferCta": "Voir l'offre"

--- a/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
@@ -86,6 +86,23 @@ export default async function SponsorDetailPage({
 
         <h1 className="mt-6 text-3xl lg:text-5xl font-bold text-noir">{sponsor.name}</h1>
 
+        {/* Years sponsored (#129): the tier is a per-year fact shown on the
+            wall, not here — past editions are just tags linking to that year. */}
+        {sponsor.editions.length > 0 && (
+          <ul className="mt-6 flex flex-wrap gap-2">
+            {sponsor.editions.map((year) => (
+              <li key={year}>
+                <Link
+                  href={`/editions/${year}`}
+                  className="rounded-[12px] bg-blanc-casse px-3 py-1 text-sm text-gris hover:text-noir transition-colors"
+                >
+                  {year}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+
         <div className="mt-8 grid grid-cols-1 gap-10 lg:grid-cols-[1fr_320px]">
           {/* Left: description. Rich-text HTML for new content (#270); older
               plain-text descriptions keep their line breaks via pre-line. */}

--- a/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
@@ -86,8 +86,18 @@ export default async function SponsorDetailPage({
 
         <h1 className="mt-6 text-3xl lg:text-5xl font-bold text-noir">{sponsor.name}</h1>
 
-        {/* Years sponsored (#129): the tier is a per-year fact shown on the
-            wall, not here — past editions are just tags linking to that year. */}
+        {/* Sponsoring this year is the headline fact (#129), so the tier gets a
+            badge in the tier's own colour. Past editions stay plain tags below:
+            their tier belongs to that year's wall, not to the company today. */}
+        {sponsor.tier && (
+          <p
+            className="mt-4 inline-block rounded-[12px] px-3 py-1 text-sm font-bold text-blanc"
+            style={{ backgroundColor: sponsor.tier.color }}
+          >
+            {t("currentTier", { tier: localizedField(sponsor.tier, "name", locale) })}
+          </p>
+        )}
+
         {sponsor.editions.length > 0 && (
           <ul className="mt-6 flex flex-wrap gap-2">
             {sponsor.editions.map((year) => (

--- a/src/frontend/src/app/admin/sponsors/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/page.tsx
@@ -39,12 +39,26 @@ export default function SponsorsDataPage() {
   }, []);
 
   async function applyBulk(value: "DRAFT" | "PUBLISHED") {
+    // publicationStatus lives on the participation (#129), so an edition has to
+    // be picked: applying to every edition a sponsor appears in would publish
+    // it on a year the admin was not even looking at (the guard #351
+    // established for speakers).
+    const editionId = selectedEditionId;
+    if (!editionId) {
+      setError("Choisissez une édition avant d'appliquer une action groupée.");
+      return;
+    }
+
+    setError(null);
     const ids = [...selectedIds];
-    const { status } = await adminFetch("/sponsors/bulk", {
+    const { status, error: apiError } = await adminFetch("/sponsors/bulk", {
       method: "POST",
-      body: JSON.stringify({ ids, action: "setStatus", value }),
+      body: JSON.stringify({ ids, action: "setStatus", value, editionId }),
     });
-    if (status !== 200) return;
+    if (status !== 200) {
+      setError(apiError ?? "Action groupée impossible.");
+      return;
+    }
     setSponsors((prev) =>
       prev.map((s) => (selectedIds.has(s.id) ? { ...s, publicationStatus: value } : s)),
     );
@@ -73,6 +87,13 @@ export default function SponsorsDataPage() {
     () => [...new Set(sponsors.map((s) => s.edition?.year).filter((y): y is number => y != null))].sort((a, b) => b - a),
     [sponsors],
   );
+
+  // The edition the bulk actions apply to, read off the year filter. A
+  // sponsor row carries a single edition here (unlike speakers), so the
+  // lookup is a plain find over `sponsors`.
+  const selectedEditionId = year
+    ? (sponsors.find((s) => String(s.edition?.year) === year)?.edition?.id ?? null)
+    : null;
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -154,7 +175,14 @@ export default function SponsorsDataPage() {
             <span className="text-sm text-gris">{filtered.length} sponsor{filtered.length > 1 ? "s" : ""}</span>
           </div>
 
-          {selectedIds.size > 0 && (
+          {selectedIds.size > 0 && !selectedEditionId && (
+            <div role="status" className="mb-4 rounded-lg bg-jaune/10 px-4 py-3 text-sm text-noir">
+              Les actions groupées s&apos;appliquent à une édition : choisissez une année dans le
+              filtre ci-dessus.
+            </div>
+          )}
+
+          {selectedIds.size > 0 && selectedEditionId && (
             <BulkActionBar
               count={selectedIds.size}
               entitySingular="sponsor"

--- a/src/frontend/src/app/edit/[token]/SponsorJobOffers.tsx
+++ b/src/frontend/src/app/edit/[token]/SponsorJobOffers.tsx
@@ -33,6 +33,7 @@ interface Labels {
   jobOfferQuotaReached: string;
   jobOfferSaved: string;
   jobOfferRejected: string;
+  noCurrentParticipation: string;
 }
 
 const inputClass =
@@ -178,6 +179,10 @@ function OfferRow({
       return;
     }
     if (res.status === 409) setError(t.jobOfferQuotaReached);
+    // No participation on the featured edition (#129): only a new offer (POST)
+    // can hit this — an existing offer's PUT is ownership-checked against the
+    // current participation and would 404 first, never 422.
+    else if (res.status === 422) setError(t.noCurrentParticipation);
     else setError(t.jobOfferRejected);
   }
 

--- a/src/frontend/src/app/edit/[token]/SponsorPrivateSection.tsx
+++ b/src/frontend/src/app/edit/[token]/SponsorPrivateSection.tsx
@@ -11,7 +11,9 @@ interface StandContact {
 
 export interface SponsorPrivate {
   // The sponsoring tier: `allowsPromoIdeas` gates the promo fields (#321).
-  tier: { allowsPromoIdeas: boolean };
+  // Null when the company has no participation on the featured edition (#129)
+  // — a past sponsor's link still opens, just without the per-year sections.
+  tier: { allowsPromoIdeas: boolean } | null;
   standContacts: StandContact[];
   comKitReceived: boolean;
   comKitLogoWebUrl: string | null;
@@ -33,6 +35,7 @@ interface Labels {
   saving: string;
   saved: string;
   rejected: string;
+  noCurrentParticipation: string;
   privateSection: string;
   privateHint: string;
   standContacts: string;
@@ -83,7 +86,7 @@ export default function SponsorPrivateSection({
   const [comKitNotes, setComKitNotes] = useState(initial.comKitNotes ?? "");
   const [platinumPromoIdea, setPlatinumPromoIdea] = useState(initial.platinumPromoIdea ?? "");
   const [platinumCoBuildIdea, setPlatinumCoBuildIdea] = useState(initial.platinumCoBuildIdea ?? "");
-  const isPlatinum = initial.tier.allowsPromoIdeas;
+  const isPlatinum = initial.tier?.allowsPromoIdeas ?? false;
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState("");
@@ -119,6 +122,13 @@ export default function SponsorPrivateSection({
     setSaving(false);
     if (res.ok) {
       setSaved(true);
+      return;
+    }
+    // No participation on the featured edition (#129): the identity fields
+    // save separately and are unaffected, but this section has nothing to
+    // attach its fields to. Say so without wiping what was typed.
+    if (res.status === 422) {
+      setError(t.noCurrentParticipation);
       return;
     }
     setError(t.rejected);

--- a/src/frontend/src/app/edit/[token]/page.tsx
+++ b/src/frontend/src/app/edit/[token]/page.tsx
@@ -126,6 +126,11 @@ const T = {
     orUrl: "ou collez l'adresse d'une image en ligne",
     rejected:
       "Une valeur est invalide : les liens doivent commencer par http:// ou https://, et les textes rester sous 5 000 caractères.",
+    // Sent instead of "rejected" when a per-year field (kit com, idées
+    // Platinum) has no participation to attach to (#129) — the form must not
+    // be wiped, only this section's save is refused.
+    noCurrentParticipation:
+      "Votre entreprise ne sponsorise pas l'édition en cours : ces informations propres à l'édition ne peuvent pas être enregistrées.",
     errors: {
       invalid: "Ce lien de modification est invalide ou a été révoqué.",
       expired:
@@ -215,6 +220,8 @@ const T = {
     orUrl: "or paste the address of an online image",
     rejected:
       "A value is invalid: links must start with http:// or https://, and text must stay under 5,000 characters.",
+    noCurrentParticipation:
+      "Your company does not sponsor the current edition: this edition-specific information cannot be saved.",
     errors: {
       invalid: "This modification link is invalid or has been revoked.",
       expired:

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -238,7 +238,7 @@ export interface SponsorDetail {
   name: string;
   logoUrl: string | null;
   // Null unless the company sponsors the featured edition (#129): the tier is
-  // a per-year fact. Shown on the sponsor wall, not on this page.
+  // a per-year fact, so it describes this year's participation only.
   tier: SponsorTierRef | null;
   // Years the company sponsored, newest first. Rendered as tags linking to
   // each edition's page.

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -237,7 +237,12 @@ export interface SponsorDetail {
   slug: string;
   name: string;
   logoUrl: string | null;
-  tier: SponsorTierRef;
+  // Null unless the company sponsors the featured edition (#129): the tier is
+  // a per-year fact. Shown on the sponsor wall, not on this page.
+  tier: SponsorTierRef | null;
+  // Years the company sponsored, newest first. Rendered as tags linking to
+  // each edition's page.
+  editions: number[];
   websiteUrl: string | null;
   descriptionFr: string | null;
   descriptionEn: string | null;


### PR DESCRIPTION
## Summary

- Le sponsor devient une **identité d'entreprise** partagée entre les éditions, et la participation à une année vit sur `EditionSponsor` (slug global, niveau acheté par édition, publication par participation).
- La chaîne complète est portée sur ce modèle : schéma + migration, routes publiques, admin, lien de modification, seeds et fixtures de test.
- Dernier apport (#375) : chaque participation **fige ce que son édition affichait** — logo et apparence du niveau — pour qu'une modification ultérieure ne réécrive jamais une année passée.

### Pourquoi le gel (#375)

La scission #129 sortait `logoUrl` de l'année à laquelle il appartenait : changer de logo en 2027 repeignait le mur 2026. Le niveau avait le problème symétrique — acheté par édition, mais son nom, sa couleur et son échelle vivent dans un catalogue partagé, donc renommer « Gold » réécrivait toutes les éditions d'un coup.

`EditionSponsor` porte désormais `logoUrl`, `tierNameFr`, `tierNameEn`, `tierColor`, `tierLogoScale`. `null` = « pas encore figé », on relit alors la valeur vivante. `key` et `rank` restent volontairement non figés : ils pilotent le regroupement et l'ordre, pas l'apparence.

Choix assumés côté lecture :
- **Mur des sponsors** et `/job-offers` → valeurs figées de l'édition.
- **Fiche entreprise** → logo courant de la société (c'est sa page, elle montre son état actuel), mais le niveau tel que l'édition en vedette l'affichait.
- **Lien de modification** → écrit sur la participation *et* rafraîchit le logo de l'identité, pour que la participation suivante reparte du bon.

### Migration

La migration `20260729120000_sponsor_identity` a été **amendée** plutôt que doublée d'une seconde : elle n'avait jamais tourné ailleurs que sur une base locale (vérifié — absente de `dev-j`, `dev` et `main`). Le backfill gèle les participations existantes en joignant le catalogue.

## Test Plan

Tout ce que la CI exécute a été passé en local :

- [x] Backend — `pnpm typecheck` propre
- [x] Backend — **560 tests / 85 fichiers** au vert, après reconstruction complète de la base (`DROP SCHEMA` + `migrate deploy` + seed : 28/28 participations figées)
- [x] Frontend — `pnpm lint` : 0 erreur (8 warnings préexistants, fichiers non touchés)
- [x] Frontend — **99 tests / 16 fichiers** au vert
- [x] Frontend — `pnpm build` réussi

Non-régression ajoutée : gel du logo par année, gel du libellé de niveau face à un renommage du catalogue, repli vers la valeur vivante quand rien n'est figé, écriture du logo par le lien de modification. Le test du mur a été vérifié « rouge sans le correctif » (il attrapait le logo de l'identité).

Vérification fonctionnelle navigateur (Chrome DevTools MCP) sur l'environnement Docker local, en cassant volontairement le logo d'identité et en renommant le niveau du catalogue :

- Mur des sponsors → affiche le logo et le libellé **de l'édition**, ignore les deux modifications. 28 logos chargés, aucune erreur console.
- Fiche sponsor → badge « Sponsor Platinum de l'édition en cours » malgré le catalogue renommé.
- Lien de modification, avec une participation 2025 créée à côté :

| Année | logoUrl | tierNameFr |
|---|---|---|
| 2025 | `/images/sponsors/logo-de-2025.svg` | `Gold 2025` |
| 2026 | `https://example.org/logo-encore-plus-recent.png` | `Platinum` |

2025 intacte, 2026 mise à jour — c'est exactement le bug corrigé.

## Notes de revue

- **PR volumineuse** : elle porte tout le chantier #129, pas seulement #375. Les commits intermédiaires ne tournent pas isolément (migration et code consommateur indissociables), d'où l'absence de découpage.
- **Frontend non modifié.** L'admin édite le logo de l'édition qu'il regarde sans que l'UI le dise — un libellé serait utile, à traiter dans une issue séparée.

Refs #129
Refs #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
