### PR TITLE
feat(sponsor): show a past edition's sponsors on its page

### DIFF
--- a/src/backend/src/__tests__/edition-sponsors.test.ts
+++ b/src/backend/src/__tests__/edition-sponsors.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { buildApp } from "./test-app.js";
+import { prisma } from "../lib/prisma.js";
+import { tierIdByKey } from "./sponsor-test-helpers.js";
+
+// #370 — a past edition's sponsors, which /api/sponsors cannot serve: it scopes
+// to the featured edition, so a past year comes back empty.
+//
+// Years 1780-1783 are this file's block. All sit below getSeededEdition()'s 2016
+// floor, so a parallel test file cannot pick one up as "the current edition"
+// (#292).
+
+const createdSponsorIds: number[] = [];
+const createdEditionIds: number[] = [];
+
+afterEach(async () => {
+  if (createdSponsorIds.length) {
+    // EditionSponsor cascades from Sponsor: delete sponsors first, so their
+    // participations are gone before the edition they point at.
+    await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
+    createdSponsorIds.length = 0;
+  }
+  if (createdEditionIds.length) {
+    await prisma.edition.deleteMany({ where: { id: { in: createdEditionIds } } });
+    createdEditionIds.length = 0;
+  }
+});
+
+describe("GET /api/editions/:year/sponsors (#370)", () => {
+  it("serves the published sponsors of a past edition, ranked by tier", async () => {
+    const past = await prisma.edition.create({ data: { year: 1780 } });
+    createdEditionIds.push(past.id);
+    const goldId = await tierIdByKey("gold");
+    const platinumId = await tierIdByKey("platinum");
+
+    // The gold name sorts before the platinum one, to prove the order comes
+    // from the tier rank (platinum first) and not from the name.
+    const gold = await prisma.sponsor.create({
+      data: {
+        name: "AAAA Gold Past Co",
+        slug: `past-gold-${Date.now()}`,
+        editions: { create: [{ editionId: past.id, tierId: goldId, publicationStatus: "PUBLISHED" }] },
+      },
+    });
+    const platinum = await prisma.sponsor.create({
+      data: {
+        name: "ZZZZ Platinum Past Co",
+        slug: `past-plat-${Date.now()}`,
+        editions: { create: [{ editionId: past.id, tierId: platinumId, publicationStatus: "PUBLISHED" }] },
+      },
+    });
+    createdSponsorIds.push(gold.id, platinum.id);
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/editions/1780/sponsors" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveLength(2);
+    expect(body[0].slug).toBe(platinum.slug);
+    expect(body[1].slug).toBe(gold.slug);
+    // Same payload as /api/sponsors, so both walls share a component and a type.
+    expect(body[0]).toMatchObject({
+      id: platinum.id,
+      name: "ZZZZ Platinum Past Co",
+      tier: { key: "platinum" },
+    });
+  });
+
+  it("excludes a draft participation and a trashed sponsor", async () => {
+    const past = await prisma.edition.create({ data: { year: 1781 } });
+    createdEditionIds.push(past.id);
+    const tierId = await tierIdByKey("gold");
+
+    const draft = await prisma.sponsor.create({
+      data: {
+        name: "Draft Past Co",
+        slug: `past-draft-${Date.now()}`,
+        editions: { create: [{ editionId: past.id, tierId, publicationStatus: "DRAFT" }] },
+      },
+    });
+    const trashed = await prisma.sponsor.create({
+      data: {
+        name: "Trashed Past Co",
+        slug: `past-trashed-${Date.now()}`,
+        deletedAt: new Date(),
+        editions: { create: [{ editionId: past.id, tierId, publicationStatus: "PUBLISHED" }] },
+      },
+    });
+    createdSponsorIds.push(draft.id, trashed.id);
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/editions/1781/sponsors" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it("serves what the edition displayed, not the live values (#375)", async () => {
+    const past = await prisma.edition.create({ data: { year: 1782 } });
+    createdEditionIds.push(past.id);
+    const tierId = await tierIdByKey("gold");
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Rebranded Past Co",
+        slug: `past-frozen-${Date.now()}`,
+        // The company's current logo — what the archive must NOT show.
+        logoUrl: "/logos/today.svg",
+        editions: {
+          create: [{
+            editionId: past.id,
+            tierId,
+            publicationStatus: "PUBLISHED",
+            logoUrl: "/logos/back-then.svg",
+            tierNameFr: "Or de 1782",
+            tierColor: "#d4af37",
+          }],
+        },
+      },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/editions/1782/sponsors" });
+    await app.close();
+
+    const [served] = res.json();
+    expect(served.logoUrl).toBe("/logos/back-then.svg");
+    expect(served.tier.nameFr).toBe("Or de 1782");
+    expect(served.tier.color).toBe("#d4af37");
+    // Not frozen: key and rank drive grouping and ordering, so they stay live.
+    expect(served.tier.key).toBe("gold");
+  });
+
+  it("returns an empty list for an edition without sponsors", async () => {
+    const past = await prisma.edition.create({ data: { year: 1783 } });
+    createdEditionIds.push(past.id);
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/editions/1783/sponsors" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it("returns 404 for an unknown year and 400 for a non-numeric one", async () => {
+    const app = await buildApp();
+    const missing = await app.inject({ method: "GET", url: "/api/editions/1799/sponsors" });
+    const invalid = await app.inject({ method: "GET", url: "/api/editions/not-a-year/sponsors" });
+    await app.close();
+
+    expect(missing.statusCode).toBe(404);
+    expect(invalid.statusCode).toBe(400);
+  });
+});

--- a/src/backend/src/lib/sponsor-archive.ts
+++ b/src/backend/src/lib/sponsor-archive.ts
@@ -1,3 +1,6 @@
+import { prisma } from "./prisma.js";
+import { notDeleted } from "./admin-helpers.js";
+
 // What a sponsor looked like on a given edition (#375).
 //
 // #129 made Sponsor a company identity shared across editions, which moved the
@@ -36,6 +39,32 @@ export function archivedLogoUrl(
   sponsor: { logoUrl: string | null },
 ): string | null {
   return participation.logoUrl ?? sponsor.logoUrl;
+}
+
+// The published sponsor wall of one edition, as that edition displayed it.
+// Serves both /api/sponsors (featured edition) and /api/editions/:year/sponsors
+// (#370) — same payload, so the public page and the archive grid share one
+// component and one type; only the edition they resolve differs.
+export async function getEditionSponsorWall(editionId: number) {
+  const links = await prisma.editionSponsor.findMany({
+    where: { editionId, publicationStatus: "PUBLISHED", sponsor: notDeleted },
+    include: {
+      sponsor: { select: { id: true, slug: true, name: true, logoUrl: true, websiteUrl: true } },
+      tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
+    },
+  });
+
+  return links
+    .map((link) => ({
+      id: link.sponsor.id,
+      slug: link.sponsor.slug,
+      name: link.sponsor.name,
+      logoUrl: archivedLogoUrl(link, link.sponsor),
+      tier: archivedTier(link),
+      websiteUrl: link.sponsor.websiteUrl,
+    }))
+    // Higher rank = more prominent (RG-221), so sort descending.
+    .sort((a, b) => (b.tier.rank - a.tier.rank) || a.name.localeCompare(b.name));
 }
 
 // The tier as this edition displayed it. `key` and `rank` are never frozen:

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { areOffersVisible } from "../lib/job-offers.js";
 import { notDeleted, parseSocialLinks, visibleCategory } from "../lib/admin-helpers.js";
+import { getEditionSponsorWall } from "../lib/sponsor-archive.js";
 
 type TicketStatus = "AVAILABLE" | "SOLD_OUT" | "COMING_SOON";
 
@@ -138,6 +139,26 @@ export default async function editionRoutes(app: FastifyInstance) {
       select: { speaker: { select: { slug: true, name: true, photoUrl: true, company: true } } },
     });
     return links.map((link) => link.speaker);
+  });
+
+  // GET /api/editions/:year/sponsors — published sponsors of any edition by
+  // year (#370). `/api/sponsors` cannot serve this: it scopes to the featured
+  // edition, so a past year comes back empty.
+  //
+  // The payload matches /api/sponsors so the public wall and this grid share
+  // their component and their type. Values are the ones frozen on the
+  // participation (#375) — an archive shows what that year displayed, not what
+  // the company logo and the tier catalogue happen to say today.
+  app.get<{ Params: { year: string } }>("/editions/:year/sponsors", {
+    schema: { params: { type: "object", required: ["year"], properties: { year: { type: "string" } } } },
+  }, async (request, reply) => {
+    const yearNum = Number(request.params.year);
+    if (isNaN(yearNum)) return reply.status(400).send({ error: "Invalid year" });
+
+    const edition = await prisma.edition.findFirst({ where: { year: yearNum, ...notDeleted }, select: { id: true } });
+    if (!edition) return reply.status(404).send({ error: "Edition not found" });
+
+    return getEditionSponsorWall(edition.id);
   });
 
   // GET /api/editions/:year/talks — published talks of any edition by year,

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -3,7 +3,7 @@ import { prisma } from "../lib/prisma.js";
 import { getFeaturedEdition } from "./editions.js";
 import { areOffersVisible } from "../lib/job-offers.js";
 import { notDeleted } from "../lib/admin-helpers.js";
-import { archivedLogoUrl, archivedTier } from "../lib/sponsor-archive.js";
+import { archivedLogoUrl, archivedTier, getEditionSponsorWall } from "../lib/sponsor-archive.js";
 
 function parseSocial(raw: string | null): Record<string, string> {
   if (!raw) return {};
@@ -22,29 +22,9 @@ export default async function sponsorRoutes(app: FastifyInstance) {
     const edition = await getFeaturedEdition();
     if (!edition) return reply.status(404).send({ error: "No edition found" });
 
-    // Since #129 the tier is bought per edition, so the query moves onto the
-    // participation join rather than the sponsor identity.
-    const links = await prisma.editionSponsor.findMany({
-      where: { editionId: edition.id, publicationStatus: "PUBLISHED", sponsor: notDeleted },
-      include: {
-        sponsor: { select: { id: true, slug: true, name: true, logoUrl: true, websiteUrl: true } },
-        tier: { select: { key: true, rank: true, nameFr: true, nameEn: true, logoScale: true, color: true } },
-      },
-    });
-
-    return links
-      .map((link) => ({
-        id: link.sponsor.id,
-        slug: link.sponsor.slug,
-        name: link.sponsor.name,
-        // Frozen per edition (#375) so the wall keeps showing what this year
-        // displayed, whatever the company or the catalogue does later.
-        logoUrl: archivedLogoUrl(link, link.sponsor),
-        tier: archivedTier(link),
-        websiteUrl: link.sponsor.websiteUrl,
-      }))
-      // Higher rank = more prominent (RG-221), so sort descending.
-      .sort((a, b) => (b.tier.rank - a.tier.rank) || a.name.localeCompare(b.name));
+    // Shared with /api/editions/:year/sponsors (#370): same wall, same frozen
+    // values (#375), only the edition resolved differs.
+    return getEditionSponsorWall(edition.id);
   });
 
   // GET /api/sponsors/:slug — detail of a published sponsor + its speakers (RG-226).

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -218,6 +218,7 @@
     "nextEdition": "Next edition",
     "speakers": "Speakers ({count})",
     "sessions": "Talks ({count})",
+    "sponsors": "Partners ({count})",
     "replay": "Watch",
     "allNews": "See all news"
   },

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -218,6 +218,7 @@
     "nextEdition": "Édition suivante",
     "speakers": "Speakers ({count})",
     "sessions": "Conférences ({count})",
+    "sponsors": "Partenaires ({count})",
     "replay": "Revoir",
     "allNews": "Voir toutes les actualités"
   },

--- a/src/frontend/src/app/[locale]/editions/[year]/page.tsx
+++ b/src/frontend/src/app/[locale]/editions/[year]/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { getLocale, getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 
-import { getEditionByYear, getEditions, getEditionSpeakers, getEditionTalks } from "@/lib/api";
+import { getEditionByYear, getEditions, getEditionSpeakers, getEditionSponsors, getEditionTalks } from "@/lib/api";
 import { localizedField } from "@/lib/i18n-helpers";
 import { absoluteUrl, jsonLdScript } from "@/lib/seo";
 import Breadcrumb from "@/components/Breadcrumb";
@@ -11,6 +11,7 @@ import YouTubeFacade from "@/components/YouTubeFacade";
 import StatIcon from "@/components/home/StatIcon";
 import EditionSpeakersGrid from "@/components/editions/EditionSpeakersGrid";
 import EditionTalksList from "@/components/editions/EditionTalksList";
+import SponsorWall from "@/components/sponsors/SponsorWall";
 import { Link } from "@/i18n/navigation";
 
 interface PageProps {
@@ -96,11 +97,12 @@ export default async function BilanPage({ params }: PageProps) {
   const locale = await getLocale();
   const t = await getTranslations("bilan");
 
-  const [edition, allEditions, speakers, talks] = await Promise.all([
+  const [edition, allEditions, speakers, talks, sponsors] = await Promise.all([
     getEditionByYear(Number(year)),
     getEditions(),
     getEditionSpeakers(Number(year)),
     getEditionTalks(Number(year)),
+    getEditionSponsors(Number(year)),
   ]);
   if (!edition) notFound();
 
@@ -305,6 +307,17 @@ export default async function BilanPage({ params }: PageProps) {
                 {t("sessions", { count: talks.length })}
               </h2>
               <EditionTalksList talks={talks} replayLabel={t("replay")} year={edition.year} />
+            </section>
+          )}
+
+          {/* Sponsors of this edition (#370) — the logos as that year showed
+              them, not as the companies look today (#375). */}
+          {sponsors.length > 0 && (
+            <section className="mt-16">
+              <h2 className="text-2xl lg:text-4xl font-bold text-noir mb-8">
+                {t("sponsors", { count: sponsors.length })}
+              </h2>
+              <SponsorWall sponsors={sponsors} locale={locale} />
             </section>
           )}
 

--- a/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { localizedField } from "@/lib/i18n-helpers";
 import { looksLikeHtml, htmlToText } from "@/lib/html";
 import Breadcrumb from "@/components/Breadcrumb";
 import { Link } from "@/i18n/navigation";
-import { jsonLdScript } from "@/lib/seo";
+import { absoluteUrl, jsonLdScript } from "@/lib/seo";
 
 export async function generateMetadata({
   params,
@@ -68,7 +68,8 @@ export default async function SponsorDetailPage({
     "@context": "https://schema.org",
     "@type": "Organization",
     name: sponsor.name,
-    ...(sponsor.logoUrl ? { logo: sponsor.logoUrl } : {}),
+    // Schema.org wants an absolute URL; the stored logo is site-relative.
+    ...(sponsor.logoUrl ? { logo: absoluteUrl(sponsor.logoUrl) } : {}),
     ...(sponsor.websiteUrl ? { url: sponsor.websiteUrl } : {}),
     ...(Object.values(sponsor.socialLinks).length > 0
       ? { sameAs: Object.values(sponsor.socialLinks) }

--- a/src/frontend/src/app/[locale]/sponsors/page.tsx
+++ b/src/frontend/src/app/[locale]/sponsors/page.tsx
@@ -2,10 +2,8 @@ import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { getCurrentEdition, getSponsors } from "@/lib/api";
-import type { SponsorPublic } from "@/lib/types";
 import Breadcrumb from "@/components/Breadcrumb";
-import SponsorCard, { bandForLogoScale } from "@/components/sponsors/SponsorCard";
-import TierHeader from "@/components/sponsors/TierHeader";
+import SponsorWall from "@/components/sponsors/SponsorWall";
 import { Link } from "@/i18n/navigation";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -21,20 +19,6 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-// Group sponsors by tier, preserving the server's rank-descending order (#321).
-function groupByTier(sponsors: SponsorPublic[]) {
-  const groups: { key: string; tier: SponsorPublic["tier"]; items: SponsorPublic[] }[] = [];
-  for (const s of sponsors) {
-    let group = groups.find((g) => g.key === s.tier.key);
-    if (!group) {
-      group = { key: s.tier.key, tier: s.tier, items: [] };
-      groups.push(group);
-    }
-    group.items.push(s);
-  }
-  return groups;
-}
-
 export default async function SponsorsPage() {
   const locale = await getLocale();
   const t = await getTranslations("sponsors");
@@ -45,8 +29,6 @@ export default async function SponsorsPage() {
     { label: t("home"), href: `/${locale}` },
     { label: t("title"), href: `/${locale}/sponsors` },
   ];
-
-  const byTier = groupByTier(sponsors);
 
   return (
     <div className="px-6 py-8 lg:py-12">
@@ -67,24 +49,11 @@ export default async function SponsorsPage() {
 
         <p className="mx-auto mt-4 max-w-[640px] text-center text-gris">{t("intro")}</p>
 
-        {byTier.length === 0 ? (
+        {sponsors.length === 0 ? (
           <p className="mt-12 text-center text-lg text-gris">{t("empty")}</p>
         ) : (
           <div className="mt-4">
-            {byTier.map(({ key, tier, items }) => {
-              const size = bandForLogoScale(tier.logoScale);
-              const title = locale === "en" ? tier.nameEn : tier.nameFr;
-              return (
-                <section key={key} className="mt-[52px] first:mt-10">
-                  <TierHeader title={title} color={tier.color} size={size} />
-                  <div className="mt-6 flex flex-wrap items-stretch justify-center gap-[18px]">
-                    {items.map((s) => (
-                      <SponsorCard key={s.id} sponsor={s} size={size} />
-                    ))}
-                  </div>
-                </section>
-              );
-            })}
+            <SponsorWall sponsors={sponsors} locale={locale} />
           </div>
         )}
       </div>

--- a/src/frontend/src/components/sponsors/SponsorWall.tsx
+++ b/src/frontend/src/components/sponsors/SponsorWall.tsx
@@ -1,0 +1,47 @@
+import type { SponsorPublic } from "@/lib/types";
+import SponsorCard, { bandForLogoScale } from "@/components/sponsors/SponsorCard";
+import TierHeader from "@/components/sponsors/TierHeader";
+
+// Group sponsors by tier, preserving the server's rank-descending order (#321).
+export function groupByTier(sponsors: SponsorPublic[]) {
+  const groups: { key: string; tier: SponsorPublic["tier"]; items: SponsorPublic[] }[] = [];
+  for (const s of sponsors) {
+    let group = groups.find((g) => g.key === s.tier.key);
+    if (!group) {
+      group = { key: s.tier.key, tier: s.tier, items: [] };
+      groups.push(group);
+    }
+    group.items.push(s);
+  }
+  return groups;
+}
+
+interface SponsorWallProps {
+  sponsors: SponsorPublic[];
+  locale: string;
+}
+
+// The tier-grouped logo wall, shared by /sponsors (featured edition) and the
+// sponsors section of a past edition page (#370). Both endpoints return the
+// same payload — values frozen per edition (#375) — so one component serves
+// the live wall and the archive alike.
+export default function SponsorWall({ sponsors, locale }: SponsorWallProps) {
+  return (
+    <>
+      {groupByTier(sponsors).map(({ key, tier, items }) => {
+        const size = bandForLogoScale(tier.logoScale);
+        const title = locale === "en" ? tier.nameEn : tier.nameFr;
+        return (
+          <section key={key} className="mt-[52px] first:mt-10">
+            <TierHeader title={title} color={tier.color} size={size} />
+            <div className="mt-6 flex flex-wrap items-stretch justify-center gap-[18px]">
+              {items.map((s) => (
+                <SponsorCard key={s.id} sponsor={s} size={size} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -254,6 +254,12 @@ export async function getEditionTalks(year: number): Promise<EditionTalk[]> {
   return (await fetchAPI<EditionTalk[]>(`/api/editions/${year}/talks`)) || [];
 }
 
+// Sponsors of a past edition (#370). Same payload as getSponsors() — the values
+// are frozen per edition (#375) — so both feed the same SponsorWall.
+export async function getEditionSponsors(year: number): Promise<SponsorPublic[]> {
+  return (await fetchAPI<SponsorPublic[]>(`/api/editions/${year}/sponsors`)) || [];
+}
+
 // Detail of one past talk (#343). Scoped by year: slugs are unique per edition,
 // and `/api/talks/:slug` would answer 404 outside the featured one.
 export async function getEditionTalkBySlug(


### PR DESCRIPTION
## Summary

- Nouvel endpoint public `GET /api/editions/:year/sponsors` : les sponsors d'une édition passée, que `/api/sponsors` ne peut pas servir puisqu'il se scope sur l'édition à la une.
- Section « Partenaires » sur la page d'une édition, masquée si l'année n'a aucun sponsor.
- Les valeurs servies sont celles **figées sur la participation** (#375) : une archive montre le logo et le libellé du niveau tels que cette année-là les affichait.

### Le mur des sponsors n'existe plus qu'une fois

Les deux routes partagent `getEditionSponsorWall()` — même requête, même tri par rang (RG-221), même payload. Elles ne diffèrent que par l'édition qu'elles résolvent. Côté frontend, le même `SponsorWall` rend le mur public et l'archive : le groupement par niveau vivait dans `sponsors/page.tsx`, il est remonté dans le composant plutôt que dupliqué.

### Ce que le merge de #387 avait déjà réglé

L'issue listait trois manques. Le premier — endpoints scopés sur l'édition à la une — **était déjà corrigé** par #387 : `/api/sponsors/:slug` résout un sponsor de n'importe quelle année. Deux points de son analyse sont par ailleurs périmés :

- l'avertissement « `Sponsor` porte `@@unique([editionId, slug])`, il faut trancher quelle fiche servir » n'a plus lieu d'être : le slug est `@unique` global depuis #387 ;
- « ne dépend pas de #123 » n'est plus vrai : le travail s'écrit désormais sur `EditionSponsor`.

La saisie de données ne nécessite aucun développement : l'admin accepte déjà n'importe quel `editionId` à la création d'une participation. Les données historiques restent à saisir — hors périmètre de cette PR.

### SEO

`Organization` JSON-LD, `canonical` et `hreflang` FR/EN étaient déjà en place sur la fiche sponsor. Seul le `logo` demandait un correctif : il partait en URL relative alors que Schema.org attend une URL absolue — `absoluteUrl()`, comme partout ailleurs dans le projet.

## Test Plan

Toute la chaîne CI passée en local :

- [x] Backend — `tsc` propre, **565 tests / 86 fichiers** (560 + 5 nouveaux)
- [x] Frontend — `tsc` propre, `lint` 0 erreur (8 warnings préexistants, fichiers non touchés), **99 tests / 16 fichiers**, `build` réussi

Tests backend ajoutés sur le nouvel endpoint : tri par rang de niveau, exclusion d'une participation en brouillon et d'un sponsor en corbeille, service des valeurs figées plutôt que des valeurs vivantes, liste vide pour une année sans sponsor, 404 sur année inconnue et 400 sur année non numérique. Vérifiés « rouges sans l'endpoint ».

Vérification fonctionnelle sur le Docker local, avec 6 participations 2025 portant le libellé figé « Or 2025 » (inexistant dans le catalogue) :

| Vérification | Résultat |
|---|---|
| `/fr/editions/2025` | « Partenaires (6) », 6 logos, libellé **« Or 2025 »** |
| `/en/editions/2025` | « Partners (6) », libellé **« Gold 2025 »** |
| `/fr/editions/2024` (0 sponsor) | Aucune section — pas de titre vide |
| `/fr/sponsors` (non-régression) | Inchangé : Platinum, Gold, Soutien et Communautés |
| JSON-LD fiche sponsor | `"logo":"http://localhost:3000/images/sponsors/aeronova-systems.svg"` — absolu |

Données de test nettoyées, base revenue à l'état de seed.

> Vérification navigateur faite en HTTP : le serveur Chrome DevTools MCP s'est déconnecté pendant la session (redémarrage de Docker Desktop). Le rendu a été contrôlé sur le HTML servi, en FR et EN.

Refs #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)
