### PR TITLE
fix(seo): conférences et sponsors dans le sitemap

### DIFF
--- a/src/backend/src/__tests__/public-sponsors.test.ts
+++ b/src/backend/src/__tests__/public-sponsors.test.ts
@@ -127,8 +127,89 @@ describe("The sponsor wall serves the edition's frozen values (#375)", () => {
   });
 });
 
-// Years 1760 and 1761 are reserved for this file's past-edition fixtures.
-// Both sit below getSeededEdition()'s 2016 floor, so parallel test files
+// #379 — the sitemap needs every company that HAS a page, which is not the same
+// set as the featured edition's wall. Getting this wrong silently drops the
+// historical sponsors from indexing while their pages answer 200.
+describe("Indexable sponsors span every edition (#379)", () => {
+  it("lists a sponsor of a past edition that the featured wall omits", async () => {
+    const past = await prisma.edition.create({ data: { year: 1762 } });
+    createdEditionIds.push(past.id);
+    const tierId = await tierIdByKey("gold");
+    const sponsor = await createSponsorFixture({
+      name: "Sitemap Past Co",
+      slug: `sitemap-past-${Date.now()}`,
+      editionId: past.id,
+      tierId,
+      publicationStatus: "PUBLISHED",
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildPublicApp();
+    const [indexable, wall, detail] = await Promise.all([
+      app.inject({ method: "GET", url: "/api/sponsors/indexable" }),
+      app.inject({ method: "GET", url: "/api/sponsors" }),
+      app.inject({ method: "GET", url: `/api/sponsors/${sponsor.slug}` }),
+    ]);
+    await app.close();
+
+    // The page exists, so the sitemap must list it...
+    expect(detail.statusCode).toBe(200);
+    expect(indexable.json().map((s: { slug: string }) => s.slug)).toContain(sponsor.slug);
+    // ...even though it is absent from the featured wall. This gap is the bug.
+    expect(wall.json().map((s: { slug: string }) => s.slug)).not.toContain(sponsor.slug);
+  });
+
+  it("omits a sponsor with no published participation", async () => {
+    const past = await prisma.edition.create({ data: { year: 1763 } });
+    createdEditionIds.push(past.id);
+    const tierId = await tierIdByKey("gold");
+    const sponsor = await createSponsorFixture({
+      name: "Sitemap Draft Co",
+      slug: `sitemap-draft-${Date.now()}`,
+      editionId: past.id,
+      tierId,
+      publicationStatus: "DRAFT",
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildPublicApp();
+    const [indexable, detail] = await Promise.all([
+      app.inject({ method: "GET", url: "/api/sponsors/indexable" }),
+      app.inject({ method: "GET", url: `/api/sponsors/${sponsor.slug}` }),
+    ]);
+    await app.close();
+
+    // Symmetry with the route: no page, no sitemap entry.
+    expect(detail.statusCode).toBe(404);
+    expect(indexable.json().map((s: { slug: string }) => s.slug)).not.toContain(sponsor.slug);
+  });
+
+  it("carries a real modification date, not the moment of the request", async () => {
+    const edition = await getSeededEdition();
+    const tierId = await tierIdByKey("gold");
+    const sponsor = await createSponsorFixture({
+      name: "Sitemap Dated Co",
+      slug: `sitemap-dated-${Date.now()}`,
+      editionId: edition.id,
+      tierId,
+      publicationStatus: "PUBLISHED",
+    });
+    createdSponsorIds.push(sponsor.id);
+
+    const app = await buildPublicApp();
+    const res = await app.inject({ method: "GET", url: "/api/sponsors/indexable" });
+    await app.close();
+
+    const mine = res.json().find((s: { slug: string }) => s.slug === sponsor.slug);
+    // A `lastmod` that always equals "now" carries no information at all, which
+    // is what the sitemap used to send.
+    expect(mine.updatedAt).toBeTruthy();
+    expect(new Date(mine.updatedAt).getTime()).toBeLessThanOrEqual(Date.now());
+  });
+});
+
+// Years 1760 to 1763 are reserved for this file's past-edition fixtures.
+// All sit below getSeededEdition()'s 2016 floor, so parallel test files
 // cannot pick them up as "the current edition" (#292).
 describe("Sponsor detail spans editions (#129)", () => {
   it("serves a sponsor of a past edition with no tier and no offers, even if it had one", async () => {

--- a/src/backend/src/lib/lastmod.test.ts
+++ b/src/backend/src/lib/lastmod.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { mostRecent } from "./lastmod.js";
+
+const OLD = new Date("2026-01-01T00:00:00Z");
+const RECENT = new Date("2026-06-01T00:00:00Z");
+
+describe("mostRecent", () => {
+  it("returns the latest of several dates", () => {
+    expect(mostRecent(OLD, RECENT)).toEqual(RECENT);
+  });
+
+  it("ignores the argument order", () => {
+    expect(mostRecent(RECENT, OLD)).toEqual(RECENT);
+  });
+
+  it("skips null and undefined", () => {
+    // A sponsor with no published participation yet: the company's own date
+    // still dates its page.
+    expect(mostRecent(OLD, null, undefined)).toEqual(OLD);
+  });
+
+  it("returns null when no date is known", () => {
+    // Better no lastmod at all than a made-up one.
+    expect(mostRecent(null, undefined)).toBeNull();
+  });
+});

--- a/src/backend/src/lib/lastmod.ts
+++ b/src/backend/src/lib/lastmod.ts
@@ -1,0 +1,12 @@
+// A page is as fresh as the most recently touched row behind it (#379).
+//
+// The sitemap used to send `new Date()` on nearly every entry, which claims
+// "modified just now" at every crawl. A signal that is always true carries no
+// information, and search engines end up ignoring it. Entities own an
+// `updatedAt`, but a page rarely renders a single row: a sponsor page shows the
+// company *and* its participations, so the later of the two dates the page.
+export function mostRecent(...dates: (Date | null | undefined)[]): Date | null {
+  const known = dates.filter((d): d is Date => d instanceof Date);
+  if (known.length === 0) return null;
+  return known.reduce((latest, d) => (d > latest ? d : latest));
+}

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -52,7 +52,8 @@ export default async function editionRoutes(app: FastifyInstance) {
     const editions = await prisma.edition.findMany({
       where: notDeleted,
       orderBy: { year: "desc" },
-      select: { id: true, year: true, status: true, archivedSiteUrl: true, startDate: true },
+      // `updatedAt` dates the edition page in the sitemap (#379).
+      select: { id: true, year: true, status: true, archivedSiteUrl: true, startDate: true, updatedAt: true },
     });
     return editions;
   });
@@ -203,6 +204,9 @@ export default async function editionRoutes(app: FastifyInstance) {
       level: t.level,
       language: t.language,
       videoUrl: t.videoUrl,
+      // Dates the talk page in the sitemap (#379). The list already carries
+      // every published slug of the year, so no extra endpoint is needed.
+      updatedAt: t.updatedAt,
       category: visibleCategory(t.category),
       speakers: t.speakers,
     }));

--- a/src/backend/src/routes/sponsors.ts
+++ b/src/backend/src/routes/sponsors.ts
@@ -4,6 +4,7 @@ import { getFeaturedEdition } from "./editions.js";
 import { areOffersVisible } from "../lib/job-offers.js";
 import { notDeleted } from "../lib/admin-helpers.js";
 import { archivedLogoUrl, archivedTier, getEditionSponsorWall } from "../lib/sponsor-archive.js";
+import { mostRecent } from "../lib/lastmod.js";
 
 function parseSocial(raw: string | null): Record<string, string> {
   if (!raw) return {};
@@ -25,6 +26,44 @@ export default async function sponsorRoutes(app: FastifyInstance) {
     // Shared with /api/editions/:year/sponsors (#370): same wall, same frozen
     // values (#375), only the edition resolved differs.
     return getEditionSponsorWall(edition.id);
+  });
+
+  // GET /api/sponsors/indexable — every company that has a page, all editions.
+  //
+  // /api/sponsors above is the featured edition's wall, so it cannot drive the
+  // sitemap (#379): a company that sponsored 2025 but not 2026 is absent from
+  // the wall while /sponsors/:slug still answers 200 for it. Reading the same
+  // condition as that route — at least one published participation on a live
+  // edition — is what keeps the sitemap and the pages in agreement.
+  //
+  // Declared before "/sponsors/:slug" for readability only: find-my-way gives
+  // static segments priority over parametric ones, so the order does not matter
+  // — but it does mean "indexable" can never be a company's slug.
+  app.get("/sponsors/indexable", async () => {
+    const sponsors = await prisma.sponsor.findMany({
+      where: {
+        ...notDeleted,
+        editions: { some: { publicationStatus: "PUBLISHED", edition: notDeleted } },
+      },
+      orderBy: { name: "asc" },
+      select: {
+        slug: true,
+        updatedAt: true,
+        // The most recent published participation dates the page as well: its
+        // logo and tier are part of what the page renders (#375).
+        editions: {
+          where: { publicationStatus: "PUBLISHED", edition: notDeleted },
+          orderBy: { updatedAt: "desc" },
+          take: 1,
+          select: { updatedAt: true },
+        },
+      },
+    });
+
+    return sponsors.map((s) => ({
+      slug: s.slug,
+      updatedAt: mostRecent(s.updatedAt, s.editions[0]?.updatedAt),
+    }));
   });
 
   // GET /api/sponsors/:slug — detail of a published sponsor + its speakers (RG-226).

--- a/src/frontend/src/app/sitemap.test.ts
+++ b/src/frontend/src/app/sitemap.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #379 — talk pages, the largest body of unique content on the site, were
+// absent from the sitemap entirely, and so were the sponsor pages. What matters
+// here is not the count but that each URL is one the site actually serves:
+// a past talk listed under /conferences/{slug} would be a 404 in the sitemap.
+
+vi.mock("@/lib/api", () => ({
+  getArticles: vi.fn(),
+  getContentPage: vi.fn(),
+  getCurrentEdition: vi.fn(),
+  getEditions: vi.fn(),
+  getEditionTalks: vi.fn(),
+  getHallOfFame: vi.fn(),
+  getIndexableSponsors: vi.fn(),
+}));
+
+import {
+  getArticles,
+  getContentPage,
+  getCurrentEdition,
+  getEditions,
+  getEditionTalks,
+  getHallOfFame,
+  getIndexableSponsors,
+} from "@/lib/api";
+import sitemap from "./sitemap";
+
+const FEATURED = { id: 1, year: 2026 };
+
+// sitemap.ts freezes BASE_URL at module load, so a hook could not change it.
+// These assertions are about paths — which URLs the sitemap lists — so compare
+// on the path and let the origin be whatever the environment supplies.
+function paths(entries: { url: string }[]): string[] {
+  return entries.map((e) => e.url.replace(/^.*?(?=\/(fr|en)(\/|$))/, ""));
+}
+
+beforeEach(() => {
+  vi.mocked(getEditions).mockResolvedValue([
+    { id: 1, year: 2026, status: "ANNOUNCEMENT", archivedSiteUrl: null, startDate: null, updatedAt: "2026-03-01T00:00:00Z" },
+    { id: 2, year: 2025, status: "SEE_YOU_NEXT_YEAR", archivedSiteUrl: null, startDate: null, updatedAt: "2025-12-01T00:00:00Z" },
+  ]);
+  vi.mocked(getCurrentEdition).mockResolvedValue({ ...FEATURED, hasVenueInfo: true } as never);
+  vi.mocked(getEditionTalks).mockImplementation(async (year: number) =>
+    year === FEATURED.year
+      ? ([{ slug: "talk-of-the-year", updatedAt: "2026-04-01T00:00:00Z" }] as never)
+      : ([{ slug: "talk-of-the-past", updatedAt: "2025-04-01T00:00:00Z" }] as never),
+  );
+  vi.mocked(getIndexableSponsors).mockResolvedValue([
+    { slug: "past-only-co", updatedAt: "2025-05-01T00:00:00Z" },
+  ]);
+  vi.mocked(getHallOfFame).mockResolvedValue([]);
+  vi.mocked(getContentPage).mockResolvedValue(null);
+  vi.mocked(getArticles).mockResolvedValue({ articles: [], total: 0, page: 1, totalPages: 0 });
+});
+
+describe("sitemap — talk pages (#379)", () => {
+  it("lists the featured edition's talks under /conferences/{slug}", async () => {
+    const entries = await sitemap();
+
+    expect(paths(entries)).toContain("/fr/conferences/talk-of-the-year");
+    expect(paths(entries)).toContain("/en/conferences/talk-of-the-year");
+  });
+
+  it("lists a past talk under its edition, never under /conferences", async () => {
+    const entries = await sitemap();
+
+    expect(paths(entries)).toContain("/fr/editions/2025/conferences/talk-of-the-past");
+    // /conferences/{slug} resolves against the featured edition only, so this
+    // URL would be a 404 — the exact mistake the two route families prevent.
+    expect(paths(entries)).not.toContain("/fr/conferences/talk-of-the-past");
+  });
+
+  it("gives every entry its three alternates", async () => {
+    const entries = await sitemap();
+    const talk = entries.find((e) => e.url.endsWith("/fr/conferences/talk-of-the-year"));
+    const languages = talk?.alternates?.languages ?? {};
+
+    expect(Object.keys(languages).sort()).toEqual(["en", "fr", "x-default"]);
+    expect(languages.fr).toBe(languages["x-default"]);
+    expect(languages.en).toMatch(/\/en\/conferences\/talk-of-the-year$/);
+  });
+});
+
+describe("sitemap — sponsor pages (#379)", () => {
+  it("lists companies from the indexable set, not the featured wall", async () => {
+    const entries = await sitemap();
+
+    // past-only-co sponsors no current edition, so it is absent from the wall
+    // while its page still answers 200.
+    expect(paths(entries)).toContain("/fr/sponsors/past-only-co");
+    expect(getIndexableSponsors).toHaveBeenCalled();
+  });
+});
+
+describe("sitemap — routes that were missing (#379)", () => {
+  it.each(["/editions", "/offres-emploi-partenaires"])("lists %s", async (route) => {
+    const entries = await sitemap();
+
+    expect(paths(entries)).toContain(`/fr${route}`);
+  });
+
+  // /lieu is not a static route: the page calls notFound() when the edition has
+  // no venue info, so listing it unconditionally would put a 404 in the sitemap.
+  it("lists /lieu only when the edition has venue info", async () => {
+    vi.mocked(getCurrentEdition).mockResolvedValue({ ...FEATURED, hasVenueInfo: true } as never);
+    expect(paths(await sitemap())).toContain("/fr/lieu");
+
+    vi.mocked(getCurrentEdition).mockResolvedValue({ ...FEATURED, hasVenueInfo: false } as never);
+    expect(paths(await sitemap())).not.toContain("/fr/lieu");
+  });
+});
+
+describe("sitemap — lastmod tells the truth (#379)", () => {
+  it("dates an entry from its entity, not from the crawl", async () => {
+    const entries = await sitemap();
+    const talk = entries.find((e) => e.url.endsWith("/fr/conferences/talk-of-the-year"));
+
+    expect(talk?.lastModified).toEqual(new Date("2026-04-01T00:00:00Z"));
+  });
+
+  it("omits lastmod rather than inventing one", async () => {
+    const entries = await sitemap();
+    // A code-backed index page has no row, so it has no modification date.
+    const home = entries.find((e) => paths([e])[0] === "/fr");
+
+    expect(home?.lastModified).toBeUndefined();
+  });
+});
+
+describe("sitemap — every article, not the first hundred (#379)", () => {
+  it("follows pagination past the first page", async () => {
+    vi.mocked(getArticles).mockImplementation(async (page = 1) => ({
+      articles: [{ slug: `article-${page}`, titleEn: "", publishedAt: "2026-01-01T00:00:00Z" }] as never,
+      total: 3,
+      page,
+      totalPages: 3,
+    }));
+
+    const entries = await sitemap();
+
+    // The old code called getArticles(1, 100) once and stopped there.
+    expect(paths(entries)).toContain("/fr/actualites/article-1");
+    expect(paths(entries)).toContain("/fr/actualites/article-3");
+  });
+});

--- a/src/frontend/src/app/sitemap.ts
+++ b/src/frontend/src/app/sitemap.ts
@@ -1,9 +1,43 @@
 import type { MetadataRoute } from "next";
-import { getArticles, getContentPage, getEditions, getHallOfFame } from "@/lib/api";
+import {
+  getArticles,
+  getContentPage,
+  getCurrentEdition,
+  getEditions,
+  getEditionTalks,
+  getHallOfFame,
+  getIndexableSponsors,
+} from "@/lib/api";
 
 const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 
 type Locale = "fr" | "en";
+
+// Articles are read page by page rather than with a fixed ceiling: a hard
+// `limit` silently drops everything past it, and a sitemap that quietly stops
+// listing content is the kind of bug nobody notices (#379).
+const ARTICLES_PER_PAGE = 100;
+const MAX_ARTICLE_PAGES = 50;
+
+async function getAllArticles() {
+  const first = await getArticles(1, ARTICLES_PER_PAGE);
+  const all = [...first.articles];
+  const pages = Math.min(first.totalPages, MAX_ARTICLE_PAGES);
+  for (let page = 2; page <= pages; page++) {
+    const next = await getArticles(page, ARTICLES_PER_PAGE);
+    all.push(...next.articles);
+  }
+  return all;
+}
+
+// `lastmod` must reflect a real modification. Sending `new Date()` claims every
+// page changed at the instant of the crawl, every crawl — a signal that is
+// always true tells a crawler nothing, so it gets discounted (#379).
+function toDate(value: string | null | undefined): Date | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? undefined : date;
+}
 
 // Routes backed by CMS content that may not be translated yet. We skip the
 // /en entry when the EN content is empty to avoid indexing a FR-only page
@@ -13,19 +47,21 @@ const CMS_BACKED_ROUTES = [
   { path: "/mentions-legales", slug: "mentions-legales" },
 ] as const;
 
-async function getLocalesWithEnContent(slug: string): Promise<Locale[]> {
+async function getCmsRouteMeta(slug: string): Promise<{ locales: Locale[]; lastModified: Date | undefined }> {
   const page = await getContentPage(slug);
-  if (!page) return ["fr"];
-  return page.titleEn.trim() && page.contentEn.trim()
-    ? ["fr", "en"]
-    : ["fr"];
+  if (!page) return { locales: ["fr"], lastModified: undefined };
+  const locales: Locale[] =
+    page.titleEn.trim() && page.contentEn.trim() ? ["fr", "en"] : ["fr"];
+  return { locales, lastModified: toDate(page.updatedAt) };
 }
 
 function buildEntry(
   url: string,
   locales: Locale[],
   path: string,
-  lastModified: Date,
+  // Omitted rather than faked when the entity carries no date: no `lastmod` at
+  // all is honest, a wrong one is worse than none.
+  lastModified: Date | undefined,
   changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"],
   priority: number,
 ): MetadataRoute.Sitemap[number] {
@@ -48,10 +84,23 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/proposer-un-talk",
     "/contact",
     "/devenir-sponsor",
+    // Were missing while they carry full metadata and sit in the navigation.
+    "/editions",
+    "/offres-emploi-partenaires",
   ];
+
+  const featured = await getCurrentEdition();
+
+  // /lieu is conditional, not static: the page itself calls notFound() when the
+  // edition has no venue info, and the nav entry is hidden the same way. Listing
+  // it unconditionally would put a 404 in the sitemap.
+  if (featured?.hasVenueInfo) fullyTranslatedRoutes.push("/lieu");
+
   const entries: MetadataRoute.Sitemap = [];
 
-  // Routes available in both locales
+  // Routes available in both locales. These are code-backed pages with no row
+  // behind them, so there is no modification date to report — the index pages
+  // change whenever their content does, which `changeFrequency` already says.
   for (const locale of ["fr", "en"] as Locale[]) {
     for (const route of fullyTranslatedRoutes) {
       entries.push(
@@ -59,7 +108,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           `${BASE_URL}/${locale}${route}`,
           ["fr", "en"],
           route,
-          new Date(),
+          undefined,
           route === "" ? "weekly" : "monthly",
           route === "" ? 1.0 : 0.7,
         ),
@@ -69,14 +118,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // CMS-backed routes (legal pages): gate /en entry on EN content presence
   for (const { path, slug } of CMS_BACKED_ROUTES) {
-    const locales = await getLocalesWithEnContent(slug);
+    const { locales, lastModified } = await getCmsRouteMeta(slug);
     for (const locale of locales) {
       entries.push(
         buildEntry(
           `${BASE_URL}/${locale}${path}`,
           locales,
           path,
-          new Date(),
+          lastModified,
           "monthly",
           0.4,
         ),
@@ -94,8 +143,60 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           `${BASE_URL}/${locale}${path}`,
           ["fr", "en"],
           path,
-          new Date(),
+          toDate(edition.updatedAt),
           "yearly",
+          0.5,
+        ),
+      );
+    }
+  }
+
+  // Talk pages, the largest body of unique content on the site and until now
+  // absent entirely (#379). Two route families, because a talk of the featured
+  // edition and an archived one are served by different pages:
+  //
+  //   /conferences/{slug}                    → featured edition only
+  //   /editions/{year}/conferences/{slug}    → any other year
+  //
+  // Listing a past talk under /conferences/{slug} would emit a 404: that route
+  // resolves against the featured edition alone.
+  for (const edition of editions) {
+    const isFeatured = featured?.year === edition.year;
+    const talks = await getEditionTalks(edition.year);
+    for (const talk of talks) {
+      const path = isFeatured
+        ? `/conferences/${talk.slug}`
+        : `/editions/${edition.year}/conferences/${talk.slug}`;
+      for (const locale of ["fr", "en"] as Locale[]) {
+        entries.push(
+          buildEntry(
+            `${BASE_URL}/${locale}${path}`,
+            ["fr", "en"],
+            path,
+            toDate(talk.updatedAt),
+            isFeatured ? "monthly" : "yearly",
+            isFeatured ? 0.7 : 0.4,
+          ),
+        );
+      }
+    }
+  }
+
+  // Sponsor pages, across every edition — not the featured wall. A company that
+  // sponsored a past year but not the current one has no entry on the wall and
+  // yet its page answers 200, so reading /api/sponsors here would silently omit
+  // exactly the historical sponsors #370 made visible.
+  const sponsors = await getIndexableSponsors();
+  for (const sponsor of sponsors) {
+    const path = `/sponsors/${sponsor.slug}`;
+    for (const locale of ["fr", "en"] as Locale[]) {
+      entries.push(
+        buildEntry(
+          `${BASE_URL}/${locale}${path}`,
+          ["fr", "en"],
+          path,
+          toDate(sponsor.updatedAt),
+          "monthly",
           0.5,
         ),
       );
@@ -115,7 +216,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           `${BASE_URL}/${locale}${path}`,
           ["fr", "en"],
           path,
-          new Date(),
+          undefined,
           "yearly",
           0.5,
         ),
@@ -124,13 +225,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   // Dynamic article pages — gate /en on titleEn presence
-  const { articles } = await getArticles(1, 100);
+  const articles = await getAllArticles();
   for (const article of articles) {
     const path = `/actualites/${article.slug}`;
     const locales: Locale[] = article.titleEn.trim() ? ["fr", "en"] : ["fr"];
-    const lastModified = article.publishedAt
-      ? new Date(article.publishedAt)
-      : new Date();
+    const lastModified = toDate(article.publishedAt);
     for (const locale of locales) {
       entries.push(
         buildEntry(

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   SponsorTierPublic,
   SponsorPublic,
   SponsorDetail,
+  IndexableSponsor,
   SponsorWithOffers,
   SpeakerPublic,
   SpeakerDetail,
@@ -216,6 +217,13 @@ export async function getSponsors(): Promise<SponsorPublic[]> {
 
 export async function getSponsorBySlug(slug: string): Promise<SponsorDetail | null> {
   return fetchAPI<SponsorDetail>(`/api/sponsors/${slug}`);
+}
+
+// Every company with a public page (#379). getSponsors() is the featured
+// edition's wall, so it would miss a company that only sponsored a past year —
+// yet its page answers 200. The sitemap needs the second set, not the first.
+export async function getIndexableSponsors(): Promise<IndexableSponsor[]> {
+  return (await fetchAPI<IndexableSponsor[]>("/api/sponsors/indexable")) || [];
 }
 
 export async function getJobOffers(): Promise<SponsorWithOffers[]> {

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -43,6 +43,7 @@ export interface EditionSummary {
   status: "PREPARATION" | "ANNOUNCEMENT" | "SEE_YOU_NEXT_YEAR";
   archivedSiteUrl: string | null;
   startDate: string | null;
+  updatedAt: string;
 }
 
 export interface SocialLinks {
@@ -351,8 +352,17 @@ export interface EditionTalk {
   level: TalkLevel | null;
   language: string;
   videoUrl: string | null;
+  updatedAt: string;
   category: { nameFr: string; nameEn: string; color: string } | null;
   speakers: { slug: string; name: string; photoUrl: string | null }[];
+}
+
+// One company that has a public page, for the sitemap (#379). Not the sponsor
+// wall: this spans every edition, so a company that only sponsored a past year
+// is here too.
+export interface IndexableSponsor {
+  slug: string;
+  updatedAt: string | null;
 }
 
 // Hall of replays (#102): a filmed talk, carrying the edition it was given in


### PR DESCRIPTION
## Résumé

- **Pages de conférence** ajoutées au sitemap — le plus gros gisement de contenu unique du site, jusqu'ici totalement absent. Deux familles de routes, pas une : `/conferences/{slug}` ne résout que l'édition mise en avant, donc une conférence passée listée là serait un 404. Les années archivées passent par `/editions/{year}/conferences/{slug}`.
- **Fiches sponsors** ajoutées, via un nouvel endpoint `/api/sponsors/indexable`.
- Corrigés au passage : routes manquantes, `lastmod` mensonger, articles plafonnés à 100.

## Le point non évident

`/api/sponsors` est le mur de l'édition en cours, mais `/sponsors/:slug` répond **200 pour toute entreprise ayant au moins une participation publiée, toutes années confondues**. Piloter le sitemap depuis le mur aurait donc silencieusement écarté précisément les sponsors historiques rendus visibles par #370.

Vérifié sur les données locales : **28 entreprises indexables contre 27 sur le mur**. L'écart est `cluster-sud-ouest`, sponsor 2025 uniquement, dont la page répond 200. Le nouvel endpoint lit la même condition que la route de détail, si bien que les deux ne peuvent plus diverger.

## Un défaut dans l'énoncé de l'issue

L'issue demandait d'ajouter `/lieu` à `fullyTranslatedRoutes` comme route statique. Elle ne l'est pas : la page appelle `notFound()` quand l'édition n'a pas d'infos lieu (`hasVenueInfo`), exactement comme l'entrée de navigation est masquée. L'ajouter tel quel **publiait un 404 dans le sitemap** — constaté en local, où `hasVenueInfo` vaut `false`. La route n'est donc listée que sous condition, et un test verrouille les deux cas.

## `lastmod`

Toutes les entrées sauf les articles annonçaient « modifié à l'instant », à chaque crawl. Un signal toujours vrai finit ignoré. Les entrées portent désormais la date de leur entité, **ou aucune** : une date absente est honnête, une date fausse ne l'est pas. 92 des 122 entrées portent une vraie date, aucune dans le futur.

## Plan de test

- `tsc` + `eslint` propres sur les deux applications.
- **Frontend : 114 tests / 18 fichiers**, dont 10 nouveaux sur le sitemap.
- **Backend : 626 tests / 92 fichiers**, dont 4 nouveaux (3 d'intégration + `mostRecent`).
- Les 5 tests visant les nouvelles boucles ont été **vérifiés rouges sans le correctif** (boucles retirées temporairement) — ils constatent bien quelque chose.
- Sitemap généré en local : **122 entrées**, toutes avec exactement 3 alternates.
- **26 URL échantillonnées couvrant toutes les familles de chemins → 0 non-200.**
- Branche archivée éprouvée en insérant une conférence 2025 temporaire (supprimée ensuite) : elle apparaît bien sous `/editions/2025/conferences/`, et **jamais** sous `/conferences/`.

### Une réserve

La page `/editions/{year}/conferences/{slug}` renvoie 404 **en local**, y compris pour une conférence préexistante — mais elle répond **200 en production**, vérifié sur une vraie conférence 2025. C'est donc un artefact de l'environnement local, pas un défaut de code, et la forme d'URL produite par le sitemap est bien celle que la prod sert.

Refs #379
