### PR TITLE
feat(sponsor): sponsor space UI + team management (#362 lots 3-4)

### DIFF
--- a/src/backend/src/__tests__/sponsor-invitation.test.ts
+++ b/src/backend/src/__tests__/sponsor-invitation.test.ts
@@ -8,6 +8,7 @@ import { prisma } from "../lib/prisma.js";
 import { generateApiKey, resolveApiKeyEnv } from "../lib/api-key.js";
 import { hasPendingInvitation } from "../lib/sponsor-invitation.js";
 import { INVITATION_TTL_DAYS } from "../lib/edit-token.js";
+import { auth } from "../lib/auth.js";
 
 // #362 — accepting an invitation binds an account to a company. The rules that
 // matter are: the email must match exactly, the token works once, and an
@@ -186,6 +187,39 @@ describe("GET /api/sponsor-invitation/:token (#362)", () => {
   it("answers the same 404 for unknown and consumed tokens", async () => {
     const res = await app.inject({ method: "GET", url: "/api/sponsor-invitation/does-not-exist" });
     expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("Sign-up through an invitation (#362)", () => {
+  // The hook's whole job: let an invited address in, and give it a role that
+  // grants nothing in the back-office. Both halves failed silently at first —
+  // better-auth drops unknown fields, so the role fell back to the column
+  // default, EDITOR, which requireAnyAuthenticated lets through.
+  it("creates the account with the SPONSOR role, never the EDITOR default", async () => {
+    const email = `signup-${Date.now()}@example.org`;
+    const { sponsor } = await createSponsorWithInvitation("Signup Co", email);
+    
+
+    await auth.api.signUpEmail({
+      body: { name: "Invited Person", email, password: "invited1234!test" },
+    });
+
+    const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+    created.userIds.push(user.id);
+    // EDITOR here would hand /api/admin/* to every sponsor.
+    expect(user.role).toBe("SPONSOR");
+  });
+
+  it("refuses an address nobody invited", async () => {
+    const email = `uninvited-${Date.now()}@example.org`;
+
+    await expect(
+      auth.api.signUpEmail({ body: { name: "Nobody", email, password: "nobody1234!test" } }),
+    ).rejects.toThrow();
+
+    // No orphan row left behind: the hook rejects before the insert, which
+    // matters most for OAuth, where the provider would otherwise mint one.
+    expect(await prisma.user.count({ where: { email } })).toBe(0);
   });
 });
 

--- a/src/backend/src/__tests__/sponsor-space-access.test.ts
+++ b/src/backend/src/__tests__/sponsor-space-access.test.ts
@@ -1,6 +1,12 @@
 process.env.BASE_URL = process.env.BASE_URL || "http://localhost:4000";
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+// Inviting a colleague sends mail; stub SMTP so no test reaches a real server.
+const { sendMailMock } = vi.hoisted(() => ({ sendMailMock: vi.fn().mockResolvedValue({}) }));
+vi.mock("nodemailer", () => ({
+  default: { createTransport: () => ({ sendMail: sendMailMock }) },
+}));
 import Fastify, { type FastifyInstance } from "fastify";
 
 import sponsorSpaceRoutes from "../routes/sponsor-space.js";
@@ -286,6 +292,146 @@ describe("PUT /api/sponsor-space/:sponsorId — writing (#362)", () => {
     expect(res.statusCode).toBe(400);
     const after = await prisma.sponsor.findUniqueOrThrow({ where: { id: sponsor.id } });
     expect(after.name).toBe("Strict Co");
+  });
+});
+
+describe("Team management from the space (#362)", () => {
+  // Inviting sends mail; the transport is stubbed at the top of this file's
+  // sibling admin test. Here we only exercise the paths that stop before it.
+  it("refuses team management to EDITEUR", async () => {
+    const sponsor = await createSponsor("No Invite Co");
+    const { user, bearer } = await createAccount("SPONSOR", `noinvite-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "EDITEUR" },
+    });
+
+    const auth = { authorization: `Bearer ${bearer}` };
+    const invite = await app.inject({
+      method: "POST",
+      url: `/api/sponsor-space/${sponsor.id}/team`,
+      headers: auth,
+      payload: { email: "someone@example.org" },
+    });
+
+    // Inviting is exactly what separates EDITEUR from RESPONSABLE.
+    expect(invite.statusCode).toBe(403);
+  });
+
+  it("lets RESPONSABLE invite a colleague at a chosen role", async () => {
+    const sponsor = await createSponsor("Inviting Co");
+    const { user, bearer } = await createAccount("SPONSOR", `inviter-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "RESPONSABLE" },
+    });
+    sendMailMock.mockClear();
+
+    const invited = `colleague-${Date.now()}@example.org`;
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/sponsor-space/${sponsor.id}/team`,
+      headers: { authorization: `Bearer ${bearer}` },
+      payload: { email: invited, name: "Colleague", accessRole: "STAND" },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.accessRole).toBe("STAND");
+    expect(body.hasAccount).toBe(false);
+    // The invitation token stays server-side, like every other secret here.
+    expect(JSON.stringify(body)).not.toContain("invitationToken");
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+
+    const stored = await prisma.sponsorContact.findFirstOrThrow({
+      where: { sponsorId: sponsor.id, email: invited },
+    });
+    expect(stored.invitationToken).toBeTruthy();
+  });
+
+  it("refuses an address already on the team", async () => {
+    const sponsor = await createSponsor("Dup Team Co");
+    const { user, bearer } = await createAccount("SPONSOR", `dupteam-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "RESPONSABLE" },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/sponsor-space/${sponsor.id}/team`,
+      headers: { authorization: `Bearer ${bearer}` },
+      // Same address, different casing: a second row would give the same person
+      // two roles with no way to tell which applies.
+      payload: { email: user.email.toUpperCase() },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe("already_on_team");
+  });
+
+  it("refuses to remove the last RESPONSABLE", async () => {
+    const sponsor = await createSponsor("Solo Boss Co");
+    const { user, bearer } = await createAccount("SPONSOR", `soloboss-${Date.now()}@example.org`);
+    const contact = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "RESPONSABLE" },
+    });
+
+    const auth = { authorization: `Bearer ${bearer}` };
+    const demote = await app.inject({
+      method: "PUT",
+      url: `/api/sponsor-space/${sponsor.id}/team/${contact.id}`,
+      headers: auth,
+      payload: { accessRole: "EDITEUR" },
+    });
+    const remove = await app.inject({
+      method: "DELETE",
+      url: `/api/sponsor-space/${sponsor.id}/team/${contact.id}`,
+      headers: auth,
+    });
+
+    // Either move would leave the space with nobody able to invite anyone back.
+    expect(demote.statusCode).toBe(409);
+    expect(remove.statusCode).toBe(409);
+    expect(await prisma.sponsorContact.count({ where: { id: contact.id } })).toBe(1);
+  });
+
+  it("allows removing a RESPONSABLE when another remains", async () => {
+    const sponsor = await createSponsor("Two Boss Co");
+    const { user, bearer } = await createAccount("SPONSOR", `twoboss-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: user.email, userId: user.id, accessRole: "RESPONSABLE" },
+    });
+    const second = await prisma.sponsorContact.create({
+      data: { sponsorId: sponsor.id, email: `second-${Date.now()}@example.org`, accessRole: "RESPONSABLE" },
+    });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/api/sponsor-space/${sponsor.id}/team/${second.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(await prisma.sponsorContact.count({ where: { id: second.id } })).toBe(0);
+  });
+
+  it("refuses to touch a contact belonging to another company", async () => {
+    const mine = await createSponsor("My Team Co");
+    const theirs = await createSponsor("Their Team Co");
+    const { user, bearer } = await createAccount("SPONSOR", `crossteam-${Date.now()}@example.org`);
+    await prisma.sponsorContact.create({
+      data: { sponsorId: mine.id, email: user.email, userId: user.id, accessRole: "RESPONSABLE" },
+    });
+    const foreign = await prisma.sponsorContact.create({
+      data: { sponsorId: theirs.id, email: `foreign-${Date.now()}@example.org`, accessRole: "EDITEUR" },
+    });
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/api/sponsor-space/${mine.id}/team/${foreign.id}`,
+      headers: { authorization: `Bearer ${bearer}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(await prisma.sponsorContact.count({ where: { id: foreign.id } })).toBe(1);
   });
 });
 

--- a/src/backend/src/lib/auth.ts
+++ b/src/backend/src/lib/auth.ts
@@ -93,6 +93,22 @@ export const auth = betterAuth({
       clientSecret: process.env.OAUTH_GITHUB_CLIENT_SECRET || "",
     },
   },
+  user: {
+    additionalFields: {
+      // User.role exists in the Prisma schema but better-auth does not know it,
+      // so it drops the value the create hook sets — a sponsor account then
+      // fell back to the column default, EDITOR, which opens the back-office
+      // (#362). Declaring it here is what makes the hook's role stick.
+      //
+      // input: false — the role is never taken from the request body: a signup
+      // payload carrying `role: "ADMIN"` must not be able to grant itself one.
+      role: {
+        type: "string",
+        required: false,
+        input: false,
+      },
+    },
+  },
   account: {
     accountLinking: {
       enabled: true,

--- a/src/backend/src/routes/sponsor-space.ts
+++ b/src/backend/src/routes/sponsor-space.ts
@@ -3,7 +3,9 @@ import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 import { getAuthContext } from "../lib/auth-context.js";
 import { notDeleted } from "../lib/admin-helpers.js";
-import { requireSponsorAccess } from "../lib/sponsor-guard.js";
+import { requireSponsorAccess, type SponsorAccessRole } from "../lib/sponsor-guard.js";
+import { generateInvitationToken } from "../lib/edit-token.js";
+import { sendSponsorInvitationEmail } from "../lib/edit-link-email.js";
 import { applySponsorEdit, writesYearField, type SponsorEditBody } from "../lib/sponsor-write.js";
 import { isSafeUrl } from "../lib/sanitize.js";
 import { getFeaturedEdition } from "./editions.js";
@@ -15,6 +17,10 @@ const SHORT_MAX = 200;
 const URL_MAX = 2_048;
 const STAND_CONTACTS_MAX = 20;
 const SOCIAL_KEYS = ["linkedin", "twitter", "bluesky", "github", "website"] as const;
+
+// Validated against a plain allow-list so an unknown value is a 422 rather than
+// a Prisma error surfacing as a 500.
+const ACCESS_ROLES: SponsorAccessRole[] = ["RESPONSABLE", "EDITEUR", "STAND"];
 
 // What a sponsor may write about itself. `name`, `slug` and the tier are the
 // organisers' business: renaming the company here would break its slug and its
@@ -281,15 +287,182 @@ export default async function sponsorSpaceRoutes(app: FastifyInstance) {
     });
 
     // Tokens never leave the server — only whether an invitation is pending.
-    return contacts.map((c) => ({
-      id: c.id,
-      email: c.email,
-      name: c.name,
-      role: c.role,
-      accessRole: c.accessRole,
-      hasAccount: !!c.userId,
-      invitationSentAt: c.invitationSentAt,
-      invitationAcceptedAt: c.invitationAcceptedAt,
-    }));
+    return contacts.map(serializeMember);
   });
+
+  // POST /api/sponsor-space/:sponsorId/team — invite someone onto the space.
+  //
+  // RESPONSABLE only (#362): that is the whole difference with EDITEUR. The
+  // company invites its own colleagues without going through the organisers.
+  app.post<{ Params: { sponsorId: string }; Body: { email?: string; name?: string; accessRole?: SponsorAccessRole } }>(
+    "/sponsor-space/:sponsorId/team",
+    { schema: { params: sponsorIdParams }, preHandler: requireSponsorAccess("RESPONSABLE") },
+    async (request, reply) => {
+      const sponsorId = request.sponsorAccess!.sponsorId;
+      const email = request.body?.email?.trim();
+      if (!email) return reply.code(400).send({ error: "email_required" });
+
+      const accessRole = request.body?.accessRole ?? "EDITEUR";
+      if (!ACCESS_ROLES.includes(accessRole)) {
+        return reply.code(422).send({ error: "invalid_access_role" });
+      }
+
+      const sponsor = await prisma.sponsor.findFirst({
+        where: { id: sponsorId, ...notDeleted },
+        select: { name: true, locale: true },
+      });
+      if (!sponsor) return reply.code(404).send({ error: "Sponsor not found" });
+
+      // Re-inviting an address already on the team would create a second row
+      // for the same person, each with its own role — and no way to tell which
+      // one applies.
+      const existing = await prisma.sponsorContact.findFirst({
+        where: { sponsorId, email: { equals: email, mode: "insensitive" } },
+        select: { id: true },
+      });
+      if (existing) return reply.code(409).send({ error: "already_on_team" });
+
+      // Send first, persist second (#223): a failed mail must leave no
+      // invitation behind.
+      const token = generateInvitationToken();
+      try {
+        await sendSponsorInvitationEmail({
+          to: email,
+          sponsorName: sponsor.name,
+          token,
+          locale: sponsor.locale,
+        });
+      } catch (err) {
+        request.log.error({ err }, "Failed to send sponsor team invitation");
+        return reply.code(502).send({ error: "email_failed" });
+      }
+
+      const contact = await prisma.sponsorContact.create({
+        data: {
+          sponsorId,
+          email,
+          name: request.body?.name?.trim() || null,
+          accessRole,
+          invitationToken: token,
+          invitationSentAt: new Date(),
+        },
+      });
+      return reply.code(201).send(serializeMember(contact));
+    },
+  );
+
+  // PUT /api/sponsor-space/:sponsorId/team/:contactId — change a member's role.
+  app.put<{ Params: { sponsorId: string; contactId: string }; Body: { accessRole?: SponsorAccessRole } }>(
+    "/sponsor-space/:sponsorId/team/:contactId",
+    {
+      schema: {
+        params: {
+          type: "object",
+          required: ["sponsorId", "contactId"],
+          properties: { sponsorId: { type: "string" }, contactId: { type: "string" } },
+        },
+      },
+      preHandler: requireSponsorAccess("RESPONSABLE"),
+    },
+    async (request, reply) => {
+      const sponsorId = request.sponsorAccess!.sponsorId;
+      const accessRole = request.body?.accessRole;
+      if (!accessRole || !ACCESS_ROLES.includes(accessRole)) {
+        return reply.code(422).send({ error: "invalid_access_role" });
+      }
+
+      const contact = await prisma.sponsorContact.findUnique({
+        where: { id: Number(request.params.contactId) },
+        select: { id: true, sponsorId: true, accessRole: true },
+      });
+      if (!contact || contact.sponsorId !== sponsorId) {
+        return reply.code(404).send({ error: "Contact not found" });
+      }
+
+      if (await wouldStrandSpace(sponsorId, contact, accessRole)) {
+        return reply.code(409).send({ error: "last_responsable" });
+      }
+
+      const updated = await prisma.sponsorContact.update({
+        where: { id: contact.id },
+        data: { accessRole },
+      });
+      return serializeMember(updated);
+    },
+  );
+
+  // DELETE /api/sponsor-space/:sponsorId/team/:contactId — revoke access.
+  //
+  // Removes the contact outright: it exists to carry the access, unlike the
+  // organisers' own contact list which survives on the admin side.
+  app.delete<{ Params: { sponsorId: string; contactId: string } }>(
+    "/sponsor-space/:sponsorId/team/:contactId",
+    {
+      schema: {
+        params: {
+          type: "object",
+          required: ["sponsorId", "contactId"],
+          properties: { sponsorId: { type: "string" }, contactId: { type: "string" } },
+        },
+      },
+      preHandler: requireSponsorAccess("RESPONSABLE"),
+    },
+    async (request, reply) => {
+      const sponsorId = request.sponsorAccess!.sponsorId;
+      const contact = await prisma.sponsorContact.findUnique({
+        where: { id: Number(request.params.contactId) },
+        select: { id: true, sponsorId: true, accessRole: true },
+      });
+      if (!contact || contact.sponsorId !== sponsorId) {
+        return reply.code(404).send({ error: "Contact not found" });
+      }
+
+      // Same guard as demoting: removing the last RESPONSABLE would leave the
+      // space with nobody able to invite anyone back into it.
+      if (await wouldStrandSpace(sponsorId, contact, null)) {
+        return reply.code(409).send({ error: "last_responsable" });
+      }
+
+      await prisma.sponsorContact.delete({ where: { id: contact.id } });
+      return reply.code(204).send();
+    },
+  );
+}
+
+// Would this change leave the space without a single RESPONSABLE? Passing null
+// as the next role means the contact is being removed altogether.
+async function wouldStrandSpace(
+  sponsorId: number,
+  contact: { id: number; accessRole: SponsorAccessRole },
+  nextRole: SponsorAccessRole | null,
+): Promise<boolean> {
+  if (contact.accessRole !== "RESPONSABLE") return false;
+  if (nextRole === "RESPONSABLE") return false;
+  const others = await prisma.sponsorContact.count({
+    where: { sponsorId, accessRole: "RESPONSABLE", id: { not: contact.id } },
+  });
+  return others === 0;
+}
+
+// Tokens never leave the server — only whether an invitation is outstanding.
+function serializeMember(c: {
+  id: number;
+  email: string;
+  name: string | null;
+  role: string | null;
+  accessRole: SponsorAccessRole;
+  userId: string | null;
+  invitationSentAt: Date | null;
+  invitationAcceptedAt: Date | null;
+}) {
+  return {
+    id: c.id,
+    email: c.email,
+    name: c.name,
+    role: c.role,
+    accessRole: c.accessRole,
+    hasAccount: !!c.userId,
+    invitationSentAt: c.invitationSentAt,
+    invitationAcceptedAt: c.invitationAcceptedAt,
+  };
 }

--- a/src/frontend/src/app/sponsor/[sponsorId]/page.tsx
+++ b/src/frontend/src/app/sponsor/[sponsorId]/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { use, useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import Tabs from "@/components/admin/Tabs";
+import PublicTab from "@/components/sponsor-space/PublicTab";
+import PrivateTab from "@/components/sponsor-space/PrivateTab";
+import TeamTab from "@/components/sponsor-space/TeamTab";
+import { getSponsorProfile, type SponsorSpaceProfile } from "@/lib/sponsor-api";
+import { signOut } from "@/lib/admin-api";
+
+// A sponsor's own space (#362), in three tabs — the split the issue asked for,
+// replacing a single page where public and private fields were stacked.
+//
+// Which tabs exist depends on the role: the API refuses what the UI hides, so
+// hiding is convenience, not protection.
+
+export default function SponsorSpacePage({ params }: { params: Promise<{ sponsorId: string }> }) {
+  const { sponsorId } = use(params);
+  const id = Number(sponsorId);
+  const router = useRouter();
+
+  const [profile, setProfile] = useState<SponsorSpaceProfile | null>(null);
+  const [isDenied, setIsDenied] = useState(false);
+  const [activeTab, setActiveTab] = useState("public");
+
+  const load = useCallback(async () => {
+    const { data, status } = await getSponsorProfile(id);
+    if (status === 401) {
+      router.replace(`/sponsor/login?next=/sponsor/${id}`);
+      return;
+    }
+    if (!data) {
+      setIsDenied(true);
+      return;
+    }
+    setProfile(data);
+  }, [id, router]);
+
+  useEffect(() => {
+    if (Number.isInteger(id)) void load();
+  }, [id, load]);
+
+  if (isDenied) {
+    return (
+      <Shell>
+        <p className="text-center text-noir">Cette fiche n&apos;est pas accessible avec votre compte.</p>
+      </Shell>
+    );
+  }
+
+  if (!profile) {
+    return <Shell><p className="text-center text-gris">Chargement…</p></Shell>;
+  }
+
+  const canEdit = profile.accessRole === "RESPONSABLE" || profile.accessRole === "EDITEUR";
+  const canManageTeam = profile.accessRole === "RESPONSABLE";
+
+  const tabs = [
+    { key: "public", label: "Fiche publique" },
+    ...(canEdit ? [{ key: "private", label: "Informations privées" }] : []),
+    ...(canManageTeam ? [{ key: "team", label: "Accès" }] : []),
+  ];
+
+  return (
+    <Shell wide>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-noir">{profile.name}</h1>
+          <p className="text-sm text-gris">Espace partenaire · {ROLE_LABELS[profile.accessRole]}</p>
+        </div>
+        <button
+          type="button"
+          onClick={async () => {
+            await signOut();
+            router.replace("/sponsor/login");
+          }}
+          className="text-sm font-medium text-gris hover:text-noir"
+        >
+          Déconnexion
+        </button>
+      </div>
+
+      <Tabs
+        tabs={tabs}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        panelId={(key) => `sponsor-panel-${key}`}
+      />
+
+      <div id={`sponsor-panel-${activeTab}`} role="tabpanel" aria-labelledby={`tab-${activeTab}`}>
+        {activeTab === "public" && <PublicTab profile={profile} canEdit={canEdit} onSaved={load} />}
+        {activeTab === "private" && canEdit && <PrivateTab sponsorId={id} />}
+        {activeTab === "team" && canManageTeam && <TeamTab sponsorId={id} />}
+      </div>
+    </Shell>
+  );
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  RESPONSABLE: "Responsable",
+  EDITEUR: "Éditeur",
+  STAND: "Stand",
+};
+
+function Shell({ children, wide }: { children: React.ReactNode; wide?: boolean }) {
+  return (
+    <div className="min-h-dvh bg-blanc-casse">
+      <header className="border-b border-gris/10 bg-blanc">
+        <div className="mx-auto flex max-w-4xl items-center gap-3 px-6 py-4">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/images/logo-devfest-96.png" alt="DevFest Toulouse" width={40} height={40} className="h-10 w-10" />
+          <span className="font-bold text-noir">DevFest Toulouse</span>
+        </div>
+      </header>
+      <main className={`mx-auto px-6 py-10 ${wide ? "max-w-4xl" : "max-w-md"}`}>{children}</main>
+    </div>
+  );
+}

--- a/src/frontend/src/app/sponsor/invitation/[token]/page.tsx
+++ b/src/frontend/src/app/sponsor/invitation/[token]/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { getInvitationPreview, acceptInvitation, type InvitationPreview } from "@/lib/sponsor-api";
+import SponsorLogin from "@/components/sponsor-space/SponsorLogin";
+
+// Accepting an invitation to a sponsor space (#362).
+//
+// Three states, in order: describe the invitation, get the visitor signed in
+// with the invited address, bind the account. The binding is a separate step
+// rather than a side effect of signing in, because the email may not match —
+// and that has to be said out loud instead of failing silently.
+
+const ROLE_LABELS: Record<string, string> = {
+  RESPONSABLE: "Responsable — gérer la fiche et inviter votre équipe",
+  EDITEUR: "Éditeur — gérer la fiche",
+  STAND: "Stand — consulter la fiche",
+};
+
+export default function SponsorInvitationPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = use(params);
+  const router = useRouter();
+
+  const [preview, setPreview] = useState<InvitationPreview | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [needsSignIn, setNeedsSignIn] = useState(false);
+
+  useEffect(() => {
+    getInvitationPreview(token).then(({ data }) => {
+      setPreview(data);
+      setIsLoading(false);
+    });
+  }, [token]);
+
+  async function accept() {
+    setIsAccepting(true);
+    setError(null);
+    const { data, status, error: apiError } = await acceptInvitation(token);
+
+    if (status === 401) {
+      // Not signed in yet — show the sign-in form rather than an error.
+      setNeedsSignIn(true);
+      setIsAccepting(false);
+      return;
+    }
+    if (status === 403 && apiError === "email_mismatch") {
+      // Deliberately does not name the invited address: whoever holds a
+      // forwarded link must not learn it (#362).
+      setError(
+        "Cette invitation a été émise pour une autre adresse email. Connectez-vous avec l'adresse qui l'a reçue, ou demandez à l'équipe DevFest de vous la renvoyer.",
+      );
+      setIsAccepting(false);
+      return;
+    }
+    if (!data) {
+      setError("Cette invitation n'est plus valable. Demandez-en une nouvelle à l'équipe DevFest.");
+      setIsAccepting(false);
+      return;
+    }
+
+    router.push(`/sponsor/${data.sponsorId}`);
+  }
+
+  if (isLoading) {
+    return <Shell><p className="text-center text-gris">Chargement…</p></Shell>;
+  }
+
+  if (!preview) {
+    return (
+      <Shell>
+        <p className="text-center text-noir">
+          Cette invitation n&apos;est plus valable — elle a peut-être expiré ou déjà été utilisée.
+        </p>
+        <p className="mt-4 text-center text-sm text-gris">
+          Demandez-en une nouvelle à l&apos;équipe DevFest Toulouse.
+        </p>
+      </Shell>
+    );
+  }
+
+  if (needsSignIn) {
+    return <SponsorLogin callbackURL={`/sponsor/invitation/${token}`} />;
+  }
+
+  return (
+    <Shell>
+      <p className="text-noir">
+        Vous avez été invité à gérer la fiche de <strong>{preview.sponsorName}</strong> sur le site du
+        DevFest Toulouse.
+      </p>
+      <p className="mt-3 text-sm text-gris">
+        Rôle proposé : {ROLE_LABELS[preview.accessRole] ?? preview.accessRole}
+      </p>
+      <p className="mt-3 text-sm text-gris">
+        Connectez-vous avec l&apos;adresse <strong>{preview.emailHint}</strong>{" "}
+        — l&apos;invitation ne fonctionne qu&apos;avec celle-ci.
+      </p>
+
+      {error && <p className="mt-4 rounded-lg bg-terre-cuite/10 p-3 text-sm text-terre-cuite">{error}</p>}
+
+      <button
+        type="button"
+        onClick={accept}
+        disabled={isAccepting}
+        className="mt-6 w-full rounded-[12px] bg-malachite px-4 py-3 font-bold text-blanc transition-colors hover:bg-malachite/90 disabled:opacity-50"
+      >
+        {isAccepting ? "Validation…" : "Accepter l'invitation"}
+      </button>
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-blanc-casse px-6 py-10">
+      <div className="w-full max-w-md rounded-3xl bg-blanc p-8 shadow-card">
+        <h1 className="mb-6 text-center text-2xl font-bold text-noir">Espace partenaire</h1>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/sponsor/login/page.tsx
+++ b/src/frontend/src/app/sponsor/login/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+import SponsorLogin from "@/components/sponsor-space/SponsorLogin";
+
+// Sign-in for a sponsor (#362). Outside [locale] like /admin and /edit: this is
+// an application screen, not a page of the public site, and next-intl would
+// otherwise prefix it with a locale.
+
+function LoginWithRedirect() {
+  const params = useSearchParams();
+  // Where to land after signing in. Confined to a path on this site so the
+  // parameter cannot bounce someone to another domain.
+  const raw = params.get("next") ?? "/sponsor";
+  const callbackURL = raw.startsWith("/") && !raw.startsWith("//") ? raw : "/sponsor";
+  return <SponsorLogin callbackURL={callbackURL} />;
+}
+
+export default function SponsorLoginPage() {
+  return (
+    <Suspense>
+      <LoginWithRedirect />
+    </Suspense>
+  );
+}

--- a/src/frontend/src/app/sponsor/page.tsx
+++ b/src/frontend/src/app/sponsor/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+import { getMySponsorSpaces, type SponsorSpaceSummary } from "@/lib/sponsor-api";
+
+// Entry point of a sponsor's space (#362). A person invited by two companies
+// has to pick one, and the frontend cannot guess the ids on its own.
+//
+// A single company is the common case, so it redirects straight through rather
+// than showing a list of one.
+
+export default function SponsorHomePage() {
+  const router = useRouter();
+  const [spaces, setSpaces] = useState<SponsorSpaceSummary[] | null>(null);
+  const [isDenied, setIsDenied] = useState(false);
+
+  useEffect(() => {
+    getMySponsorSpaces().then(({ data, status }) => {
+      if (status === 401) {
+        router.replace("/sponsor/login?next=/sponsor");
+        return;
+      }
+      if (!data) {
+        setIsDenied(true);
+        return;
+      }
+      if (data.length === 1) {
+        router.replace(`/sponsor/${data[0].id}`);
+        return;
+      }
+      setSpaces(data);
+    });
+  }, [router]);
+
+  if (isDenied) {
+    return (
+      <Shell>
+        <p className="text-center text-noir">
+          Votre compte n&apos;est rattaché à aucune fiche partenaire.
+        </p>
+        <p className="mt-3 text-center text-sm text-gris">
+          Si vous venez de recevoir une invitation, ouvrez le lien qu&apos;elle contient.
+        </p>
+      </Shell>
+    );
+  }
+
+  if (!spaces) {
+    return <Shell><p className="text-center text-gris">Chargement…</p></Shell>;
+  }
+
+  if (spaces.length === 0) {
+    return (
+      <Shell>
+        <p className="text-center text-noir">Aucune fiche partenaire rattachée à votre compte.</p>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      <p className="mb-4 text-sm text-gris">Choisissez la fiche à gérer :</p>
+      <ul className="space-y-2">
+        {spaces.map((s) => (
+          <li key={s.id}>
+            <Link
+              href={`/sponsor/${s.id}`}
+              className="flex items-center justify-between rounded-lg border border-gris/20 bg-blanc px-4 py-3 transition-colors hover:border-malachite"
+            >
+              <span className="font-medium text-noir">{s.name}</span>
+              <span className="text-xs text-gris">{ROLE_SHORT[s.accessRole]}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </Shell>
+  );
+}
+
+const ROLE_SHORT: Record<string, string> = {
+  RESPONSABLE: "Responsable",
+  EDITEUR: "Éditeur",
+  STAND: "Stand",
+};
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-blanc-casse px-6 py-10">
+      <div className="w-full max-w-md rounded-3xl bg-blanc p-8 shadow-card">
+        <h1 className="mb-6 text-center text-2xl font-bold text-noir">Espace partenaire</h1>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/sponsor-space/PrivateTab.tsx
+++ b/src/frontend/src/components/sponsor-space/PrivateTab.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getSponsorPrivate, saveSponsorProfile, type SponsorSpacePrivate } from "@/lib/sponsor-api";
+
+// The com kit and booth staff (#362) — what the company and the organisers
+// exchange privately. Never rendered on the public site.
+//
+// Only reachable by EDITEUR and above: STAND does not get this tab at all, and
+// the API refuses it too.
+
+export default function PrivateTab({ sponsorId }: { sponsorId: number }) {
+  const [data, setData] = useState<SponsorSpacePrivate | null>(null);
+  const [comKitNotes, setComKitNotes] = useState("");
+  const [promoIdea, setPromoIdea] = useState("");
+  const [coBuildIdea, setCoBuildIdea] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [message, setMessage] = useState<{ isOk: boolean; text: string } | null>(null);
+
+  useEffect(() => {
+    getSponsorPrivate(sponsorId).then(({ data }) => {
+      if (!data) return;
+      setData(data);
+      // The current edition is the one being prepared — the only year a sponsor
+      // may still edit. Ordered year-descending by the API.
+      const current = data.editions[0];
+      setComKitNotes(current?.comKitNotes ?? "");
+      setPromoIdea(current?.platinumPromoIdea ?? "");
+      setCoBuildIdea(current?.platinumCoBuildIdea ?? "");
+    });
+  }, [sponsorId]);
+
+  if (!data) return <p className="text-sm text-gris">Chargement…</p>;
+
+  const current = data.editions[0];
+  const allowsPromoIdeas = current?.tier.allowsPromoIdeas ?? false;
+
+  async function save() {
+    setIsSaving(true);
+    setMessage(null);
+    const { status } = await saveSponsorProfile(sponsorId, {
+      comKitNotes,
+      ...(allowsPromoIdeas ? { platinumPromoIdea: promoIdea, platinumCoBuildIdea: coBuildIdea } : {}),
+    });
+    setIsSaving(false);
+    setMessage(
+      status === 200
+        ? { isOk: true, text: "Modifications enregistrées." }
+        : { isOk: false, text: "L'enregistrement a échoué. Réessayez." },
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <p className="rounded-lg bg-blanc-casse p-3 text-sm text-gris">
+        Ces informations ne sont visibles que par vous et l&apos;équipe DevFest. Elles n&apos;apparaissent
+        jamais sur le site public.
+      </p>
+
+      {current ? (
+        <>
+          <div className="rounded-lg border border-gris/20 p-4">
+            <p className="mb-3 text-sm font-medium text-noir">
+              Kit de communication — édition {current.edition.year}
+            </p>
+            <p className="text-sm text-gris">
+              {current.comKitReceived
+                ? "Reçu par l'équipe DevFest."
+                : "Pas encore reçu. Envoyez vos fichiers à l'équipe DevFest."}
+            </p>
+            <ul className="mt-3 space-y-1 text-sm">
+              <FileLine label="Logo web" url={current.comKitLogoWebUrl} />
+              <FileLine label="Logo print" url={current.comKitLogoPrintUrl} />
+              <FileLine label="Charte graphique" url={current.comKitCharterUrl} />
+            </ul>
+          </div>
+
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-noir">Notes / autres supports</span>
+            <textarea
+              value={comKitNotes}
+              onChange={(e) => setComKitNotes(e.target.value)}
+              rows={4}
+              className={inputClass}
+            />
+          </label>
+
+          {allowsPromoIdeas && (
+            <>
+              <label className="block">
+                <span className="mb-1 block text-sm font-medium text-noir">
+                  Contenu promotionnel à mettre en avant
+                </span>
+                <textarea
+                  value={promoIdea}
+                  onChange={(e) => setPromoIdea(e.target.value)}
+                  rows={4}
+                  className={inputClass}
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-sm font-medium text-noir">
+                  Idées de contenu à co-construire
+                </span>
+                <textarea
+                  value={coBuildIdea}
+                  onChange={(e) => setCoBuildIdea(e.target.value)}
+                  rows={4}
+                  className={inputClass}
+                />
+              </label>
+            </>
+          )}
+        </>
+      ) : (
+        <p className="text-sm text-gris">
+          Aucune participation en cours. Ces informations seront disponibles dès que votre
+          participation à l&apos;édition en préparation sera enregistrée.
+        </p>
+      )}
+
+      {data.standContacts.length > 0 && (
+        <div>
+          <span className="mb-2 block text-sm font-medium text-noir">Équipe sur le stand</span>
+          <ul className="space-y-1 text-sm text-gris">
+            {data.standContacts.map((c, i) => (
+              <li key={i}>{c.name || "—"}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {message && (
+        <p className={`text-sm ${message.isOk ? "text-malachite" : "text-terre-cuite"}`}>
+          {message.text}
+        </p>
+      )}
+
+      {current && (
+        <button
+          type="button"
+          onClick={save}
+          disabled={isSaving}
+          className="rounded-[12px] bg-malachite px-5 py-2.5 font-bold text-blanc transition-colors hover:bg-malachite/90 disabled:opacity-50"
+        >
+          {isSaving ? "Enregistrement…" : "Enregistrer"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function FileLine({ label, url }: { label: string; url: string | null }) {
+  return (
+    <li className="flex items-center gap-2">
+      <span className="text-gris">{label} :</span>
+      {url ? (
+        <a href={url} target="_blank" rel="noopener noreferrer" className="text-bleu hover:underline">
+          voir le fichier
+        </a>
+      ) : (
+        <span className="text-gris">non fourni</span>
+      )}
+    </li>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";

--- a/src/frontend/src/components/sponsor-space/PublicTab.tsx
+++ b/src/frontend/src/components/sponsor-space/PublicTab.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+
+import BilingualTabs from "@/components/admin/BilingualTabs";
+import RichTextEditor from "@/components/admin/RichTextEditor";
+import { saveSponsorProfile, type SponsorSpaceProfile } from "@/lib/sponsor-api";
+
+// What the public site shows about the company (#362). Read-only for STAND:
+// the booth team sees the page without being able to rewrite it.
+
+const SOCIAL_FIELDS = [
+  { key: "linkedin", label: "LinkedIn" },
+  { key: "twitter", label: "X / Twitter" },
+  { key: "bluesky", label: "Bluesky" },
+] as const;
+
+export default function PublicTab({
+  profile,
+  canEdit,
+  onSaved,
+}: {
+  profile: SponsorSpaceProfile;
+  canEdit: boolean;
+  onSaved: () => void;
+}) {
+  const [descriptionFr, setDescriptionFr] = useState(profile.descriptionFr ?? "");
+  const [descriptionEn, setDescriptionEn] = useState(profile.descriptionEn ?? "");
+  const [websiteUrl, setWebsiteUrl] = useState(profile.websiteUrl ?? "");
+  const [logoUrl, setLogoUrl] = useState(profile.logoUrl ?? "");
+  const [social, setSocial] = useState<Record<string, string>>(profile.socialLinks ?? {});
+  const [isSaving, setIsSaving] = useState(false);
+  const [message, setMessage] = useState<{ isOk: boolean; text: string } | null>(null);
+
+  async function save() {
+    setIsSaving(true);
+    setMessage(null);
+    const { status, error } = await saveSponsorProfile(profile.id, {
+      descriptionFr,
+      descriptionEn,
+      websiteUrl,
+      logoUrl,
+      socialLinks: social,
+    });
+    setIsSaving(false);
+
+    if (status === 200) {
+      setMessage({ isOk: true, text: "Modifications enregistrées." });
+      onSaved();
+      return;
+    }
+    setMessage({
+      isOk: false,
+      text:
+        error === "unsafe_url"
+          ? "Une des adresses saisies n'est pas valide. Utilisez une URL commençant par http:// ou https://."
+          : "L'enregistrement a échoué. Réessayez.",
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {!canEdit && (
+        <p className="rounded-lg bg-blanc-casse p-3 text-sm text-gris">
+          Votre accès est en lecture seule. Demandez au responsable de votre équipe de vous donner
+          les droits d&apos;édition.
+        </p>
+      )}
+
+      {/* Both panels stay mounted (BilingualTabs hides the inactive one), so
+          the editor keeps its undo history across language switches. */}
+      <BilingualTabs
+        label="Description"
+        isEmpty={(lang) => !(lang === "fr" ? descriptionFr : descriptionEn).trim()}
+        renderPanel={(lang) =>
+          canEdit ? (
+            <RichTextEditor
+              label={lang === "fr" ? "Description (français)" : "Description (English)"}
+              name={`description-${lang}`}
+              value={lang === "fr" ? descriptionFr : descriptionEn}
+              onChange={lang === "fr" ? setDescriptionFr : setDescriptionEn}
+            />
+          ) : (
+            // RichTextEditor has no read-only mode; STAND gets the rendered
+            // text rather than a disabled editor. Safe to inject: the field is
+            // sanitized on write by sanitizeRichHtml (#270), and the public
+            // sponsor page renders the very same value the same way.
+            <div
+              className="rounded-lg border border-gris/20 bg-blanc-casse p-3 text-sm text-noir"
+              dangerouslySetInnerHTML={{ __html: lang === "fr" ? descriptionFr : descriptionEn }}
+            />
+          )
+        }
+      />
+
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium text-noir">Site web</span>
+        <input
+          value={websiteUrl}
+          onChange={(e) => setWebsiteUrl(e.target.value)}
+          disabled={!canEdit}
+          className={inputClass}
+        />
+      </label>
+
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium text-noir">Logo (URL)</span>
+        <input
+          value={logoUrl}
+          onChange={(e) => setLogoUrl(e.target.value)}
+          disabled={!canEdit}
+          className={inputClass}
+        />
+        <span className="mt-1 block text-xs text-gris">
+          Haute définition (largeur ≥ 1000 px), sans marge autour du logo, PNG ou WebP à fond
+          transparent de préférence.
+        </span>
+      </label>
+
+      <fieldset className="space-y-3">
+        <legend className="mb-1 text-sm font-medium text-noir">Réseaux sociaux</legend>
+        {SOCIAL_FIELDS.map((f) => (
+          <label key={f.key} className="block">
+            <span className="mb-1 block text-xs text-gris">{f.label}</span>
+            <input
+              value={social[f.key] ?? ""}
+              onChange={(e) => setSocial({ ...social, [f.key]: e.target.value })}
+              disabled={!canEdit}
+              className={inputClass}
+            />
+          </label>
+        ))}
+      </fieldset>
+
+      {profile.editions.length > 0 && (
+        <div>
+          <span className="mb-2 block text-sm font-medium text-noir">Participations</span>
+          <ul className="space-y-1">
+            {profile.editions.map((e) => (
+              <li key={e.editionId} className="flex items-center gap-3 text-sm">
+                <span className="font-medium text-noir">{e.edition.year}</span>
+                <span className="text-gris">{e.tier.nameFr}</span>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                    e.publicationStatus === "PUBLISHED"
+                      ? "bg-malachite/10 text-malachite"
+                      : "bg-gris/10 text-gris"
+                  }`}
+                >
+                  {e.publicationStatus === "PUBLISHED" ? "Publié" : "Brouillon"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {message && (
+        <p className={`text-sm ${message.isOk ? "text-malachite" : "text-terre-cuite"}`}>
+          {message.text}
+        </p>
+      )}
+
+      {canEdit && (
+        <button
+          type="button"
+          onClick={save}
+          disabled={isSaving}
+          className="rounded-[12px] bg-malachite px-5 py-2.5 font-bold text-blanc transition-colors hover:bg-malachite/90 disabled:opacity-50"
+        >
+          {isSaving ? "Enregistrement…" : "Enregistrer"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50 disabled:bg-blanc-casse disabled:text-gris";

--- a/src/frontend/src/components/sponsor-space/SponsorLogin.tsx
+++ b/src/frontend/src/components/sponsor-space/SponsorLogin.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { signInWithSocial, signInWithEmail } from "@/lib/admin-api";
+import { requestMagicLink } from "@/lib/sponsor-api";
+
+// Sign-in for a sponsor (#362). Deliberately not the admin screen: a sponsor
+// account holds no back-office role, and landing on a page titled "DevFest
+// Admin" would suggest otherwise. Same providers underneath.
+
+interface Providers {
+  google: boolean;
+  github: boolean;
+}
+
+export default function SponsorLogin({ callbackURL }: { callbackURL: string }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [linkSent, setLinkSent] = useState(false);
+  const [providers, setProviders] = useState<Providers | null>(null);
+
+  useEffect(() => {
+    fetch("/api/auth/providers")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => data && setProviders(data))
+      .catch(() => {});
+  }, []);
+
+  async function handlePassword(e: React.FormEvent) {
+    e.preventDefault();
+    setIsLoading(true);
+    setError(null);
+    const result = await signInWithEmail(email, password);
+    if (result.success) {
+      window.location.href = callbackURL;
+      return;
+    }
+    setError(result.error || "Erreur de connexion");
+    setIsLoading(false);
+  }
+
+  async function handleMagicLink() {
+    if (!email.trim()) {
+      setError("Renseignez votre adresse email.");
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    await requestMagicLink(email.trim(), callbackURL);
+    // Same message whether or not an account exists: telling them apart would
+    // turn this button into a way to find out who has one.
+    setLinkSent(true);
+    setIsLoading(false);
+  }
+
+  async function handleSocial(provider: "google" | "github") {
+    setIsLoading(true);
+    setError(null);
+    const result = await signInWithSocial(provider);
+    if (!result.ok) {
+      setError(result.error || "Connexion impossible");
+      setIsLoading(false);
+    }
+    // On success the browser navigates away to the provider.
+  }
+
+  if (linkSent) {
+    return (
+      <Shell>
+        <p className="text-center text-noir">
+          Si un compte existe pour <strong>{email.trim()}</strong>, un lien de connexion vient d&apos;y
+          être envoyé. Il est valable 60 minutes et ne peut servir qu&apos;une fois.
+        </p>
+        <button
+          type="button"
+          onClick={() => setLinkSent(false)}
+          className="mt-6 w-full text-sm font-medium text-gris hover:text-noir"
+        >
+          Utiliser une autre méthode
+        </button>
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell>
+      {(providers?.google || providers?.github) && (
+        <div className="space-y-3">
+          {providers.google && (
+            <button
+              type="button"
+              onClick={() => handleSocial("google")}
+              disabled={isLoading}
+              className="w-full rounded-[12px] border border-gris/30 px-4 py-3 font-medium text-noir transition-colors hover:bg-blanc-casse disabled:opacity-50"
+            >
+              Continuer avec Google
+            </button>
+          )}
+          {providers.github && (
+            <button
+              type="button"
+              onClick={() => handleSocial("github")}
+              disabled={isLoading}
+              className="w-full rounded-[12px] border border-gris/30 px-4 py-3 font-medium text-noir transition-colors hover:bg-blanc-casse disabled:opacity-50"
+            >
+              Continuer avec GitHub
+            </button>
+          )}
+          <div className="flex items-center gap-3 py-2">
+            <span className="h-px flex-1 bg-gris/20" />
+            <span className="text-xs text-gris">ou</span>
+            <span className="h-px flex-1 bg-gris/20" />
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handlePassword} className="space-y-4">
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-noir">Email</span>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={inputClass}
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-noir">Mot de passe</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={inputClass}
+          />
+        </label>
+
+        {error && <p className="text-sm text-terre-cuite">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={isLoading || !email.trim() || !password}
+          className="w-full rounded-[12px] bg-malachite px-4 py-3 font-bold text-blanc transition-colors hover:bg-malachite/90 disabled:opacity-50"
+        >
+          {isLoading ? "Connexion…" : "Me connecter"}
+        </button>
+      </form>
+
+      <button
+        type="button"
+        onClick={handleMagicLink}
+        disabled={isLoading}
+        className="mt-4 w-full text-sm font-medium text-bleu hover:underline disabled:opacity-50"
+      >
+        Recevoir un lien de connexion par email
+      </button>
+
+      <p className="mt-6 text-center text-xs text-gris">
+        Accès sur invitation uniquement. Contactez l&apos;équipe DevFest si vous n&apos;avez pas encore
+        reçu la vôtre.
+      </p>
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-blanc-casse px-6 py-10">
+      <div className="w-full max-w-md rounded-3xl bg-blanc p-8 shadow-card">
+        <h1 className="mb-2 text-center text-2xl font-bold text-noir">Espace partenaire</h1>
+        <p className="mb-6 text-center text-sm text-gris">DevFest Toulouse</p>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";

--- a/src/frontend/src/components/sponsor-space/TeamTab.tsx
+++ b/src/frontend/src/components/sponsor-space/TeamTab.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  getSponsorTeam,
+  inviteTeamMember,
+  setTeamMemberRole,
+  revokeTeamMember,
+  type SponsorAccessRole,
+  type SponsorTeamMember,
+} from "@/lib/sponsor-api";
+
+// Who may act on this space, and as what (#362). RESPONSABLE only — inviting is
+// the whole difference between that role and EDITEUR.
+
+const ROLE_OPTIONS: { value: SponsorAccessRole; label: string; hint: string }[] = [
+  { value: "RESPONSABLE", label: "Responsable", hint: "Gère la fiche et invite l'équipe" },
+  { value: "EDITEUR", label: "Éditeur", hint: "Gère la fiche" },
+  { value: "STAND", label: "Stand", hint: "Consulte la fiche publique" },
+];
+
+export default function TeamTab({ sponsorId }: { sponsorId: number }) {
+  const [members, setMembers] = useState<SponsorTeamMember[] | null>(null);
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [accessRole, setAccessRole] = useState<SponsorAccessRole>("EDITEUR");
+  const [isBusy, setIsBusy] = useState(false);
+  const [message, setMessage] = useState<{ isOk: boolean; text: string } | null>(null);
+
+  async function load() {
+    const { data } = await getSponsorTeam(sponsorId);
+    setMembers(data ?? []);
+  }
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sponsorId]);
+
+  async function invite() {
+    if (!email.trim()) {
+      setMessage({ isOk: false, text: "Renseignez une adresse email." });
+      return;
+    }
+    setIsBusy(true);
+    setMessage(null);
+    const { status, error } = await inviteTeamMember(sponsorId, {
+      email: email.trim(),
+      name: name.trim() || undefined,
+      accessRole,
+    });
+    setIsBusy(false);
+
+    if (status === 201) {
+      setMessage({ isOk: true, text: `Invitation envoyée à ${email.trim()}.` });
+      setEmail("");
+      setName("");
+      void load();
+      return;
+    }
+    setMessage({
+      isOk: false,
+      text:
+        error === "already_on_team"
+          ? "Cette adresse fait déjà partie de l'équipe."
+          : error === "email_failed"
+            ? "L'email n'a pas pu être envoyé. Réessayez."
+            : "L'invitation a échoué.",
+    });
+  }
+
+  async function changeRole(member: SponsorTeamMember, next: SponsorAccessRole) {
+    setIsBusy(true);
+    setMessage(null);
+    const { status, error } = await setTeamMemberRole(sponsorId, member.id, next);
+    setIsBusy(false);
+    if (status === 200) {
+      void load();
+      return;
+    }
+    setMessage({
+      isOk: false,
+      text:
+        error === "last_responsable"
+          ? "Il doit rester au moins un responsable : nommez quelqu'un d'autre avant de changer ce rôle."
+          : "Le changement de rôle a échoué.",
+    });
+  }
+
+  async function revoke(member: SponsorTeamMember) {
+    if (!window.confirm(`Retirer l'accès de ${member.name || member.email} ?`)) return;
+    setIsBusy(true);
+    setMessage(null);
+    const { status, error } = await revokeTeamMember(sponsorId, member.id);
+    setIsBusy(false);
+    if (status === 204) {
+      setMessage({ isOk: true, text: "Accès retiré." });
+      void load();
+      return;
+    }
+    setMessage({
+      isOk: false,
+      text:
+        error === "last_responsable"
+          ? "Il doit rester au moins un responsable : nommez quelqu'un d'autre avant de retirer cet accès."
+          : "Le retrait a échoué.",
+    });
+  }
+
+  if (!members) return <p className="text-sm text-gris">Chargement…</p>;
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-gris">
+        Invitez les personnes de votre équipe et choisissez ce que chacune peut faire.
+      </p>
+
+      <ul className="space-y-2">
+        {members.map((m) => (
+          <li
+            key={m.id}
+            className="flex flex-wrap items-center gap-3 rounded-lg border border-gris/15 bg-blanc px-3 py-2"
+          >
+            <div className="min-w-[180px] flex-1">
+              <p className="text-sm font-medium text-noir">{m.name || m.email}</p>
+              {m.name && <p className="text-xs text-gris">{m.email}</p>}
+              {!m.hasAccount && (
+                <p className="text-xs text-orange">
+                  {m.invitationSentAt ? "Invitation envoyée, en attente" : "Pas encore invité"}
+                </p>
+              )}
+            </div>
+
+            <label className="sr-only" htmlFor={`role-${m.id}`}>
+              Rôle de {m.name || m.email}
+            </label>
+            <select
+              id={`role-${m.id}`}
+              value={m.accessRole}
+              onChange={(e) => changeRole(m, e.target.value as SponsorAccessRole)}
+              disabled={isBusy}
+              className="rounded-lg border border-gris/30 bg-blanc px-2 py-1.5 text-sm text-noir"
+            >
+              {ROLE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+
+            <button
+              type="button"
+              onClick={() => revoke(m)}
+              disabled={isBusy}
+              className="text-xs font-medium text-terre-cuite hover:underline disabled:opacity-50"
+            >
+              Retirer
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="rounded-lg border border-gris/20 bg-blanc-casse/50 p-4">
+        <p className="mb-3 text-sm font-medium text-noir">Inviter quelqu&apos;un</p>
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="min-w-[200px] flex-1">
+            <span className="mb-1 block text-xs text-gris">Email</span>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="prenom@societe.fr"
+              className={inputClass}
+            />
+          </label>
+          <label className="min-w-[140px]">
+            <span className="mb-1 block text-xs text-gris">Nom (optionnel)</span>
+            <input value={name} onChange={(e) => setName(e.target.value)} className={inputClass} />
+          </label>
+          <label className="min-w-[150px]">
+            <span className="mb-1 block text-xs text-gris">Rôle</span>
+            <select
+              value={accessRole}
+              onChange={(e) => setAccessRole(e.target.value as SponsorAccessRole)}
+              className={inputClass}
+            >
+              {ROLE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={invite}
+            disabled={isBusy}
+            className="rounded-lg bg-malachite px-3 py-2 text-sm font-medium text-blanc hover:bg-malachite/90 disabled:opacity-50"
+          >
+            Inviter
+          </button>
+        </div>
+        <p className="mt-3 text-xs text-gris">
+          {ROLE_OPTIONS.find((o) => o.value === accessRole)?.hint}
+          {" · "}
+          L&apos;invitation est valable 7 jours et doit être acceptée avec cette adresse exacte.
+        </p>
+      </div>
+
+      {message && (
+        <p className={`text-sm ${message.isOk ? "text-malachite" : "text-terre-cuite"}`}>
+          {message.text}
+        </p>
+      )}
+    </div>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50";

--- a/src/frontend/src/lib/sponsor-api.ts
+++ b/src/frontend/src/lib/sponsor-api.ts
@@ -1,0 +1,173 @@
+// Client for a sponsor's own space (#362). Separate from admin-api.ts: that one
+// prefixes /api/admin and is meant for the organisers, whose accounts hold a
+// back-office role. A sponsor account holds none — its rights come from its
+// SponsorContact — so these calls go to /api/sponsor-space/*.
+
+export type SponsorAccessRole = "RESPONSABLE" | "EDITEUR" | "STAND";
+
+export interface SponsorSpaceSummary {
+  id: number;
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  accessRole: SponsorAccessRole;
+}
+
+export interface SponsorSpaceParticipation {
+  editionId: number;
+  edition: { year: number };
+  publicationStatus: "DRAFT" | "PUBLISHED";
+  tier: { key: string; nameFr: string; nameEn: string };
+}
+
+export interface SponsorSpaceProfile {
+  id: number;
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  websiteUrl: string | null;
+  descriptionFr: string | null;
+  descriptionEn: string | null;
+  socialLinks: Record<string, string>;
+  editions: SponsorSpaceParticipation[];
+  accessRole: SponsorAccessRole;
+}
+
+export interface SponsorSpacePrivate {
+  standContacts: { name?: string; linkedin?: string; twitter?: string; bluesky?: string }[];
+  editions: {
+    editionId: number;
+    edition: { year: number };
+    comKitReceived: boolean;
+    comKitLogoWebUrl: string | null;
+    comKitLogoPrintUrl: string | null;
+    comKitCharterUrl: string | null;
+    comKitNotes: string | null;
+    platinumPromoIdea: string | null;
+    platinumCoBuildIdea: string | null;
+    tier: { allowsPromoIdeas: boolean };
+  }[];
+}
+
+export interface SponsorTeamMember {
+  id: number;
+  email: string;
+  name: string | null;
+  // Free-text job title, not a permission — accessRole below carries the right.
+  role: string | null;
+  accessRole: SponsorAccessRole;
+  hasAccount: boolean;
+  invitationSentAt: string | null;
+  invitationAcceptedAt: string | null;
+}
+
+export interface InvitationPreview {
+  sponsorName: string;
+  accessRole: SponsorAccessRole;
+  // Masked ("c•••••t@societe.fr") so a forwarded link does not hand the mailbox
+  // to whoever opens it.
+  emailHint: string;
+}
+
+interface Result<T> {
+  data: T | null;
+  status: number;
+  error?: string;
+}
+
+async function call<T>(path: string, options: RequestInit = {}): Promise<Result<T>> {
+  try {
+    const headers: Record<string, string> = {};
+    if (options.body) headers["Content-Type"] = "application/json";
+
+    const res = await fetch(path, {
+      credentials: "include",
+      headers: { ...headers, ...options.headers },
+      ...options,
+    });
+
+    if (res.status === 204) return { data: null, status: 204 };
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      return { data: null, status: res.status, ...(body?.error ? { error: body.error } : {}) };
+    }
+
+    return { data: (await res.json()) as T, status: res.status };
+  } catch {
+    return { data: null, status: 0 };
+  }
+}
+
+export function getMySponsorSpaces() {
+  return call<SponsorSpaceSummary[]>("/api/sponsor-space/mine");
+}
+
+export function getSponsorProfile(sponsorId: number) {
+  return call<SponsorSpaceProfile>(`/api/sponsor-space/${sponsorId}`);
+}
+
+export function getSponsorPrivate(sponsorId: number) {
+  return call<SponsorSpacePrivate>(`/api/sponsor-space/${sponsorId}/private`);
+}
+
+export function saveSponsorProfile(sponsorId: number, body: Record<string, unknown>) {
+  return call<{ saved: boolean }>(`/api/sponsor-space/${sponsorId}`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+export function getSponsorTeam(sponsorId: number) {
+  return call<SponsorTeamMember[]>(`/api/sponsor-space/${sponsorId}/team`);
+}
+
+export function inviteTeamMember(
+  sponsorId: number,
+  body: { email: string; name?: string; accessRole: SponsorAccessRole },
+) {
+  return call<SponsorTeamMember>(`/api/sponsor-space/${sponsorId}/team`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function setTeamMemberRole(sponsorId: number, contactId: number, accessRole: SponsorAccessRole) {
+  return call<SponsorTeamMember>(`/api/sponsor-space/${sponsorId}/team/${contactId}`, {
+    method: "PUT",
+    body: JSON.stringify({ accessRole }),
+  });
+}
+
+export function revokeTeamMember(sponsorId: number, contactId: number) {
+  return call<null>(`/api/sponsor-space/${sponsorId}/team/${contactId}`, { method: "DELETE" });
+}
+
+// Ask for a sign-in link by email (#362). better-auth's magic-link plugin runs
+// with disableSignUp, so this never creates an account: an address with no
+// account gets the same answer as one that has it, which is deliberate — the
+// endpoint must not become a way to probe who is registered.
+export async function requestMagicLink(email: string, callbackURL: string): Promise<{ ok: boolean }> {
+  try {
+    const res = await fetch("/api/auth/sign-in/magic-link", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, callbackURL }),
+    });
+    return { ok: res.ok };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function getInvitationPreview(token: string) {
+  return call<InvitationPreview>(`/api/sponsor-invitation/${token}`);
+}
+
+export function acceptInvitation(token: string) {
+  return call<{ sponsorId: number; sponsorSlug: string; accessRole: SponsorAccessRole }>(
+    `/api/sponsor-invitation/${token}/accept`,
+    { method: "POST" },
+  );
+}

--- a/src/frontend/src/proxy.ts
+++ b/src/frontend/src/proxy.ts
@@ -13,7 +13,14 @@ export default function proxy(request: NextRequest) {
   // visit to a public page).
   // Admin and the token-based edit pages are mono-language: bypass i18n routing
   // but forward the pathname so the root layout can pin <html lang>.
-  if (pathname.startsWith("/admin") || pathname.startsWith("/edit/")) {
+  // /sponsor and /sponsor/* joined them in #362: a sponsor's own space is an
+  // application screen, not a page of the public site. Without this, next-intl
+  // rewrites it to /fr/sponsor and every link 404s.
+  //
+  // Matched exactly, NOT by prefix: the public wall lives at /sponsors, one
+  // letter away, and must keep going through i18n routing.
+  const isSponsorSpace = pathname === "/sponsor" || pathname.startsWith("/sponsor/");
+  if (pathname.startsWith("/admin") || pathname.startsWith("/edit/") || isSponsorSpace) {
     const requestHeaders = new Headers(request.headers);
     requestHeaders.set("x-pathname", pathname);
     return NextResponse.next({ request: { headers: requestHeaders } });


### PR DESCRIPTION
## Summary

Lots **3 et 4** de #362 — l'interface. Le backend avait tout ; rien n'était atteignable.

- **`/sponsor/login`** — page de connexion dédiée (OAuth, mot de passe, magic link). Volontairement pas l'écran admin : un sponsor arrivant sur une page intitulée « DevFest Admin » en déduirait raisonnablement qu'il a accès au back-office.
- **`/sponsor/invitation/[token]`** — décrit l'invitation, fait se connecter, rattache le compte.
- **`/sponsor`** — sélecteur d'entreprise (redirige directement quand il n'y en a qu'une).
- **`/sponsor/[id]`** — l'espace en **trois onglets** : Fiche publique / Informations privées / Accès.

Les onglets suivent le rôle. L'API refuse ce que l'UI masque : masquer est un confort, pas une protection.

Côté backend, ce lot ajoute la **gestion d'équipe** (inviter, changer un rôle, révoquer), réservée au RESPONSABLE — ce qui le distingue vraiment d'EDITEUR.

## Une faille trouvée par le navigateur, pas par les 617 tests

Le compte sponsor créé via invitation recevait le rôle **`EDITOR`**, pas `SPONSOR` : il entrait donc dans `/api/admin/*`.

better-auth **ignore les champs qu'il ne connaît pas**. Le `return { data: { role: "SPONSOR" } }` du hook n'atteignait jamais la base, et la colonne retombait sur son défaut — `EDITOR`, que `requireAnyAuthenticated` laisse passer. Exactement le trou que le lot 1 visait à fermer, rouvert une couche plus bas.

Correctif : déclarer `role` dans `user.additionalFields`, avec `input: false` pour qu'un payload d'inscription ne puisse pas s'attribuer un rôle. Vérifié après coup :

```
signup                        -> 200, role = SPONSOR
GET /api/admin/sponsors       -> 403
GET /api/sponsor-space/mine   -> 200
```

**Deux tests ajoutés**, tous deux vérifiés « rouges sans le correctif ». Ils manquaient : les lots 1-2 testaient le garde, jamais ce que l'inscription écrivait réellement.

## Routage

`/sponsor` et `/sponsor/*` contournent l'i18n comme `/admin` et `/edit`, mais en **correspondance exacte** et non par préfixe : le mur public vit à `/sponsors`, à une lettre près, et doit garder sa locale. Vérifié : `/fr/sponsors` et `/sponsors/[slug]` sont intacts.

## Test Plan

- [x] Backend — `tsc` propre, **619 tests / 91 fichiers**
- [x] Frontend — `tsc` propre, `lint` 0 erreur (8 warnings préexistants), **99 tests**, `build` réussi

Parcours complet vérifié en navigateur (Chrome DevTools MCP) :

| Étape | Résultat |
|---|---|
| Page d'invitation | Entreprise, rôle, adresse **masquée** (`b•••••s@aeronova.example.org`) |
| « Accepter » sans être connecté | Bascule vers la connexion, pas une erreur |
| Connexion puis acceptation | Rattachement, redirection vers l'espace |
| Espace en RESPONSABLE | 3 onglets, description, participations, équipe |
| Onglet Accès | Membre listé, sélecteur de rôle, formulaire d'invitation |
| Espace en STAND | **1 seul onglet**, champs désactivés, message explicite, pas de bouton d'enregistrement |
| Inscription non invitée | 403, aucun compte créé |

Deux défauts d'espacement typographique corrigés au passage. Données de test nettoyées.

## Notes de revue

- **Ergonomie assumée comme provisoire** : ces écrans tomberont dans le périmètre de la passe UX globale prévue après le backlog. Le risque de refonte a été accepté explicitement.
- **Le champ libre `role` et le sélecteur de droit d'accès dans l'admin** restent à trancher — consignés en commentaire sur #362.
- **STAND lit la description en HTML rendu** plutôt qu'un éditeur désactivé (`RichTextEditor` n'a pas de mode lecture seule). Le HTML est assaini à l'écriture par `sanitizeRichHtml` (#270), comme sur la page publique.

Refs #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
