### PR TITLE
docs(claude): corriger et alléger les instructions agent

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1,25 +1,28 @@
 # Code Quality
 
-## Backwards Compatibility
-- Do not add backwards-compatibility hacks: no renaming to `_unused`, no re-exporting dead types, no `// removed` comments
-- If something is unused, delete it completely
+Write code that reads like the code around it: match its naming, its comment density, its idiom.
+The existing files are the specification — a new component in `src/frontend/src/components/admin/`
+should be indistinguishable in style from its neighbours.
 
-## Imports
-- Order: external packages → internal modules → relative imports, separated by blank lines
-- No unused imports — let the linter enforce this
+## Delete, don't deprecate
 
-## Size Guidelines
-- Functions: if it doesn't fit on one screen (~40 lines), consider splitting
-- Files: if it exceeds ~300 lines, look for extraction opportunities
+No backwards-compatibility scaffolding: no renaming to `_unused`, no re-exporting dead types, no
+`// removed` comments, no shim kept "just in case". If something is unused, delete it. This is a
+young codebase with one consumer — a stale shim costs more than a rewrite.
 
-## Duplication
-- Tolerate 2-3 similar occurrences before extracting
-- Extract only when the duplicated logic has a single reason to change
+## Comments carry the why
 
-## Documentation lookup
-- **Always** use Context7 MCP to fetch up-to-date documentation before using any library, framework, or API
-- This applies to all dependencies, even well-known ones (React, Next.js, Prisma, etc.) — training data may be outdated
-- Prefer Context7 docs over training data for: API syntax, configuration, version migration, setup instructions
+The code says what it does. A comment earns its place by saying what the code cannot: why this
+approach over the obvious one, which bug it prevents, which constraint forced it. Reference the
+issue when there is one — `(#375)` tells the next reader where to look.
 
-## Performance
-- Be mindful of N+1 queries, unbounded loops, and memory leaks
+Do not add docstrings, type annotations or comments to code you did not otherwise change.
+
+## Abstraction
+
+Tolerate two or three similar occurrences before extracting. Extract when the duplicated logic
+has a single reason to change, not when it merely looks alike. Three similar lines beat a
+premature abstraction.
+
+Watch for N+1 queries, unbounded reads on tables that keep growing, and unbounded loops. When a
+query needs a ceiling, make it a guard well above the real volume and say so in a comment.

--- a/.claude/rules/coding-style.md
+++ b/.claude/rules/coding-style.md
@@ -1,16 +1,12 @@
 # Coding Style
 
-- Do not add docstrings, type annotations, or comments to code you did not change
-- Avoid over-engineering: no premature abstractions, no feature flags for one-time operations
-- Three similar lines of code is better than a premature abstraction
-- Boolean variables: use `is`, `has`, `can`, `should` prefixes
-- Functions: use verbs (`get`, `create`, `update`, `delete`, `validate`, `handle`)
-- Only validate at system boundaries (user input, external APIs); trust internal code
+Formatting is Prettier's and ESLint's job — do not fix by hand what tooling handles, and do not
+bikeshed it.
 
-## Formatting
-- Delegate to tooling (Prettier, ESLint) — don't manually fix formatting
-- Do not bikeshed on style that the formatter handles
+Booleans read as assertions: `is`, `has`, `can`, `should`. Functions are verbs. `UPPER_SNAKE_CASE`
+is for true compile-time constants, `camelCase` for anything merely assigned once at runtime.
 
-## Constants
-- Use `UPPER_SNAKE_CASE` for true constants (compile-time values, config keys)
-- Use regular `camelCase` for values that are just assigned once at runtime
+Validate at system boundaries — user input, external APIs — and trust internal code.
+
+Avoid premature abstraction and one-off feature flags. The bar for a new indirection is a second
+real caller, not an imagined one.

--- a/.claude/rules/communication.md
+++ b/.claude/rules/communication.md
@@ -1,9 +1,12 @@
 # Communication
 
-- When corrected: apply fix, update auto memory. Pattern: "Correction received -> Fix applied -> Memory updated"
-- Consult CLAUDE.md and specification documents before making assumptions
-- Don't explain verbosely what you're about to do; just do it
+**Langue** : code, commentaires, commits et noms de branche en **anglais** ; échanges avec
+Julien en **français**, sauf s'il écrit en anglais.
 
-## Language
-- Code, comments, commits, and branch names: **English**
-- Communication with the user: **French** (unless the user writes in English)
+Ne pas annoncer ce qu'on va faire — le faire. Ce qui mérite d'être dit, c'est ce qu'on a trouvé
+en chemin : une hypothèse de départ fausse, un défaut dans l'énoncé d'une issue, une vérification
+qu'on n'a pas pu mener. Dire explicitement ce qui n'a **pas** été vérifié vaut mieux qu'un compte
+rendu qui laisse croire à une couverture complète.
+
+Quand une correction est reçue : appliquer, puis consigner le pourquoi en mémoire si le piège
+peut se reproduire.

--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -1,29 +1,21 @@
 # Error Handling
 
-## General Principles
-- Fail fast: detect errors early and surface them immediately
-- Handle errors at the appropriate level — don't catch and ignore
-- Never swallow exceptions silently; at minimum, log them
-- Use specific error types/classes over generic ones when the distinction matters
+Usual principles hold: fail fast, let errors propagate through internal code, catch at system
+boundaries, never swallow an exception silently, never leak stack traces or internal paths to a
+client. Log with enough context to identify the operation and the resource, and never log
+secrets or personal data.
 
-## Error Boundaries
-- **System boundaries** (API endpoints, scrapers): catch, log, return structured error responses
-- **Internal code**: let errors propagate — don't wrap every call in try/catch
-- **Background jobs** (scrapers, cron): catch at the top level, log, and continue processing remaining items
+## "Missing" and "broken" are not the same thing
 
-## Logging
-- Log at the right level: `error` for failures, `warn` for recoverable issues, `info` for key events
-- Include context: what operation failed, which resource, relevant IDs
-- Never log sensitive data (passwords, tokens, personal information)
-- Use structured logging (JSON) for machine-parseable output
+`fetchAPI` in `src/frontend/src/lib/api.ts` draws this distinction on purpose. A 404 returns
+`null`; an outage throws `BackendUnavailableError`.
 
-## Retry Strategy
-- Only retry transient failures (network errors, 5xx, rate limits)
-- Use exponential backoff with jitter
-- Set a max retry count (typically 3) — don't retry forever
-- Log each retry attempt with the attempt number
+Collapsing the two is what made #345 expensive: an outage returned `null`, the page called
+`notFound()`, and `s-maxage=3600` then served that 404 for an hour on a resource that existed.
+Keep them apart, and keep the list helpers' `|| []` fallback meaning "nothing to show" — never
+"the backend is down".
 
-## User-Facing Errors
-- Show helpful, non-technical messages to the user
-- Never expose stack traces, internal paths, or database details to the client
-- Map internal errors to appropriate HTTP status codes (see `api-conventions` skill)
+## User-facing messages
+
+Say what happened and what to do about it, in French, without technical detail. A failure must
+not be silently dismissible: a save error that fades on its own reads as a success (#394).

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,143 +1,52 @@
 # Git Workflow
 
-## Commits
-- Conventional Commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`
-- Subject line under 72 characters
-- Stage specific files only — never `git add .` or `git add -A`
-- Run each git command in a separate Bash tool call (no `&&` chaining)
+Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`), sujet sous
+72 caractères. Le corps du message dit **pourquoi**, pas quoi — le diff dit déjà quoi.
 
-## Branch strategy
+Étager les fichiers un par un, jamais `git add .`. Une commande git par appel Bash : ni `&&`,
+ni `cd`, ni `git -C`.
 
-### Branches permanentes
+## Branches
 
-| Branche | Environnement | URL | Rôle |
-|---------|---------------|-----|------|
-| `main` | Production | `https://devfesttoulouse.fr` | Code en production, toujours stable et déployable. **Déploiement manuel** : un push sur `main` ne déploie **pas** tout seul — le Redeploy Coolify est lancé à la main. |
-| `dev` | Bêta | `https://beta.site.devfesttoulouse.fr` | Intégration des développements. Les features terminées y sont mergées pour être testées ensemble avant la mise en production. **Déploiement automatique** : tout push/merge sur `dev` déclenche le build + déploiement Coolify sans geste manuel (~5 min ; vérifier via `/api/health`). |
+| Branche | Environnement | Déploiement |
+|---|---|---|
+| `main` | Production — `devfesttoulouse.fr` | **Manuel** : un push ne déploie pas, le Redeploy Coolify est lancé à la main |
+| `dev` | Bêta — `beta.site.devfesttoulouse.fr` | **Automatique** sur push (~5 min ; vérifier `/api/health`) |
+| `dev-{initiale}` | Dev perso — `dev-j.site.devfesttoulouse.fr` ou local | Selon le développeur |
 
-### Branches de développeur
-
-Chaque développeur dispose d'une branche personnelle `dev-{initiale}` où `{initiale}` est la première lettre de son prénom (en minuscule). Si deux développeurs ont la même initiale, on ajoute des lettres pour désambiguïser (ex. `dev-ju`, `dev-je`).
-
-| Branche | Environnement | URL |
-|---------|---------------|-----|
-| `dev-j` | Dev perso (optionnel) | `https://dev-j.site.devfesttoulouse.fr` ou local |
-| `dev-m` | Dev perso (optionnel) | `https://dev-m.site.devfesttoulouse.fr` ou local |
-
-Les branches de développeur peuvent aussi être testées uniquement en local (Docker Compose).
-
-### Branches feature
-
-Pour chaque fonctionnalité ou correction, le développeur crée une branche depuis sa branche `dev-{initiale}` :
-
-- Format : `feature/us-xxx-description` ou `feature/description`
-- Nommage en anglais, en kebab-case
-
-### Flux de merge
+Une branche personnelle par développeur (`dev-j`, `dev-m`… ; on désambiguïse en `dev-ju`/`dev-je`
+si besoin). Les branches feature partent de la branche perso : `feature/us-xxx-description`, en
+anglais, en kebab-case, supprimées après merge.
 
 ```
-feature/us-xxx-description
-        ↓ PR (revue de code)
-    dev-{initiale}         ← test local ou sur dev-{initiale}.site.devfesttoulouse.fr
-        ↓ PR (revue de code)
-       dev                 ← test d'intégration sur beta.site.devfesttoulouse.fr
-        ↓ PR (revue de code + validation fonctionnelle)
-      main                 ← déploiement en production sur devfesttoulouse.fr
+feature/us-xxx  →  dev-{initiale}  →  dev  →  main
+                        (local)      (beta)   (prod)
 ```
 
-### Règles
+- `main` et `dev` sont **protégées** : merge par PR uniquement, jamais de push direct ni de
+  force-push. Sur sa branche perso, le développeur a les pleins droits.
+- **Squash** vers `dev` et `main` (un commit par feature) ; merge classique de feature vers la
+  branche perso.
+- Une PR `dev-j → dev` peut lever de **faux conflits add/add** après squash : c'est une branche
+  de promotion, et `-X ours` y duplique des blocs. Vérifier l'arbre plutôt que de faire
+  confiance à la résolution automatique.
 
-- **`main` est protégée** : merge uniquement par PR approuvée, jamais de push direct, jamais de force-push.
-- **`dev` est protégée** : merge uniquement par PR depuis une branche `dev-{initiale}`.
-- **Les branches `dev-{initiale}`** : le développeur y a les pleins droits (push direct autorisé). Les PRs depuis les branches feature sont recommandées mais pas obligatoires.
-- Les branches feature sont supprimées après merge.
-- Stratégie de merge : **squash merge** pour les PRs vers `dev` et `main` (un commit propre par feature). Merge classique autorisé de feature vers `dev-{initiale}`.
+## Pull requests
 
-## Issues, milestones et versions
+Titre sous 70 caractères. Un résumé en 1 à 3 points, et un plan de test qui dit ce qui a été
+vérifié **et ce qui ne l'a pas été**. Les points non évidents — une hypothèse fausse au départ,
+un défaut dans l'énoncé de l'issue, une réserve — valent plus que l'énumération des fichiers
+touchés.
 
-Trois outils, trois questions distinctes — ne pas les mélanger.
+`Refs #123` sur une PR feature (elle ne ferme rien), `Closes #123` seulement sur la PR de
+promotion vers `main`. Le détail est dans `.claude/rules/issue-lifecycle.md`.
 
-| Outil | Répond à | Se ferme quand |
-|-------|----------|----------------|
-| **Milestone « Lot N »** | Le périmètre initial est-il couvert ? | Toutes ses issues sont faites |
-| **Release `vX.Y.Z`** | Qu'est-ce qui est parti en prod, et quand ? | Le tag est poussé |
-| **Label** (`bug`, `enhancement`…) | De quoi s'agit-il ? | — (filtre, pas compteur) |
+## Opérations distantes
 
-### Fermeture des issues
-
-`main` est la branche par défaut : GitHub n'honore les mots-clés de fermeture
-(`Closes`, `Fixes`) que sur une PR mergée **dans `main`**. Une PR feature mergée
-dans `dev-{initiale}` ne ferme donc **rien**.
-
-- **PR feature → `dev-{initiale}`** : écrire `Refs #123` (lie sans fermer).
-- **PR de promotion `dev → main`** : écrire `Closes #123` pour **chaque** issue
-  embarquée. Les issues se ferment ainsi au moment exact de la mise en prod.
-
-Les PRs vers `dev` et `main` étant **squashées**, les SHA d'origine disparaissent :
-la PR de promotion est le **seul** endroit fiable pour porter les `Closes`. La skill
-`deploy-to-prod` collecte les `Refs #` du diff `main..dev` pour construire ce bloc.
-
-### Label `corrigé` — suivi entre le merge et la prod
-
-Une issue corrigée reste **ouverte** jusqu'à la mise en prod (cf. ci-dessus). Sans marqueur,
-elle apparaît comme « à faire » alors que le travail est fait. D'où le label `corrigé`.
-
-**Dès l'arrivée du correctif sur `dev-{initiale}`** (merge de la branche feature, ou commit
-direct), pour chaque issue traitée :
-
-1. Poser le label `corrigé` sur l'issue.
-2. **Commenter l'issue** en citant le ou les commits qui la corrigent (SHA court + sujet).
-   Le commentaire porte le *quand* et le *quoi* ; le label ne sert qu'à filtrer.
-
-```bash
-gh issue edit <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --add-label "corrigé"
-gh issue comment <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --body-file - <<'EOF'
-**Corrigé** — mergé sur `dev-j`, en attente de mise en production.
-
-- `<sha>` — `<sujet du commit>`
-
-L'issue sera fermée automatiquement lors de la promotion `dev → main` (release).
-EOF
-```
-
-> Le label dit que **le correctif est écrit et mergé sur la branche de dev** — pas qu'il est
-> déployé en beta ni en prod. C'est voulu : il décrit l'état de l'issue, qui ne change plus.
-> L'environnement, lui, se lit dans les branches (`main..dev`) et les releases.
-
-Filtres GitHub correspondants :
-
-| Recherche | Donne |
-|---|---|
-| `is:issue is:open -label:corrigé` | **Ce qu'il reste à corriger** |
-| `is:issue is:open label:corrigé` | Corrigé, en attente de mise en prod |
-
-Le label **n'est jamais retiré** : il décrit l'état de l'issue (`corrigé`), pas un
-environnement. À la release, l'issue se ferme via `Closes` et le label reste vrai.
-
-### Rattachement au milestone
-
-- Une issue va dans un milestone **seulement si elle appartient au périmètre du Lot** —
-  y compris un bug qui empêche de déclarer le Lot terminé.
-- Un **bug ou une amélioration découverts après la livraison du Lot** n'ont **pas**
-  de milestone : ils portent un label (`bug`, `enhancement`) et apparaissent dans les
-  notes de la release qui les embarque.
-- Test : « peut-on déclarer le Lot terminé en laissant cette issue ouverte ? »
-  Oui → pas de milestone. Non → milestone.
-- Ne **jamais** créer de milestone fourre-tout permanent (`Backlog`, `v1.x`,
-  `Maintenance`) : sans fin, la barre de progression ne veut rien dire. Utiliser un label.
-
-## Remote Operations
-- Remote git commands are allowed (`git push`, `git pull`, `git fetch`, `gh pr create`, etc.)
-- SSH is configured via PuTTY/Pageant — no special handling needed
-- Still confirm before force-push or destructive remote operations
+`push`, `pull`, `fetch`, `gh pr create` sont autorisés sans confirmation (SSH via
+PuTTY/Pageant). Demander avant tout force-push ou opération destructive.
 
 ## Worktrees
 
-- Use git worktrees for parallel work: spin up multiple worktrees, each running its own Claude session
-- Worktrees live in `.claude/worktrees/` (managed by Claude Code's `/worktree` command)
-- Useful patterns: one worktree per feature, a dedicated "analysis" worktree for read-only tasks (logs, queries)
-
-## Pull Requests
-- Title under 70 characters
-- Include a Summary section with 1-3 bullet points
-- Include a Test Plan section
+Pour du travail parallèle : un worktree par feature, chacun avec sa session. Ils vivent dans
+`.claude/worktrees/`.

--- a/.claude/rules/issue-lifecycle.md
+++ b/.claude/rules/issue-lifecycle.md
@@ -1,0 +1,78 @@
+# Cycle de vie d'une issue
+
+À lire quand on ferme, étiquette ou rattache une issue — pas avant. La mise en production
+elle-même est couverte par la skill `deploy-to-prod`, qui construit le bloc `Closes` de la PR de
+promotion.
+
+## Issues, milestones et versions
+
+Trois outils, trois questions distinctes — ne pas les mélanger.
+
+| Outil | Répond à | Se ferme quand |
+|-------|----------|----------------|
+| **Milestone « Lot N »** | Le périmètre initial est-il couvert ? | Toutes ses issues sont faites |
+| **Release `vX.Y.Z`** | Qu'est-ce qui est parti en prod, et quand ? | Le tag est poussé |
+| **Label** (`bug`, `enhancement`…) | De quoi s'agit-il ? | — (filtre, pas compteur) |
+
+### Fermeture des issues
+
+`main` est la branche par défaut : GitHub n'honore les mots-clés de fermeture
+(`Closes`, `Fixes`) que sur une PR mergée **dans `main`**. Une PR feature mergée
+dans `dev-{initiale}` ne ferme donc **rien**.
+
+- **PR feature → `dev-{initiale}`** : écrire `Refs #123` (lie sans fermer).
+- **PR de promotion `dev → main`** : écrire `Closes #123` pour **chaque** issue
+  embarquée. Les issues se ferment ainsi au moment exact de la mise en prod.
+
+Les PRs vers `dev` et `main` étant **squashées**, les SHA d'origine disparaissent :
+la PR de promotion est le **seul** endroit fiable pour porter les `Closes`. La skill
+`deploy-to-prod` collecte les `Refs #` du diff `main..dev` pour construire ce bloc.
+
+### Label `corrigé` — suivi entre le merge et la prod
+
+Une issue corrigée reste **ouverte** jusqu'à la mise en prod (cf. ci-dessus). Sans marqueur,
+elle apparaît comme « à faire » alors que le travail est fait. D'où le label `corrigé`.
+
+**Dès l'arrivée du correctif sur `dev-{initiale}`** (merge de la branche feature, ou commit
+direct), pour chaque issue traitée :
+
+1. Poser le label `corrigé` sur l'issue.
+2. **Commenter l'issue** en citant le ou les commits qui la corrigent (SHA court + sujet).
+   Le commentaire porte le *quand* et le *quoi* ; le label ne sert qu'à filtrer.
+
+```bash
+gh issue edit <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --add-label "corrigé"
+gh issue comment <NN> --repo GDGToulouse/Site-Devfest-Toulouse-2026 --body-file - <<'EOF'
+**Corrigé** — mergé sur `dev-j`, en attente de mise en production.
+
+- `<sha>` — `<sujet du commit>`
+
+L'issue sera fermée automatiquement lors de la promotion `dev → main` (release).
+EOF
+```
+
+> Le label dit que **le correctif est écrit et mergé sur la branche de dev** — pas qu'il est
+> déployé en beta ni en prod. C'est voulu : il décrit l'état de l'issue, qui ne change plus.
+> L'environnement, lui, se lit dans les branches (`main..dev`) et les releases.
+
+Filtres GitHub correspondants :
+
+| Recherche | Donne |
+|---|---|
+| `is:issue is:open -label:corrigé` | **Ce qu'il reste à corriger** |
+| `is:issue is:open label:corrigé` | Corrigé, en attente de mise en prod |
+
+Le label **n'est jamais retiré** : il décrit l'état de l'issue (`corrigé`), pas un
+environnement. À la release, l'issue se ferme via `Closes` et le label reste vrai.
+
+### Rattachement au milestone
+
+- Une issue va dans un milestone **seulement si elle appartient au périmètre du Lot** —
+  y compris un bug qui empêche de déclarer le Lot terminé.
+- Un **bug ou une amélioration découverts après la livraison du Lot** n'ont **pas**
+  de milestone : ils portent un label (`bug`, `enhancement`) et apparaissent dans les
+  notes de la release qui les embarque.
+- Test : « peut-on déclarer le Lot terminé en laissant cette issue ouverte ? »
+  Oui → pas de milestone. Non → milestone.
+- Ne **jamais** créer de milestone fourre-tout permanent (`Backlog`, `v1.x`,
+  `Maintenance`) : sans fin, la barre de progression ne veut rien dire. Utiliser un label.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,38 +1,16 @@
 # Security
 
-## Secrets Management
-- Never hardcode secrets (API keys, passwords, tokens) in source code
-- Use environment variables via `.env` files (excluded from git via `.gitignore`)
-- Never log secrets — mask or omit them from error messages and stack traces
-- Never commit `.env` files; provide a `.env.example` with placeholder values
+Standard practice applies (validate at boundaries, parameterize queries, escape output, never
+log or commit secrets, verify permissions server-side on every request). What follows is what is
+specific to *this* codebase — the parts that have already gone wrong, or would.
 
-## Input Validation
-- Validate and sanitize all user input at system boundaries (API endpoints, form handlers)
-- Validate type, length, format, and allowed ranges
-- Reject unexpected fields — use allowlists, not blocklists
-- Parameterize all database queries — never interpolate user input into SQL
+## Secrets
 
-## Common Vulnerabilities (OWASP)
-- **Injection**: use parameterized queries and prepared statements
-- **XSS**: escape output rendered in HTML; use framework auto-escaping
-- **CSRF**: use anti-CSRF tokens on state-changing requests
-- **Sensitive data exposure**: never return passwords, tokens, or internal IDs in API responses unless required
+Secrets come from the environment, injected by Docker Compose. `.env` is gitignored;
+`.env.example` carries placeholders. Never echo a secret into a log line, an error message, or a
+test fixture.
 
-## Dependencies
-- Prefer well-maintained packages with active security advisories
-- Review dependency additions — avoid pulling in large transitive trees for small features
-
-## Security Headers
-- Set `Content-Security-Policy` to restrict script/style sources
-- Enable `Strict-Transport-Security` (HSTS) with a long max-age
-- Set `X-Frame-Options: DENY` (or use CSP `frame-ancestors`)
-- Set `X-Content-Type-Options: nosniff`
-
-## Authentication & Authorization
-- Verify permissions on every request — never rely solely on client-side checks
-- Use constant-time comparison for tokens and secrets
-
-### Opening account creation to a new kind of user
+## Opening account creation to a new kind of user
 
 `User.role` is `UserRole @default(EDITOR)`, and `requireAnyAuthenticated` lets
 `EDITOR` through. Any account created without an explicit role therefore gets
@@ -50,7 +28,18 @@ So, before opening sign-up to a new kind of user (sponsor #362, speaker #363):
 - Reject the account at `user.create.before` rather than after the fact, so a
   failed attempt leaves no orphan row behind.
 
-## Dependency Updates
-- Run `npm audit` / `yarn audit` regularly
-- Update dependencies with known vulnerabilities promptly
-- Pin major versions to avoid unexpected breaking changes
+## better-auth drops fields it does not know about
+
+Setting `role` in a `databaseHooks.user.create.before` hook is not enough: better-auth strips
+any field absent from its own user model, so the value never reaches the database and the column
+default (`EDITOR`) wins. The field must also be declared in `user.additionalFields` with
+`input: false`.
+
+This failed silently — 617 green tests, and the account still landed with back-office access.
+It was only visible in the browser. A test that asserts the hook was called proves nothing here;
+assert the **stored** role.
+
+## Dependencies
+
+`pnpm audit` (not npm — both lockfiles exist, only `pnpm-lock.yaml` is tracked). Prefer
+well-maintained packages, and weigh a large transitive tree against the feature it buys.

--- a/.claude/rules/task-management.md
+++ b/.claude/rules/task-management.md
@@ -1,24 +1,12 @@
 # Task Management
 
-- Only one task should be in_progress at a time
-- Compact context proactively when working on long tasks (before hitting limits)
+Start non-trivial work in plan mode, and go back to it when an approach turns out to be wrong —
+pushing a broken plan further is the expensive failure mode. Plan the verification too, not only
+the building.
 
-## Compaction
+Offload independent research and codebase-wide search to subagents (`Explore` for search) so the
+main context stays on the task. Subagents report conclusions, not file dumps — take their
+findings as input to check, not as verified fact.
 
-When compacting, always preserve:
-- List of modified files and their purpose
-- Architectural decisions made during the session
-- Current task progress and remaining steps
-
-## Plan Mode
-
-- Start every complex task in plan mode — pour energy into the plan so implementation can be done in one shot
-- When something goes sideways, switch back to plan mode and re-plan — don't keep pushing a broken approach
-- Use plan mode for verification steps too, not just for building
-
-## Subagents
-
-- Use subagents to keep the main context window clean and focused
-- Offload independent research, exploration, or analysis tasks to subagents
-- For complex requests, append "use subagents" to throw more compute at the problem
-- Prefer the `Explore` subagent for codebase search over multiple manual Glob/Grep calls
+When context is compacted, what must survive is: which files changed and why, the architectural
+decisions taken during the session, and what remains to do.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -14,50 +14,50 @@
 - One assertion per concept (multiple asserts are fine if they test the same behavior)
 - No logic in tests (no if/else, no loops) — tests should be linear
 
-## Development workflow — Test Driven Development
+## Development workflow
 
-Every feature or fix follows this strict cycle. Do not skip steps.
+Code and tests ship together, and nothing is pushed that has not been seen working. The order
+below is what that implies; it is not a ritual to perform for its own sake.
 
-### Step 1 — Write code + unit/integration tests
-1. Write the implementation code.
-2. Write the associated automated tests (unit and/or integration).
-3. **Commit** the code and tests together (`feat:` or `fix:`).
+### 1 — Write the code and its tests, commit them together
 
-### Step 2 — Run automated tests
-4. Run the full test suite (`npm test` or equivalent).
-5. If tests fail: fix the code or tests, then **commit** the fix (`fix: correct ...`).
-6. Repeat until all tests pass.
+A test that passes without the fix proves nothing. When fixing a bug, make the test fail first
+(revert the fix, watch it go red) — that is the only way to know it is testing the right thing.
 
-### Step 3 — Functional testing via browser
-7. Start the local Docker environment (`docker compose up`) if not running.
-8. Use the **Chrome DevTools MCP** to navigate to the relevant page(s) on the local Docker instance.
-9. Verify the feature visually and interactively:
-   - Does the page render correctly?
-   - Do interactions work (clicks, forms, navigation)?
-   - Are there console errors?
-   - Is the layout correct on the target viewport?
-10. If issues are found: fix, **commit**, and re-test (go back to step 7).
+### 2 — Run the suites
 
-### Step 4 — Push
-11. All automated tests pass, functional verification is clean.
-12. **Push** to the remote branch.
+```bash
+# frontend
+cd src/frontend && pnpm exec vitest run
 
-### Summary
-
-```
-Write code + tests
-      ↓
-   Commit
-      ↓
-Run automated tests ──fail──→ Fix → Commit → (re-run)
-      ↓ pass
-Functional test (Chrome DevTools MCP) ──fail──→ Fix → Commit → (re-test)
-      ↓ pass
-    Push
+# backend — DATABASE_URL must point at localhost, or ~44 tests fail with 500s
+cd src/backend && DATABASE_URL="postgresql://devfest:devfest@localhost:5432/devfest?schema=public" pnpm exec vitest run
 ```
 
-### Rules
-- Never push code that has failing tests.
-- Never push code that has not been functionally verified in the browser.
-- Each fix is its own commit — do not amend the original commit.
-- If a fix changes the implementation significantly, update the tests accordingly.
+Integration tests share one database and run in parallel: an isolated failure that does not
+reproduce is usually a fixture collision, not a regression. Re-run before chasing it, and say so
+rather than passing it off as green.
+
+### 3 — Verify in the browser
+
+```bash
+docker compose -f docker-compose.local.yml up -d
+```
+
+Drive the real page through the **Chrome DevTools MCP**: does it render, do the interactions
+work, is the console clean, does the layout hold at the target viewport? Tests pass on code that
+is wired to nothing — several bugs on this project (a silent security fallback, a 404 in the
+sitemap) were invisible to the suites and obvious in the browser.
+
+If the environment misbehaves rather than the code, say which and why. Every route 404ing means
+a stale `.next` volume, not a broken feature.
+
+### 4 — Push
+
+Only once the suites pass and the feature has been seen working. State what was verified and
+what was not — an unobserved behaviour is not a verified one.
+
+### Non-negotiable
+
+- Never push failing tests, and never push what has not been seen working in the browser.
+- Each fix is its own commit — do not amend the original.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,148 +1,115 @@
 # CLAUDE.md
 
-## Project Overview
-
-DevFest Toulouse 2026 website — a new site built to replace the WordPress (Avada) site used for 2023-2025 editions. The goal is a durable, maintainable site that can be managed across editions.
+DevFest Toulouse 2026 — site remplaçant le WordPress (Avada) des éditions 2023-2025.
+Objectif : un site durable, maintenable d'une édition à l'autre.
 
 ## Architecture
 
-The project is split into two independent applications:
+Deux applications indépendantes, **sous `src/`** :
 
-- **`frontend/`** — Next.js (App Router, Server Components) — SSR pages, UI, static assets
-- **`backend/`** — API REST — business logic, database access, email, third-party integrations
+- **`src/frontend/`** — Next.js 16 (App Router, Server Components), Tailwind v4, next-intl, pnpm
+- **`src/backend/`** — API REST Fastify, Prisma 7, PostgreSQL
 
-The frontend calls the backend via HTTP (`http://backend:4000` in Docker, configurable via `BACKEND_URL`). The backend exposes a public REST API that can be consumed by the frontend, mobile apps, or any other client. Prisma and the database are owned by the backend; the frontend never accesses the database directly.
+Le frontend appelle le backend en HTTP (`http://backend:4000` en Docker, via `BACKEND_URL`).
+**Le backend seul possède Prisma et la base** ; le frontend n'accède jamais à la base directement.
 
-### Tech Stack
+Auth : better-auth (admin uniquement). Hébergement : VPS + Coolify. CI : GitHub Actions.
 
-| Layer | Technology |
-|-------|------------|
-| Frontend | Next.js 16 (App Router), Tailwind CSS v4, next-intl, pnpm |
-| Backend | Node.js (Fastify), Prisma, PostgreSQL |
-| Auth | better-auth (email/password + Google + GitHub OAuth) — admin only |
-| Email | SMTP (Postfix or equivalent, MailHog in dev) |
-| Hosting | VPS + Coolify, Docker Compose |
-| CI/CD | GitHub Actions (lint, typecheck, tests) |
+## Pièges de ce dépôt
 
-## Project Structure
+Ce que le code ne dit pas, ou dit de façon trompeuse.
 
-```
-frontend/                      # Next.js application
-├── src/
-│   ├── app/[locale]/          # Pages with i18n routing (/fr/..., /en/...)
-│   ├── components/            # Shared React components
-│   ├── lib/                   # Utilities (auth, api client)
-│   └── i18n/                  # next-intl configuration
-├── messages/                  # Translation files (fr.json, en.json)
-├── public/                    # Static assets (favicon, fonts, images)
-├── next.config.ts
-├── tailwind.config.ts         # (or @theme in globals.css for Tailwind v4)
-├── package.json
-└── Dockerfile
+**Routes.** `src/frontend/src/app/admin/` est **hors** de `[locale]/` : le back-office est sur
+`/admin`, **pas** `/fr/admin` (qui renvoie 404). next-intl préfixe les routes racine même sans
+middleware — toute route technique doit vivre sous `/api/`.
 
-backend/                       # REST API
-├── src/
-│   ├── routes/                # API route handlers
-│   ├── services/              # Business logic
-│   ├── lib/                   # Utilities (prisma, email, auth)
-│   ├── generated/prisma/      # Generated Prisma client (gitignored, Prisma 7)
-│   └── index.ts               # Server entry point
-├── prisma/                    # Database schema, migrations, seeds
-│   ├── schema.prisma
-│   ├── migrations/
-│   ├── seed.ts                # Base seed (idempotent, runs on boot)
-│   ├── seed-dev.ts            # Dev-only test accounts + sample data
-│   ├── devfest-history.json   # Past editions 2016-2025 (327 speakers, 279 sessions)
-│   └── import-history.ts      # Imports the above (run manually, idempotent)
-├── prisma.config.ts           # Prisma 7 config (schema, migrations, datasource URL)
-├── package.json
-└── Dockerfile
+**Docker.** Pas de `docker-compose.yml` : trois fichiers distincts, dont
+`docker-compose.local.yml` pour le dev local. Toujours passer `-f`.
 
-docs/                          # Specification documents (in French)
-├── fonctionnalites-2026.md    # Feature list for the 2026 site
-├── objectifs-techniques.md    # Technical objectives (SEO, perf, a11y, rendering)
-├── historique-sites.md        # Analysis of past DevFest Toulouse sites (2016-2025)
-├── modele-donnees-historique.md  # Data model for devfest-history.json
-├── modele-donnees-metier.md   # Business data model (entities, relationships)
-├── maquettes-figma.md         # Figma mockups inventory and structure
-├── design-system.md           # Design system, tokens, UI kit, brand guidelines
-├── variables-environnement.md # Environment variables reference (Docker Compose)
-├── maquettes/                 # SVG exports of all Figma mockups
-└── assets/                    # Logo files, sketch illustrations (3 colors)
+**Le `.next` du frontend local est un volume nommé.** Après une reconstruction de la base ou un
+changement de routes, un `restart` ne suffit pas : purger le volume, sinon *toutes* les routes
+dynamiques renvoient 404. Test discriminant : si une route **sans rapport** tombe aussi en 404,
+c'est l'environnement, pas le code.
 
-docker-compose.yml             # Dev environment: frontend + backend + db + mailhog
-.env.example                   # Environment variables template
-.claude/rules/                 # Detailed coding & workflow rules
-```
+**Le backend en Docker ne recharge pas à chaud** (`tsx watch` ne voit pas les écritures de
+l'hôte) : redémarrer le conteneur après une modification.
 
-## Dev Test Accounts
+**Tests backend depuis l'hôte** : préfixer `DATABASE_URL` sur `localhost:5432`, sinon ~44 faux
+échecs en 500.
 
-Local dev accounts provisioned by `src/backend/prisma/seed-dev.ts` (run manually) — use for browser testing:
+**Prisma 7** : `migrate dev` est interactif et inutilisable ici — écrire les migrations à la main.
 
-| Role | Email | Password |
-|------|-------|----------|
+**Sponsors et speakers sont des entités partagées entre éditions** (#129, #351) : le slug
+identifie une *entreprise* ou une *personne*, pas une participation. Ce qu'une édition a affiché
+(logo, libellé de niveau) est **figé** sur la participation (#375) — un écran qui édite « le
+logo » doit dire de quelle année il parle.
+
+**`User.role` vaut `EDITOR` par défaut, et `EDITOR` ouvre le back-office.** Tout compte tiers
+(sponsor, speaker) doit porter un rôle neutre explicite à la création. Détail dans
+`.claude/rules/security.md`.
+
+## Comptes de dev local
+
+Provisionnés par `src/backend/prisma/seed-dev.ts` (lancé à la main) — connexion sur `/admin` :
+
+| Rôle | Email | Mot de passe |
+|------|-------|--------------|
 | ADMIN | `admin@devfesttoulouse.fr` | `admin1234!dev` |
 | EDITOR | `editor@devfesttoulouse.fr` | `editor1234!dev` |
 
-Login at http://localhost:3000/fr/admin — Details in `docs/comptes-dev-local.md`.
+Après un reseed, `seed.ts` l'emporte sur `seed-dev.ts` et le mot de passe admin ne marche plus :
+recréer le compte via l'API auth. Détails dans `docs/comptes-dev-local.md`.
 
-## Specification Documents
+## Documentation
 
-Always consult these documents before making assumptions about features or architecture:
+Consulter avant de faire des hypothèses sur le métier ou l'architecture. `docs/` (en français) :
 
-- **`docs/fonctionnalites-2026.md`** — Complete feature list (pages, components, user roles)
-- **`docs/objectifs-techniques.md`** — Technical objectives: SSR + cache strategy, Lighthouse targets (≥90), Core Web Vitals, SEO, accessibility (WCAG 2.1 AA), i18n readiness, security headers
-- **`docs/historique-sites.md`** — Evolution of past sites (stacks, features per year)
-- **`docs/modele-donnees-historique.md`** — Schema for `src/backend/prisma/devfest-history.json` (327 speakers, 279 sessions across 7 editions)
-- **`docs/modele-donnees-metier.md`** — Business data model: all domain entities, attributes, relationships and bilingual strategy
-- **`docs/maquettes-figma.md`** — Figma mockups: pages designed, shared components, structure ([Figma file](https://www.figma.com/design/5dw9ggMfrdFrB9qEKYvHH6/DevFestToulouse-2025?node-id=22-499))
-- **`docs/design-system.md`** — Design system: brand guidelines, color palette (Google Sans), design tokens, UI kit (Font Awesome icons), content style guide
-- **`docs/variables-environnement.md`** — All environment variables: database, SMTP, OAuth, API keys, secrets — injected via Docker Compose
-- **`docs/comptes-dev-local.md`** — Dev test accounts (ADMIN + EDITOR), login instructions, MailHog setup
+| Fichier | Contenu |
+|---|---|
+| `fonctionnalites-2026.md` | Périmètre fonctionnel (pages, composants, rôles) |
+| `objectifs-techniques.md` | SSR + cache, Lighthouse ≥90, Core Web Vitals, SEO, WCAG 2.1 AA, i18n |
+| `modele-donnees-metier.md` | Entités, relations, stratégie bilingue |
+| `modele-donnees-historique.md` | Schéma de `devfest-history.json` (327 speakers, 279 sessions) |
+| `historique-sites.md` | Évolution des sites passés (2016-2025) |
+| `design-system.md` | Charte, palette, tokens, kit UI |
+| `maquettes-figma.md` | Inventaire des maquettes ([Figma](https://www.figma.com/design/5dw9ggMfrdFrB9qEKYvHH6/DevFestToulouse-2025?node-id=22-499)) |
+| `api-publique.md` | API REST publique (OpenAPI/Swagger) |
+| `variables-environnement.md` | Variables d'environnement |
+| `comptes-dev-local.md` | Comptes de test, MailHog |
+| `priorisation-developpement.md` | Lots de développement, rétroplanning 2026 |
+| `mise-en-production.md` | Procédure de déploiement en production |
+| `deployer-nouvel-environnement.md` | Ajouter un environnement (`dev-x`, beta, prod) |
+| `coolify-pieges-multi-environnements.md` | Pièges Coolify récurrents |
+| `traduction-ia.md` | Traduction assistée pour les éditeurs |
 
-## Key Technical Decisions (from specs)
+## Décisions structurantes
 
-- **Architecture**: frontend (Next.js) + backend (REST API) separated, communicating via HTTP
-- **Rendering**: SSR + HTTP cache for all public pages; hybrid SSR+SPA for authenticated pages
-- **Cache**: `Cache-Control: s-maxage=3600, stale-while-revalidate=60`; on-demand invalidation via admin
-- **Homepage**: conditional content based on annual status (preparation / announcement / see-you-next-year)
-- **User roles**: admin, sponsor, speaker — sponsors and speakers can edit their own profiles via magic links
-- **SEO**: Schema.org (Event, Organization, Person, Article), Open Graph, Twitter Cards, dynamic OG images
-- **Performance**: Lighthouse ≥90 all categories, LCP <2.5s, INP <200ms, CLS <0.1
-- **Accessibility**: WCAG 2.1 AA, keyboard nav, skip-to-content, axe-core in CI
-- **i18n**: natively bilingual (FR default + EN), localized URLs (`/fr/...`, `/en/...`)
-- **Database**: PostgreSQL, accessed only by the backend via Prisma ORM
-- **API**: REST, publicly accessible, backend owns all business logic and data
+- **Rendu** : SSR + cache HTTP sur les pages publiques (`s-maxage=3600, stale-while-revalidate=60`),
+  invalidation à la demande depuis l'admin ; SSR+SPA hybride sur les pages authentifiées.
+- **Accueil** : contenu conditionné par le statut de l'édition (préparation / annonce / à l'année prochaine).
+- **Rôles** : admin, sponsor, speaker — sponsors et speakers éditent leur fiche via magic link.
+- **SEO** : Schema.org (Event, Organization, Person, Article), Open Graph, images OG dynamiques.
+- **i18n** : bilingue FR (défaut) + EN, URLs localisées.
 
-## Critical Rules
+## Règles impératives
 
-### Always
-- Read code before modifying it
-- Consult specification documents in `docs/` before making assumptions
-- Stage specific files only — never `git add .` or `git add -A`
-- Use Context7 MCP to fetch up-to-date library docs before using fast-moving dependencies
-- Run each git command in its own separate Bash call — never chain with `cd` or `&&`
+- Étager les fichiers un par un — jamais `git add .` ni `git add -A`
+- Une commande git par appel Bash — jamais de `&&`, jamais `cd`, jamais `git -C`
+- Jamais de force-push sur `main`, jamais de `--no-verify`
+- Utiliser Context7 MCP pour la doc des bibliothèques avant de les employer
 
-### Never
-- Never force-push to `main`
-- Never skip git hooks (`--no-verify`)
-- Never chain multiple git commands in a single Bash call
-- Never use `git -C` — always run git from the repo root
+## Règles détaillées
 
-## MCP — Context7
+À lire quand le sujet se présente — ne pas charger d'avance :
 
-Use the **Context7 MCP server** to fetch up-to-date documentation for libraries before using them.
-Always prefer Context7 docs over training data when working with fast-moving dependencies.
-
-## Project Rules
-
-Detailed rules are in `.claude/rules/`:
-
-- **code-quality.md** — Imports, size guidelines, duplication, performance
-- **coding-style.md** — Naming conventions, formatting, constants
-- **communication.md** — Correction workflow, language conventions
-- **error-handling.md** — Error boundaries, logging, retry strategy, user-facing errors
-- **git-workflow.md** — Conventional Commits, branch naming, PRs, worktrees
-- **security.md** — Secrets, input validation, OWASP, auth, headers, dependencies
-- **task-management.md** — Plan mode, subagents, compaction, context management
-- **testing.md** — Test strategy, naming conventions, test structure
+| Fichier | Quand |
+|---|---|
+| `.claude/rules/git-workflow.md` | Commits, branches, PR, worktrees |
+| `.claude/rules/issue-lifecycle.md` | Fermer, étiqueter (`corrigé`) ou rattacher une issue |
+| `.claude/rules/testing.md` | Écrire ou lancer des tests, vérifier avant de pousser |
+| `.claude/rules/security.md` | Auth, secrets, validation d'entrées, headers, ouverture des comptes |
+| `.claude/rules/error-handling.md` | Gestion et remontée des erreurs |
+| `.claude/rules/code-quality.md` | Imports, taille, duplication, performance |
+| `.claude/rules/coding-style.md` | Nommage, constantes, formatage |
+| `.claude/rules/task-management.md` | Mode plan, sous-agents, compaction |
+| `.claude/rules/communication.md` | Langue, workflow de correction |


### PR DESCRIPTION
## Résumé

- **8 instructions fausses corrigées** dans `CLAUDE.md` et `.claude/rules/` — c'est le vrai sujet : une instruction fausse est suivie.
- **Contexte permanent : ~6 435 → ~1 502 tokens (−77 %)**, sans rien perdre — le savoir déplacé en chargement à la demande.
- Cycle de vie des issues extrait dans `.claude/rules/issue-lifecycle.md`.

Suite de la lecture de [*The new rules of context engineering for Claude 5 generation models*](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models).

## Les erreurs, d'abord

| Fichier | Affirmation | Réalité |
|---|---|---|
| `CLAUDE.md` | `frontend/` et `backend/` à la racine | Sous `src/` |
| `CLAUDE.md` | `docker-compose.yml` à la racine | N'existe pas : trois fichiers, le local exige `-f` |
| `CLAUDE.md` | `backend/src/services/` | Dossier jamais créé |
| `CLAUDE.md` | Login sur `/fr/admin` | **404** — `admin/` est hors de `[locale]/` |
| `rules/testing.md` | `npm test` | Projet en **pnpm** |
| `rules/testing.md` | `docker compose up` | Sans `-f docker-compose.local.yml`, ne démarre rien |
| `rules/security.md` | `npm audit` / `yarn audit` | pnpm |
| `rules/error-handling.md` | « see `api-conventions` skill » | Cette skill n'existe pas |

La ligne `/fr/admin` a provoqué un mauvais diagnostic cette semaine : 404 attribué à un manifeste Turbopack gelé alors que l'URL était fausse.

## L'allègement ensuite

L'arbre ASCII de `Project Structure` pesait ~700 tokens pour décrire ce qu'un `ls` donne — et c'était justement la partie fausse. Remplacé par une section « Pièges de ce dépôt » : ce que le code ne dit pas, ou dit de façon trompeuse.

Les règles détaillées sont indexées avec un « quand les lire » au lieu d'être chargées d'avance. `git add .` était interdit dans 3 fichiers, le mode plan dans 3, « read code before modifying » dans 2.

**Le savoir projet a été conservé et enrichi** — better-auth qui supprime les champs inconnus (617 tests verts, faille quand même), le contrat `null` vs `throw` de `fetchAPI`, le volume `.next` gelé et son test discriminant, les valeurs figées par édition.

## Deux écarts assumés avec l'article

- **`rules/testing.md`** reste prescriptif. C'est ce workflow qui a attrapé la faille #362 et le 404 sur `/lieu` — invisibles aux tests automatisés. Seules les commandes fausses ont été corrigées.
- **`rules/git-workflow.md`** garde la stratégie de branches en détail : non déductible du code, et une erreur y coûte cher (branches protégées, faux conflits de squash).

## Plan de test

Pas de code applicatif touché — aucun test à lancer. La vérification porte sur la justesse :

- Chaque `docs/*.md` et chaque `.claude/rules/*.md` cité **existe** (vérifié par script).
- Les affirmations structurelles (`src/`, compose, position de `admin/`) sont contrôlées contre le dépôt.
- Les affirmations techniques ajoutées sont vérifiées contre le code : `BackendUnavailableError`, `additionalFields`, `accessRole`, `requireAnyAuthenticated`.
- `/doctor` lancé après coup : rien de plus à corriger côté dépôt.

**Réserve** : les 5 fichiers `.claude/agents/` et les 3 skills n'ont **pas** été audités. Ils peuvent porter les mêmes défauts — noté dans le reste-à-faire de #399.

Refs #399
