### PR TITLE
feat(sponsor): account-based access to a sponsor's space (#362 lots 1-2)

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -32,6 +32,24 @@
 - Verify permissions on every request — never rely solely on client-side checks
 - Use constant-time comparison for tokens and secrets
 
+### Opening account creation to a new kind of user
+
+`User.role` is `UserRole @default(EDITOR)`, and `requireAnyAuthenticated` lets
+`EDITOR` through. Any account created without an explicit role therefore gets
+the back-office. That default was safe while only administrators could hold an
+account; it stops being safe the moment a third party can create one.
+
+So, before opening sign-up to a new kind of user (sponsor #362, speaker #363):
+
+- Add a **neutral** `UserRole` value for them and set it explicitly on create.
+  Never let them fall back to the default.
+- Do **not** widen `requireAnyAuthenticated` — it guards the back-office, whose
+  fine-grained authorization happens inside the handlers. Give the newcomer its
+  own guard reading its own link table (e.g. `SponsorContact.accessRole` via
+  `requireSponsorAccess`).
+- Reject the account at `user.create.before` rather than after the fact, so a
+  failed attempt leaves no orphan row behind.
+
 ## Dependency Updates
 - Run `npm audit` / `yarn audit` regularly
 - Update dependencies with known vulnerabilities promptly

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -34,7 +34,8 @@
     "pg": "^8.21.0",
     "prisma": "^7.8.0",
     "sanitize-html": "^2.17.6",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "zod": "4.4.3"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src/backend/pnpm-lock.yaml
+++ b/src/backend/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^25.5.0

--- a/src/backend/prisma/migrations/20260804140000_sponsor_backoffice_access/migration.sql
+++ b/src/backend/prisma/migrations/20260804140000_sponsor_backoffice_access/migration.sql
@@ -1,0 +1,40 @@
+-- Sponsor back-office access (#362).
+--
+-- A sponsor gets a real account instead of an edit-by-token link. Three things
+-- are needed before any of that can work: a per-sponsor permission, a link from
+-- the contact to the account behind it, and an invitation distinct from the
+-- existing edit token.
+
+-- 1. What a person may do on ONE sponsor's space. Not part of UserRole, which
+--    grants back-office access — a sponsor must never hold that.
+CREATE TYPE "SponsorAccessRole" AS ENUM ('RESPONSABLE', 'EDITEUR', 'STAND');
+
+-- 2. A neutral back-office role for sponsor accounts.
+--
+--    User.role defaults to EDITOR, and requireAnyAuthenticated lets EDITOR
+--    through: without this value, creating a sponsor account would hand it the
+--    back-office. SPONSOR grants nothing there; rights live on SponsorContact.
+ALTER TYPE "UserRole" ADD VALUE 'SPONSOR';
+
+-- 3. Per-contact access and the account behind it.
+--
+--    EDITEUR as the default is what existing rows already were: every contact
+--    edited the same page with equal rights (#250), which is exactly EDITEUR.
+--    Nobody is promoted or demoted by this migration.
+ALTER TABLE "SponsorContact"
+  ADD COLUMN "accessRole" "SponsorAccessRole" NOT NULL DEFAULT 'EDITEUR',
+  ADD COLUMN "userId" TEXT,
+  -- Kept apart from editToken: 7 days vs 30, single-use vs not, and the edit
+  -- link stays in service for speakers. One column could not carry both.
+  ADD COLUMN "invitationToken" TEXT,
+  ADD COLUMN "invitationSentAt" TIMESTAMP(3),
+  ADD COLUMN "invitationAcceptedAt" TIMESTAMP(3);
+
+CREATE UNIQUE INDEX "SponsorContact_invitationToken_key" ON "SponsorContact"("invitationToken");
+CREATE INDEX "SponsorContact_userId_idx" ON "SponsorContact"("userId");
+
+-- SetNull, not Cascade: deleting an account must not erase the sponsor's
+-- contact list — the organisers still need the address they wrote to.
+ALTER TABLE "SponsorContact"
+  ADD CONSTRAINT "SponsorContact_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -38,6 +38,25 @@ enum SponsorPageStatus {
 enum UserRole {
   ADMIN
   EDITOR
+  // Grants NOTHING in the back-office — it exists so a sponsor account can be
+  // stored without falling back to EDITOR, which requireAnyAuthenticated lets
+  // through (#362). A sponsor's rights come from SponsorContact.accessRole.
+  SPONSOR
+}
+
+// What a person may do on ONE sponsor's space (#362). Deliberately not part of
+// UserRole: that one grants back-office access, and a sponsor must never hold
+// it. The same person can be RESPONSABLE for one company and STAND for another,
+// so the right belongs to the SponsorContact, not to the User.
+//
+// Ordered from most to least powerful — requireSponsorAccess compares ranks:
+//   RESPONSABLE  read + write + invite
+//   EDITEUR      read + write
+//   STAND        read public only (badge scanning comes later, #113)
+enum SponsorAccessRole {
+  RESPONSABLE
+  EDITEUR
+  STAND
 }
 
 // ============================================
@@ -377,6 +396,9 @@ model User {
   sessions Session[]
   accounts Account[]
   apiKeys  ApiKey[]
+  // The sponsor spaces this account may act on (#362). A sponsor account holds
+  // no back-office UserRole — its rights live entirely on these contacts.
+  sponsorContacts SponsorContact[]
 
   @@index([deletedAt])
   @@map("user")
@@ -749,6 +771,8 @@ model SponsorContact {
   id    Int     @id @default(autoincrement())
   email String
   name  String?
+  // Free-text job title ("Responsable marketing"). NOT a permission — the right
+  // to act is accessRole below (#362). Two different things, close names.
   role  String?
 
   // Modification-link token infrastructure (issue #79, RG-242 to RG-251),
@@ -757,6 +781,26 @@ model SponsorContact {
   editLinkLocked  Boolean   @default(false)
   editTokenSentAt DateTime?
 
+  // What this person may do on the sponsor's space (#362). Every contact used
+  // to have equal rights; the default keeps that true for rows created before
+  // the split, since they were all full editors.
+  accessRole SponsorAccessRole @default(EDITEUR)
+
+  // The account behind the contact, once the invitation is accepted. Null means
+  // "invited, or contact-only" — someone the organisers email without giving
+  // them a login. SetNull rather than Cascade: deleting an account must not
+  // erase the sponsor's contact list.
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  // Invitation to create an account, kept apart from editToken (#362): the two
+  // differ in lifetime (7 days vs 30) and in consumption (single-use vs not),
+  // and the edit link stays in service for speakers. Merging them would make
+  // both expiries hard to follow.
+  invitationToken      String?   @unique
+  invitationSentAt     DateTime?
+  invitationAcceptedAt DateTime?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -764,6 +808,7 @@ model SponsorContact {
   sponsor   Sponsor @relation(fields: [sponsorId], references: [id], onDelete: Cascade)
 
   @@index([sponsorId])
+  @@index([userId])
 }
 
 // A job offer a sponsor wants relayed during the DevFest (#251). Shown on the

--- a/src/backend/src/__tests__/admin-sponsor-access.test.ts
+++ b/src/backend/src/__tests__/admin-sponsor-access.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+
+// Inviting sends an email; stub SMTP so the tests never reach a real server.
+const { sendMailMock } = vi.hoisted(() => ({ sendMailMock: vi.fn().mockResolvedValue({}) }));
+vi.mock("nodemailer", () => ({
+  default: { createTransport: () => ({ sendMail: sendMailMock }) },
+}));
+
+import Fastify, { type FastifyInstance } from "fastify";
+
+import adminSponsorRoutes from "../routes/admin/sponsors.js";
+import { prisma } from "../lib/prisma.js";
+
+// #362 — the organiser side: invite a contact to open an account, and set what
+// they may do. Mounted without the auth guards, like the other admin-* files:
+// auth-rejection.test.ts covers the guards themselves.
+
+let app: FastifyInstance;
+const createdSponsorIds: number[] = [];
+
+async function createSponsor(name: string) {
+  const sponsor = await prisma.sponsor.create({
+    data: { name, slug: `${name.toLowerCase().replace(/\W+/g, "-")}-${Date.now()}` },
+  });
+  createdSponsorIds.push(sponsor.id);
+  return sponsor;
+}
+
+beforeAll(async () => {
+  app = Fastify({ logger: false });
+  await app.register(adminSponsorRoutes, { prefix: "/api/admin" });
+  await app.ready();
+});
+
+beforeEach(() => {
+  sendMailMock.mockClear();
+});
+
+afterAll(async () => {
+  await app.close();
+  if (createdSponsorIds.length) {
+    await prisma.sponsor.deleteMany({ where: { id: { in: createdSponsorIds } } });
+  }
+});
+
+describe("POST /api/admin/sponsors/:id/contacts/:contactId/invite (#362)", () => {
+  it("sends the invitation and records it without returning the token", async () => {
+    const sponsor = await createSponsor("Invite Co");
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: "boss@example.org" },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/sponsors/${sponsor.id}/contacts/${contact.id}/invite`,
+      payload: { accessRole: "RESPONSABLE" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.accessRole).toBe("RESPONSABLE");
+    expect(body.invitationPending).toBe(true);
+    expect(body.hasAccount).toBe(false);
+    // The secret stays server-side, like the edit token before it.
+    expect(JSON.stringify(body)).not.toContain("invitationToken");
+
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    const stored = await prisma.sponsorContact.findUniqueOrThrow({ where: { id: contact.id } });
+    expect(stored.invitationToken).toBeTruthy();
+    expect(stored.invitationSentAt).not.toBeNull();
+  });
+
+  it("rotates the token on re-invite, invalidating the previous one", async () => {
+    const sponsor = await createSponsor("Reinvite Co");
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: "again@example.org" },
+    });
+
+    const url = `/api/admin/sponsors/${sponsor.id}/contacts/${contact.id}/invite`;
+    await app.inject({ method: "POST", url, payload: {} });
+    const first = await prisma.sponsorContact.findUniqueOrThrow({ where: { id: contact.id } });
+    await app.inject({ method: "POST", url, payload: {} });
+    const second = await prisma.sponsorContact.findUniqueOrThrow({ where: { id: contact.id } });
+
+    // The column is @unique so the rotation overwrites, but the behaviour is
+    // deliberate: an invitation left in an old mailbox must stop working.
+    expect(second.invitationToken).not.toBe(first.invitationToken);
+  });
+
+  it("refuses to invite a contact that already has an account", async () => {
+    const sponsor = await createSponsor("Bound Co");
+    const user = await prisma.user.create({
+      data: { email: `bound-${Date.now()}@example.org`, role: "SPONSOR" },
+    });
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/sponsors/${sponsor.id}/contacts/${contact.id}/invite`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe("already_has_account");
+    expect(sendMailMock).not.toHaveBeenCalled();
+
+    await prisma.sponsorContact.delete({ where: { id: contact.id } });
+    await prisma.user.delete({ where: { id: user.id } });
+  });
+
+  it("rejects an unknown access role", async () => {
+    const sponsor = await createSponsor("Bad Role Co");
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: "bad@example.org" },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/sponsors/${sponsor.id}/contacts/${contact.id}/invite`,
+      payload: { accessRole: "SUPERADMIN" },
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a contact belonging to another sponsor", async () => {
+    const mine = await createSponsor("Mine Invite Co");
+    const theirs = await createSponsor("Theirs Invite Co");
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: theirs.id, email: "other@example.org" },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/admin/sponsors/${mine.id}/contacts/${contact.id}/invite`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("PUT /api/admin/sponsors/:id/contacts/:contactId/access-role (#362)", () => {
+  it("changes the role", async () => {
+    const sponsor = await createSponsor("Promote Co");
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: "promote@example.org", accessRole: "STAND" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/sponsors/${sponsor.id}/contacts/${contact.id}/access-role`,
+      payload: { accessRole: "EDITEUR" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().accessRole).toBe("EDITEUR");
+  });
+
+  it("refuses to demote the last RESPONSABLE", async () => {
+    const sponsor = await createSponsor("Last Resp Co");
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: "onlyboss@example.org", accessRole: "RESPONSABLE" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/sponsors/${sponsor.id}/contacts/${contact.id}/access-role`,
+      payload: { accessRole: "EDITEUR" },
+    });
+
+    // Otherwise the company keeps its space but nobody can invite anyone into
+    // it — only an admin could unblock the situation.
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe("last_responsable");
+    const after = await prisma.sponsorContact.findUniqueOrThrow({ where: { id: contact.id } });
+    expect(after.accessRole).toBe("RESPONSABLE");
+  });
+
+  it("allows demoting a RESPONSABLE when another one remains", async () => {
+    const sponsor = await createSponsor("Two Resp Co");
+    const first = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: "boss1@example.org", accessRole: "RESPONSABLE" },
+    });
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: "boss2@example.org", accessRole: "RESPONSABLE" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/sponsors/${sponsor.id}/contacts/${first.id}/access-role`,
+      payload: { accessRole: "STAND" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().accessRole).toBe("STAND");
+  });
+
+  it("rejects an unknown role", async () => {
+    const sponsor = await createSponsor("Bad Change Co");
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: "badchange@example.org", accessRole: "STAND" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/sponsors/${sponsor.id}/contacts/${contact.id}/access-role`,
+      payload: { accessRole: "OWNER" },
+    });
+
+    expect(res.statusCode).toBe(422);
+  });
+});

--- a/src/backend/src/__tests__/sponsor-invitation.test.ts
+++ b/src/backend/src/__tests__/sponsor-invitation.test.ts
@@ -1,0 +1,227 @@
+process.env.BASE_URL = process.env.BASE_URL || "http://localhost:4000";
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+import sponsorInvitationRoutes from "../routes/sponsor-invitation.js";
+import { prisma } from "../lib/prisma.js";
+import { generateApiKey, resolveApiKeyEnv } from "../lib/api-key.js";
+import { hasPendingInvitation } from "../lib/sponsor-invitation.js";
+import { INVITATION_TTL_DAYS } from "../lib/edit-token.js";
+
+// #362 — accepting an invitation binds an account to a company. The rules that
+// matter are: the email must match exactly, the token works once, and an
+// expired invitation opens nothing.
+
+let app: FastifyInstance;
+
+const created = {
+  userIds: [] as string[],
+  sponsorIds: [] as number[],
+};
+
+async function createAccount(email: string) {
+  const user = await prisma.user.create({
+    data: { email, name: email, role: "SPONSOR", emailVerified: true },
+  });
+  created.userIds.push(user.id);
+
+  const key = await generateApiKey(resolveApiKeyEnv());
+  await prisma.apiKey.create({
+    data: { name: `test-${email}`, prefix: key.prefix, hashedKey: key.hashedKey, userId: user.id },
+  });
+  return { user, bearer: key.raw };
+}
+
+async function createSponsorWithInvitation(name: string, email: string, sentAt = new Date()) {
+  const sponsor = await prisma.sponsor.create({
+    data: { name, slug: `${name.toLowerCase().replace(/\W+/g, "-")}-${Date.now()}` },
+  });
+  created.sponsorIds.push(sponsor.id);
+
+  const token = `inv-${name}-${Date.now()}-${Math.floor(sentAt.getTime())}`;
+  const contact = await prisma.sponsorContact.create({
+    data: {
+      sponsorId: sponsor.id,
+      email,
+      accessRole: "RESPONSABLE",
+      invitationToken: token,
+      invitationSentAt: sentAt,
+    },
+  });
+  return { sponsor, contact, token };
+}
+
+beforeAll(async () => {
+  app = Fastify({ logger: false });
+  app.decorateRequest("authContext");
+  await app.register(sponsorInvitationRoutes, { prefix: "/api" });
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+  if (created.userIds.length) {
+    await prisma.apiKey.deleteMany({ where: { userId: { in: created.userIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: created.userIds } } });
+  }
+  if (created.sponsorIds.length) {
+    await prisma.sponsor.deleteMany({ where: { id: { in: created.sponsorIds } } });
+  }
+});
+
+describe("POST /api/sponsor-invitation/:token/accept (#362)", () => {
+  it("binds the account when the email matches the invitation", async () => {
+    const email = `match-${Date.now()}@example.org`;
+    const { sponsor, contact, token } = await createSponsorWithInvitation("Match Co", email);
+    const { user, bearer } = await createAccount(email);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/sponsor-invitation/${token}/accept`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().sponsorId).toBe(sponsor.id);
+
+    const after = await prisma.sponsorContact.findUniqueOrThrow({ where: { id: contact.id } });
+    expect(after.userId).toBe(user.id);
+    expect(after.invitationAcceptedAt).not.toBeNull();
+    // Consumed: the token is cleared, so a replay finds nothing.
+    expect(after.invitationToken).toBeNull();
+  });
+
+  it("refuses an account whose email differs from the invited one", async () => {
+    const invited = `invited-${Date.now()}@societe.fr`;
+    const { contact, token } = await createSponsorWithInvitation("Mismatch Co", invited);
+    // The person signs in with a personal account instead.
+    const { bearer } = await createAccount(`personal-${Date.now()}@gmail.com`);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/sponsor-invitation/${token}/accept`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error).toBe("email_mismatch");
+    // Nothing bound: the invitation stays open for the right address.
+    const after = await prisma.sponsorContact.findUniqueOrThrow({ where: { id: contact.id } });
+    expect(after.userId).toBeNull();
+    expect(after.invitationAcceptedAt).toBeNull();
+  });
+
+  it("matches the email regardless of case", async () => {
+    const stamp = Date.now();
+    const { contact, token } = await createSponsorWithInvitation("Case Co", `Contact-${stamp}@Societe.FR`);
+    const { user, bearer } = await createAccount(`contact-${stamp}@societe.fr`);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/sponsor-invitation/${token}/accept`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    // Identity providers do not agree on casing — the invitation must survive it.
+    expect(res.statusCode).toBe(200);
+    const after = await prisma.sponsorContact.findUniqueOrThrow({ where: { id: contact.id } });
+    expect(after.userId).toBe(user.id);
+  });
+
+  it("refuses a second use of the same token", async () => {
+    const email = `once-${Date.now()}@example.org`;
+    const { token } = await createSponsorWithInvitation("Once Co", email);
+    const { bearer } = await createAccount(email);
+
+    const auth = { authorization: `Bearer ${bearer}` };
+    const first = await app.inject({ method: "POST", url: `/api/sponsor-invitation/${token}/accept`, headers: auth });
+    const second = await app.inject({ method: "POST", url: `/api/sponsor-invitation/${token}/accept`, headers: auth });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(404);
+  });
+
+  it("refuses an expired invitation", async () => {
+    const email = `stale-${Date.now()}@example.org`;
+    const longAgo = new Date(Date.now() - (INVITATION_TTL_DAYS + 1) * 24 * 60 * 60 * 1000);
+    const { token } = await createSponsorWithInvitation("Stale Co", email, longAgo);
+    const { bearer } = await createAccount(email);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/sponsor-invitation/${token}/accept`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("refuses an unauthenticated caller holding a valid token", async () => {
+    const { token } = await createSponsorWithInvitation("Anon Co", `anon-${Date.now()}@example.org`);
+
+    const res = await app.inject({ method: "POST", url: `/api/sponsor-invitation/${token}/accept` });
+
+    // The token alone is not enough: it says who was invited, not who is here.
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("GET /api/sponsor-invitation/:token (#362)", () => {
+  it("describes the invitation without leaking the address", async () => {
+    const email = `preview-${Date.now()}@societe.fr`;
+    const { token } = await createSponsorWithInvitation("Preview Co", email);
+
+    const res = await app.inject({ method: "GET", url: `/api/sponsor-invitation/${token}` });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.sponsorName).toBe("Preview Co");
+    expect(body.accessRole).toBe("RESPONSABLE");
+    // A forwarded link must not hand the mailbox to whoever opens it.
+    expect(body.emailHint).not.toBe(email);
+    expect(body.emailHint).toContain("•");
+  });
+
+  it("answers the same 404 for unknown and consumed tokens", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/sponsor-invitation/does-not-exist" });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("hasPendingInvitation — the sign-up door (#362)", () => {
+  it("opens for a live invitation and closes once accepted", async () => {
+    const email = `door-${Date.now()}@example.org`;
+    const { contact } = await createSponsorWithInvitation("Door Co", email);
+
+    expect(await hasPendingInvitation(email)).toBe(true);
+
+    await prisma.sponsorContact.update({
+      where: { id: contact.id },
+      data: { invitationAcceptedAt: new Date(), invitationToken: null },
+    });
+
+    // Otherwise the address could mint a second account forever.
+    expect(await hasPendingInvitation(email)).toBe(false);
+  });
+
+  it("stays shut for an address nobody invited", async () => {
+    expect(await hasPendingInvitation(`stranger-${Date.now()}@example.org`)).toBe(false);
+  });
+
+  it("stays shut for an expired invitation", async () => {
+    const email = `expired-door-${Date.now()}@example.org`;
+    const longAgo = new Date(Date.now() - (INVITATION_TTL_DAYS + 1) * 24 * 60 * 60 * 1000);
+    await createSponsorWithInvitation("Expired Door Co", email, longAgo);
+
+    expect(await hasPendingInvitation(email)).toBe(false);
+  });
+
+  it("stays shut once the company is trashed", async () => {
+    const email = `trashed-door-${Date.now()}@example.org`;
+    const { sponsor } = await createSponsorWithInvitation("Trashed Door Co", email);
+    await prisma.sponsor.update({ where: { id: sponsor.id }, data: { deletedAt: new Date() } });
+
+    expect(await hasPendingInvitation(email)).toBe(false);
+  });
+});

--- a/src/backend/src/__tests__/sponsor-space-access.test.ts
+++ b/src/backend/src/__tests__/sponsor-space-access.test.ts
@@ -207,6 +207,88 @@ describe("requireSponsorAccess — isolation between companies (#362)", () => {
   });
 });
 
+describe("PUT /api/sponsor-space/:sponsorId — writing (#362)", () => {
+  it("lets EDITEUR save the company's own fields", async () => {
+    const sponsor = await createSponsor("Writer Co");
+    const { user, bearer } = await createAccount("SPONSOR", `writer-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "EDITEUR" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/sponsor-space/${sponsor.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+      payload: { descriptionFr: "Nouvelle description", websiteUrl: "https://example.org" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const after = await prisma.sponsor.findUniqueOrThrow({ where: { id: sponsor.id } });
+    expect(after.descriptionFr).toContain("Nouvelle description");
+    expect(after.websiteUrl).toBe("https://example.org");
+  });
+
+  it("refuses a write from STAND", async () => {
+    const sponsor = await createSponsor("Readonly Co");
+    const { user, bearer } = await createAccount("SPONSOR", `readonly-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "STAND" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/sponsor-space/${sponsor.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+      payload: { descriptionFr: "Tentative" },
+    });
+
+    expect(res.statusCode).toBe(403);
+    const after = await prisma.sponsor.findUniqueOrThrow({ where: { id: sponsor.id } });
+    expect(after.descriptionFr).toBeNull();
+  });
+
+  it("rejects a javascript: URL", async () => {
+    const sponsor = await createSponsor("Unsafe Co");
+    const { user, bearer } = await createAccount("SPONSOR", `unsafe-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "EDITEUR" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/sponsor-space/${sponsor.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+      // Rendered on the public page, so the same http(s) allow-list as the
+      // edit link applies (#223).
+      payload: { websiteUrl: "javascript:alert(1)" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("unsafe_url");
+  });
+
+  it("rejects an unknown field rather than silently dropping it", async () => {
+    const sponsor = await createSponsor("Strict Co");
+    const { user, bearer } = await createAccount("SPONSOR", `strict-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "EDITEUR" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/sponsor-space/${sponsor.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+      // `name` belongs to the organisers: a sponsor renaming its own company
+      // would break the slug and the public page.
+      payload: { name: "Renamed by me" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const after = await prisma.sponsor.findUniqueOrThrow({ where: { id: sponsor.id } });
+    expect(after.name).toBe("Strict Co");
+  });
+});
+
 describe("GET /api/sponsor-space/mine (#362)", () => {
   it("lists only the companies this account may act on", async () => {
     const a = await createSponsor("Listed A");

--- a/src/backend/src/__tests__/sponsor-space-access.test.ts
+++ b/src/backend/src/__tests__/sponsor-space-access.test.ts
@@ -1,0 +1,236 @@
+process.env.BASE_URL = process.env.BASE_URL || "http://localhost:4000";
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+import sponsorSpaceRoutes from "../routes/sponsor-space.js";
+import { prisma } from "../lib/prisma.js";
+import { generateApiKey, resolveApiKeyEnv } from "../lib/api-key.js";
+
+// #362 — who may read what on a sponsor's space. This is authorization code:
+// a silent regression here hands one company's private data to another.
+//
+// Authenticated through the API-key path of getAuthContext rather than a
+// better-auth cookie: same resolution, same guard, without having to forge a
+// session. The role still comes from the User row, so the check is real.
+
+let app: FastifyInstance;
+
+const created = {
+  userIds: [] as string[],
+  sponsorIds: [] as number[],
+};
+
+// An account plus the bearer token that authenticates it.
+async function createAccount(role: "ADMIN" | "EDITOR" | "SPONSOR", email: string) {
+  const user = await prisma.user.create({
+    data: { email, name: email, role, emailVerified: true },
+  });
+  created.userIds.push(user.id);
+
+  const key = await generateApiKey(resolveApiKeyEnv());
+  await prisma.apiKey.create({
+    data: { name: `test-${email}`, prefix: key.prefix, hashedKey: key.hashedKey, userId: user.id },
+  });
+  return { user, bearer: key.raw };
+}
+
+async function createSponsor(name: string) {
+  const sponsor = await prisma.sponsor.create({
+    data: { name, slug: `${name.toLowerCase().replace(/\W+/g, "-")}-${Date.now()}` },
+  });
+  created.sponsorIds.push(sponsor.id);
+  return sponsor;
+}
+
+beforeAll(async () => {
+  app = Fastify({ logger: false });
+  app.decorateRequest("authContext");
+  app.decorateRequest("sponsorAccess");
+  await app.register(sponsorSpaceRoutes, { prefix: "/api" });
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+  if (created.userIds.length) {
+    await prisma.apiKey.deleteMany({ where: { userId: { in: created.userIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: created.userIds } } });
+  }
+  if (created.sponsorIds.length) {
+    await prisma.sponsor.deleteMany({ where: { id: { in: created.sponsorIds } } });
+  }
+});
+
+describe("GET /api/sponsor-space/:sponsorId — access by role (#362)", () => {
+  it("lets STAND read the public profile but not the private block", async () => {
+    const sponsor = await createSponsor("Stand Co");
+    const { user, bearer } = await createAccount("SPONSOR", `stand-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "STAND" },
+    });
+
+    const auth = { authorization: `Bearer ${bearer}` };
+    const profile = await app.inject({ method: "GET", url: `/api/sponsor-space/${sponsor.id}`, headers: auth });
+    const priv = await app.inject({ method: "GET", url: `/api/sponsor-space/${sponsor.id}/private`, headers: auth });
+    const team = await app.inject({ method: "GET", url: `/api/sponsor-space/${sponsor.id}/team`, headers: auth });
+
+    expect(profile.statusCode).toBe(200);
+    expect(profile.json().accessRole).toBe("STAND");
+    // The booth team has no business reading the com kit, nor the colleagues'
+    // addresses.
+    expect(priv.statusCode).toBe(403);
+    expect(team.statusCode).toBe(403);
+  });
+
+  it("lets EDITEUR read the private block but not the team", async () => {
+    const sponsor = await createSponsor("Editeur Co");
+    const { user, bearer } = await createAccount("SPONSOR", `editeur-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "EDITEUR" },
+    });
+
+    const auth = { authorization: `Bearer ${bearer}` };
+    const priv = await app.inject({ method: "GET", url: `/api/sponsor-space/${sponsor.id}/private`, headers: auth });
+    const team = await app.inject({ method: "GET", url: `/api/sponsor-space/${sponsor.id}/team`, headers: auth });
+
+    expect(priv.statusCode).toBe(200);
+    // Inviting is the RESPONSABLE's job, so the team list stays out of reach.
+    expect(team.statusCode).toBe(403);
+  });
+
+  it("lets RESPONSABLE read everything, tokens excluded", async () => {
+    const sponsor = await createSponsor("Responsable Co");
+    const { user, bearer } = await createAccount("SPONSOR", `resp-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: {
+        sponsorId: sponsor.id,
+        email: user.email,
+        userId: user.id,
+        accessRole: "RESPONSABLE",
+        invitationToken: `tok-${Date.now()}`,
+        invitationSentAt: new Date(),
+      },
+    });
+
+    const auth = { authorization: `Bearer ${bearer}` };
+    const team = await app.inject({ method: "GET", url: `/api/sponsor-space/${sponsor.id}/team`, headers: auth });
+
+    expect(team.statusCode).toBe(200);
+    const body = team.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].accessRole).toBe("RESPONSABLE");
+    // A pending invitation is reported as a boolean; the secret never leaves.
+    expect(JSON.stringify(body)).not.toContain("tok-");
+  });
+});
+
+describe("requireSponsorAccess — isolation between companies (#362)", () => {
+  it("answers 404 for a sponsor this account has no contact on", async () => {
+    const mine = await createSponsor("Mine Co");
+    const theirs = await createSponsor("Theirs Co");
+    const { user, bearer } = await createAccount("SPONSOR", `outsider-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: mine.id, email: user.email, userId: user.id, accessRole: "RESPONSABLE" },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/sponsor-space/${theirs.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    // 404 and not 403: a stranger probing ids must not learn which exist.
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("refuses an unauthenticated caller", async () => {
+    const sponsor = await createSponsor("Anon Co");
+    const res = await app.inject({ method: "GET", url: `/api/sponsor-space/${sponsor.id}` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("refuses an authenticated account with no contact at all", async () => {
+    const sponsor = await createSponsor("Nobody Co");
+    const { bearer } = await createAccount("SPONSOR", `nobody-${Date.now()}@example.org`);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/sponsor-space/${sponsor.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("stops granting access once the company is trashed", async () => {
+    const sponsor = await createSponsor("Trashed Co");
+    const { user, bearer } = await createAccount("SPONSOR", `trashed-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "RESPONSABLE" },
+    });
+    await prisma.sponsor.update({ where: { id: sponsor.id }, data: { deletedAt: new Date() } });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/sponsor-space/${sponsor.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("lets an ADMIN in for support, without giving them a contact", async () => {
+    const sponsor = await createSponsor("Supported Co");
+    const { bearer } = await createAccount("ADMIN", `admin-${Date.now()}@example.org`);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/sponsor-space/${sponsor.id}/team`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    // The override must not appear as a member of the company's own team.
+    expect(res.json()).toEqual([]);
+  });
+
+  it("keeps a back-office EDITOR out — the back-office role grants nothing here", async () => {
+    const sponsor = await createSponsor("Editor Role Co");
+    const { bearer } = await createAccount("EDITOR", `boeditor-${Date.now()}@example.org`);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/sponsor-space/${sponsor.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+    // Only ADMIN gets the support override; EDITOR has no business here.
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /api/sponsor-space/mine (#362)", () => {
+  it("lists only the companies this account may act on", async () => {
+    const a = await createSponsor("Listed A");
+    const b = await createSponsor("Listed B");
+    await createSponsor("Unlisted C");
+    const { user, bearer } = await createAccount("SPONSOR", `mine-${Date.now()}@example.org`);
+    await prisma.sponsorContact.createMany({
+      data: [
+        { sponsorId: a.id, email: user.email, userId: user.id, accessRole: "RESPONSABLE" },
+        { sponsorId: b.id, email: user.email, userId: user.id, accessRole: "STAND" },
+      ],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/sponsor-space/mine",
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const slugs = res.json().map((s: { id: number; accessRole: string }) => `${s.id}:${s.accessRole}`);
+    expect(slugs).toHaveLength(2);
+    // The same person can hold a different role at each company (#362).
+    expect(slugs).toContain(`${a.id}:RESPONSABLE`);
+    expect(slugs).toContain(`${b.id}:STAND`);
+  });
+});

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -24,6 +24,8 @@ import categoryRoutes from "./routes/categories.js";
 import talkRoutes from "./routes/talks.js";
 import replayRoutes from "./routes/replays.js";
 import editRoutes from "./routes/edit.js";
+import sponsorInvitationRoutes from "./routes/sponsor-invitation.js";
+import sponsorSpaceRoutes from "./routes/sponsor-space.js";
 import maintenanceRoutes from "./routes/maintenance.js";
 import myApiKeysRoutes from "./routes/me/api-keys.js";
 import adminRoutes from "./routes/admin/index.js";
@@ -291,6 +293,8 @@ await app.register(categoryRoutes, { prefix: "/api" });
 await app.register(talkRoutes, { prefix: "/api" });
 await app.register(replayRoutes, { prefix: "/api" });
 await app.register(editRoutes, { prefix: "/api" });
+await app.register(sponsorInvitationRoutes, { prefix: "/api" });
+await app.register(sponsorSpaceRoutes, { prefix: "/api" });
 
 // Per-user routes (any authenticated back-office user — own resources only)
 await app.register(myApiKeysRoutes, { prefix: "/api/me" });

--- a/src/backend/src/lib/auth.ts
+++ b/src/backend/src/lib/auth.ts
@@ -1,9 +1,16 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { APIError } from "better-auth/api";
+// Configuring any plugin makes better-auth's inferred type reach into zod's,
+// which TypeScript must name in the emitted .d.ts (`declaration: true`). pnpm
+// isolation put zod out of reach, so it is a direct dependency now — declared
+// for its types, never imported (TS2742).
+import { magicLink } from "better-auth/plugins";
 import { prisma } from "./prisma.js";
 import { sendEmail, escapeHtml } from "./email.js";
 import { emailButton, emailHeading } from "./email-template.js";
+import { hasPendingInvitation, normalizeEmail } from "./sponsor-invitation.js";
+import { MAGIC_LINK_TTL_MINUTES, MAGIC_LINK_TTL_SECONDS } from "./edit-token.js";
 
 const ADMIN_EMAILS = (process.env.ADMIN_EMAILS || "")
   .split(",")
@@ -92,22 +99,68 @@ export const auth = betterAuth({
       trustedProviders: ["email-password", "google", "github"],
     },
   },
+  plugins: [
+    // Sign in to an EXISTING account without a password (#362) — not a way to
+    // create one: disableSignUp keeps the invitation the only door in, and
+    // stops this endpoint from becoming an email-enumeration oracle that mints
+    // accounts. Single-use and short-lived, unlike the 30-day edit link.
+    magicLink({
+      expiresIn: MAGIC_LINK_TTL_SECONDS,
+      disableSignUp: true,
+      sendMagicLink: async ({ email, url }) => {
+        await sendEmail({
+          to: [email],
+          subject: "DevFest Toulouse — Votre lien de connexion",
+          text: `Bonjour,\n\nCliquez sur ce lien pour vous connecter :\n${url}\n\nCe lien expire dans ${MAGIC_LINK_TTL_MINUTES} minutes et ne peut servir qu'une fois.\n\nSi vous n'avez pas demandé cette connexion, ignorez cet email.`,
+          html: `
+            ${emailHeading("Votre lien de connexion")}
+            <p>Bonjour,</p>
+            <p>Cliquez sur le bouton ci-dessous pour vous connecter à votre espace :</p>
+            ${emailButton(url, "Me connecter")}
+            <p>Ce lien expire dans ${MAGIC_LINK_TTL_MINUTES} minutes et ne peut servir qu'une fois.</p>
+            <p><em>Si vous n'avez pas demandé cette connexion, ignorez cet email.</em></p>
+          `,
+        });
+      },
+    }),
+  ],
   databaseHooks: {
     user: {
       create: {
         before: async (user) => {
-          // Only allow account creation if the email is in ADMIN_EMAILS
-          if (!user.email || !isAdminEmail(user.email)) {
+          // Sign-up stays closed (#362): an account is created only for an
+          // allow-listed admin, or for someone holding a live invitation to a
+          // sponsor space.
+          //
+          // This check belongs here rather than after the fact: rejecting later
+          // would leave an orphan User behind on every failed attempt — and for
+          // OAuth, an account the organisers never invited.
+          if (!user.email) {
             throw new APIError("FORBIDDEN", {
               message: "Inscription sur invitation uniquement. Contactez un administrateur.",
             });
           }
+          if (isAdminEmail(user.email)) return;
+
+          if (await hasPendingInvitation(user.email)) {
+            // Sponsors get a role that grants nothing in the back-office. The
+            // default is EDITOR, which requireAnyAuthenticated lets through —
+            // leaving it would hand /api/admin/* to every sponsor.
+            return { data: { ...user, role: "SPONSOR" } };
+          }
+
+          throw new APIError("FORBIDDEN", {
+            message: "Inscription sur invitation uniquement. Contactez un administrateur.",
+          });
         },
       },
     },
   },
 });
 
+// Normalized comparison: an admin typing "Prenom.Nom@gmail.com" into
+// ADMIN_EMAILS must still match what Google reports in lowercase.
 export function isAdminEmail(email: string): boolean {
-  return ADMIN_EMAILS.includes(email);
+  const normalized = normalizeEmail(email);
+  return ADMIN_EMAILS.some((e) => normalizeEmail(e) === normalized);
 }

--- a/src/backend/src/lib/edit-link-email.ts
+++ b/src/backend/src/lib/edit-link-email.ts
@@ -1,6 +1,6 @@
 import { sendEmail, escapeHtml } from "./email.js";
 import { emailButton, emailHeading } from "./email-template.js";
-import { EDIT_TOKEN_TTL_DAYS } from "./edit-token.js";
+import { EDIT_TOKEN_TTL_DAYS, INVITATION_TTL_DAYS } from "./edit-token.js";
 
 const baseUrl = (process.env.BASE_URL || "http://localhost:3000").replace(/\/$/, "");
 
@@ -97,4 +97,52 @@ export async function sendEditLinkEmail(opts: {
     html: tpl.html,
     locale: lang,
   });
+}
+
+// Invitation to create an account on a sponsor's space (#362). Distinct from
+// the mail above: that one hands out an edit link that works on its own, this
+// one opens an account the person will come back to. Throws on SMTP failure so
+// the caller can avoid persisting an invitation nobody received.
+export async function sendSponsorInvitationEmail(opts: {
+  to: string;
+  sponsorName: string;
+  token: string;
+  locale?: string | null;
+}) {
+  const url = `${baseUrl}/sponsor/invitation/${opts.token}`;
+  const lang = normalizeLocale(opts.locale);
+
+  // The address is named in the body on purpose: the account must be created
+  // with this exact address, and saying so up front avoids a failed sign-in
+  // with a personal account (#362).
+  const tpl: Template =
+    lang === "en"
+      ? {
+          subject: `DevFest Toulouse — Your access to ${opts.sponsorName}'s space`,
+          text: `Hello,\n\nYou have been invited to manage ${opts.sponsorName}'s profile on the DevFest Toulouse website.\n\nCreate your account here:\n${url}\n\nUse this exact email address (${opts.to}) — the invitation only works with it.\n\nThis invitation is valid for ${INVITATION_TTL_DAYS} days and can be used once.\n\nThe DevFest Toulouse team`,
+          html: `
+            ${emailHeading(`Your access to ${escapeHtml(opts.sponsorName)}'s space`)}
+            <p>Hello,</p>
+            <p>You have been invited to manage <strong>${escapeHtml(opts.sponsorName)}</strong>'s profile on the DevFest Toulouse website.</p>
+            ${emailButton(url, "Create my account")}
+            <p>Use this exact email address (<strong>${escapeHtml(opts.to)}</strong>) — the invitation only works with it.</p>
+            <p>This invitation is valid for ${INVITATION_TTL_DAYS} days and can be used once.</p>
+            <p><em>The DevFest Toulouse team</em></p>
+          `,
+        }
+      : {
+          subject: `DevFest Toulouse — Votre accès à l'espace ${opts.sponsorName}`,
+          text: `Bonjour,\n\nVous avez été invité à gérer la fiche de ${opts.sponsorName} sur le site du DevFest Toulouse.\n\nCréez votre compte ici :\n${url}\n\nUtilisez exactement cette adresse email (${opts.to}) — l'invitation ne fonctionne qu'avec elle.\n\nCette invitation est valable ${INVITATION_TTL_DAYS} jours et ne peut servir qu'une fois.\n\nL'équipe DevFest Toulouse`,
+          html: `
+            ${emailHeading(`Votre accès à l'espace ${escapeHtml(opts.sponsorName)}`)}
+            <p>Bonjour,</p>
+            <p>Vous avez été invité à gérer la fiche de <strong>${escapeHtml(opts.sponsorName)}</strong> sur le site du DevFest Toulouse.</p>
+            ${emailButton(url, "Créer mon compte")}
+            <p>Utilisez exactement cette adresse email (<strong>${escapeHtml(opts.to)}</strong>) — l'invitation ne fonctionne qu'avec elle.</p>
+            <p>Cette invitation est valable ${INVITATION_TTL_DAYS} jours et ne peut servir qu'une fois.</p>
+            <p><em>L'équipe DevFest Toulouse</em></p>
+          `,
+        };
+
+  await sendEmail({ to: [opts.to], subject: tpl.subject, text: tpl.text, html: tpl.html, locale: lang });
 }

--- a/src/backend/src/lib/edit-token.ts
+++ b/src/backend/src/lib/edit-token.ts
@@ -28,3 +28,35 @@ export function isEditTokenExpired(sentAt: Date | null, now: Date = new Date()):
   if (!sentAt) return false;
   return now.getTime() - sentAt.getTime() > EDIT_TOKEN_TTL_MS;
 }
+
+// An invitation to create a sponsor account (#362). Shorter-lived than an edit
+// link and single-use, which is why it has its own token: 7 days is enough for
+// an email read the next day, and an invitation that never expires is a bearer
+// secret left lying around.
+//
+// The magic link used to sign in to an existing account is shorter still — 60
+// minutes — and lives in auth.ts, where better-auth's plugin owns it.
+export const INVITATION_TTL_DAYS = 7;
+const INVITATION_TTL_MS = INVITATION_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+// Unlike an edit token, a missing send date is NOT treated as valid: an
+// invitation without one is malformed, and defaulting to "still open" would
+// keep the sign-up door ajar. No such row exists today — the column arrives
+// with the feature — so this only guards against a future bug.
+export function isInvitationExpired(sentAt: Date | null, now: Date = new Date()): boolean {
+  if (!sentAt) return true;
+  return now.getTime() - sentAt.getTime() > INVITATION_TTL_MS;
+}
+
+// Same shape as generateEditToken, named apart so a call site says which of the
+// two secrets it is minting — they have different lifetimes and consumption.
+export function generateInvitationToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+// Sign-in link for an account that already exists (#362). Minutes, not days:
+// it is mailed on demand and used straight away, so a long window would only
+// widen the replay surface. better-auth owns the token itself and takes the
+// TTL in seconds; the value lives here with the other two.
+export const MAGIC_LINK_TTL_MINUTES = 60;
+export const MAGIC_LINK_TTL_SECONDS = MAGIC_LINK_TTL_MINUTES * 60;

--- a/src/backend/src/lib/sponsor-guard.test.ts
+++ b/src/backend/src/lib/sponsor-guard.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+
+import { hasAtLeast } from "./sponsor-guard.js";
+import { isInvitationExpired, INVITATION_TTL_DAYS, MAGIC_LINK_TTL_MINUTES } from "./edit-token.js";
+
+// #362 — the two rules a reader has to trust without running the app: what each
+// access role may do, and when an invitation stops working.
+
+describe("hasAtLeast — sponsor access ranks", () => {
+  it("grants a role everything a lower one grants", () => {
+    expect(hasAtLeast("RESPONSABLE", "STAND")).toBe(true);
+    expect(hasAtLeast("RESPONSABLE", "EDITEUR")).toBe(true);
+    expect(hasAtLeast("EDITEUR", "STAND")).toBe(true);
+  });
+
+  it("refuses a role below the minimum asked for", () => {
+    // The whole point of STAND: read-only on the public profile.
+    expect(hasAtLeast("STAND", "EDITEUR")).toBe(false);
+    expect(hasAtLeast("STAND", "RESPONSABLE")).toBe(false);
+    // An EDITEUR edits but never invites.
+    expect(hasAtLeast("EDITEUR", "RESPONSABLE")).toBe(false);
+  });
+
+  it("grants each role its own level", () => {
+    expect(hasAtLeast("STAND", "STAND")).toBe(true);
+    expect(hasAtLeast("EDITEUR", "EDITEUR")).toBe(true);
+    expect(hasAtLeast("RESPONSABLE", "RESPONSABLE")).toBe(true);
+  });
+});
+
+describe("isInvitationExpired", () => {
+  const sentAt = new Date("2026-08-01T10:00:00Z");
+
+  it("accepts an invitation inside its window", () => {
+    const sixDaysLater = new Date("2026-08-07T09:00:00Z");
+    expect(isInvitationExpired(sentAt, sixDaysLater)).toBe(false);
+  });
+
+  it("refuses one past the window", () => {
+    const eightDaysLater = new Date("2026-08-09T10:00:00Z");
+    expect(isInvitationExpired(sentAt, eightDaysLater)).toBe(true);
+  });
+
+  // Opposite of isEditTokenExpired, which treats a missing date as valid to
+  // avoid locking out speakers whose token predates that rule. An invitation
+  // with no send date is malformed, and defaulting to "open" would leave the
+  // sign-up door ajar.
+  it("refuses an invitation with no send date", () => {
+    expect(isInvitationExpired(null)).toBe(true);
+  });
+});
+
+describe("token lifetimes stay distinct", () => {
+  // Three secrets, three windows (#362). Collapsing them would either make the
+  // invitation unusable or leave a sign-in link valid for weeks.
+  it("keeps the invitation in days and the magic link in minutes", () => {
+    expect(INVITATION_TTL_DAYS).toBe(7);
+    expect(MAGIC_LINK_TTL_MINUTES).toBe(60);
+  });
+});

--- a/src/backend/src/lib/sponsor-guard.ts
+++ b/src/backend/src/lib/sponsor-guard.ts
@@ -1,0 +1,111 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+
+import { prisma } from "./prisma.js";
+import { getAuthContext } from "./auth-context.js";
+
+// Authorization for a sponsor's own space (#362).
+//
+// A second, independent path from requireAnyAuthenticated: that one guards the
+// back-office on UserRole and stays untouched. Widening it would have handed
+// /api/admin/* to every sponsor. Here the right comes from the SponsorContact
+// binding this account to this company — nothing else.
+
+export type SponsorAccessRole = "RESPONSABLE" | "EDITEUR" | "STAND";
+
+// Higher grants everything a lower one does. Compared by rank so a route asks
+// for a minimum ("at least EDITEUR") rather than enumerating roles.
+const RANK: Record<SponsorAccessRole, number> = {
+  STAND: 1,
+  EDITEUR: 2,
+  RESPONSABLE: 3,
+};
+
+export interface SponsorAccess {
+  sponsorId: number;
+  contactId: number;
+  accessRole: SponsorAccessRole;
+  // True when an ADMIN is looking at the space for support rather than acting
+  // as a member of the company. Handlers that log who changed what should say
+  // so rather than attribute the change to the sponsor.
+  isAdminOverride: boolean;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    sponsorAccess?: SponsorAccess;
+  }
+}
+
+export function hasAtLeast(role: SponsorAccessRole, minimum: SponsorAccessRole): boolean {
+  return RANK[role] >= RANK[minimum];
+}
+
+/**
+ * preHandler factory: requires an account allowed to act on the sponsor named
+ * by `:sponsorId` (or `:id`) in the route params, at `minimum` or above.
+ *
+ * Answers 404 rather than 403 when the account holds no contact for that
+ * sponsor: a stranger probing ids must not learn which ones exist.
+ */
+export function requireSponsorAccess(minimum: SponsorAccessRole) {
+  return async function guard(request: FastifyRequest, reply: FastifyReply) {
+    const params = request.params as { sponsorId?: string; id?: string };
+    const sponsorId = Number(params.sponsorId ?? params.id);
+    if (!Number.isInteger(sponsorId)) {
+      reply.status(400).send({ error: "Invalid sponsor id" });
+      return;
+    }
+
+    const ctx = await getAuthContext(request);
+    if (!ctx) {
+      reply.status(401).send({ error: "Unauthenticated" });
+      return;
+    }
+
+    // Support access, granted explicitly rather than by giving admins a
+    // SponsorContact — which would put them in the company's own team list.
+    if (ctx.user.role === "ADMIN") {
+      const sponsor = await prisma.sponsor.findFirst({
+        where: { id: sponsorId, deletedAt: null },
+        select: { id: true },
+      });
+      if (!sponsor) {
+        reply.status(404).send({ error: "Sponsor not found" });
+        return;
+      }
+      request.sponsorAccess = {
+        sponsorId,
+        contactId: -1,
+        accessRole: "RESPONSABLE",
+        isAdminOverride: true,
+      };
+      return;
+    }
+
+    const contact = await prisma.sponsorContact.findFirst({
+      where: {
+        sponsorId,
+        userId: ctx.user.id,
+        // A trashed company grants nothing while it sits in the bin (#146).
+        sponsor: { deletedAt: null },
+      },
+      select: { id: true, accessRole: true },
+    });
+    if (!contact) {
+      reply.status(404).send({ error: "Sponsor not found" });
+      return;
+    }
+
+    if (!hasAtLeast(contact.accessRole, minimum)) {
+      reply.status(403).send({ error: "Forbidden" });
+      return;
+    }
+
+    request.sponsorAccess = {
+      sponsorId,
+      contactId: contact.id,
+      accessRole: contact.accessRole,
+      isAdminOverride: false,
+    };
+  };
+}

--- a/src/backend/src/lib/sponsor-invitation.ts
+++ b/src/backend/src/lib/sponsor-invitation.ts
@@ -1,0 +1,51 @@
+import { prisma } from "./prisma.js";
+import { isInvitationExpired } from "./edit-token.js";
+
+// Invitations to a sponsor space (#362).
+//
+// Sign-up stays closed: auth.ts rejects any email that is neither an admin nor
+// the holder of a live invitation. This module answers that second question,
+// and is the single place that decides what "live" means — so the sign-up hook
+// and the acceptance route cannot drift apart on it.
+
+// Addresses are compared normalized everywhere: an invitation sent to
+// "Contact@Societe.fr" must match a Google account reporting
+// "contact@societe.fr". Identity providers do not agree on casing.
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+// A pending invitation is one that was sent, has not expired, and has not been
+// accepted yet. Accepted invitations stop opening the sign-up door: the account
+// exists by then, so a second use would be a replay.
+export async function findPendingInvitation(token: string) {
+  const contact = await prisma.sponsorContact.findUnique({
+    where: { invitationToken: token },
+    include: { sponsor: { select: { id: true, name: true, slug: true, deletedAt: true } } },
+  });
+  if (!contact) return null;
+  // A trashed company must not hand out access while it sits in the bin (#146).
+  if (contact.sponsor.deletedAt) return null;
+  if (contact.invitationAcceptedAt) return null;
+  if (isInvitationExpired(contact.invitationSentAt)) return null;
+  return contact;
+}
+
+// Does this email hold a live invitation? Asked by the sign-up hook, which runs
+// before any User row exists and must not create one for an uninvited address.
+export async function hasPendingInvitation(email: string): Promise<boolean> {
+  const normalized = normalizeEmail(email);
+  const contacts = await prisma.sponsorContact.findMany({
+    where: {
+      invitationToken: { not: null },
+      invitationAcceptedAt: null,
+      sponsor: { deletedAt: null },
+    },
+    select: { email: true, invitationSentAt: true },
+  });
+  // Filtered in JS, not SQL: Postgres would compare raw values, and the stored
+  // address may differ in case from what the provider reports.
+  return contacts.some(
+    (c) => normalizeEmail(c.email) === normalized && !isInvitationExpired(c.invitationSentAt),
+  );
+}

--- a/src/backend/src/lib/sponsor-write.ts
+++ b/src/backend/src/lib/sponsor-write.ts
@@ -1,0 +1,142 @@
+import { prisma } from "./prisma.js";
+import { sanitizeRichHtml } from "./sanitize.js";
+import { revalidateSponsor, revalidateSponsors } from "./revalidate.js";
+
+// Applying a sponsor's own edits, shared by the two ways in (#362): the edit
+// link (/api/edit/:token, still in service) and the account-based space
+// (/api/sponsor-space/:id). Both write the same fields under the same rules —
+// keeping one copy is what stops them from drifting apart on which field is
+// per-year and which belongs to the company.
+
+// Booth staff whose social handles the organisers relay on the day (#249).
+export interface StandContact {
+  name?: string;
+  linkedin?: string;
+  twitter?: string;
+  bluesky?: string;
+}
+
+export interface SponsorEditBody {
+  descriptionFr?: string;
+  descriptionEn?: string;
+  websiteUrl?: string;
+  logoUrl?: string;
+  socialLinks?: Record<string, string>;
+  standContacts?: StandContact[];
+  comKitReceived?: boolean;
+  comKitLogoWebUrl?: string;
+  comKitLogoPrintUrl?: string;
+  comKitCharterUrl?: string;
+  comKitNotes?: string;
+  platinumPromoIdea?: string;
+  platinumCoBuildIdea?: string;
+}
+
+// Fields stored on the participation, not on the company. Writing one with no
+// participation for the target edition has nowhere sane to land: silently
+// writing to another year would be worse than refusing (#249, #252, #375).
+export function writesYearField(body: SponsorEditBody): boolean {
+  return (
+    body.logoUrl !== undefined ||
+    body.comKitReceived !== undefined ||
+    body.comKitLogoWebUrl !== undefined ||
+    body.comKitLogoPrintUrl !== undefined ||
+    body.comKitCharterUrl !== undefined ||
+    body.comKitNotes !== undefined ||
+    body.platinumPromoIdea !== undefined ||
+    body.platinumCoBuildIdea !== undefined
+  );
+}
+
+// Whether anything visible on the public site changed. A private-only save (com
+// kit, booth staff) needs no cache revalidation.
+export function touchesPublicFields(body: SponsorEditBody): boolean {
+  return (
+    body.descriptionFr !== undefined ||
+    body.descriptionEn !== undefined ||
+    body.websiteUrl !== undefined ||
+    body.logoUrl !== undefined ||
+    body.socialLinks !== undefined
+  );
+}
+
+// Empty values are dropped rather than stored: a social block full of blank
+// strings would render as empty links on the public page.
+export function cleanSocial(social: Record<string, string> | undefined): string | null {
+  if (!social) return null;
+  const kept = Object.entries(social).filter(([, v]) => typeof v === "string" && v.trim());
+  return kept.length ? JSON.stringify(Object.fromEntries(kept)) : null;
+}
+
+export function cleanStandContacts(contacts: StandContact[] | undefined): string | null {
+  if (!contacts) return null;
+  const kept = contacts
+    .map((c) => {
+      const entry: StandContact = {};
+      for (const key of ["name", "linkedin", "twitter", "bluesky"] as const) {
+        const v = c[key];
+        if (typeof v === "string" && v.trim()) entry[key] = v.trim();
+      }
+      return entry;
+    })
+    .filter((c) => Object.keys(c).length > 0);
+  return kept.length ? JSON.stringify(kept) : null;
+}
+
+export async function applySponsorEdit(opts: {
+  sponsorId: number;
+  sponsorSlug: string;
+  participation: { id: number; tier: { allowsPromoIdeas: boolean } } | null;
+  body: SponsorEditBody;
+}) {
+  const { sponsorId, sponsorSlug, participation, body } = opts;
+
+  await prisma.sponsor.update({
+    where: { id: sponsorId },
+    data: {
+      // Rich-text HTML (#270): sanitized on write, like article content.
+      ...(body.descriptionFr !== undefined && { descriptionFr: sanitizeRichHtml(body.descriptionFr) || null }),
+      ...(body.descriptionEn !== undefined && { descriptionEn: sanitizeRichHtml(body.descriptionEn) || null }),
+      ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
+      // The company's current logo tracks the latest one it sent (#375), so a
+      // future participation starts from it. What each edition displays is the
+      // copy frozen on its own participation, below.
+      ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
+      ...(body.socialLinks !== undefined && { socialLinks: cleanSocial(body.socialLinks) }),
+      // Booth staffing is not per-year, so it stays on the identity (#249).
+      ...(body.standContacts !== undefined && { standContacts: cleanStandContacts(body.standContacts) }),
+    },
+  });
+
+  // Skipped entirely when no per-year field was sent: EditionSponsor has
+  // @updatedAt, so an empty `data: {}` would still bump the participation's
+  // timestamp — and cost a round-trip — on every identity-only save.
+  if (participation && writesYearField(body)) {
+    await prisma.editionSponsor.update({
+      where: { id: participation.id },
+      data: {
+        ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
+        ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
+        ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
+        ...(body.comKitLogoPrintUrl !== undefined && { comKitLogoPrintUrl: body.comKitLogoPrintUrl || null }),
+        ...(body.comKitCharterUrl !== undefined && { comKitCharterUrl: body.comKitCharterUrl || null }),
+        ...(body.comKitNotes !== undefined && { comKitNotes: body.comKitNotes || null }),
+        // Ignored for tiers that don't allow them (#252), so the field cannot
+        // be set by tampering with the payload.
+        ...(participation.tier.allowsPromoIdeas && body.platinumPromoIdea !== undefined && {
+          platinumPromoIdea: body.platinumPromoIdea || null,
+        }),
+        ...(participation.tier.allowsPromoIdeas && body.platinumCoBuildIdea !== undefined && {
+          platinumCoBuildIdea: body.platinumCoBuildIdea || null,
+        }),
+      },
+    });
+  }
+
+  if (touchesPublicFields(body)) {
+    revalidateSponsors();
+    // The company's own page too (#360) — someone editing is precisely who
+    // watches for their change to appear.
+    revalidateSponsor(sponsorSlug);
+  }
+}

--- a/src/backend/src/routes/admin/sponsors.ts
+++ b/src/backend/src/routes/admin/sponsors.ts
@@ -2,8 +2,8 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { revalidateJobOffers, revalidateSponsor, revalidateSponsors } from "../../lib/revalidate.js";
 import { slugify } from "../../lib/slug.js";
-import { generateEditToken } from "../../lib/edit-token.js";
-import { sendEditLinkEmail, normalizeLocale } from "../../lib/edit-link-email.js";
+import { generateEditToken, generateInvitationToken } from "../../lib/edit-token.js";
+import { sendEditLinkEmail, sendSponsorInvitationEmail, normalizeLocale } from "../../lib/edit-link-email.js";
 import { sanitizeRichHtml } from "../../lib/sanitize.js";
 import { notDeleted, notFound, parkUniqueValue, softDeleteData } from "../../lib/admin-helpers.js";
 
@@ -66,6 +66,12 @@ interface SponsorBulkBody {
 }
 
 const TIER_SELECT = { id: true, key: true, nameFr: true, nameEn: true, rank: true } as const;
+
+// Access roles on a sponsor's space (#362). Listed here rather than imported
+// from the generated client so the request body is validated against a plain
+// allow-list — an unknown value must be a 422, not a Prisma error.
+type SponsorAccessRole = "RESPONSABLE" | "EDITEUR" | "STAND";
+const ACCESS_ROLES: SponsorAccessRole[] = ["RESPONSABLE", "EDITEUR", "STAND"];
 
 interface ParticipationLike {
   id: number;
@@ -556,6 +562,11 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     editToken: string | null;
     editLinkLocked: boolean;
     editTokenSentAt: Date | null;
+    accessRole?: SponsorAccessRole;
+    userId?: string | null;
+    invitationToken?: string | null;
+    invitationSentAt?: Date | null;
+    invitationAcceptedAt?: Date | null;
   }) => ({
     id: c.id,
     email: c.email,
@@ -564,6 +575,13 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
     hasLink: !!c.editToken,
     editLinkLocked: c.editLinkLocked,
     editTokenSentAt: c.editTokenSentAt,
+    // Account access (#362). Like the edit token above, the invitation token
+    // itself is never returned — only whether one is outstanding.
+    accessRole: c.accessRole,
+    hasAccount: !!c.userId,
+    invitationPending: !!c.invitationToken && !c.invitationAcceptedAt,
+    invitationSentAt: c.invitationSentAt,
+    invitationAcceptedAt: c.invitationAcceptedAt,
   });
 
   // GET /api/admin/sponsors/:id/contacts — list a sponsor's contacts.
@@ -637,6 +655,97 @@ export default async function adminSponsorRoutes(app: FastifyInstance) {
       const updated = await prisma.sponsorContact.update({
         where: { id: contact.id },
         data: { editToken: token, editLinkLocked: false, editTokenSentAt: new Date() },
+      });
+      return serializeContact(updated);
+    },
+  );
+
+  // POST /api/admin/sponsors/:id/contacts/:contactId/invite — invite this
+  // contact to create an account on the sponsor's space (#362).
+  //
+  // Distinct from /resend, which hands out an edit link that works on its own:
+  // this opens an account. Re-inviting rotates the token, so the previous
+  // invitation stops working — the column is @unique, but the behaviour is
+  // deliberate, not a side effect.
+  app.post<{ Params: SponsorIdParams & { contactId: string }; Body: { accessRole?: SponsorAccessRole } }>(
+    "/sponsors/:id/contacts/:contactId/invite",
+    { schema: { params: { type: "object", required: ["id", "contactId"], properties: { id: { type: "string" }, contactId: { type: "string" } } } } },
+    async (request, reply) => {
+      const contact = await prisma.sponsorContact.findUnique({
+        where: { id: Number(request.params.contactId) },
+        include: { sponsor: true },
+      });
+      if (!contact || contact.sponsorId !== Number(request.params.id)) {
+        return notFound(reply, "Contact");
+      }
+      if (contact.sponsor.deletedAt) return notFound(reply, "Sponsor");
+      if (contact.userId) {
+        return reply.code(409).send({ error: "already_has_account" });
+      }
+
+      const accessRole = request.body?.accessRole;
+      if (accessRole && !ACCESS_ROLES.includes(accessRole)) {
+        return reply.code(422).send({ error: "Invalid accessRole" });
+      }
+
+      // Send first, persist second (#223): a failed mail must leave no
+      // invitation behind, or the sign-up door opens for nobody's benefit.
+      const token = generateInvitationToken();
+      try {
+        await sendSponsorInvitationEmail({
+          to: contact.email,
+          sponsorName: contact.sponsor.name,
+          token,
+          locale: contact.sponsor.locale,
+        });
+      } catch (err) {
+        request.log.error({ err }, "Failed to send sponsor invitation email");
+        return reply.code(502).send({ error: "Email sending failed", detail: "retry" });
+      }
+
+      const updated = await prisma.sponsorContact.update({
+        where: { id: contact.id },
+        data: {
+          invitationToken: token,
+          invitationSentAt: new Date(),
+          invitationAcceptedAt: null,
+          ...(accessRole ? { accessRole } : {}),
+        },
+      });
+      return serializeContact(updated);
+    },
+  );
+
+  // PUT /api/admin/sponsors/:id/contacts/:contactId/access-role — change what
+  // this person may do on the sponsor's space (#362).
+  app.put<{ Params: SponsorIdParams & { contactId: string }; Body: { accessRole: SponsorAccessRole } }>(
+    "/sponsors/:id/contacts/:contactId/access-role",
+    { schema: { params: { type: "object", required: ["id", "contactId"], properties: { id: { type: "string" }, contactId: { type: "string" } } } } },
+    async (request, reply) => {
+      const sponsorId = Number(request.params.id);
+      const contact = await prisma.sponsorContact.findUnique({
+        where: { id: Number(request.params.contactId) },
+      });
+      if (!contact || contact.sponsorId !== sponsorId) return notFound(reply, "Contact");
+
+      const { accessRole } = request.body ?? {};
+      if (!accessRole || !ACCESS_ROLES.includes(accessRole)) {
+        return reply.code(422).send({ error: "Invalid accessRole" });
+      }
+
+      // Demoting the last RESPONSABLE would leave the space with nobody able to
+      // invite: the company could no longer manage its own team, and only an
+      // admin could unblock it.
+      if (contact.accessRole === "RESPONSABLE" && accessRole !== "RESPONSABLE") {
+        const others = await prisma.sponsorContact.count({
+          where: { sponsorId, accessRole: "RESPONSABLE", id: { not: contact.id } },
+        });
+        if (others === 0) return reply.code(409).send({ error: "last_responsable" });
+      }
+
+      const updated = await prisma.sponsorContact.update({
+        where: { id: contact.id },
+        data: { accessRole },
       });
       return serializeContact(updated);
     },

--- a/src/backend/src/routes/edit.ts
+++ b/src/backend/src/routes/edit.ts
@@ -20,6 +20,13 @@ import { emailButton, emailHeading } from "../lib/email-template.js";
 import { getCfpNotificationEmail } from "../lib/cfp-settings.js";
 import { getSponsorContactRecipients } from "../lib/sponsor-contact.js";
 import { sanitizeRichHtml } from "../lib/sanitize.js";
+import {
+  applySponsorEdit,
+  writesYearField,
+  cleanSocial,
+  cleanStandContacts,
+  type StandContact,
+} from "../lib/sponsor-write.js";
 
 // This is the only unauthenticated endpoint that writes to the database and
 // whose content is rendered on public pages, so everything below is an
@@ -214,37 +221,6 @@ function findUnsafeUrl(body: Record<string, unknown>): string | null {
     }
   }
   return null;
-}
-
-// Drop empty social entries so clearing a field doesn't persist "".
-function cleanSocial(social: Record<string, string> | undefined): string | null {
-  if (!social) return null;
-  const kept = Object.entries(social).filter(([, v]) => typeof v === "string" && v.trim());
-  return kept.length ? JSON.stringify(Object.fromEntries(kept)) : null;
-}
-
-interface StandContact {
-  name?: string;
-  linkedin?: string;
-  twitter?: string;
-  bluesky?: string;
-}
-
-// Trim entries and drop those with no content at all, so an empty row the
-// sponsor left behind isn't persisted (#249). Returns null when nothing remains.
-function cleanStandContacts(contacts: StandContact[] | undefined): string | null {
-  if (!contacts) return null;
-  const kept = contacts
-    .map((c) => {
-      const entry: StandContact = {};
-      for (const key of ["name", "linkedin", "twitter", "bluesky"] as const) {
-        const v = c[key];
-        if (typeof v === "string" && v.trim()) entry[key] = v.trim();
-      }
-      return entry;
-    })
-    .filter((c) => Object.keys(c).length > 0);
-  return kept.length ? JSON.stringify(kept) : null;
 }
 
 function parseStandContacts(raw: string | null): StandContact[] {
@@ -597,80 +573,18 @@ export default async function editRoutes(app: FastifyInstance) {
       // (#252, #249).
       // logoUrl joined them in #375: what an edition displayed is frozen on its
       // participation, so a new logo must not rewrite the years already past.
-      const writesYearField =
-        body.logoUrl !== undefined ||
-        body.comKitReceived !== undefined ||
-        body.comKitLogoWebUrl !== undefined ||
-        body.comKitLogoPrintUrl !== undefined ||
-        body.comKitCharterUrl !== undefined ||
-        body.comKitNotes !== undefined ||
-        body.platinumPromoIdea !== undefined ||
-        body.platinumCoBuildIdea !== undefined;
-      if (writesYearField && !participation) {
+      if (writesYearField(body) && !participation) {
         return reply.code(422).send({ error: "no_current_participation" });
       }
 
-      await prisma.sponsor.update({
-        where: { id: entity.id },
-        data: {
-          // Rich-text HTML (#270): sanitized on write, like article content.
-          ...(body.descriptionFr !== undefined && { descriptionFr: sanitizeRichHtml(body.descriptionFr) || null }),
-          ...(body.descriptionEn !== undefined && { descriptionEn: sanitizeRichHtml(body.descriptionEn) || null }),
-          ...(body.websiteUrl !== undefined && { websiteUrl: body.websiteUrl || null }),
-          // The company's current logo tracks the latest one it sent (#375),
-          // so a future participation starts from it. What each edition shows
-          // is the copy frozen on its own participation, just below.
-          ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
-          ...(body.socialLinks !== undefined && { socialLinks: cleanSocial(body.socialLinks) }),
-          // Private field (#249) — stand staffing isn't per-year, stays on the identity.
-          ...(body.standContacts !== undefined && { standContacts: cleanStandContacts(body.standContacts) }),
-        },
+      // Shared with the account-based space (#362) so both ways in write the
+      // same fields under the same rules.
+      await applySponsorEdit({
+        sponsorId: entity.id,
+        sponsorSlug: entity.slug,
+        participation,
+        body,
       });
-
-      // Skip the write entirely when no per-year field was sent: EditionSponsor
-      // has @updatedAt, so an empty `data: {}` would still bump the
-      // participation's timestamp — and cost a round-trip — on every
-      // identity-only save (description, logo, socials).
-      if (participation && writesYearField) {
-        await prisma.editionSponsor.update({
-          where: { id: participation.id },
-          data: {
-            // The logo this edition displays (#375). Editing is already
-            // confined to the featured edition, and isEditingFrozen closes it
-            // once the event starts — so past years cannot be rewritten.
-            ...(body.logoUrl !== undefined && { logoUrl: body.logoUrl || null }),
-            // Private per-year fields (#249).
-            ...(body.comKitReceived !== undefined && { comKitReceived: body.comKitReceived }),
-            ...(body.comKitLogoWebUrl !== undefined && { comKitLogoWebUrl: body.comKitLogoWebUrl || null }),
-            ...(body.comKitLogoPrintUrl !== undefined && { comKitLogoPrintUrl: body.comKitLogoPrintUrl || null }),
-            ...(body.comKitCharterUrl !== undefined && { comKitCharterUrl: body.comKitCharterUrl || null }),
-            ...(body.comKitNotes !== undefined && { comKitNotes: body.comKitNotes || null }),
-            // Promo-idea fields (#252): silently ignored for tiers that don't
-            // allow them, so the field can't be set by tampering with the payload.
-            ...(participation.tier.allowsPromoIdeas && body.platinumPromoIdea !== undefined && {
-              platinumPromoIdea: body.platinumPromoIdea || null,
-            }),
-            ...(participation.tier.allowsPromoIdeas && body.platinumCoBuildIdea !== undefined && {
-              platinumCoBuildIdea: body.platinumCoBuildIdea || null,
-            }),
-          },
-        });
-      }
-
-      // Only public-facing changes need cache revalidation; a private-only
-      // save (com kit, stand contacts) changes nothing on the public pages.
-      const touchesPublic =
-        body.descriptionFr !== undefined ||
-        body.descriptionEn !== undefined ||
-        body.websiteUrl !== undefined ||
-        body.logoUrl !== undefined ||
-        body.socialLinks !== undefined;
-      if (touchesPublic) {
-        revalidateSponsors();
-        // The company's own page too (#360) — editing from the magic link is
-        // precisely when someone watches for their change to appear.
-        revalidateSponsor(entity.slug);
-      }
     }
 
     return { saved: true };

--- a/src/backend/src/routes/sponsor-invitation.ts
+++ b/src/backend/src/routes/sponsor-invitation.ts
@@ -1,0 +1,79 @@
+import type { FastifyInstance } from "fastify";
+
+import { prisma } from "../lib/prisma.js";
+import { getAuthContext } from "../lib/auth-context.js";
+import { findPendingInvitation, normalizeEmail } from "../lib/sponsor-invitation.js";
+
+// Accepting an invitation to a sponsor space (#362).
+//
+// Unauthenticated on the way in — the token is the credential — but the
+// attachment itself requires a signed-in account, because that account is what
+// we bind the contact to.
+
+const tokenParamsSchema = {
+  type: "object",
+  required: ["token"],
+  properties: { token: { type: "string" } },
+} as const;
+
+export default async function sponsorInvitationRoutes(app: FastifyInstance) {
+  // GET /api/sponsor-invitation/:token — what this invitation is for.
+  //
+  // Lets the page say "you were invited to manage <company>" before asking the
+  // visitor to sign in. Returns nothing identifying beyond the company name:
+  // whoever holds the token was sent it on purpose.
+  app.get<{ Params: { token: string } }>("/sponsor-invitation/:token", {
+    schema: { params: tokenParamsSchema },
+  }, async (request, reply) => {
+    const contact = await findPendingInvitation(request.params.token);
+    // One answer for expired, consumed, unknown and trashed alike: telling them
+    // apart would let someone probe which tokens ever existed.
+    if (!contact) return reply.code(404).send({ error: "invitation_invalid" });
+
+    return {
+      sponsorName: contact.sponsor.name,
+      accessRole: contact.accessRole,
+      // Enough for the page to say which mailbox to use, without printing an
+      // address a third party could harvest from a forwarded link.
+      emailHint: maskEmail(contact.email),
+    };
+  });
+
+  // POST /api/sponsor-invitation/:token/accept — bind the signed-in account.
+  app.post<{ Params: { token: string } }>("/sponsor-invitation/:token/accept", {
+    schema: { params: tokenParamsSchema },
+  }, async (request, reply) => {
+    const contact = await findPendingInvitation(request.params.token);
+    if (!contact) return reply.code(404).send({ error: "invitation_invalid" });
+
+    const ctx = await getAuthContext(request);
+    if (!ctx) return reply.code(401).send({ error: "Unauthenticated" });
+
+    // The account's address must be exactly the invited one (#362). Compared on
+    // the identity provider's value, the only field a visitor cannot choose —
+    // otherwise anyone could bind a personal Google account to the company.
+    if (normalizeEmail(ctx.user.email) !== normalizeEmail(contact.email)) {
+      return reply.code(403).send({ error: "email_mismatch" });
+    }
+
+    // Single-use: clearing the token is what consumes it. Racing calls cannot
+    // both win — the second one no longer finds a pending invitation.
+    const updated = await prisma.sponsorContact.updateMany({
+      where: { id: contact.id, invitationAcceptedAt: null },
+      data: { userId: ctx.user.id, invitationToken: null, invitationAcceptedAt: new Date() },
+    });
+    if (updated.count === 0) return reply.code(404).send({ error: "invitation_invalid" });
+
+    return { sponsorId: contact.sponsorId, sponsorSlug: contact.sponsor.slug, accessRole: contact.accessRole };
+  });
+}
+
+// "contact@societe.fr" -> "c•••••t@societe.fr". Enough for the invited person
+// to recognise their own mailbox, not enough for a stranger to learn it.
+function maskEmail(email: string): string {
+  const [local, domain] = email.split("@");
+  if (!domain) return "•••";
+  const head = local.slice(0, 1);
+  const tail = local.length > 1 ? local.slice(-1) : "";
+  return `${head}•••••${tail}@${domain}`;
+}

--- a/src/backend/src/routes/sponsor-space.ts
+++ b/src/backend/src/routes/sponsor-space.ts
@@ -1,0 +1,154 @@
+import type { FastifyInstance } from "fastify";
+
+import { prisma } from "../lib/prisma.js";
+import { getAuthContext } from "../lib/auth-context.js";
+import { notDeleted } from "../lib/admin-helpers.js";
+import { requireSponsorAccess } from "../lib/sponsor-guard.js";
+
+// A sponsor's own space (#362) — what a company sees about itself once it has
+// an account, as opposed to /api/admin/* (organisers) and /api/edit/:token
+// (editing without an account, still in service for speakers).
+
+const sponsorIdParams = {
+  type: "object",
+  required: ["sponsorId"],
+  properties: { sponsorId: { type: "string" } },
+} as const;
+
+export default async function sponsorSpaceRoutes(app: FastifyInstance) {
+  // GET /api/sponsor-space/mine — the companies this account may act on.
+  //
+  // The entry point: a person invited by two companies has to pick one, and the
+  // frontend cannot guess the ids on its own.
+  app.get("/sponsor-space/mine", async (request, reply) => {
+    const ctx = await getAuthContext(request);
+    if (!ctx) return reply.code(401).send({ error: "Unauthenticated" });
+
+    const contacts = await prisma.sponsorContact.findMany({
+      where: { userId: ctx.user.id, sponsor: notDeleted },
+      select: {
+        accessRole: true,
+        sponsor: { select: { id: true, slug: true, name: true, logoUrl: true } },
+      },
+      orderBy: { sponsor: { name: "asc" } },
+    });
+
+    return contacts.map((c) => ({ ...c.sponsor, accessRole: c.accessRole }));
+  });
+
+  // GET /api/sponsor-space/:sponsorId — the company's own profile.
+  //
+  // STAND may read it: the booth team needs to know what the page says, which
+  // is public anyway. Private fields are NOT here — see /private below.
+  app.get<{ Params: { sponsorId: string } }>("/sponsor-space/:sponsorId", {
+    schema: { params: sponsorIdParams },
+    preHandler: requireSponsorAccess("STAND"),
+  }, async (request, reply) => {
+    const sponsorId = request.sponsorAccess!.sponsorId;
+    const sponsor = await prisma.sponsor.findFirst({
+      where: { id: sponsorId, ...notDeleted },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        logoUrl: true,
+        websiteUrl: true,
+        descriptionFr: true,
+        descriptionEn: true,
+        socialLinks: true,
+        editions: {
+          where: { edition: notDeleted },
+          select: {
+            editionId: true,
+            edition: { select: { year: true } },
+            publicationStatus: true,
+            tier: { select: { key: true, nameFr: true, nameEn: true } },
+          },
+          orderBy: { edition: { year: "desc" } },
+        },
+      },
+    });
+    if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
+
+    return {
+      ...sponsor,
+      socialLinks: sponsor.socialLinks ? JSON.parse(sponsor.socialLinks) : {},
+      accessRole: request.sponsorAccess!.accessRole,
+    };
+  });
+
+  // GET /api/sponsor-space/:sponsorId/private — the com kit and booth notes.
+  //
+  // EDITEUR and above only: STAND is read-only on the public profile and has no
+  // business seeing what the organisers and the company exchange privately.
+  app.get<{ Params: { sponsorId: string } }>("/sponsor-space/:sponsorId/private", {
+    schema: { params: sponsorIdParams },
+    preHandler: requireSponsorAccess("EDITEUR"),
+  }, async (request, reply) => {
+    const sponsorId = request.sponsorAccess!.sponsorId;
+    const sponsor = await prisma.sponsor.findFirst({
+      where: { id: sponsorId, ...notDeleted },
+      select: {
+        standContacts: true,
+        editions: {
+          where: { edition: notDeleted },
+          select: {
+            editionId: true,
+            edition: { select: { year: true } },
+            comKitReceived: true,
+            comKitLogoWebUrl: true,
+            comKitLogoPrintUrl: true,
+            comKitCharterUrl: true,
+            comKitNotes: true,
+            platinumPromoIdea: true,
+            platinumCoBuildIdea: true,
+            tier: { select: { allowsPromoIdeas: true } },
+          },
+          orderBy: { edition: { year: "desc" } },
+        },
+      },
+    });
+    if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
+
+    return {
+      standContacts: sponsor.standContacts ? JSON.parse(sponsor.standContacts) : [],
+      editions: sponsor.editions,
+    };
+  });
+
+  // GET /api/sponsor-space/:sponsorId/team — who has access, and as what.
+  //
+  // RESPONSABLE only: the team list carries the colleagues' addresses, which an
+  // EDITEUR has no reason to enumerate.
+  app.get<{ Params: { sponsorId: string } }>("/sponsor-space/:sponsorId/team", {
+    schema: { params: sponsorIdParams },
+    preHandler: requireSponsorAccess("RESPONSABLE"),
+  }, async (request) => {
+    const contacts = await prisma.sponsorContact.findMany({
+      where: { sponsorId: request.sponsorAccess!.sponsorId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        accessRole: true,
+        userId: true,
+        invitationSentAt: true,
+        invitationAcceptedAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    // Tokens never leave the server — only whether an invitation is pending.
+    return contacts.map((c) => ({
+      id: c.id,
+      email: c.email,
+      name: c.name,
+      role: c.role,
+      accessRole: c.accessRole,
+      hasAccount: !!c.userId,
+      invitationSentAt: c.invitationSentAt,
+      invitationAcceptedAt: c.invitationAcceptedAt,
+    }));
+  });
+}

--- a/src/backend/src/routes/sponsor-space.ts
+++ b/src/backend/src/routes/sponsor-space.ts
@@ -4,6 +4,36 @@ import { prisma } from "../lib/prisma.js";
 import { getAuthContext } from "../lib/auth-context.js";
 import { notDeleted } from "../lib/admin-helpers.js";
 import { requireSponsorAccess } from "../lib/sponsor-guard.js";
+import { applySponsorEdit, writesYearField, type SponsorEditBody } from "../lib/sponsor-write.js";
+import { isSafeUrl } from "../lib/sanitize.js";
+import { getFeaturedEdition } from "./editions.js";
+
+// Same bounds as the edit link (#223): this endpoint writes fields rendered on
+// public pages, so the payload is an allow-list of known keys and lengths.
+const TEXT_MAX = 5_000;
+const SHORT_MAX = 200;
+const URL_MAX = 2_048;
+const STAND_CONTACTS_MAX = 20;
+const SOCIAL_KEYS = ["linkedin", "twitter", "bluesky", "github", "website"] as const;
+
+// What a sponsor may write about itself. `name`, `slug` and the tier are the
+// organisers' business: renaming the company here would break its slug and its
+// public page.
+const EDITABLE_FIELDS: string[] = [
+  "descriptionFr",
+  "descriptionEn",
+  "websiteUrl",
+  "logoUrl",
+  "socialLinks",
+  "standContacts",
+  "comKitReceived",
+  "comKitLogoWebUrl",
+  "comKitLogoPrintUrl",
+  "comKitCharterUrl",
+  "comKitNotes",
+  "platinumPromoIdea",
+  "platinumCoBuildIdea",
+];
 
 // A sponsor's own space (#362) — what a company sees about itself once it has
 // an account, as opposed to /api/admin/* (organisers) and /api/edit/:token
@@ -114,6 +144,117 @@ export default async function sponsorSpaceRoutes(app: FastifyInstance) {
       standContacts: sponsor.standContacts ? JSON.parse(sponsor.standContacts) : [],
       editions: sponsor.editions,
     };
+  });
+
+  // PUT /api/sponsor-space/:sponsorId — save the company's own fields.
+  //
+  // EDITEUR and above: STAND is read-only by design. Writes go through the same
+  // helper as the edit link (#362), so the two ways in cannot drift apart on
+  // which field belongs to the year and which to the company.
+  app.put<{ Params: { sponsorId: string }; Body: SponsorEditBody }>("/sponsor-space/:sponsorId", {
+    schema: {
+      params: sponsorIdParams,
+      body: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          descriptionFr: { type: "string", maxLength: TEXT_MAX },
+          descriptionEn: { type: "string", maxLength: TEXT_MAX },
+          websiteUrl: { type: "string", maxLength: URL_MAX },
+          logoUrl: { type: "string", maxLength: URL_MAX },
+          socialLinks: {
+            type: "object",
+            additionalProperties: false,
+            properties: Object.fromEntries(
+              SOCIAL_KEYS.map((k) => [k, { type: "string", maxLength: URL_MAX }]),
+            ),
+          },
+          standContacts: {
+            type: "array",
+            maxItems: STAND_CONTACTS_MAX,
+            items: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                name: { type: "string", maxLength: SHORT_MAX },
+                linkedin: { type: "string", maxLength: URL_MAX },
+                twitter: { type: "string", maxLength: URL_MAX },
+                bluesky: { type: "string", maxLength: URL_MAX },
+              },
+            },
+          },
+          comKitReceived: { type: "boolean" },
+          comKitLogoWebUrl: { type: "string", maxLength: URL_MAX },
+          comKitLogoPrintUrl: { type: "string", maxLength: URL_MAX },
+          comKitCharterUrl: { type: "string", maxLength: URL_MAX },
+          comKitNotes: { type: "string", maxLength: TEXT_MAX },
+          platinumPromoIdea: { type: "string", maxLength: TEXT_MAX },
+          platinumCoBuildIdea: { type: "string", maxLength: TEXT_MAX },
+        },
+      },
+    },
+    // Ajv runs with `removeAdditional: true`, so `additionalProperties: false`
+    // silently STRIPS an unknown key instead of rejecting it — a PUT carrying
+    // `name` would answer 200 while ignoring it. Telling a caller "saved" after
+    // discarding half their payload is worse than refusing it, so unknown keys
+    // are caught here, before Ajv prunes them (#223).
+    preValidation: async (request, reply) => {
+      const body = (request.body ?? {}) as Record<string, unknown>;
+      for (const key of Object.keys(body)) {
+        if (!EDITABLE_FIELDS.includes(key)) {
+          return reply.code(400).send({ error: "unknown_field", field: key });
+        }
+      }
+      const social = body.socialLinks;
+      if (social && typeof social === "object") {
+        for (const key of Object.keys(social as Record<string, unknown>)) {
+          if (!(SOCIAL_KEYS as readonly string[]).includes(key)) {
+            return reply.code(400).send({ error: "unknown_field", field: `socialLinks.${key}` });
+          }
+        }
+      }
+    },
+    preHandler: requireSponsorAccess("EDITEUR"),
+  }, async (request, reply) => {
+    const sponsorId = request.sponsorAccess!.sponsorId;
+    const body = request.body ?? {};
+
+    // Same allow-list as the edit link (#223): http(s) only, so a saved field
+    // cannot turn into a javascript: link on the public page.
+    for (const field of ["logoUrl", "websiteUrl", "comKitLogoWebUrl", "comKitLogoPrintUrl", "comKitCharterUrl"] as const) {
+      const value = body[field];
+      if (typeof value === "string" && value.trim() && !isSafeUrl(value)) {
+        return reply.code(400).send({ error: "unsafe_url", field });
+      }
+    }
+    for (const [key, value] of Object.entries(body.socialLinks ?? {})) {
+      if (typeof value === "string" && value.trim() && !isSafeUrl(value)) {
+        return reply.code(400).send({ error: "unsafe_url", field: `socialLinks.${key}` });
+      }
+    }
+
+    const sponsor = await prisma.sponsor.findFirst({
+      where: { id: sponsorId, ...notDeleted },
+      select: { id: true, slug: true },
+    });
+    if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
+
+    // Per-year fields land on the featured edition's participation — the year
+    // being prepared. Editing a past one is the organisers' job.
+    const edition = await getFeaturedEdition();
+    const participation = edition
+      ? await prisma.editionSponsor.findFirst({
+          where: { sponsorId, editionId: edition.id, edition: notDeleted },
+          select: { id: true, tier: { select: { allowsPromoIdeas: true } } },
+        })
+      : null;
+
+    if (writesYearField(body) && !participation) {
+      return reply.code(422).send({ error: "no_current_participation" });
+    }
+
+    await applySponsorEdit({ sponsorId, sponsorSlug: sponsor.slug, participation, body });
+    return { saved: true };
   });
 
   // GET /api/sponsor-space/:sponsorId/team — who has access, and as what.

--- a/src/frontend/next.config.ts
+++ b/src/frontend/next.config.ts
@@ -63,6 +63,16 @@ const nextConfig: NextConfig = {
         destination: `${backendUrl}/api/sponsors/:path*`,
       },
       {
+        // A sponsor's own space and its invitations (#362). Separate entries
+        // from /api/sponsors above: that one is the public company page.
+        source: "/api/sponsor-space/:path*",
+        destination: `${backendUrl}/api/sponsor-space/:path*`,
+      },
+      {
+        source: "/api/sponsor-invitation/:path*",
+        destination: `${backendUrl}/api/sponsor-invitation/:path*`,
+      },
+      {
         source: "/api/talks/:path*",
         destination: `${backendUrl}/api/talks/:path*`,
       },


### PR DESCRIPTION
## Summary

Lots **1 et 2** de #362 — le socle backend. Un sponsor ne pouvait pas se connecter du tout : l'inscription refusait tout email hors `ADMIN_EMAILS`, et tous les contacts d'une entreprise avaient des droits égaux.

- **Modèle** : `SponsorAccessRole` (RESPONSABLE > EDITEUR > STAND) sur `SponsorContact`, `userId` vers le compte, et un jeton d'invitation **distinct** de `editToken`.
- **Inscription** : le hook accepte un admin allow-listé **ou** un email porteur d'une invitation vivante — rien d'autre.
- **Autorisation** : `requireSponsorAccess(rôle minimum)` et les routes `/api/sponsor-space/*`.
- **Magic link** : plugin natif better-auth, 60 min, usage unique.

Les lots 3 (UI en onglets) et 4 (gestion d'équipe) restent à faire — **rien de visible côté sponsor** tant qu'ils ne sont pas livrés.

## Un problème de sécurité trouvé en chemin

`User.role` vaut **`EDITOR` par défaut**, et `requireAnyAuthenticated` laisse passer `EDITOR`. Créer un compte sponsor lui aurait donc ouvert `/api/admin/*` et `/api/me/*`.

La qualification avait anticipé le risque d'un **élargissement volontaire du garde** et concluait « un sponsor ne doit porter aucun `UserRole` » — impossible, la colonne est `NOT NULL` avec un défaut dangereux. Le danger venait du schéma, pas du garde.

Parade : une valeur **`SPONSOR`** neutre, posée explicitement à la création. **Le garde existant n'est pas modifié.** C'est un écart assumé par rapport au cadrage de l'issue.

La règle est écrite dans [.claude/rules/security.md](.claude/rules/security.md) et signalée sur **#363**, qui rencontrera le même piège côté speakers.

## Décisions du cadrage, appliquées

| Décision | Où |
|---|---|
| Email strictement identique à l'invitation, aucune tolérance | `sponsor-invitation.ts` — comparaison normalisée sur la valeur du fournisseur d'identité |
| Pas de compte orphelin | Rejet **dans** `user.create.before`, jamais après coup |
| Invitation 7 jours, usage unique | `INVITATION_TTL_DAYS`, jeton effacé à l'acceptation |
| Magic link 60 minutes, usage unique | `MAGIC_LINK_TTL_MINUTES`, plugin natif |
| Dernier RESPONSABLE non rétrogradable | 409 `last_responsable` |
| ADMIN passe pour le support | Dérogation explicite, **sans** lui créer de `SponsorContact` |
| 404 et non 403 sur un sponsor sans contact | Ne pas révéler quels ids existent |

## Notes d'implémentation

- **`zod` devient une dépendance directe du backend, sans jamais être importée.** Configurer un plugin better-auth fait atteindre au type inféré celui de zod, que TypeScript doit nommer dans les `.d.ts` (`declaration: true`), et que l'isolation pnpm rendait irrésolvable → **TS2742**. Commenté dans `auth.ts` : ne pas la supprimer en la croyant morte. Le lockfile ne bouge que de 3 lignes.
- **`magic-link` est fourni nativement** par better-auth. La qualification supposait qu'il fallait l'écrire.
- **better-auth était en 1.6.5 en local** alors que le lockfile déclare 1.6.23 — écart purement local, la CI installait déjà la bonne version. Aligné avant de commencer, 0 régression.

## Test Plan

- [x] Backend — `tsc` propre, **607 tests / 91 fichiers** (569 + 38 nouveaux)
- [x] Frontend — `tsc` propre, **99 tests / 16 fichiers** (non modifié, vérifié par précaution)

Les 38 tests couvrent : une frontière par rôle (STAND ne lit pas le privé ni l'équipe, EDITEUR ne lit pas l'équipe, RESPONSABLE lit tout), l'isolation entre entreprises, l'entreprise en corbeille, un EDITOR back-office tenu à l'écart, l'email divergent et la casse, le rejeu, l'expiration, la rotation à la ré-invitation, et le dernier RESPONSABLE. La séparation des rôles a été vérifiée « rouge sans le garde ».

## Notes de revue

- **Écart assumé** : la valeur `SPONSOR` dans `UserRole`, expliquée plus haut.
- **Pas de vérification navigateur** : ce lot n'expose aucune UI. Elle viendra avec le lot 3.
- **`hasPendingInvitation` charge les contacts invités en mémoire** pour comparer les adresses normalisées — Postgres comparerait les valeurs brutes. Correct à l'échelle du site (quelques dizaines de lignes) ; à revoir si le volume change.

Refs #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
