### PR TITLE
Aligner dev sur la prod — route /[slug] des pages admin

### DIFF
--- a/src/frontend/src/app/[locale]/[slug]/page.test.tsx
+++ b/src/frontend/src/app/[locale]/[slug]/page.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// #421 — a page created from the admin used to 404: no route could serve an
+// arbitrary slug. What matters here is that an existing slug renders and a
+// missing one still reaches the site's 404 rather than an empty shell.
+
+vi.mock("@/lib/api", () => ({ getContentPage: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("next-intl/server", () => ({
+  getLocale: vi.fn(async () => locale),
+  getTranslations: vi.fn(async () => (key: string) => key),
+}));
+
+vi.mock("@/components/Breadcrumb", () => ({ default: () => null }));
+
+import { getContentPage } from "@/lib/api";
+import { notFound } from "next/navigation";
+import ContentPageBySlug, { generateMetadata } from "./page";
+
+let locale = "fr";
+
+const PAGE = {
+  id: 3,
+  slug: "mentions-legales-applinkedin",
+  titleFr: "Politique de confidentialité App LinkedIn",
+  titleEn: "LinkedIn App Privacy Policy",
+  contentFr: "<p>Contenu français</p>",
+  contentEn: "<p>English content</p>",
+  updatedAt: "2026-08-17T00:00:00Z",
+};
+
+const params = (slug: string) => Promise.resolve({ slug });
+
+beforeEach(() => {
+  locale = "fr";
+  vi.mocked(getContentPage).mockReset();
+});
+
+describe("dynamic content page", () => {
+  it("renders the page matching the slug", async () => {
+    vi.mocked(getContentPage).mockResolvedValue(PAGE);
+
+    const element = await ContentPageBySlug({ params: params(PAGE.slug) });
+
+    expect(getContentPage).toHaveBeenCalledWith(PAGE.slug);
+    expect(JSON.stringify(element)).toContain("Politique de confidentialité App LinkedIn");
+  });
+
+  it("serves the English columns under the en locale", async () => {
+    locale = "en";
+    vi.mocked(getContentPage).mockResolvedValue(PAGE);
+
+    const element = await ContentPageBySlug({ params: params(PAGE.slug) });
+
+    expect(JSON.stringify(element)).toContain("English content");
+  });
+
+  it("calls notFound when no page carries the slug", async () => {
+    vi.mocked(getContentPage).mockResolvedValue(null);
+
+    await expect(ContentPageBySlug({ params: params("slug-bidon") })).rejects.toThrow(
+      "NEXT_NOT_FOUND",
+    );
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("builds metadata with fr/en alternates on the same slug", async () => {
+    vi.mocked(getContentPage).mockResolvedValue(PAGE);
+
+    const meta = await generateMetadata({ params: params(PAGE.slug) });
+
+    expect(meta.title).toBe(PAGE.titleFr);
+    expect(meta.alternates?.languages).toMatchObject({
+      fr: `/fr/${PAGE.slug}`,
+      en: `/en/${PAGE.slug}`,
+    });
+  });
+
+  // A missing page must not surface "undefined" as a title in <head>.
+  it("returns empty metadata for an unknown slug", async () => {
+    vi.mocked(getContentPage).mockResolvedValue(null);
+
+    await expect(generateMetadata({ params: params("slug-bidon") })).resolves.toEqual({});
+  });
+});

--- a/src/frontend/src/app/[locale]/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/[slug]/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getLocale, getTranslations } from "next-intl/server";
+
+import { getContentPage } from "@/lib/api";
+import { localizedField } from "@/lib/i18n-helpers";
+import { htmlToText } from "@/lib/html";
+import Breadcrumb from "@/components/Breadcrumb";
+
+// Serves any page created from the admin (#421). Slugs are unique and not
+// localized, so the same URL answers under /fr and /en with the matching
+// language columns. Statically-declared routes (mentions-legales,
+// code-de-conduite) keep priority over this segment and are untouched.
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const page = await getContentPage(slug);
+
+  if (!page) return {};
+
+  const title = localizedField(page, "title", locale);
+  const description = htmlToText(localizedField(page, "content", locale)).slice(0, 160);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/${locale}/${slug}`,
+      languages: { fr: `/fr/${slug}`, en: `/en/${slug}`, "x-default": `/fr/${slug}` },
+    },
+  };
+}
+
+export default async function ContentPageBySlug({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const locale = await getLocale();
+  const t = await getTranslations("legalNotice");
+  const page = await getContentPage(slug);
+
+  if (!page) notFound();
+
+  const title = localizedField(page, "title", locale);
+  const content = localizedField(page, "content", locale);
+
+  const breadcrumbItems = [
+    { label: t("home"), href: `/${locale}` },
+    { label: title, href: `/${locale}/${slug}` },
+  ];
+
+  return (
+    <div className="px-6 py-8 lg:py-12">
+      <div className="mx-auto max-w-4xl">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
+          {title}
+        </h1>
+
+        {/* Admin-authored HTML, rendered raw like the two hardcoded pages it
+            generalizes. Safe while only administrators can write a page; to be
+            sanitized when page creation opens to sponsors or speakers (#419). */}
+        <div
+          className="mt-8 prose prose-lg max-w-none text-noir
+            [&_h4]:text-2xl [&_h4]:font-bold [&_h4]:mt-8 [&_h4]:mb-4
+            [&_h5]:text-xl [&_h5]:font-bold [&_h5]:mt-6 [&_h5]:mb-3
+            [&_p]:leading-relaxed [&_p]:mb-4
+            [&_a]:text-bismarck [&_a]:underline
+            [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:mb-4
+            [&_li]:mb-1"
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

Aligne `dev` sur la production après le hotfix #423 (mergé sur `main`, déployé et vérifié en ligne). Sans ce report, `dev` ne porte pas la route, et la prochaine promotion `dev → main` **supprimerait de la production** une page actuellement en ligne.

Report ciblé du seul commit `6c038ed` (cherry-pick, appliqué sans conflit) : deux fichiers **nouveaux**, aucune modification de l'existant.

> Volontairement **pas** une promotion `dev-j → dev` : `dev-j` a 361 commits d'avance sur `dev`, dont du contenu encore en attente de validation. Cette PR ne porte que le correctif déjà en production.

## Contenu

`[locale]/[slug]/page.tsx` sert n'importe quelle page créée depuis l'admin. Le bouton « Nouvelle page » existait depuis avant la v1.6.0, mais aucune route ne pouvait servir le résultat : les deux consommateurs de `ContentPage` passent un slug **littéral**, donc tout autre slug tombait en 404 au niveau du routeur Next, avant même l'appel à l'API.

Aucune migration, aucun changement d'API. `mentions-legales/` et `code-de-conduite/` gardent la priorité (segment statique sur segment dynamique).

## Vérifié sur la base de `dev`

- `tsc --noEmit` : propre (après purge du `.next`).
- Suite frontend complète : **128 tests / 21 fichiers au vert**, dont les 5 de la nouvelle route.

Déjà vérifié en amont : CI complète au vert sur #423 (backend, frontend, Lighthouse, version guard), build de production réussi, et **comportement confirmé en production après déploiement** — `/fr/` et `/en/mentions-legales-applinkedin` en 200 avec le contenu dans la bonne langue, `/fr/mentions-legales` et `/fr/code-de-conduite` inchangées, `/fr/slug-bidon` toujours en 404, `canonical` et `hreflang` corrects.

## Après merge

Déploiement beta automatique (~5 min). À vérifier : `https://beta.site.devfesttoulouse.fr/fr/mentions-legales` répond toujours 200. La page LinkedIn elle-même n'existe qu'en base de **production** — son URL restera donc en 404 en beta, ce qui est normal et n'indique pas un problème de la route.

## Réserves (inchangées)

Le statut brouillon/publié, la corbeille et la suppression restent dans #419 ; la navigation dans #420. **Quand #419 ajoutera le champ de statut, le filtre sur `GET /api/pages/:slug` devra atterrir dans le même changement** — sinon tout brouillon deviendra public via cette route.

Refs #421
