### PR TITLE
feat(admin): attach a sponsor to an edition from either side

### DIFF
--- a/src/backend/src/__tests__/admin-sponsor-editions.test.ts
+++ b/src/backend/src/__tests__/admin-sponsor-editions.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+import adminSponsorRoutes from "../routes/admin/sponsors.js";
+import { prisma } from "../lib/prisma.js";
+import { tierIdByKey } from "./sponsor-test-helpers.js";
+
+// #389 — attaching an existing company to an edition, from either side of the
+// admin. The endpoint existed since #129 but no UI called it, so nothing
+// covered it.
+//
+// Years 1790-1793 are this file's block, below getSeededEdition()'s 2016 floor
+// so a parallel file cannot pick one up as "the current edition" (#292).
+
+async function buildSponsorsApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  await app.register(adminSponsorRoutes, { prefix: "/api/admin" });
+  return app;
+}
+
+const createdSponsorIds: number[] = [];
+const createdEditionIds: number[] = [];
+
+afterEach(async () => {
+  if (createdSponsorIds.length) {
+    await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
+    createdSponsorIds.length = 0;
+  }
+  if (createdEditionIds.length) {
+    await prisma.edition.deleteMany({ where: { id: { in: createdEditionIds } } });
+    createdEditionIds.length = 0;
+  }
+});
+
+describe("POST /api/admin/sponsors/:id/editions (#389)", () => {
+  it("freezes the tier appearance on the participation it attaches (#375)", async () => {
+    const edition = await prisma.edition.create({ data: { year: 1790 } });
+    createdEditionIds.push(edition.id);
+    const tierId = await tierIdByKey("gold");
+    const tier = await prisma.sponsorTier.findUniqueOrThrow({ where: { id: tierId } });
+
+    const sponsor = await prisma.sponsor.create({
+      data: { name: "Attach Co", slug: `attach-${Date.now()}`, logoUrl: "/logos/attach.svg" },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildSponsorsApp();
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/sponsors/${sponsor.id}/editions`,
+      payload: { editionId: edition.id, tierId },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const participation = await prisma.editionSponsor.findFirstOrThrow({
+      where: { sponsorId: sponsor.id, editionId: edition.id },
+    });
+    // Without this, renaming the shared catalogue would repaint the edition —
+    // the very regression #375 closed on the create path.
+    expect(participation.tierNameFr).toBe(tier.nameFr);
+    expect(participation.tierColor).toBe(tier.color);
+    expect(participation.tierLogoScale).toBe(tier.logoScale);
+    // The company's current logo is all it has to start from.
+    expect(participation.logoUrl).toBe("/logos/attach.svg");
+    // A new participation is never published straight away.
+    expect(participation.publicationStatus).toBe("DRAFT");
+  });
+
+  it("re-freezes the appearance when the same edition is attached again", async () => {
+    const edition = await prisma.edition.create({ data: { year: 1791 } });
+    createdEditionIds.push(edition.id);
+    const goldId = await tierIdByKey("gold");
+    const platinumId = await tierIdByKey("platinum");
+    const platinum = await prisma.sponsorTier.findUniqueOrThrow({ where: { id: platinumId } });
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Upgraded Co",
+        slug: `upgrade-${Date.now()}`,
+        editions: { create: [{ editionId: edition.id, tierId: goldId, tierNameFr: "Or figé" }] },
+      },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildSponsorsApp();
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/sponsors/${sponsor.id}/editions`,
+      payload: { editionId: edition.id, tierId: platinumId },
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const participation = await prisma.editionSponsor.findFirstOrThrow({
+      where: { sponsorId: sponsor.id, editionId: edition.id },
+    });
+    // Moving to another tier must not leave the label of the one it left.
+    expect(participation.tierId).toBe(platinumId);
+    expect(participation.tierNameFr).toBe(platinum.nameFr);
+  });
+
+  it("rejects an unknown tier and an unknown sponsor", async () => {
+    const edition = await prisma.edition.create({ data: { year: 1792 } });
+    createdEditionIds.push(edition.id);
+    const tierId = await tierIdByKey("gold");
+
+    const sponsor = await prisma.sponsor.create({
+      data: { name: "Guarded Co", slug: `guarded-${Date.now()}` },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildSponsorsApp();
+    const badTier = await app.inject({
+      method: "POST",
+      url: `/api/admin/sponsors/${sponsor.id}/editions`,
+      payload: { editionId: edition.id, tierId: 999_999 },
+    });
+    const badSponsor = await app.inject({
+      method: "POST",
+      url: "/api/admin/sponsors/999999/editions",
+      payload: { editionId: edition.id, tierId },
+    });
+    await app.close();
+
+    expect(badTier.statusCode).toBe(422);
+    expect(badSponsor.statusCode).toBe(404);
+  });
+});
+
+describe("DELETE /api/admin/sponsors/:id/editions/:editionId (#389)", () => {
+  it("detaches the participation and keeps the company", async () => {
+    const edition = await prisma.edition.create({ data: { year: 1793 } });
+    createdEditionIds.push(edition.id);
+    const tierId = await tierIdByKey("gold");
+
+    const sponsor = await prisma.sponsor.create({
+      data: {
+        name: "Detach Co",
+        slug: `detach-${Date.now()}`,
+        editions: { create: [{ editionId: edition.id, tierId }] },
+      },
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildSponsorsApp();
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/api/admin/sponsors/${sponsor.id}/editions/${edition.id}`,
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(204);
+    expect(
+      await prisma.editionSponsor.count({ where: { sponsorId: sponsor.id, editionId: edition.id } }),
+    ).toBe(0);
+    // The trash operates on the identity: detaching a year never removes it.
+    expect(await prisma.sponsor.count({ where: { id: sponsor.id } })).toBe(1);
+  });
+});

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -488,10 +488,33 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
       if (!editionId || !tierId) {
         return reply.code(400).send({ error: "editionId and tierId are required" });
       }
+      // Same freeze as on create (#375): a participation attached here must
+      // carry the tier's appearance too, or renaming the shared catalogue
+      // later would repaint this edition. The logo comes from the identity,
+      // which is all this company has at this point.
+      const sponsor = await prisma.sponsor.findFirst({
+        where: { id: sponsorId, ...notDeleted },
+        select: { logoUrl: true },
+      });
+      if (!sponsor) return notFound(reply, "Sponsor");
+
+      const tier = await prisma.sponsorTier.findFirst({
+        where: { id: tierId, ...notDeleted },
+        select: { id: true, nameFr: true, nameEn: true, color: true, logoScale: true },
+      });
+      if (!tier) return reply.code(422).send({ error: "Invalid tierId: no such sponsor tier" });
+
+      const frozen = {
+        tierId: tier.id,
+        tierNameFr: tier.nameFr,
+        tierNameEn: tier.nameEn,
+        tierColor: tier.color,
+        tierLogoScale: tier.logoScale,
+      };
       const participation = await prisma.editionSponsor.upsert({
         where: { sponsorId_editionId: { sponsorId, editionId } },
-        create: { sponsorId, editionId, tierId, publicationStatus: "DRAFT" },
-        update: { tierId },
+        create: { sponsorId, editionId, ...frozen, logoUrl: sponsor.logoUrl, publicationStatus: "DRAFT" },
+        update: frozen,
         select: { id: true, editionId: true, tierId: true, publicationStatus: true },
       });
       revalidateSponsors();

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -11,6 +11,7 @@ import TicketingTab from "@/components/admin/edition-detail/TicketingTab";
 import CfpTab from "@/components/admin/edition-detail/CfpTab";
 import KeyFiguresTab from "@/components/admin/edition-detail/KeyFiguresTab";
 import SponsoringTab from "@/components/admin/edition-detail/SponsoringTab";
+import EditionSponsorsTab from "@/components/admin/edition-detail/EditionSponsorsTab";
 import SynthesisOverview from "@/components/admin/edition-detail/SynthesisOverview";
 
 interface EditionData {
@@ -50,7 +51,10 @@ const TABS = [
   { key: "general", label: "Général" },
   { key: "venue", label: "Lieu" },
   { key: "ticketing", label: "Billetterie" },
+  // "Sponsoring" configures the tiers offered (#320); "Sponsors" lists the
+  // companies actually signed for the edition (#389). Neighbouring, distinct.
   { key: "sponsoring", label: "Sponsoring" },
+  { key: "sponsors", label: "Sponsors" },
   { key: "cfp", label: "CFP" },
   { key: "key-figures", label: "Chiffres clés" },
 ];
@@ -130,6 +134,9 @@ export default function EditionDetailPage() {
         )}
         {activeTab === "sponsoring" && (
           <SponsoringTab editionId={edition.id} />
+        )}
+        {activeTab === "sponsors" && (
+          <EditionSponsorsTab editionId={edition.id} />
         )}
         {activeTab === "cfp" && (
           <CfpTab />

--- a/src/frontend/src/app/admin/sponsors/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { adminFetch } from "@/lib/admin-api";
 import type { Sponsor, AdminSponsorTier } from "@/lib/types";
 import SponsorContacts from "@/components/admin/sponsors/SponsorContacts";
+import SponsorEditions from "@/components/admin/sponsors/SponsorEditions";
 import SponsorForm, { emptySponsorForm, type SponsorFormValue } from "@/components/admin/sponsors/SponsorForm";
 
 interface SponsorData extends Sponsor {
@@ -28,6 +29,8 @@ export default function SponsorEditorPage() {
   const [isLoading, setIsLoading] = useState(!isNew);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Set when the chosen name belongs to a company already in base (#389).
+  const [existingSponsorId, setExistingSponsorId] = useState<number | null>(null);
 
   // The tier catalogue drives the "Niveau" <select> and the promo-idea gating.
   useEffect(() => {
@@ -116,8 +119,16 @@ export default function SponsorEditorPage() {
     };
 
     if (isNew) {
-      const { data, status } = await adminFetch<{ id: number }>("/sponsors", { method: "POST", body: JSON.stringify(payload) });
+      const { data, status, errorBody } = await adminFetch<{ id: number }>("/sponsors", { method: "POST", body: JSON.stringify(payload) });
       setIsSaving(false);
+      // The slug is global since #129, so a taken name means the company is
+      // already there — offer to attach it to the chosen edition rather than
+      // leaving the editor at a dead end (#389).
+      if (status === 409 && typeof errorBody?.id === "number") {
+        setExistingSponsorId(errorBody.id);
+        setError(null);
+        return;
+      }
       if (status >= 400 || !data) {
         setError("Échec de la création.");
         return;
@@ -131,6 +142,23 @@ export default function SponsorEditorPage() {
         return;
       }
       router.push("/admin/sponsors");
+    }
+  }
+
+  // Attach the existing company to the edition picked above, then open its
+  // sheet where the other participations are managed.
+  async function attachExisting() {
+    if (!existingSponsorId || !editionId || !form.tierId) return;
+    setIsSaving(true);
+    const { status } = await adminFetch(`/sponsors/${existingSponsorId}/editions`, {
+      method: "POST",
+      body: JSON.stringify({ editionId, tierId: form.tierId }),
+    });
+    setIsSaving(false);
+    if (status === 200 || status === 201) {
+      router.push(`/admin/sponsors/${existingSponsorId}`);
+    } else {
+      setError("Échec du rattachement.");
     }
   }
 
@@ -160,12 +188,58 @@ export default function SponsorEditorPage() {
             </select>
           </label>
         ) : (
-          <p className="text-sm text-gris">Édition : <span className="font-medium text-noir">{editionYear ?? "—"}</span></p>
+          // The form edits the participation of this year; the other years are
+          // managed just below (#389).
+          <p className="text-sm text-gris">
+            Édition en cours d&apos;édition : <span className="font-medium text-noir">{editionYear ?? "—"}</span>
+          </p>
         )}
 
-        <SponsorForm value={form} onChange={setForm} tiers={tiers} />
+        <SponsorForm
+          value={form}
+          // Editing the name invalidates the "already exists" notice: it was
+          // about the previous one (#389).
+          onChange={(next) => {
+            if (next.name !== form.name) setExistingSponsorId(null);
+            setForm(next);
+          }}
+          tiers={tiers}
+        />
+
+        {!isNew && current && <SponsorEditions sponsorId={current.id} tiers={tiers} />}
 
         {!isNew && current && <SponsorContacts sponsorId={current.id} />}
+
+        {existingSponsorId !== null && (
+          <div className="rounded-lg border border-orange/40 bg-orange/10 p-3 text-sm text-noir">
+            <p>
+              <span className="font-medium">{form.name.trim()}</span>{" "}
+              existe déjà. Une entreprise n&apos;est saisie qu&apos;une fois : rattachez-la à
+              l&apos;édition{" "}
+              <span className="font-medium">
+                {editions.find((e) => e.id === editionId)?.year ?? "sélectionnée"}
+              </span>{" "}
+              plutôt que de la recréer.
+            </p>
+            <div className="mt-2 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={attachExisting}
+                disabled={isSaving}
+                className="rounded-lg bg-malachite px-3 py-2 text-sm font-medium text-blanc hover:bg-malachite/90 disabled:opacity-50"
+              >
+                Rattacher à cette édition
+              </button>
+              <button
+                type="button"
+                onClick={() => router.push(`/admin/sponsors/${existingSponsorId}`)}
+                className="text-sm font-medium text-noir hover:underline"
+              >
+                Ouvrir la fiche existante
+              </button>
+            </div>
+          </div>
+        )}
 
         {error && <p className="text-sm text-terre-cuite">{error}</p>}
 

--- a/src/frontend/src/components/admin/edition-detail/EditionSponsorsTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/EditionSponsorsTab.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { AdminSponsorTier } from "@/lib/types";
+
+interface SponsorRow {
+  id: number;
+  name: string;
+  publicationStatus?: "DRAFT" | "PUBLISHED";
+  tier?: { id: number; nameFr: string };
+}
+
+interface EditionSponsorsTabProps {
+  editionId: number;
+}
+
+// The sponsors signed for this edition, and attaching an existing company to it
+// (#389). Distinct from the "Sponsoring" tab, which configures the *tiers
+// offered* for the edition (#320) — the offer, not the signatures.
+export default function EditionSponsorsTab({ editionId }: EditionSponsorsTabProps) {
+  const [attached, setAttached] = useState<SponsorRow[]>([]);
+  const [allSponsors, setAllSponsors] = useState<SponsorRow[]>([]);
+  const [tiers, setTiers] = useState<AdminSponsorTier[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [pickedSponsorId, setPickedSponsorId] = useState<number | null>(null);
+  const [pickedTierId, setPickedTierId] = useState<number | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+  const [message, setMessage] = useState<{ isOk: boolean; text: string } | null>(null);
+
+  async function load() {
+    const [ofEdition, everyone, catalogue] = await Promise.all([
+      adminFetch<SponsorRow[]>(`/sponsors?editionId=${editionId}`),
+      adminFetch<SponsorRow[]>("/sponsors"),
+      adminFetch<AdminSponsorTier[]>("/sponsor-tiers"),
+    ]);
+    setAttached(ofEdition.data ?? []);
+    setAllSponsors(everyone.data ?? []);
+    setTiers(catalogue.data ?? []);
+    setIsLoading(false);
+  }
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editionId]);
+
+  useEffect(() => {
+    if (pickedTierId === null && tiers[0]) setPickedTierId(tiers[0].id);
+  }, [tiers, pickedTierId]);
+
+  // Only companies not already attached to this edition, narrowed by the search
+  // box — the full list runs to dozens of rows.
+  const candidates = useMemo(() => {
+    const taken = new Set(attached.map((s) => s.id));
+    const needle = search.trim().toLowerCase();
+    return allSponsors
+      .filter((s) => !taken.has(s.id))
+      .filter((s) => !needle || s.name.toLowerCase().includes(needle));
+  }, [allSponsors, attached, search]);
+
+  useEffect(() => {
+    if (pickedSponsorId === null || !candidates.some((s) => s.id === pickedSponsorId)) {
+      setPickedSponsorId(candidates[0]?.id ?? null);
+    }
+  }, [candidates, pickedSponsorId]);
+
+  async function attach() {
+    if (!pickedSponsorId || !pickedTierId) return;
+    setIsBusy(true);
+    setMessage(null);
+    const { status } = await adminFetch(`/sponsors/${pickedSponsorId}/editions`, {
+      method: "POST",
+      body: JSON.stringify({ editionId, tierId: pickedTierId }),
+    });
+    setIsBusy(false);
+    if (status === 200 || status === 201) {
+      const name = allSponsors.find((s) => s.id === pickedSponsorId)?.name;
+      setMessage({ isOk: true, text: `${name} rattaché à cette édition, en brouillon.` });
+      setSearch("");
+      void load();
+    } else {
+      setMessage({ isOk: false, text: "Échec du rattachement." });
+    }
+  }
+
+  async function detach(sponsor: SponsorRow) {
+    if (!window.confirm(`Retirer ${sponsor.name} de cette édition ? La fiche de l'entreprise est conservée.`)) return;
+    setIsBusy(true);
+    setMessage(null);
+    const { status } = await adminFetch(`/sponsors/${sponsor.id}/editions/${editionId}`, { method: "DELETE" });
+    setIsBusy(false);
+    if (status === 204) {
+      setMessage({ isOk: true, text: `${sponsor.name} retiré de cette édition.` });
+      void load();
+    } else {
+      setMessage({ isOk: false, text: "Échec du retrait." });
+    }
+  }
+
+  if (isLoading) return <p className="text-sm text-gris">Chargement…</p>;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="mb-1 text-lg font-bold text-noir">Sponsors de cette édition</h2>
+        <p className="text-sm text-gris">
+          Les entreprises qui sponsorisent cette année. Pour configurer les niveaux proposés sur
+          la page « Devenir sponsor », voir l&apos;onglet Sponsoring.
+        </p>
+      </div>
+
+      {attached.length === 0 ? (
+        <p className="text-sm text-gris">Aucun sponsor rattaché à cette édition.</p>
+      ) : (
+        <ul className="space-y-2">
+          {attached.map((s) => (
+            <li
+              key={s.id}
+              className="flex flex-wrap items-center gap-3 rounded-lg border border-gris/15 bg-blanc px-3 py-2"
+            >
+              <Link href={`/admin/sponsors/${s.id}`} className="min-w-[180px] flex-1 text-sm font-medium text-noir hover:underline">
+                {s.name}
+              </Link>
+              <span className="text-sm text-gris">{s.tier?.nameFr ?? "—"}</span>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                  s.publicationStatus === "PUBLISHED"
+                    ? "bg-malachite/10 text-malachite"
+                    : "bg-gris/10 text-gris"
+                }`}
+              >
+                {s.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+              </span>
+              <button
+                type="button"
+                onClick={() => detach(s)}
+                disabled={isBusy}
+                className="text-xs font-medium text-terre-cuite hover:underline disabled:opacity-50"
+              >
+                Retirer
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="rounded-lg border border-gris/20 bg-blanc-casse/50 p-4">
+        <p className="mb-3 text-sm font-medium text-noir">Rattacher une entreprise existante</p>
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="min-w-[180px] flex-1">
+            <span className="mb-1 block text-xs text-gris">Rechercher</span>
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Nom de l'entreprise"
+              className={inputClass}
+            />
+          </label>
+          <label className="min-w-[200px] flex-1">
+            <span className="mb-1 block text-xs text-gris">Entreprise</span>
+            <select
+              value={pickedSponsorId ?? ""}
+              onChange={(e) => setPickedSponsorId(Number(e.target.value))}
+              disabled={candidates.length === 0}
+              className={inputClass}
+            >
+              {candidates.map((s) => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+          </label>
+          <label className="min-w-[160px]">
+            <span className="mb-1 block text-xs text-gris">Niveau</span>
+            <select
+              value={pickedTierId ?? ""}
+              onChange={(e) => setPickedTierId(Number(e.target.value))}
+              className={inputClass}
+            >
+              {tiers.map((t) => (
+                <option key={t.id} value={t.id}>{t.nameFr}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={attach}
+            disabled={isBusy || !pickedSponsorId || !pickedTierId}
+            className="rounded-lg bg-malachite px-3 py-2 text-sm font-medium text-blanc hover:bg-malachite/90 disabled:opacity-50"
+          >
+            Rattacher
+          </button>
+        </div>
+        {candidates.length === 0 && (
+          <p className="mt-2 text-sm text-gris">
+            {search.trim()
+              ? "Aucune entreprise ne correspond à cette recherche."
+              : "Toutes les entreprises sont déjà rattachées à cette édition."}
+          </p>
+        )}
+        <p className="mt-3 text-xs text-gris">
+          L&apos;entreprise n&apos;existe pas encore ?{" "}
+          <Link href={`/admin/sponsors/new?editionId=${editionId}`} className="font-medium text-malachite hover:underline">
+            Créer un sponsor pour cette édition
+          </Link>
+        </p>
+      </div>
+
+      {message && (
+        <p className={`text-sm ${message.isOk ? "text-malachite" : "text-terre-cuite"}`}>{message.text}</p>
+      )}
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";

--- a/src/frontend/src/components/admin/sponsors/SponsorEditions.tsx
+++ b/src/frontend/src/components/admin/sponsors/SponsorEditions.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { adminFetch } from "@/lib/admin-api";
+import type { AdminSponsorTier } from "@/lib/types";
+
+interface Participation {
+  editionId: number;
+  edition: { id: number; year: number };
+  tier: { id: number; nameFr: string };
+  publicationStatus: "DRAFT" | "PUBLISHED";
+}
+
+interface SponsorEditionsProps {
+  sponsorId: number;
+  tiers: AdminSponsorTier[];
+}
+
+// A company's participations (#389). Since #129 a sponsor spans editions, so
+// attaching it to another year is adding a participation — not duplicating the
+// company, which the global slug forbids anyway.
+export default function SponsorEditions({ sponsorId, tiers }: SponsorEditionsProps) {
+  const [participations, setParticipations] = useState<Participation[]>([]);
+  const [editions, setEditions] = useState<{ id: number; year: number }[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [newEditionId, setNewEditionId] = useState<number | null>(null);
+  const [newTierId, setNewTierId] = useState<number | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+  const [message, setMessage] = useState<{ isOk: boolean; text: string } | null>(null);
+
+  async function load() {
+    const [sponsor, allEditions] = await Promise.all([
+      adminFetch<{ editions?: Participation[] }>(`/sponsors/${sponsorId}`),
+      adminFetch<{ id: number; year: number }[]>("/editions"),
+    ]);
+    setParticipations(sponsor.data?.editions ?? []);
+    setEditions(allEditions.data ?? []);
+    setIsLoading(false);
+  }
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sponsorId]);
+
+  // A year already attached cannot be added twice — @@unique([sponsorId,
+  // editionId]) — so it leaves the picker instead of failing on submit.
+  const availableEditions = useMemo(() => {
+    const taken = new Set(participations.map((p) => p.editionId));
+    return editions.filter((e) => !taken.has(e.id));
+  }, [editions, participations]);
+
+  useEffect(() => {
+    if (newEditionId === null || !availableEditions.some((e) => e.id === newEditionId)) {
+      setNewEditionId(availableEditions[0]?.id ?? null);
+    }
+  }, [availableEditions, newEditionId]);
+
+  useEffect(() => {
+    if (newTierId === null && tiers[0]) setNewTierId(tiers[0].id);
+  }, [tiers, newTierId]);
+
+  async function attach() {
+    if (!newEditionId || !newTierId) return;
+    setIsBusy(true);
+    setMessage(null);
+    const { status } = await adminFetch(`/sponsors/${sponsorId}/editions`, {
+      method: "POST",
+      body: JSON.stringify({ editionId: newEditionId, tierId: newTierId }),
+    });
+    setIsBusy(false);
+    if (status === 200 || status === 201) {
+      const year = editions.find((e) => e.id === newEditionId)?.year;
+      setMessage({ isOk: true, text: `Édition ${year} rattachée, en brouillon.` });
+      void load();
+    } else {
+      setMessage({ isOk: false, text: "Échec du rattachement." });
+    }
+  }
+
+  async function detach(participation: Participation) {
+    const year = participation.edition.year;
+    if (!window.confirm(`Retirer la participation ${year} ? La fiche de l'entreprise est conservée.`)) return;
+    setIsBusy(true);
+    setMessage(null);
+    const { status } = await adminFetch(`/sponsors/${sponsorId}/editions/${participation.editionId}`, {
+      method: "DELETE",
+    });
+    setIsBusy(false);
+    if (status === 204) {
+      setMessage({ isOk: true, text: `Participation ${year} retirée.` });
+      void load();
+    } else {
+      setMessage({ isOk: false, text: "Échec du retrait." });
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-gris/20 bg-blanc-casse/50 p-4 space-y-4">
+      <p className="text-sm font-medium text-noir">Éditions</p>
+
+      {isLoading ? (
+        <p className="text-sm text-gris">Chargement…</p>
+      ) : participations.length === 0 ? (
+        <p className="text-sm text-gris">Aucune participation pour l&apos;instant.</p>
+      ) : (
+        <ul className="space-y-2">
+          {participations.map((p) => (
+            <li
+              key={p.editionId}
+              className="flex flex-wrap items-center gap-3 rounded-lg border border-gris/15 bg-blanc px-3 py-2"
+            >
+              <span className="min-w-[60px] text-sm font-medium text-noir">{p.edition.year}</span>
+              <span className="flex-1 text-sm text-gris">{p.tier.nameFr}</span>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                  p.publicationStatus === "PUBLISHED"
+                    ? "bg-malachite/10 text-malachite"
+                    : "bg-gris/10 text-gris"
+                }`}
+              >
+                {p.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+              </span>
+              <button
+                type="button"
+                onClick={() => detach(p)}
+                disabled={isBusy}
+                className="text-xs font-medium text-terre-cuite hover:underline disabled:opacity-50"
+              >
+                Retirer
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="border-t border-gris/15 pt-3">
+        <p className="mb-2 text-xs font-semibold text-gris">Rattacher à une édition</p>
+        {availableEditions.length === 0 ? (
+          <p className="text-sm text-gris">Cette entreprise participe déjà à toutes les éditions.</p>
+        ) : (
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="min-w-[120px]">
+              <span className="mb-1 block text-xs text-gris">Édition</span>
+              <select
+                value={newEditionId ?? ""}
+                onChange={(e) => setNewEditionId(Number(e.target.value))}
+                className={inputClass}
+              >
+                {availableEditions.map((e) => (
+                  <option key={e.id} value={e.id}>{e.year}</option>
+                ))}
+              </select>
+            </label>
+            <label className="min-w-[160px]">
+              <span className="mb-1 block text-xs text-gris">Niveau</span>
+              <select
+                value={newTierId ?? ""}
+                onChange={(e) => setNewTierId(Number(e.target.value))}
+                className={inputClass}
+              >
+                {tiers.map((t) => (
+                  <option key={t.id} value={t.id}>{t.nameFr}</option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={attach}
+              disabled={isBusy || !newEditionId || !newTierId}
+              className="rounded-lg bg-malachite px-3 py-2 text-sm font-medium text-blanc hover:bg-malachite/90 disabled:opacity-50"
+            >
+              Rattacher
+            </button>
+          </div>
+        )}
+      </div>
+
+      {message && (
+        <p className={`text-sm ${message.isOk ? "text-malachite" : "text-terre-cuite"}`}>{message.text}</p>
+      )}
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -11,7 +11,7 @@ interface AdminUser {
 export async function adminFetch<T>(
   path: string,
   options: RequestInit = {},
-): Promise<{ data: T | null; status: number; error?: string }> {
+): Promise<{ data: T | null; status: number; error?: string; errorBody?: Record<string, unknown> }> {
   try {
     const headers: Record<string, string> = {};
     if (options.body && !(options.body instanceof FormData)) {
@@ -37,7 +37,15 @@ export async function adminFetch<T>(
     if (!res.ok) {
       const body = await res.json().catch(() => null);
       const error = body?.error || body?.message;
-      return { data: null, status: res.status, ...(error ? { error } : {}) };
+      // Some errors carry more than a message: the 409 on a taken sponsor slug
+      // returns the existing company's id, which the caller offers to attach
+      // rather than leaving the editor stuck (#389).
+      return {
+        data: null,
+        status: res.status,
+        ...(error ? { error } : {}),
+        ...(body && typeof body === "object" ? { errorBody: body as Record<string, unknown> } : {}),
+      };
     }
 
     // 204 No Content (e.g. a DELETE) has an empty body: res.json() would throw


### PR DESCRIPTION
## Summary

Trois chemins pour rattacher une entreprise existante à une édition, tous sur des endpoints qui existaient depuis #129 et que **aucune UI n'appelait** :

- **Fiche sponsor** → section « Éditions » : ses participations (année, niveau, statut), avec rattachement et retrait. Une année déjà rattachée sort du sélecteur au lieu d'échouer à la validation.
- **Page édition** → nouvel onglet « Sponsors » : les entreprises signées pour l'année, avec recherche par nom pour en rattacher une. Distinct de l'onglet « Sponsoring », qui configure les niveaux *proposés* (#320).
- **Le 409 lui-même** : à la création d'un nom déjà pris, l'écran proposait « Échec de la création. » — une impasse. Il propose maintenant de rattacher l'entreprise existante à l'édition choisie.

## Un défaut trouvé en chemin

`POST /sponsors/:id/editions` **ne figeait pas l'apparence du niveau** sur la participation créée. Une participation rattachée par ce chemin aurait donc été repeinte par un renommage ultérieur du catalogue — exactement la régression que #375 vient de fermer sur le chemin de création. Corrigé, avec deux tests qui échouent sans le correctif.

L'endpoint acceptait par ailleurs **n'importe quel `tierId`** et n'importe quel `sponsorId` : il valide désormais les deux (422 / 404).

## Note d'implémentation

`adminFetch` gagne `errorBody`, pour qu'un appelant puisse lire ce qu'une erreur porte au-delà de son message — ici l'`id` de l'entreprise existante renvoyé par le 409. Ajout rétrocompatible : les appelants existants ne voient aucun changement.

## Test Plan

Toute la chaîne CI passée en local :

- [x] Backend — `tsc` propre, **569 tests / 87 fichiers** (565 + 4 nouveaux)
- [x] Frontend — `tsc` propre, `lint` 0 erreur (8 warnings préexistants, fichiers non touchés), **99 tests / 16 fichiers**, `build` réussi

Tests backend ajoutés : gel de l'apparence au rattachement, re-gel au changement de niveau, rejet d'un niveau et d'un sponsor inconnus, détachement qui conserve l'entreprise. Les deux tests de gel ont été vérifiés « rouges sans le correctif ».

Vérification navigateur (Chrome DevTools MCP) sur l'admin Docker local :

| Parcours | Résultat |
|---|---|
| Fiche sponsor → rattacher 2025 | Participation créée en brouillon, liste rafraîchie, 2026 exclue du sélecteur |
| Fiche sponsor, toutes années prises | « Cette entreprise participe déjà à toutes les éditions. » |
| Onglet Sponsors → recherche « garonne » | 2 résultats sur 27, entreprise déjà rattachée exclue |
| Onglet Sponsors → rattacher en Gold | Créé au bon niveau, recherche vidée, liste à jour |
| Création d'un nom existant | Bandeau + « Rattacher à cette édition » / « Ouvrir la fiche existante » |
| Bouton de rattachement | Participation créée au niveau choisi, redirection vers la fiche |

Vérifié en base : les trois participations créées portent chacune le niveau choisi (Platinum, Gold, Discovery). Données de test nettoyées, base revenue à l'état de seed.

## Notes de revue

- **Emplacement de l'onglet** : j'ai retenu un onglet « Sponsors » distinct plutôt qu'une section dans « Sponsoring », les deux notions étant voisines mais différentes (entreprises signées vs niveaux offerts). Un texte d'aide renvoie de l'un à l'autre. C'est le point que l'issue laissait ouvert — à trancher en revue si tu préfères l'autre option.
- **Hors périmètre** : la fusion de doublons créés avant #129, et la saisie des données historiques elles-mêmes.

Refs #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
