### PR TITLE
Servir les pages créées en admin via une route /[slug]

### DIFF
--- a/src/frontend/src/app/[locale]/[slug]/page.test.tsx
+++ b/src/frontend/src/app/[locale]/[slug]/page.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #421 — a page created from the admin used to 404: no route could serve an
+// arbitrary slug. What matters here is that an existing slug renders and a
+// missing one still reaches the site's 404 rather than an empty shell.
+
+vi.mock("@/lib/api", () => ({ getContentPage: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("next-intl/server", () => ({
+  getLocale: vi.fn(async () => locale),
+  getTranslations: vi.fn(async () => (key: string) => key),
+}));
+
+vi.mock("@/components/Breadcrumb", () => ({ default: () => null }));
+
+import { getContentPage } from "@/lib/api";
+import { notFound } from "next/navigation";
+import ContentPageBySlug, { generateMetadata } from "./page";
+
+let locale = "fr";
+
+const PAGE = {
+  id: 3,
+  slug: "mentions-legales-applinkedin",
+  titleFr: "Politique de confidentialité App LinkedIn",
+  titleEn: "LinkedIn App Privacy Policy",
+  contentFr: "<p>Contenu français</p>",
+  contentEn: "<p>English content</p>",
+  updatedAt: "2026-08-17T00:00:00Z",
+};
+
+const params = (slug: string) => Promise.resolve({ slug });
+
+beforeEach(() => {
+  locale = "fr";
+  vi.mocked(getContentPage).mockReset();
+});
+
+describe("dynamic content page", () => {
+  it("renders the page matching the slug", async () => {
+    vi.mocked(getContentPage).mockResolvedValue(PAGE);
+
+    const element = await ContentPageBySlug({ params: params(PAGE.slug) });
+
+    expect(getContentPage).toHaveBeenCalledWith(PAGE.slug);
+    expect(JSON.stringify(element)).toContain("Politique de confidentialité App LinkedIn");
+  });
+
+  it("serves the English columns under the en locale", async () => {
+    locale = "en";
+    vi.mocked(getContentPage).mockResolvedValue(PAGE);
+
+    const element = await ContentPageBySlug({ params: params(PAGE.slug) });
+
+    expect(JSON.stringify(element)).toContain("English content");
+  });
+
+  it("calls notFound when no page carries the slug", async () => {
+    vi.mocked(getContentPage).mockResolvedValue(null);
+
+    await expect(ContentPageBySlug({ params: params("slug-bidon") })).rejects.toThrow(
+      "NEXT_NOT_FOUND",
+    );
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("builds metadata with fr/en alternates on the same slug", async () => {
+    vi.mocked(getContentPage).mockResolvedValue(PAGE);
+
+    const meta = await generateMetadata({ params: params(PAGE.slug) });
+
+    expect(meta.title).toBe(PAGE.titleFr);
+    expect(meta.alternates?.languages).toMatchObject({
+      fr: `/fr/${PAGE.slug}`,
+      en: `/en/${PAGE.slug}`,
+    });
+  });
+
+  // A missing page must not surface "undefined" as a title in <head>.
+  it("returns empty metadata for an unknown slug", async () => {
+    vi.mocked(getContentPage).mockResolvedValue(null);
+
+    await expect(generateMetadata({ params: params("slug-bidon") })).resolves.toEqual({});
+  });
+});

--- a/src/frontend/src/app/[locale]/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/[slug]/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { getContentPage } from "@/lib/api";
+import { localizedField } from "@/lib/i18n-helpers";
+import { htmlToText } from "@/lib/html";
+import Breadcrumb from "@/components/Breadcrumb";
+
+// Serves any page created from the admin (#421). Slugs are unique and not
+// localized, so the same URL answers under /fr and /en with the matching
+// language columns. Statically-declared routes (mentions-legales,
+// code-de-conduite) keep priority over this segment and are untouched.
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const page = await getContentPage(slug);
+
+  if (!page) return {};
+
+  const title = localizedField(page, "title", locale);
+  const description = htmlToText(localizedField(page, "content", locale)).slice(0, 160);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/${locale}/${slug}`,
+      languages: { fr: `/fr/${slug}`, en: `/en/${slug}`, "x-default": `/fr/${slug}` },
+    },
+  };
+}
+
+export default async function ContentPageBySlug({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const t = await getTranslations("legalNotice");
+  const page = await getContentPage(slug);
+
+  if (!page) notFound();
+
+  const title = localizedField(page, "title", locale);
+  const content = localizedField(page, "content", locale);
+
+  const breadcrumbItems = [
+    { label: t("home"), href: `/${locale}` },
+    { label: title, href: `/${locale}/${slug}` },
+  ];
+
+  return (
+    <div className="px-6 py-8 lg:py-12">
+      <div className="mx-auto max-w-4xl">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
+          {title}
+        </h1>
+
+        {/* Admin-authored HTML, rendered raw like the two hardcoded pages it
+            generalizes. Safe while only administrators can write a page; to be
+            sanitized when page creation opens to sponsors or speakers (#419). */}
+        <div
+          className="mt-8 prose prose-lg max-w-none text-noir
+            [&_h4]:text-2xl [&_h4]:font-bold [&_h4]:mt-8 [&_h4]:mb-4
+            [&_h5]:text-xl [&_h5]:font-bold [&_h5]:mt-6 [&_h5]:mb-3
+            [&_p]:leading-relaxed [&_p]:mb-4
+            [&_a]:text-bismarck [&_a]:underline
+            [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:mb-4
+            [&_li]:mb-1"
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

- Ajoute `[locale]/[slug]/page.tsx`, qui sert n'importe quelle page créée depuis l'admin. Le bouton « Nouvelle page » existe en production depuis avant la v1.6.0, mais aucune route ne pouvait servir le résultat : les deux consommateurs de `ContentPage` passent un slug **littéral**, donc tout autre slug tombait en 404 **au niveau du routeur Next**, avant même l'appel à l'API.
- **Aucune migration, aucun changement d'API.** `getContentPage()` était déjà générique et échappait le slug.
- `mentions-legales/` et `code-de-conduite/` sont **conservées telles quelles** : le segment statique garde la priorité sur le segment dynamique.

## Pourquoi c'est livrable sans le statut de publication (#419)

Le piège d'ordre relevé dans #419 — « le filtre de publication doit précéder l'ouverture de la route » — ne s'applique **pas tant que le statut n'existe pas**. `GET /api/pages/:slug` sert déjà toute ligne en base sans aucun filtre, production comprise. Cette PR n'expose donc rien qui ne le soit déjà : il n'y a pas de brouillon à protéger.

**À l'implémentation de #419, le filtre devra atterrir dans le même changement que le champ de statut** — pas après. C'est noté en commentaire dans le code et sur l'issue.

## Vérifié

- `tsc --noEmit` : propre. Lint : 0 erreur (8 warnings préexistants, tous dans `components/admin/`).
- Suite frontend complète : **128 tests / 21 fichiers au vert**, dont `sitemap.test.ts` et `nav.test.ts` — pas de régression.
- **Les tests échouent sans le correctif** : fichier de route déplacé → rouge, restauré → vert.
- **Navigateur** (Docker local, page de test insérée en base puis supprimée) :
  - `/fr/mentions-legales-applinkedin` et `/en/...` → 200, titre + contenu dans la bonne langue ;
  - `/fr/mentions-legales` et `/fr/code-de-conduite` → 200, titre et `canonical` inchangés ;
  - `/fr/slug-bidon` → **la vraie page 404 du site**, pas une coquille vide ;
  - `alternates` `canonical` / `fr` / `en` / `x-default` corrects ;
  - console sans erreur (2 warnings préexistants sur le logo, présents sur tout le site) ;
  - rendu mobile 390 px correct, sans débordement.

## Non vérifié

- **Que la page existe en base de production.** L'API admin est protégée (403), je n'ai pas pu lister les pages de prod. La page a été recréée **localement** pour le test, puis supprimée. Si `mentions-legales-applinkedin` n'a été créée qu'en local ou en beta, il faudra la créer en prod — sinon l'URL restera en 404 malgré cette PR.
- **Le cache.** Les pages publiques sont en `s-maxage=3600` et l'URL renvoie 404 en ce moment : après déploiement, prévoir une purge, sinon la 404 peut persister jusqu'à une heure (cf. #345, #232).

## Réserves documentées, non traitées ici

- Le contenu reste rendu via `dangerouslySetInnerHTML`, à l'identique des deux pages qu'il généralise. Acceptable tant que seuls des administrateurs rédigent ces pages ; à assainir quand la création s'ouvrira (#419). Commentaire posé dans le code.
- **Collision de slug silencieuse** : une page nommée `sponsors` ou `contact` ne sera jamais servie, le segment statique gagnant toujours. Renvoyé vers #419.

Refs #421
