### PR TITLE
feat(sponsors): plaquette servie dans la langue du demandeur

### DIFF
--- a/src/backend/prisma/migrations/20260806120000_sponsor_brochure_en/migration.sql
+++ b/src/backend/prisma/migrations/20260806120000_sponsor_brochure_en/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Edition" ADD COLUMN     "sponsorBrochureUrlEn" TEXT;

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -102,8 +102,12 @@ model Edition {
   aftermovieUrl           String?
   galleryUrl              String?
   archivedSiteUrl         String?
-  // URL of the sponsor brochure PDF (stored under /uploads/, picked from /admin/files)
+  // URL of the sponsor brochure PDF (stored under /uploads/, picked from /admin/files).
+  // The unsuffixed field is the French one — it predates the English variant (#401)
+  // and renaming it would rewrite existing rows for no gain. When the English
+  // brochure is missing, English requesters fall back to the French one.
   sponsorBrochureUrl      String?
+  sponsorBrochureUrlEn    String?
   // Optional hero image specific to the /devenir-sponsor page. When null,
   // the page falls back to heroImageUrl.
   sponsorHeroImageUrl     String?

--- a/src/backend/src/__tests__/public-brochure.test.ts
+++ b/src/backend/src/__tests__/public-brochure.test.ts
@@ -19,24 +19,39 @@ async function buildApp() {
 
 let editionId: number;
 let previousUrl: string | null;
+let previousUrlEn: string | null;
 let messageId: number;
+let englishMessageId: number;
 const BROCHURE_URL = "https://example.org/brochure-test.pdf";
+const BROCHURE_URL_EN = "https://example.org/brochure-test-en.pdf";
 
 beforeAll(async () => {
   const edition = await getSeededEdition();
   editionId = edition.id;
   previousUrl = edition.sponsorBrochureUrl;
-  await prisma.edition.update({ where: { id: editionId }, data: { sponsorBrochureUrl: BROCHURE_URL } });
+  previousUrlEn = edition.sponsorBrochureUrlEn;
+  await prisma.edition.update({
+    where: { id: editionId },
+    data: { sponsorBrochureUrl: BROCHURE_URL, sponsorBrochureUrlEn: BROCHURE_URL_EN },
+  });
 
   const msg = await prisma.contactMessage.create({
     data: { firstName: "Bro", lastName: "Chure", email: "bro@example.org", message: "brochure please" },
   });
   messageId = msg.id;
+
+  const englishMsg = await prisma.contactMessage.create({
+    data: { firstName: "Eng", lastName: "Lish", email: "eng@example.org", message: "brochure please", locale: "en" },
+  });
+  englishMessageId = englishMsg.id;
 });
 
 afterAll(async () => {
-  await prisma.contactMessage.deleteMany({ where: { id: messageId } });
-  await prisma.edition.update({ where: { id: editionId }, data: { sponsorBrochureUrl: previousUrl } });
+  await prisma.contactMessage.deleteMany({ where: { id: { in: [messageId, englishMessageId] } } });
+  await prisma.edition.update({
+    where: { id: editionId },
+    data: { sponsorBrochureUrl: previousUrl, sponsorBrochureUrlEn: previousUrlEn },
+  });
 });
 
 describe("Public brochure redirector (#308)", () => {
@@ -77,5 +92,68 @@ describe("Public brochure redirector (#308)", () => {
 
     expect(res.statusCode).toBe(302);
     expect(res.headers.location).toBe(BROCHURE_URL);
+  });
+});
+
+// #401 — the token carries only the message id, so the language comes from the
+// locale stored when the form was submitted. Before the fix every requester got
+// the French file.
+describe("Brochure language (#401)", () => {
+  it("302s to the English brochure for a request made in English", async () => {
+    const token = makeToken(englishMessageId)!;
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/brochure/${token}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe(BROCHURE_URL_EN);
+  });
+
+  it("falls back to the French brochure when no English one is configured", async () => {
+    await prisma.edition.update({ where: { id: editionId }, data: { sponsorBrochureUrlEn: null } });
+    const token = makeToken(englishMessageId)!;
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/brochure/${token}` });
+    await app.close();
+
+    await prisma.edition.update({ where: { id: editionId }, data: { sponsorBrochureUrlEn: BROCHURE_URL_EN } });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe(BROCHURE_URL);
+  });
+
+  it("serves the English brochure to a French requester when only the English one exists", async () => {
+    await prisma.edition.update({ where: { id: editionId }, data: { sponsorBrochureUrl: null } });
+    const token = makeToken(messageId)!;
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/brochure/${token}` });
+    await app.close();
+
+    await prisma.edition.update({ where: { id: editionId }, data: { sponsorBrochureUrl: BROCHURE_URL } });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe(BROCHURE_URL_EN);
+  });
+
+  it("404s when neither brochure is configured", async () => {
+    await prisma.edition.update({
+      where: { id: editionId },
+      data: { sponsorBrochureUrl: null, sponsorBrochureUrlEn: null },
+    });
+    const token = makeToken(messageId)!;
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/brochure/${token}` });
+    await app.close();
+
+    await prisma.edition.update({
+      where: { id: editionId },
+      data: { sponsorBrochureUrl: BROCHURE_URL, sponsorBrochureUrlEn: BROCHURE_URL_EN },
+    });
+
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/src/backend/src/lib/trash-registry.ts
+++ b/src/backend/src/lib/trash-registry.ts
@@ -119,7 +119,7 @@ export const TRASH_ENTITIES: readonly TrashEntity[] = [
     labelField: "year",
     // `year` is unique but numeric — same limitation as ticket sortOrder.
     parkedFields: [],
-    fileFields: ["heroImageUrl", "sponsorHeroImageUrl", "sponsorBrochureUrl"],
+    fileFields: ["heroImageUrl", "sponsorHeroImageUrl", "sponsorBrochureUrl", "sponsorBrochureUrlEn"],
     adminOnly: true,
   },
   {

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -25,6 +25,7 @@ interface EditionBody {
   galleryUrl?: string;
   archivedSiteUrl?: string;
   sponsorBrochureUrl?: string;
+  sponsorBrochureUrlEn?: string;
   sponsorHeroImageUrl?: string;
   sponsorPageStatus?: "PRE_ANNOUNCEMENT" | "TEMPORARY" | "OPEN" | "SOLD_OUT";
   sponsorTemporaryFormUrl?: string;
@@ -147,6 +148,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         galleryUrl: edition.galleryUrl,
         archivedSiteUrl: edition.archivedSiteUrl,
         sponsorBrochureUrl: edition.sponsorBrochureUrl,
+        sponsorBrochureUrlEn: edition.sponsorBrochureUrlEn,
         sponsorHeroImageUrl: edition.sponsorHeroImageUrl,
         sponsorPageStatus: edition.sponsorPageStatus,
         sponsorTemporaryFormUrl: edition.sponsorTemporaryFormUrl,
@@ -208,6 +210,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         galleryUrl: body.galleryUrl !== undefined ? (body.galleryUrl || null) : existing.galleryUrl,
         archivedSiteUrl: body.archivedSiteUrl !== undefined ? (body.archivedSiteUrl || null) : existing.archivedSiteUrl,
         sponsorBrochureUrl: body.sponsorBrochureUrl !== undefined ? (body.sponsorBrochureUrl || null) : existing.sponsorBrochureUrl,
+        sponsorBrochureUrlEn: body.sponsorBrochureUrlEn !== undefined ? (body.sponsorBrochureUrlEn || null) : existing.sponsorBrochureUrlEn,
         sponsorHeroImageUrl: body.sponsorHeroImageUrl !== undefined ? (body.sponsorHeroImageUrl || null) : existing.sponsorHeroImageUrl,
         sponsorPageStatus: body.sponsorPageStatus ?? existing.sponsorPageStatus,
         sponsorTemporaryFormUrl: body.sponsorTemporaryFormUrl !== undefined ? (body.sponsorTemporaryFormUrl || null) : existing.sponsorTemporaryFormUrl,

--- a/src/backend/src/routes/brochure.ts
+++ b/src/backend/src/routes/brochure.ts
@@ -8,7 +8,8 @@ import { getFeaturedEdition } from "./editions.js";
 //   1. validates the HMAC-signed token (id is bound to a server secret),
 //   2. atomically increments the brochure download counter on the matching
 //      ContactMessage,
-//   3. issues a 302 to the current edition's sponsorBrochureUrl.
+//   3. issues a 302 to the current edition's brochure, in the language the
+//      requester used on the form (#401).
 //
 // We intentionally use a 302 (not 301) — the brochure URL can change between
 // sponsor cycles, and we don't want intermediaries to cache the redirect.
@@ -23,26 +24,43 @@ export default async function brochureRoutes(app: FastifyInstance) {
     }
 
     const featured = await getFeaturedEdition();
+    const frenchUrl = featured?.sponsorBrochureUrl ?? null;
+    const englishUrl = featured?.sponsorBrochureUrlEn ?? null;
 
-    if (!featured?.sponsorBrochureUrl) {
-      // Nothing to redirect to — treat as gone.
+    // Either brochure will do as a fallback for the other, so a single missing
+    // file is not an error — only having neither is.
+    const anyBrochureUrl = frenchUrl ?? englishUrl;
+    if (anyBrochureUrl === null) {
+      // Nothing to redirect to — treat as gone, and don't count a download
+      // that never happened.
       return reply.status(404).send({ error: "Brochure unavailable" });
     }
 
     // Best-effort: a missing/already-deleted message just skips the bookkeeping
     // but still serves the file (the email was legitimate when it was sent).
+    // The same write gives us the stored locale, so picking the language costs
+    // no extra query — and the token carries only the id, never the language.
+    let locale: string | null = null;
     try {
-      await prisma.contactMessage.update({
+      const message = await prisma.contactMessage.update({
         where: { id },
         data: {
           brochureDownloadCount: { increment: 1 },
           brochureDownloadedAt: new Date(),
         },
+        select: { locale: true },
       });
+      locale = message.locale;
     } catch (err) {
       request.log.warn({ err, id }, "[brochure] could not update download counter");
     }
 
-    return reply.redirect(featured.sponsorBrochureUrl, 302);
+    // English requesters fall back to the French brochure when no English one
+    // is configured: a stale-language PDF beats a dead link in an email that
+    // has already been sent. The reverse fallback covers an edition that only
+    // ever uploaded the English file.
+    const url = locale === "en" ? (englishUrl ?? anyBrochureUrl) : anyBrochureUrl;
+
+    return reply.redirect(url, 302);
   });
 }

--- a/src/backend/src/routes/contact.ts
+++ b/src/backend/src/routes/contact.ts
@@ -194,10 +194,17 @@ export default async function contactRoutes(app: FastifyInstance) {
           // secret are configured; falls back to the raw URL otherwise so
           // the email stays useful in dev.
           const brochureToken = makeToken(stored.id);
-          const brochureUrl = edition?.sponsorBrochureUrl
+          // Untracked fallback only: the tracked link resolves the language
+          // itself from the stored locale (#401), so it needs no variant here.
+          const directBrochureUrl =
+            (lang === "en" ? edition?.sponsorBrochureUrlEn : null) ??
+            edition?.sponsorBrochureUrl ??
+            edition?.sponsorBrochureUrlEn ??
+            null;
+          const brochureUrl = directBrochureUrl
             ? brochureToken
               ? `${baseUrl}/api/brochure/${brochureToken}`
-              : `${baseUrl}${edition.sponsorBrochureUrl}`
+              : `${baseUrl}${directBrochureUrl}`
             : "";
 
           const vars = {

--- a/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
@@ -13,6 +13,7 @@ interface EditionSettings {
   sponsorPageStatus: SponsorPageStatus;
   sponsorTemporaryFormUrl: string | null;
   sponsorBrochureUrl: string | null;
+  sponsorBrochureUrlEn: string | null;
   sponsorHeroImageUrl: string | null;
 }
 
@@ -55,11 +56,13 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
     sponsorPageStatus: "PRE_ANNOUNCEMENT",
     sponsorTemporaryFormUrl: null,
     sponsorBrochureUrl: null,
+    sponsorBrochureUrlEn: null,
     sponsorHeroImageUrl: null,
   });
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);
   const [settingsSaved, setSettingsSaved] = useState(false);
   const [isBrochurePickerOpen, setIsBrochurePickerOpen] = useState(false);
+  const [isBrochureEnPickerOpen, setIsBrochureEnPickerOpen] = useState(false);
   const [isHeroPickerOpen, setIsHeroPickerOpen] = useState(false);
 
   async function loadSettings() {
@@ -69,6 +72,7 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
         sponsorPageStatus: data.sponsorPageStatus ?? "PRE_ANNOUNCEMENT",
         sponsorTemporaryFormUrl: data.sponsorTemporaryFormUrl ?? null,
         sponsorBrochureUrl: data.sponsorBrochureUrl ?? null,
+        sponsorBrochureUrlEn: data.sponsorBrochureUrlEn ?? null,
         sponsorHeroImageUrl: data.sponsorHeroImageUrl ?? null,
       });
     }
@@ -144,6 +148,7 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
         sponsorPageStatus: settings.sponsorPageStatus,
         sponsorTemporaryFormUrl: settings.sponsorTemporaryFormUrl ?? "",
         sponsorBrochureUrl: settings.sponsorBrochureUrl ?? "",
+        sponsorBrochureUrlEn: settings.sponsorBrochureUrlEn ?? "",
         sponsorHeroImageUrl: settings.sponsorHeroImageUrl ?? "",
       }),
     });
@@ -229,34 +234,76 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
           />
         </div>
 
-        <div>
-          <label className="block text-sm font-medium text-noir mb-1">Plaquette sponsors (PDF)</label>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={() => setIsBrochurePickerOpen(true)}
-              className="px-3 py-1.5 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
-            >
-              {settings.sponsorBrochureUrl ? "Changer le fichier" : "Choisir un fichier"}
-            </button>
-            {settings.sponsorBrochureUrl && (
-              <button
-                type="button"
-                onClick={() => setSettings({ ...settings, sponsorBrochureUrl: null })}
-                className="text-sm text-terre-cuite hover:underline"
-              >
-                Supprimer
-              </button>
-            )}
+        {/* One brochure per language (#401): the tracked link in the
+            confirmation email resolves the file from the locale the requester
+            filled the form in. */}
+        <fieldset>
+          <legend className="block text-sm font-medium text-noir mb-1">Plaquette sponsors (PDF)</legend>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <p className="text-sm text-noir mb-1">Français</p>
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setIsBrochurePickerOpen(true)}
+                  className="px-3 py-1.5 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+                >
+                  {settings.sponsorBrochureUrl ? "Changer le fichier" : "Choisir un fichier"}
+                </button>
+                {settings.sponsorBrochureUrl && (
+                  <button
+                    type="button"
+                    onClick={() => setSettings({ ...settings, sponsorBrochureUrl: null })}
+                    className="text-sm text-terre-cuite hover:underline"
+                  >
+                    Supprimer <span className="sr-only">la plaquette française</span>
+                  </button>
+                )}
+              </div>
+              {settings.sponsorBrochureUrl && <p className="mt-1 text-xs text-gris">{settings.sponsorBrochureUrl}</p>}
+            </div>
+
+            <div>
+              <p className="text-sm text-noir mb-1">Anglais (optionnel)</p>
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setIsBrochureEnPickerOpen(true)}
+                  className="px-3 py-1.5 text-sm rounded-lg border border-gris/30 text-noir hover:bg-blanc-casse"
+                >
+                  {settings.sponsorBrochureUrlEn ? "Changer le fichier" : "Choisir un fichier"}
+                </button>
+                {settings.sponsorBrochureUrlEn && (
+                  <button
+                    type="button"
+                    onClick={() => setSettings({ ...settings, sponsorBrochureUrlEn: null })}
+                    className="text-sm text-terre-cuite hover:underline"
+                  >
+                    Supprimer <span className="sr-only">la plaquette anglaise</span>
+                  </button>
+                )}
+              </div>
+              {settings.sponsorBrochureUrlEn && <p className="mt-1 text-xs text-gris">{settings.sponsorBrochureUrlEn}</p>}
+            </div>
           </div>
-          {settings.sponsorBrochureUrl && <p className="mt-1 text-xs text-gris">{settings.sponsorBrochureUrl}</p>}
+          {!settings.sponsorBrochureUrlEn && (
+            <p className="mt-2 text-xs text-gris">
+              Sans plaquette anglaise, les demandes faites en anglais reçoivent la plaquette française.
+            </p>
+          )}
           <FilePickerDialog
             open={isBrochurePickerOpen}
             onClose={() => setIsBrochurePickerOpen(false)}
             onSelect={(url) => setSettings({ ...settings, sponsorBrochureUrl: url })}
-            title="Bibliothèque de plaquettes"
+            title="Bibliothèque de plaquettes — français"
           />
-        </div>
+          <FilePickerDialog
+            open={isBrochureEnPickerOpen}
+            onClose={() => setIsBrochureEnPickerOpen(false)}
+            onSelect={(url) => setSettings({ ...settings, sponsorBrochureUrlEn: url })}
+            title="Bibliothèque de plaquettes — anglais"
+          />
+        </fieldset>
 
         <div className="flex items-center gap-3">
           <button


### PR DESCRIPTION
## Résumé

- Le lien de plaquette suivi (`/api/brochure/:token`) sert désormais le PDF **anglais** aux demandes faites en anglais. Le token n'encodant que l'id du message, la langue vient de `ContactMessage.locale` — que le formulaire stockait déjà.
- Nouveau champ `Edition.sponsorBrochureUrlEn` + deux sélecteurs de fichier (FR / EN optionnel) dans l'onglet Sponsoring de l'édition.
- Sans plaquette anglaise, l'anglophone reçoit la française : les mails sont déjà partis, un PDF dans la mauvaise langue vaut mieux qu'un lien mort.

## Ce que l'analyse a changé par rapport à l'énoncé

L'issue laissait penser à un problème d'e-mail. En réalité **le mail était déjà bilingue** ([contact.ts:185](../blob/feature/us-401-brochure-locale/src/backend/src/routes/contact.ts#L185) choisit `confirmationSubjectEn`/`confirmationBodyEn`) : seul le lien inséré dedans pointait vers le PDF français. Le correctif porte donc sur le redirecteur, pas sur le gabarit d'e-mail.

Point de conception : la langue est lue sur la ligne que le redirecteur **écrit déjà** pour incrémenter le compteur de téléchargements — donc aucune requête supplémentaire, et le **format du token est inchangé**, ce qui préserve les liens des mails déjà envoyés.

Deux décisions prises avec Julien : repli sur le FR plutôt qu'un 404, et deux sélecteurs côte à côte plutôt que des onglets FR/EN (on voit d'un coup d'œil si l'anglaise manque).

## Plan de test

**Vérifié**

- Suites complètes : **623/623 backend**, **104/104 frontend**. `tsc --noEmit` et ESLint propres sur les deux applications.
- 4 nouveaux tests : redirection EN, repli sur FR quand l'EN manque, repli inverse (seul l'EN existe), 404 quand aucune plaquette n'est configurée.
- **Navigateur** (Chrome DevTools MCP, admin local) : les deux sélecteurs s'affichent, la boîte s'intitule bien « — anglais », la sélection se pose sur le bon champ sans toucher au français, l'enregistrement persiste dans la bonne colonne (vérifié en SQL).
- **Redirections réelles** sur le serveur, avec deux PDF distincts : message sans locale → PDF FR, message `locale=en` → PDF EN. Puis `sponsorBrochureUrlEn` mis à NULL → l'anglophone bascule bien sur le PDF FR.
- Console navigateur propre (seul un avertissement d'icône de manifeste, préexistant et sans rapport).

**Non vérifié**

- Le parcours **complet depuis le formulaire public** (soumission → réception du mail dans MailHog → clic sur le lien) : j'ai testé le redirecteur directement avec des tokens signés, pas la chaîne de bout en bout. La page `/devenir-sponsor` doit être en statut `OPEN` pour exposer le formulaire intégré, ce qui n'est pas le cas de l'édition locale.
- Le repli non tracké dans `contact.ts` (quand `BROCHURE_TOKEN_SECRET` est absent) : la logique de langue y est alignée sur celle du redirecteur, mais ce chemin de dev n'a pas été exercé.

## Réserve

`sponsorBrochureUrl` reste sans suffixe `Fr` : c'est la version française, et la renommer réécrirait les lignes existantes sans rien apporter. Le commentaire du schéma le dit explicitement.

À noter, découvert au passage : le champ `sponsorBrochureUrl` est exposé dans le type public [types.ts:27](../blob/feature/us-401-brochure-locale/src/frontend/src/lib/types.ts#L27) mais **aucune page publique ne l'affiche** — le PDF ne circule que par e-mail. Je n'ai donc pas ajouté la variante EN à la route publique, qui n'aurait aucun consommateur.

Refs #401
