### PR TITLE
fix: défauts d'accès sponsor et de retour d'action dans l'admin

### DIFF
--- a/src/frontend/src/app/admin/api-keys/page.tsx
+++ b/src/frontend/src/app/admin/api-keys/page.tsx
@@ -76,7 +76,7 @@ export default function AdminApiKeysPage() {
       </div>
 
       {error && (
-        <div className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
+        <div role="alert" aria-live="assertive" className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
       )}
 
       {isLoading ? (

--- a/src/frontend/src/app/admin/articles/page.tsx
+++ b/src/frontend/src/app/admin/articles/page.tsx
@@ -31,6 +31,7 @@ export default function ArticlesListPage() {
   const [totalPages, setTotalPages] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
   const [deleteTarget, setDeleteTarget] = useState<ArticleSummary | null>(null);
+  const [error, setError] = useState("");
 
   async function loadArticles(p = 1) {
     setIsLoading(true);
@@ -49,8 +50,15 @@ export default function ArticlesListPage() {
 
   async function handleDelete() {
     if (!deleteTarget) return;
-    await adminFetch(`/articles/${deleteTarget.id}`, { method: "DELETE" });
+    setError("");
+    const { status } = await adminFetch(`/articles/${deleteTarget.id}`, { method: "DELETE" });
     setDeleteTarget(null);
+    // A refused delete closed the dialog and reloaded the list, so the article
+    // reappeared with nothing said about why (#412).
+    if (status !== 204 && status !== 200) {
+      setError("La suppression a échoué. Réessayez.");
+      return;
+    }
     loadArticles(page);
   }
 
@@ -65,6 +73,12 @@ export default function ArticlesListPage() {
           Nouvel article
         </Link>
       </div>
+
+      {error && (
+        <p role="alert" aria-live="assertive" className="mb-6 rounded-xl bg-terre-cuite/10 p-4 text-sm text-terre-cuite">
+          {error}
+        </p>
+      )}
 
       {isLoading ? (
         <p className="text-gris">Chargement...</p>

--- a/src/frontend/src/app/admin/categories/[id]/page.tsx
+++ b/src/frontend/src/app/admin/categories/[id]/page.tsx
@@ -97,7 +97,7 @@ export default function CategoryEditorPage() {
       <div className="bg-blanc rounded-xl shadow-card p-6 space-y-4">
         <CategoryForm value={form} onChange={setForm} editions={editions} />
 
-        {error && <p className="text-sm text-terre-cuite">{error}</p>}
+        {error && <p role="alert" aria-live="assertive" className="text-sm text-terre-cuite">{error}</p>}
 
         <div className="flex items-center gap-3 pt-2">
           <button

--- a/src/frontend/src/app/admin/editions/page.tsx
+++ b/src/frontend/src/app/admin/editions/page.tsx
@@ -81,7 +81,7 @@ export default function EditionsPage() {
   }
 
   async function handleSetFeatured(editionId: number) {
-    setError("");
+    setError(null);
     const { status } = await adminFetch("/editions/featured", {
       method: "PUT",
       body: JSON.stringify({ editionId }),
@@ -119,7 +119,7 @@ export default function EditionsPage() {
       </div>
 
       {error && (
-        <div className="mb-6 p-4 rounded-xl bg-terre-cuite/10 text-terre-cuite">{error}</div>
+        <div role="alert" aria-live="assertive" className="mb-6 p-4 rounded-xl bg-terre-cuite/10 text-terre-cuite">{error}</div>
       )}
 
       <div className="space-y-3">

--- a/src/frontend/src/app/admin/editions/page.tsx
+++ b/src/frontend/src/app/admin/editions/page.tsx
@@ -71,16 +71,26 @@ export default function EditionsPage() {
     const { status, error: apiError } = await adminFetch(`/editions/${deleteTarget.id}`, { method: "DELETE" });
     if (status === 409) {
       setError(apiError || "Impossible de supprimer cette édition");
+    } else if (status !== 204 && status !== 200) {
+      // Only the 409 used to speak up; any other failure closed the dialog and
+      // reloaded, so the edition came back with no explanation (#412).
+      setError("La suppression a échoué. Réessayez.");
     }
     setDeleteTarget(null);
     loadEditions();
   }
 
   async function handleSetFeatured(editionId: number) {
-    await adminFetch("/editions/featured", {
+    setError("");
+    const { status } = await adminFetch("/editions/featured", {
       method: "PUT",
       body: JSON.stringify({ editionId }),
     });
+    // The badge used to move on its own authority, whatever the server said.
+    if (status !== 200) {
+      setError("La mise à la une a échoué. Réessayez.");
+      return;
+    }
     setFeaturedId(editionId);
   }
 

--- a/src/frontend/src/app/admin/files/page.tsx
+++ b/src/frontend/src/app/admin/files/page.tsx
@@ -111,8 +111,15 @@ export default function FilesAdminPage() {
 
   async function handleDelete() {
     if (!deleteTarget) return;
-    await adminFetch(`/files/${deleteTarget}`, { method: "DELETE" });
+    setError("");
+    const { status } = await adminFetch(`/files/${deleteTarget}`, { method: "DELETE" });
     setDeleteTarget(null);
+    // A file still referenced elsewhere comes back on the next load; without
+    // this the dialog just closed and the file silently reappeared (#412).
+    if (status !== 204 && status !== 200) {
+      setError("La suppression a échoué. Le fichier est peut-être encore utilisé.");
+      return;
+    }
     loadFiles();
   }
 
@@ -192,7 +199,7 @@ export default function FilesAdminPage() {
       </div>
 
       {error && (
-        <div className="mb-6 p-4 rounded-xl bg-terre-cuite/10 text-terre-cuite">{error}</div>
+        <div role="alert" aria-live="assertive" className="mb-6 p-4 rounded-xl bg-terre-cuite/10 text-terre-cuite">{error}</div>
       )}
 
       {filtered.length === 0 ? (

--- a/src/frontend/src/app/admin/pages/page.tsx
+++ b/src/frontend/src/app/admin/pages/page.tsx
@@ -5,6 +5,7 @@ import { adminFetch } from "@/lib/admin-api";
 import BilingualInput from "@/components/admin/BilingualInput";
 import BilingualTabs from "@/components/admin/BilingualTabs";
 import RichTextEditor from "@/components/admin/RichTextEditor";
+import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
 
 interface PageSummary {
   id: number;
@@ -29,6 +30,7 @@ export default function PagesAdminPage() {
   const [createError, setCreateError] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [saveState, setSaveState] = useState<SaveState>(null);
 
   async function loadPages() {
     setIsLoading(true);
@@ -63,13 +65,16 @@ export default function PagesAdminPage() {
       setCreateError("Une page avec ce slug existe déjà");
       return;
     }
-    if (data) {
-      setIsCreating(false);
-      setNewSlug("");
-      setNewTitleFr("");
-      setNewTitleEn("");
-      loadPages();
+    if (!data) {
+      // Any other failure used to leave the form untouched and silent (#412).
+      setCreateError("La création a échoué. Réessayez.");
+      return;
     }
+    setIsCreating(false);
+    setNewSlug("");
+    setNewTitleFr("");
+    setNewTitleEn("");
+    loadPages();
   }
 
   async function startEdit(page: PageSummary) {
@@ -80,7 +85,8 @@ export default function PagesAdminPage() {
   async function handleSave() {
     if (!editing) return;
     setIsSaving(true);
-    await adminFetch(`/pages/${editing.id}`, {
+    setSaveState(null);
+    const { status } = await adminFetch(`/pages/${editing.id}`, {
       method: "PUT",
       body: JSON.stringify({
         titleFr: editing.titleFr,
@@ -90,6 +96,12 @@ export default function PagesAdminPage() {
       }),
     });
     setIsSaving(false);
+    // Closing the editor regardless of the answer lost the edits and read as a
+    // success (#412) — keep it open on failure so they can be retried.
+    if (status !== 200) {
+      setSaveState({ kind: "error", text: "L'enregistrement a échoué. Réessayez." });
+      return;
+    }
     setEditing(null);
     loadPages();
   }
@@ -146,7 +158,7 @@ export default function PagesAdminPage() {
             </div>
           </div>
           {createError && (
-            <p className="text-sm text-terre-cuite">{createError}</p>
+            <p role="alert" aria-live="assertive" className="text-sm text-terre-cuite">{createError}</p>
           )}
           <div className="flex gap-3">
             <button
@@ -187,7 +199,8 @@ export default function PagesAdminPage() {
             }
           />
 
-          <div className="flex justify-end">
+          <div className="flex items-center justify-end gap-3">
+            <SaveFeedback state={saveState} onDismiss={() => setSaveState(null)} />
             <button onClick={handleSave} disabled={isSaving} className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50">
               {isSaving ? "Sauvegarde..." : "Sauvegarder"}
             </button>

--- a/src/frontend/src/app/admin/profile/page.tsx
+++ b/src/frontend/src/app/admin/profile/page.tsx
@@ -156,7 +156,7 @@ export default function ProfilePage() {
           </div>
 
           {profileError && (
-            <div className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{profileError}</div>
+            <div role="alert" aria-live="assertive" className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{profileError}</div>
           )}
 
           <div className="flex items-center gap-4">
@@ -218,7 +218,7 @@ export default function ProfilePage() {
           </div>
 
           {passwordError && (
-            <div className="mt-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{passwordError}</div>
+            <div role="alert" aria-live="assertive" className="mt-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{passwordError}</div>
           )}
 
           <div className="flex items-center gap-4 mt-4">

--- a/src/frontend/src/app/admin/settings/page.tsx
+++ b/src/frontend/src/app/admin/settings/page.tsx
@@ -372,7 +372,7 @@ function ContactsTab({
         >
           {isSaving ? "Enregistrement..." : "Enregistrer"}
         </button>
-        {saved && <span className="text-sm text-malachite">Enregistré !</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
     </form>
   );
@@ -569,7 +569,7 @@ function IdentityTab({
         >
           {isSaving ? "Enregistrement..." : "Enregistrer"}
         </button>
-        {saved && <span className="text-sm text-malachite">Enregistré !</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
     </form>
   );
@@ -781,7 +781,7 @@ function EcosystemTab({
         >
           {isSaving ? "Enregistrement..." : "Enregistrer"}
         </button>
-        {saved && <span className="text-sm text-malachite">Enregistré !</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
     </form>
   );
@@ -962,7 +962,7 @@ function CarouselTab({
         >
           {isSaving ? "Enregistrement..." : "Enregistrer"}
         </button>
-        {saved && <span className="text-sm text-malachite">Enregistré !</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
 
       <ImagePickerDialog
@@ -1117,7 +1117,7 @@ function SeoTab({
         >
           {isSaving ? "Enregistrement..." : "Enregistrer"}
         </button>
-        {saved && <span className="text-sm text-malachite">Enregistré !</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
     </form>
   );

--- a/src/frontend/src/app/admin/sponsor-tiers/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsor-tiers/[id]/page.tsx
@@ -109,7 +109,7 @@ export default function SponsorTierEditorPage() {
       <div className="bg-blanc rounded-xl shadow-card p-6 space-y-4">
         <SponsorTierForm value={form} onChange={setForm} isNew={isNew} />
 
-        {error && <p className="text-sm text-terre-cuite">{error}</p>}
+        {error && <p role="alert" aria-live="assertive" className="text-sm text-terre-cuite">{error}</p>}
 
         <div className="flex items-center gap-3 pt-2">
           <button

--- a/src/frontend/src/app/admin/talks/[id]/page.tsx
+++ b/src/frontend/src/app/admin/talks/[id]/page.tsx
@@ -110,7 +110,10 @@ export default function TalkEditorPage() {
         setError("Échec de l'enregistrement.");
         return;
       }
-      router.push("/admin/talks");
+      // Staying put, like the sponsor and speaker sheets (#394): creating left
+      // the editor on the talk, saving then threw them back to the list, and
+      // the SaveFeedback below never got the chance to say anything (#412).
+      setSaveState({ kind: "ok", text: "Modifications enregistrées." });
     }
   }
 

--- a/src/frontend/src/app/admin/users/page.tsx
+++ b/src/frontend/src/app/admin/users/page.tsx
@@ -103,7 +103,7 @@ export default function UsersAdminPage() {
       </div>
 
       {error && (
-        <div className="mb-6 p-4 rounded-xl bg-terre-cuite/10 text-terre-cuite">{error}</div>
+        <div role="alert" aria-live="assertive" className="mb-6 p-4 rounded-xl bg-terre-cuite/10 text-terre-cuite">{error}</div>
       )}
 
       {showForm && (

--- a/src/frontend/src/components/admin/AdminLogin.tsx
+++ b/src/frontend/src/components/admin/AdminLogin.tsx
@@ -78,7 +78,7 @@ export default function AdminLogin() {
         </p>
 
         {error && (
-          <div className="mb-4 p-3 rounded-[12px] bg-rouge/10 text-bismarck text-sm">{error}</div>
+          <div role="alert" aria-live="assertive" className="mb-4 p-3 rounded-[12px] bg-rouge/10 text-bismarck text-sm">{error}</div>
         )}
         {success && (
           <div className="mb-4 p-3 rounded-[12px] bg-malachite/10 text-[#0A6B4B] text-sm">{success}</div>

--- a/src/frontend/src/components/admin/ApiKeysSection.tsx
+++ b/src/frontend/src/components/admin/ApiKeysSection.tsx
@@ -257,7 +257,7 @@ export default function ApiKeysSection() {
       )}
 
       {error && (
-        <div className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
+        <div role="alert" aria-live="assertive" className="mb-4 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
       )}
 
       {/* Keys list */}

--- a/src/frontend/src/components/admin/EditLinkActions.tsx
+++ b/src/frontend/src/components/admin/EditLinkActions.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import { adminFetch } from "@/lib/admin-api";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 
 interface EditLinkActionsProps {
   // "speakers" | "sponsors" — the admin route segment.
@@ -25,6 +26,7 @@ export default function EditLinkActions({
   const [locked, setLocked] = useState(initialLocked);
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const [busy, setBusy] = useState(false);
+  const [isRevoking, setIsRevoking] = useState(false);
 
   async function send() {
     if (!email.trim()) {
@@ -50,6 +52,7 @@ export default function EditLinkActions({
     setMsg(null);
     const { status } = await adminFetch(`/${resource}/${entityId}/edit-link`, { method: "DELETE" });
     setBusy(false);
+    setIsRevoking(false);
     setMsg(status === 200 ? { ok: true, text: "Lien révoqué." } : { ok: false, text: "Échec." });
   }
 
@@ -91,7 +94,7 @@ export default function EditLinkActions({
         </button>
         <button
           type="button"
-          onClick={revoke}
+          onClick={() => setIsRevoking(true)}
           disabled={busy}
           className="px-3 py-2 text-sm rounded-lg border border-gris/30 text-gris hover:bg-blanc disabled:opacity-50"
         >
@@ -107,8 +110,26 @@ export default function EditLinkActions({
         </button>
       </div>
       {msg && (
-        <p className={`text-sm ${msg.ok ? "text-malachite" : "text-terre-cuite"}`}>{msg.text}</p>
+        <p
+          role={msg.ok ? "status" : "alert"}
+          aria-live={msg.ok ? "polite" : "assertive"}
+          className={`text-sm ${msg.ok ? "text-malachite" : "text-terre-cuite"}`}
+        >
+          {msg.text}
+        </p>
       )}
+
+      {/* The link is already in someone's mailbox: revoking it strands them with
+          no warning on either side (#414). */}
+      <ConfirmDialog
+        isOpen={isRevoking}
+        title="Révoquer le lien"
+        message="Le lien déjà envoyé cessera de fonctionner immédiatement. Son destinataire ne pourra plus modifier sa fiche tant qu'un nouveau lien ne lui aura pas été envoyé."
+        confirmLabel="Révoquer"
+        variant="danger"
+        onConfirm={revoke}
+        onCancel={() => setIsRevoking(false)}
+      />
     </div>
   );
 }

--- a/src/frontend/src/components/admin/FilePickerDialog.tsx
+++ b/src/frontend/src/components/admin/FilePickerDialog.tsx
@@ -175,7 +175,7 @@ export default function FilePickerDialog({
         </div>
 
         {error && (
-          <div className="mx-4 mt-3 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
+          <div role="alert" aria-live="assertive" className="mx-4 mt-3 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
         )}
 
         <div className="flex-1 overflow-y-auto p-4">

--- a/src/frontend/src/components/admin/ImagePickerDialog.tsx
+++ b/src/frontend/src/components/admin/ImagePickerDialog.tsx
@@ -275,7 +275,7 @@ export default function ImagePickerDialog({ open, onClose, onSelect }: ImagePick
         </div>
 
         {error && (
-          <div className="mx-4 mt-3 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
+          <div role="alert" aria-live="assertive" className="mx-4 mt-3 p-3 rounded-lg bg-terre-cuite/10 text-terre-cuite text-sm">{error}</div>
         )}
         {notice && (
           <div className="mx-4 mt-3 p-3 rounded-lg bg-malachite/10 text-malachite text-sm">

--- a/src/frontend/src/components/admin/edition-detail/CfpTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/CfpTab.tsx
@@ -87,7 +87,7 @@ export default function CfpTab() {
         <button onClick={handleSave} disabled={isSaving} className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50">
           {isSaving ? "Sauvegarde..." : "Sauvegarder"}
         </button>
-        {saved && <span className="text-sm text-malachite">Sauvegardé !</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
     </div>
   );

--- a/src/frontend/src/components/admin/edition-detail/EditionSponsorsTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/EditionSponsorsTab.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 
 import { adminFetch } from "@/lib/admin-api";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 import type { AdminSponsorTier } from "@/lib/types";
 
 interface SponsorRow {
@@ -30,6 +31,7 @@ export default function EditionSponsorsTab({ editionId }: EditionSponsorsTabProp
   const [pickedTierId, setPickedTierId] = useState<number | null>(null);
   const [isBusy, setIsBusy] = useState(false);
   const [message, setMessage] = useState<{ isOk: boolean; text: string } | null>(null);
+  const [detachTarget, setDetachTarget] = useState<SponsorRow | null>(null);
 
   async function load() {
     const [ofEdition, everyone, catalogue] = await Promise.all([
@@ -87,12 +89,14 @@ export default function EditionSponsorsTab({ editionId }: EditionSponsorsTabProp
     }
   }
 
+  // ConfirmDialog rather than window.confirm (#414): the native box is outside
+  // the charter, unstyleable, and its wording is the browser's, not ours.
   async function detach(sponsor: SponsorRow) {
-    if (!window.confirm(`Retirer ${sponsor.name} de cette édition ? La fiche de l'entreprise est conservée.`)) return;
     setIsBusy(true);
     setMessage(null);
     const { status } = await adminFetch(`/sponsors/${sponsor.id}/editions/${editionId}`, { method: "DELETE" });
     setIsBusy(false);
+    setDetachTarget(null);
     if (status === 204) {
       setMessage({ isOk: true, text: `${sponsor.name} retiré de cette édition.` });
       void load();
@@ -137,7 +141,7 @@ export default function EditionSponsorsTab({ editionId }: EditionSponsorsTabProp
               </span>
               <button
                 type="button"
-                onClick={() => detach(s)}
+                onClick={() => setDetachTarget(s)}
                 disabled={isBusy}
                 className="text-xs font-medium text-terre-cuite hover:underline disabled:opacity-50"
               >
@@ -210,8 +214,24 @@ export default function EditionSponsorsTab({ editionId }: EditionSponsorsTabProp
       </div>
 
       {message && (
-        <p className={`text-sm ${message.isOk ? "text-malachite" : "text-terre-cuite"}`}>{message.text}</p>
+        <p
+          role={message.isOk ? "status" : "alert"}
+          aria-live={message.isOk ? "polite" : "assertive"}
+          className={`text-sm ${message.isOk ? "text-malachite" : "text-terre-cuite"}`}
+        >
+          {message.text}
+        </p>
       )}
+
+      <ConfirmDialog
+        isOpen={!!detachTarget}
+        title="Retirer de cette édition"
+        message={`Retirer ${detachTarget?.name} de cette édition ? La fiche de l'entreprise est conservée.`}
+        confirmLabel="Retirer"
+        variant="danger"
+        onConfirm={() => detachTarget && detach(detachTarget)}
+        onCancel={() => setDetachTarget(null)}
+      />
     </div>
   );
 }

--- a/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
@@ -166,7 +166,7 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
         >
           {isSaving ? "Sauvegarde..." : "Sauvegarder"}
         </button>
-        {saved && <span className="text-sm text-malachite">Sauvegardé !</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
 
       <ConfirmDialog

--- a/src/frontend/src/components/admin/edition-detail/KeyFiguresTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/KeyFiguresTab.tsx
@@ -94,7 +94,7 @@ export default function KeyFiguresTab({ editionId }: KeyFiguresTabProps) {
         >
           {isSaving ? "Sauvegarde..." : "Sauvegarder les chiffres"}
         </button>
-        {saved && <span className="text-sm text-malachite">Sauvegardé !</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
     </div>
   );

--- a/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/SponsoringTab.tsx
@@ -50,6 +50,7 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
   const [rows, setRows] = useState<EditionTierRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [savingTierId, setSavingTierId] = useState<number | null>(null);
+  const [tierError, setTierError] = useState("");
 
   // Page settings (status, temporary form URL, brochure/hero) — live on Edition.
   const [settings, setSettings] = useState<EditionSettings>({
@@ -113,19 +114,24 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
 
   // The single checkbox: checking publishes the offer on /devenir-sponsor (PUT
   // the link, visible), unchecking removes the link entirely.
+  // No confirmation on a checkbox — asking on every tick would be worse than the
+  // mistake it prevents. But the box used to move whatever the server answered,
+  // so a refused change left it showing a state the edition did not have (#412).
   async function toggleOffered(row: EditionTierRow) {
     setSavingTierId(row.tier.id);
-    if (row.offered) {
-      await adminFetch(`/editions/${editionId}/sponsor-tiers/${row.tier.id}`, { method: "DELETE" });
-      patchRow(row.tier.id, { offered: false });
-    } else {
-      await adminFetch(`/editions/${editionId}/sponsor-tiers/${row.tier.id}`, {
-        method: "PUT",
-        body: JSON.stringify({ isVisible: true, price: row.price || null, sortOrder: Number(row.sortOrder) || 0 }),
-      });
-      patchRow(row.tier.id, { offered: true });
-    }
+    setTierError("");
+    const { status } = row.offered
+      ? await adminFetch(`/editions/${editionId}/sponsor-tiers/${row.tier.id}`, { method: "DELETE" })
+      : await adminFetch(`/editions/${editionId}/sponsor-tiers/${row.tier.id}`, {
+          method: "PUT",
+          body: JSON.stringify({ isVisible: true, price: row.price || null, sortOrder: Number(row.sortOrder) || 0 }),
+        });
     setSavingTierId(null);
+    if (status !== 200 && status !== 204) {
+      setTierError("La modification a échoué. Réessayez.");
+      return;
+    }
+    patchRow(row.tier.id, { offered: !row.offered });
   }
 
   // Persist the price/order of an already-published offer, on blur.
@@ -328,6 +334,12 @@ export default function SponsoringTab({ editionId }: SponsoringTabProps) {
           d&apos;affichage. Le catalogue lui-même se gère dans « Offres de sponsoring ».
         </p>
       </div>
+
+      {tierError && (
+        <p role="alert" aria-live="assertive" className="rounded-lg bg-terre-cuite/10 px-3 py-2 text-sm text-terre-cuite">
+          {tierError}
+        </p>
+      )}
 
       {rows.length === 0 ? (
         <p className="text-gris text-sm">

--- a/src/frontend/src/components/admin/edition-detail/VenueTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/VenueTab.tsx
@@ -159,7 +159,7 @@ export default function VenueTab({ edition, onSaved }: VenueTabProps) {
         >
           {isSaving ? "Enregistrement…" : "Enregistrer"}
         </button>
-        {saved && <span className="text-sm text-malachite">Enregistré ✓</span>}
+        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
       </div>
     </div>
   );

--- a/src/frontend/src/components/admin/speakers/SpeakerEditionsPanel.tsx
+++ b/src/frontend/src/components/admin/speakers/SpeakerEditionsPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import type { SpeakerEdition } from "@/lib/types";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 import StatusBadge from "@/components/admin/StatusBadge";
 import ParticipationSponsorSelect from "@/components/admin/speakers/ParticipationSponsorSelect";
 
@@ -30,6 +31,9 @@ export default function SpeakerEditionsPanel({
 }: SpeakerEditionsPanelProps) {
   const [pendingEditionId, setPendingEditionId] = useState<string>("");
   const [busyId, setBusyId] = useState<number | null>(null);
+  // Detaching a sponsor from an edition asks first; this did not, for the same
+  // gesture on the other side of the model (#414).
+  const [detachTarget, setDetachTarget] = useState<SpeakerEdition | null>(null);
 
   const attachedIds = new Set(editions.map((e) => e.id));
   const available = allEditions.filter((e) => !attachedIds.has(e.id));
@@ -114,7 +118,7 @@ export default function SpeakerEditionsPanel({
                   <button
                     type="button"
                     disabled={busyId === participation.id}
-                    onClick={() => run(participation.id, () => onDetach(participation.id))}
+                    onClick={() => setDetachTarget(participation)}
                     className="text-sm text-terre-cuite hover:underline disabled:opacity-50"
                   >
                     Retirer
@@ -155,6 +159,21 @@ export default function SpeakerEditionsPanel({
           </button>
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={!!detachTarget}
+        title="Retirer de cette édition"
+        message={`Retirer ce speaker de l'édition ${detachTarget?.year} ? Sa fiche et ses autres participations sont conservées.`}
+        confirmLabel="Retirer"
+        variant="danger"
+        onConfirm={() => {
+          if (!detachTarget) return;
+          const id = detachTarget.id;
+          setDetachTarget(null);
+          void run(id, () => onDetach(id));
+        }}
+        onCancel={() => setDetachTarget(null)}
+      />
     </section>
   );
 }

--- a/src/frontend/src/components/admin/sponsors/SponsorContacts.tsx
+++ b/src/frontend/src/components/admin/sponsors/SponsorContacts.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { adminFetch } from "@/lib/admin-api";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
 import StatusBadge from "@/components/admin/StatusBadge";
 import { SPONSOR_ROLE_OPTIONS } from "@/lib/sponsor-roles";
 import type { SponsorAccessRole } from "@/lib/sponsor-api";
@@ -36,6 +37,7 @@ export default function SponsorContacts({ sponsorId }: { sponsorId: number }) {
   const [role, setRole] = useState("");
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<Contact | null>(null);
 
   async function load() {
     const { data } = await adminFetch<Contact[]>(`/sponsors/${sponsorId}/contacts`);
@@ -126,9 +128,19 @@ export default function SponsorContacts({ sponsorId }: { sponsorId: number }) {
     setMsg(null);
     const { status } = await adminFetch(`/sponsors/${sponsorId}/contacts/${id}`, { method: "DELETE" });
     setBusy(false);
+    setRemoveTarget(null);
     if (status === 204) void load();
     else setMsg({ ok: false, text: "Échec de la suppression." });
   }
+
+  // Demoting the last RESPONSABLE is refused server-side, but removing them was
+  // not — same outcome by another route, and nothing warned about it (#407).
+  // The admin stays free to do it: they are the only recourse when someone has
+  // left the company. They just get told what it costs.
+  const isLastResponsable =
+    !!removeTarget &&
+    removeTarget.accessRole === "RESPONSABLE" &&
+    contacts.filter((c) => c.accessRole === "RESPONSABLE").length === 1;
 
   return (
     <div className="rounded-lg border border-gris/20 bg-blanc-casse/50 p-4 space-y-4">
@@ -197,7 +209,7 @@ export default function SponsorContacts({ sponsorId }: { sponsorId: number }) {
                   {c.editLinkLocked ? "Déverrouiller" : "Verrouiller"}<span className="sr-only"> l&apos;ancien lien de {c.email}</span>
                 </button>
               )}
-              <button type="button" onClick={() => remove(c.id)} disabled={busy} className={`${rowActionClass} text-terre-cuite focus:ring-terre-cuite/50`}>
+              <button type="button" onClick={() => setRemoveTarget(c)} disabled={busy} className={`${rowActionClass} text-terre-cuite focus:ring-terre-cuite/50`}>
                 Retirer<span className="sr-only"> le contact {c.email}</span>
               </button>
             </li>
@@ -239,6 +251,20 @@ export default function SponsorContacts({ sponsorId }: { sponsorId: number }) {
           {msg.text}
         </p>
       )}
+
+      <ConfirmDialog
+        isOpen={!!removeTarget}
+        title="Retirer ce contact"
+        message={
+          isLastResponsable
+            ? `${removeTarget?.email} est le seul responsable de ce partenaire. En le retirant, plus personne ne pourra inviter d'équipe depuis l'espace partenaire — il faudra passer par vous. Nommez un autre responsable d'abord pour l'éviter.`
+            : `Retirer ${removeTarget?.email} des contacts de ce partenaire ? Son accès à l'espace partenaire sera révoqué.`
+        }
+        confirmLabel="Retirer"
+        variant="danger"
+        onConfirm={() => removeTarget && remove(removeTarget.id)}
+        onCancel={() => setRemoveTarget(null)}
+      />
     </div>
   );
 }

--- a/src/frontend/src/components/sponsor-space/SponsorLogin.tsx
+++ b/src/frontend/src/components/sponsor-space/SponsorLogin.tsx
@@ -73,7 +73,7 @@ export default function SponsorLogin({
   async function handleSocial(provider: "google" | "github") {
     setIsLoading(true);
     setError(null);
-    const result = await signInWithSocial(provider);
+    const result = await signInWithSocial(provider, callbackURL);
     if (!result.ok) {
       setError(result.error || "Connexion impossible");
       setIsLoading(false);
@@ -163,14 +163,19 @@ export default function SponsorLogin({
         </button>
       </form>
 
-      <button
-        type="button"
-        onClick={handleMagicLink}
-        disabled={isLoading}
-        className="mt-4 w-full text-sm font-medium text-bleu hover:underline disabled:opacity-50"
-      >
-        Recevoir un lien de connexion par email
-      </button>
+      {/* Sign-in only: the magic link runs with disableSignUp, so on this screen
+          — where no account exists yet — it silently sends nothing and lands the
+          visitor back here (#408). */}
+      {mode === "signin" && (
+        <button
+          type="button"
+          onClick={handleMagicLink}
+          disabled={isLoading}
+          className="mt-4 w-full text-sm font-medium text-bleu hover:underline disabled:opacity-50"
+        >
+          Recevoir un lien de connexion par email
+        </button>
+      )}
 
       <p className="mt-6 text-center text-xs text-gris">
         {mode === "signup"

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -106,10 +106,15 @@ export async function purgeExpiredTrash(): Promise<{
 // authorization URL as JSON ({ url, redirect }) instead of issuing a 302. A
 // plain <a href> performed a GET and got back `null` (404). We POST, then
 // navigate to the returned URL.
+// path defaults to the back-office, but a sponsor signing in from its own space
+// must come back there: landing on /admin got them a 403 loop, and the page
+// that binds their invitation never reloaded, so the account stayed orphaned
+// (#409).
 export async function signInWithSocial(
   provider: "google" | "github",
+  path = "/admin",
 ): Promise<{ ok: boolean; error?: string }> {
-  const callbackURL = typeof window !== "undefined" ? `${window.location.origin}/admin` : "/admin";
+  const callbackURL = typeof window !== "undefined" ? `${window.location.origin}${path}` : path;
   try {
     const res = await fetch(`/api/auth/sign-in/social`, {
       method: "POST",


### PR DESCRIPTION
Les six défauts trouvés en testant #362 sur la beta et en auditant l'ergonomie du
back-office.

## Ce que ça corrige

**Accès sponsor** — `signInWithSocial` codait `/admin` en dur : un sponsor
choisissant Google ou GitHub atterrissait sur une page que son rôle refuse,
bouclait sur un 403, et son invitation restait non rattachée faute de retour sur
la page qui la lie (#409). GitHub était touché à l'identique, même fonction. Le
bouton « Recevoir un lien de connexion » disparaît de l'écran d'inscription : le
magic link tourne avec `disableSignUp`, il n'y envoyait jamais rien (#408).

**Retours d'action** — quatre handlers jetaient le status qu'ils recevaient.
Observé sur `/admin/pages` avec le backend coupé : l'éditeur se fermait,
« Chargement… » restait à l'écran indéfiniment, deux 500 en console et aucun
message (#412). La fiche conférence montait `SaveFeedback` sans jamais
l'alimenter, et redirigeait de toute façon avant tout affichage.

**Accessibilité** — une vingtaine de messages d'erreur étaient des `div` muets,
sans `role` ni `aria-live` : l'arbre d'accessibilité les rendait `generic`, donc
inaudibles (#413, WCAG 2.1 AA critère 4.1.3). `SaveFeedback` faisait déjà ce
qu'il fallait à côté. Les neuf confirmations d'enregistrement suivent, et
adoptent les mêmes mots — elles disaient « Enregistré ! », « Sauvegardé ! » ou
« Enregistré ✓ » selon l'onglet.

**Confirmations** — quatre suppressions passaient sans rien demander, dont la
révocation d'un lien déjà dans une boîte mail (#414). Détacher un speaker d'une
édition ne demandait rien là où le même geste sur un sponsor demandait
confirmation. Retirer le dernier responsable d'un sponsor dit désormais ce que
ça coûte, sans l'interdire — un admin reste le seul recours quand quelqu'un a
quitté l'entreprise (#407).

## Plan de test

**Vérifié au navigateur**, dans les conditions exactes du défaut d'origine :
backend coupé sur `/admin/pages` → l'éditeur reste ouvert, le message apparaît
en `alert aria-live="assertive"`, les modifications sont conservées. Dialogue de
retrait du dernier responsable : `modal`, focus sur « Annuler », avertissement
spécifique affiché. Écran d'inscription sponsor : plus de bouton magic link.

**Suites** : 644/644 backend (91 fichiers), 123/123 frontend (20 fichiers),
`tsc` propre, lint à 0 erreur (8 avertissements préexistants, aucun sur les
fichiers touchés).

**Non vérifié** : le parcours OAuth complet — les providers ne sont pas
configurés en local, c'est précisément ce qui avait laissé passer #409. À
exercer en beta après déploiement, sur Google **et** GitHub.

**Sans test automatisé** : ces défauts sont tous des comportements d'interface
qu'aucune suite ne voyait. Les couvrir demanderait un harnais de rendu que le
projet n'a pas pour ces écrans.

## Hors périmètre

#410 (largeur des écrans de détail), #415 (uniformisation) et #416 (pagination)
relèvent de la passe d'ergonomie globale, pas d'un correctif de défaut. La case
à cocher de `SponsoringTab` ne gagne pas de confirmation — demander à chaque
bascule serait pire que l'erreur évitée — mais elle ne bouge plus quand le
serveur refuse.

Refs #407 #408 #409 #412 #413 #414
