### PR TITLE
Quatre correctifs avant la mise en production

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -13,6 +13,7 @@
     "conferences": "Talks",
     "program": "Schedule",
     "speakers": "Speakers",
+    "hallOfFame": "Hall of fame",
     "sponsors": "Sponsors",
     "jobOffers": "Job offers",
     "venue": "Venue",

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -366,7 +366,7 @@
   },
   "replays": {
     "title": "Replays",
-    "pageTitle": "Replays — every recorded talk | DevFest Toulouse",
+    "pageTitle": "Replays — every recorded talk",
     "heading": "Replays",
     "description": "Watch again the recorded talks from DevFest Toulouse, across all editions.",
     "home": "Home",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -366,7 +366,7 @@
   },
   "replays": {
     "title": "Replays",
-    "pageTitle": "Replays — toutes les conférences filmées | DevFest Toulouse",
+    "pageTitle": "Replays — toutes les conférences filmées",
     "heading": "Replays",
     "description": "Revoyez les conférences filmées du DevFest Toulouse, toutes éditions confondues.",
     "home": "Accueil",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -13,6 +13,7 @@
     "conferences": "Conférences",
     "program": "Programme",
     "speakers": "Speakers",
+    "hallOfFame": "Hall of fame",
     "sponsors": "Sponsors",
     "jobOffers": "Offres d'emploi",
     "venue": "Lieu",

--- a/src/frontend/src/app/[locale]/editions/[year]/page.tsx
+++ b/src/frontend/src/app/[locale]/editions/[year]/page.tsx
@@ -71,7 +71,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const locale = await getLocale();
   const t = await getTranslations("bilan");
   return {
-    title: t("pageTitle", { year }),
+    // Absolute: the label already carries the brand and the year, so the
+    // layout template turned it into "DevFest Toulouse 2025 — DevFest Toulouse
+    // 2026" — two different years in one title (#381). The same key feeds the
+    // breadcrumb, where the brand belongs, so the fix is here and not in the
+    // wording.
+    title: { absolute: t("pageTitle", { year }) },
     description: t("description", { year }),
     alternates: {
       canonical: `/${locale}/editions/${year}`,

--- a/src/frontend/src/app/admin/articles/[id]/page.tsx
+++ b/src/frontend/src/app/admin/articles/[id]/page.tsx
@@ -174,7 +174,9 @@ export default function ArticleEditorPage() {
       setTranslateError("La traduction a cassé la structure du contenu. Réessayez ou corrigez manuellement.");
       return;
     }
-    if (status >= 400) {
+    // Anything but 200 failed, network included: a dropped connection comes
+    // back as status 0, which `>= 400` let through as a translation (#428).
+    if (status !== 200) {
       setTranslateError(translateApiError || "La traduction a échoué.");
       return;
     }

--- a/src/frontend/src/app/admin/categories/[id]/page.tsx
+++ b/src/frontend/src/app/admin/categories/[id]/page.tsx
@@ -76,7 +76,11 @@ export default function CategoryEditorPage() {
       setError(apiError ?? "Une catégorie porte déjà ce nom.");
       return;
     }
-    if (status >= 400 || (isNew && !data)) {
+    // Creation answers 201 and an update 200, so only the update can be pinned
+    // to a status; on create it is the absent body that proves the failure.
+    // Either way a dropped connection lands here as status 0, which `>= 400`
+    // announced as a success (#428).
+    if (isNew ? !data : status !== 200) {
       setError(apiError ?? (isNew ? "Échec de la création." : "Échec de l'enregistrement."));
       return;
     }

--- a/src/frontend/src/app/admin/speakers/[id]/page.tsx
+++ b/src/frontend/src/app/admin/speakers/[id]/page.tsx
@@ -131,7 +131,9 @@ export default function SpeakerEditorPage() {
     } else {
       const { status } = await adminFetch(`/speakers/${speakerId}`, { method: "PUT", body: JSON.stringify(payload) });
       setIsSaving(false);
-      if (status >= 400) {
+      // Anything but 200 failed, network included: a dropped connection comes
+      // back as status 0, which `>= 400` announced as a save (#428).
+      if (status !== 200) {
         setSaveState({ kind: "error", text: "Échec de l'enregistrement. Réessayez." });
         return;
       }

--- a/src/frontend/src/app/admin/sponsor-tiers/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsor-tiers/[id]/page.tsx
@@ -85,7 +85,9 @@ export default function SponsorTierEditorPage() {
     } else {
       const { status } = await adminFetch(`/sponsor-tiers/${tierId}`, { method: "PUT", body: JSON.stringify(payload) });
       setIsSaving(false);
-      if (status >= 400) {
+      // Anything but 200 failed, network included: a dropped connection comes
+      // back as status 0, which `>= 400` announced as a save (#428).
+      if (status !== 200) {
         setError("Échec de l'enregistrement.");
         return;
       }

--- a/src/frontend/src/app/admin/sponsors/[id]/page.test.tsx
+++ b/src/frontend/src/app/admin/sponsors/[id]/page.test.tsx
@@ -133,6 +133,35 @@ describe("Sponsor sheet — panels separate identity from participation (#393)",
   });
 });
 
+describe("Sponsor sheet — a save that never left says so (#428)", () => {
+  it("reports an error when the request does not reach the backend", async () => {
+    const user = userEvent.setup();
+    // What `adminFetch` returns when fetch itself throws: no answer, no body.
+    // The screen used to test `status >= 400`, which 0 does not satisfy, so a
+    // dropped connection displayed "Modifications enregistrées."
+    adminFetch.mockImplementation((path: string, init?: { method?: string }) => {
+      if (init?.method === "PUT") return Promise.resolve({ data: null, status: 0 });
+      if (path === "/sponsor-tiers") return Promise.resolve({ data: TIERS, status: 200 });
+      if (path === "/sponsors/42") return Promise.resolve({ data: SPONSOR, status: 200 });
+      return Promise.resolve({ data: [], status: 200 });
+    });
+
+    render(<SponsorEditorPage />);
+    await user.click(await screen.findByRole("button", { name: "Enregistrer" }));
+
+    expect(await screen.findByText("Échec de l'enregistrement. Réessayez.")).toBeInTheDocument();
+    expect(screen.queryByText("Modifications enregistrées.")).not.toBeInTheDocument();
+  });
+
+  it("still confirms a save that did reach the backend", async () => {
+    const user = userEvent.setup();
+    render(<SponsorEditorPage />);
+    await user.click(await screen.findByRole("button", { name: "Enregistrer" }));
+
+    expect(await screen.findByText("Modifications enregistrées.")).toBeInTheDocument();
+  });
+});
+
 describe("Sponsor sheet — a blocked save explains itself (#393)", () => {
   it("says which field is missing and where it lives", async () => {
     const user = userEvent.setup();

--- a/src/frontend/src/app/admin/sponsors/[id]/page.tsx
+++ b/src/frontend/src/app/admin/sponsors/[id]/page.tsx
@@ -173,7 +173,9 @@ export default function SponsorEditorPage() {
     } else {
       const { status } = await adminFetch(`/sponsors/${sponsorId}`, { method: "PUT", body: JSON.stringify(payload) });
       setIsSaving(false);
-      if (status >= 400) {
+      // Anything but 200 failed, network included: a dropped connection comes
+      // back as status 0, which `>= 400` announced as a save (#428).
+      if (status !== 200) {
         setSaveState({ kind: "error", text: "Échec de l'enregistrement. Réessayez." });
         return;
       }

--- a/src/frontend/src/app/admin/talks/[id]/page.tsx
+++ b/src/frontend/src/app/admin/talks/[id]/page.tsx
@@ -106,7 +106,9 @@ export default function TalkEditorPage() {
     } else {
       const { status } = await adminFetch(`/talks/${talkId}`, { method: "PUT", body: JSON.stringify(payload) });
       setIsSaving(false);
-      if (status >= 400) {
+      // Anything but 200 failed, network included: a dropped connection comes
+      // back as status 0, which `>= 400` announced as a save (#428).
+      if (status !== 200) {
         setError("Échec de l'enregistrement.");
         return;
       }

--- a/src/frontend/src/app/sitemap.test.ts
+++ b/src/frontend/src/app/sitemap.test.ts
@@ -24,7 +24,7 @@ import {
   getHallOfFame,
   getIndexableSponsors,
 } from "@/lib/api";
-import sitemap from "./sitemap";
+import sitemap, { dynamic } from "./sitemap";
 
 const FEATURED = { id: 1, year: 2026 };
 
@@ -142,5 +142,15 @@ describe("sitemap — every article, not the first hundred (#379)", () => {
     // The old code called getArticles(1, 100) once and stopped there.
     expect(paths(entries)).toContain("/fr/actualites/article-1");
     expect(paths(entries)).toContain("/fr/actualites/article-3");
+  });
+});
+
+describe("sitemap — never served from the build (#426)", () => {
+  it("opts out of prerendering", async () => {
+    // `next build` has no backend: prerendering this route bakes in a sitemap
+    // holding the static routes and nothing else, and that is what the first
+    // crawler after a deployment receives. Observed on beta, 28 URLs against
+    // the 1310 a fresh render produces.
+    expect(dynamic).toBe("force-dynamic");
   });
 });

--- a/src/frontend/src/app/sitemap.ts
+++ b/src/frontend/src/app/sitemap.ts
@@ -11,6 +11,21 @@ import {
 
 const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 
+// Rendered per request, never prerendered (#426). `next build` runs with no
+// backend reachable — `fetchAPI` degrades to null there by design — so a
+// build-time render lists the static routes and nothing else. That empty
+// sitemap is then served to whoever asks first after a deployment, and stays
+// served until some request happens to trigger a revalidation: observed on
+// beta, 28 URLs for more than a day where a fresh render gives 1310. Measured
+// on a build made without a backend: 28 URLs prerendered, 122 rendered.
+//
+// The cost is one render per request, on a URL crawlers fetch a few times a
+// day — and the fetches keep their own hour-long cache, so a backend outage
+// serves the last good sitemap rather than a truncated one. Only a cold cache
+// and a dead backend together produce a 500, which a crawler retries; a 200
+// announcing a site with no content is what it would never question (#345).
+export const dynamic = "force-dynamic";
+
 type Locale = "fr" | "en";
 
 // Articles are read page by page rather than with a fixed ceiling: a hard

--- a/src/frontend/src/components/Footer.tsx
+++ b/src/frontend/src/components/Footer.tsx
@@ -72,10 +72,17 @@ export default async function Footer() {
             {(() => {
               // Flatten parent + children into one list (the footer has no
               // dropdowns); children render indented under their parent (#203).
-              const footerEntries = getPublicNavEntries(edition).flatMap((entry) => [
-                { ...entry, indented: false },
-                ...(entry.children ?? []).map((child) => ({ ...child, indented: true })),
-              ]);
+              const footerEntries = getPublicNavEntries(edition)
+                .flatMap((entry) => [
+                  { ...entry, indented: false },
+                  ...(entry.children ?? []).map((child) => ({ ...child, indented: true })),
+                ])
+                // The hall of fame joined the header under Speakers (#369), and
+                // the footer already lists it in the cross-edition column next
+                // to the replays — where it belongs, and where it stays visible
+                // before any speaker is announced. Flattening it here as well
+                // put it twice in the same footer.
+                .filter((entry) => entry.key !== "hall-of-fame");
               if (footerEntries.length === 0) return null;
               return (
                 <div>

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -57,6 +57,10 @@ export async function adminFetch<T>(
     const data = await res.json();
     return { data, status: res.status };
   } catch {
+    // Status 0 means the request never reached the backend — a network
+    // failure, not an answer. Callers must not test `status >= 400` alone: 0
+    // slips through it, and the screen then reports a save that never happened
+    // (#428). Success is 200 on an update, 201 on a creation.
     return { data: null, status: 0 };
   }
 }

--- a/src/frontend/src/lib/messages.test.ts
+++ b/src/frontend/src/lib/messages.test.ts
@@ -36,3 +36,24 @@ describe("translation placeholders", () => {
     }
   });
 });
+
+describe("page titles and the brand (#381)", () => {
+  // The layout appends " — DevFest Toulouse 2026" to every title. A `pageTitle`
+  // that already names the brand therefore ships it twice: /replays read
+  // "Replays — toutes les conférences filmées | DevFest Toulouse — DevFest
+  // Toulouse 2026", 83 characters, cut by Google mid-repetition.
+  it("does not name the brand in a title the template completes", () => {
+    for (const [name, messages] of locales) {
+      expect(messages.replays.pageTitle as string, `${name}: replays.pageTitle`).not.toMatch(/DevFest/);
+    }
+  });
+
+  // `bilan.pageTitle` is the exception and stays one: it also labels the
+  // breadcrumb, where "DevFest Toulouse 2025" is the right wording. The page
+  // opts out of the template with `title.absolute` instead.
+  it("keeps the brand in the edition label, which the breadcrumb needs", () => {
+    for (const [name, messages] of locales) {
+      expect(messages.bilan.pageTitle as string, `${name}: bilan.pageTitle`).toContain("DevFest Toulouse");
+    }
+  });
+});

--- a/src/frontend/src/lib/nav.test.ts
+++ b/src/frontend/src/lib/nav.test.ts
@@ -54,6 +54,15 @@ describe("getPublicNavEntries", () => {
     expect(keys(getPublicNavEntries(edition({ hasSpeakers: true })))).toEqual(["speakers", "blog"]);
   });
 
+  it("nests the hall of fame under Speakers (#369)", () => {
+    const entries = getPublicNavEntries(edition({ hasSpeakers: true }));
+    const speakers = entries.find((e) => e.key === "speakers");
+    expect(speakers?.children?.map((c) => c.key)).toEqual(["hall-of-fame"]);
+    // Under the parent, not beside it: a second top-level entry is what #276
+    // cost us on Sponsors.
+    expect(keys(entries)).not.toContain("hall-of-fame");
+  });
+
   it("shows Sponsors without a submenu when there are no job offers", () => {
     const entries = getPublicNavEntries(edition({ hasSponsors: true }));
     const sponsors = entries.find((e) => e.key === "sponsors");

--- a/src/frontend/src/lib/nav.test.ts
+++ b/src/frontend/src/lib/nav.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 
 import { getPublicNavEntries } from "./nav";
 import type { Edition } from "./types";
+import fr from "../../messages/fr.json";
+import en from "../../messages/en.json";
 
 // getPublicNavEntries drives which public menu links show. Its branches encode
 // real rules that have already caused bugs (#203 program nesting, #276 the
@@ -80,6 +82,34 @@ describe("getPublicNavEntries", () => {
   it("shows the venue link only when the edition has venue info (#109)", () => {
     expect(keys(getPublicNavEntries(edition()))).not.toContain("venue");
     expect(keys(getPublicNavEntries(edition({ hasVenueInfo: true })))).toEqual(["venue", "blog"]);
+  });
+
+  // A labelKey with no entry under the `nav` namespace renders as the raw key:
+  // the header shipped "nav.hallOfFame" to visitors while every structural test
+  // stayed green, because they all assert the key and never its translation.
+  // Caught in the browser, not here — hence this (#369).
+  it("gives every entry and child a label in both locales", () => {
+    const entries = getPublicNavEntries(
+      edition({
+        isScheduleReady: true,
+        isProgramPublished: true,
+        hasSpeakers: true,
+        hasSponsors: true,
+        hasJobOffers: true,
+        hasVenueInfo: true,
+      }),
+    );
+    const labelKeys = entries.flatMap((e) => [
+      e.labelKey,
+      ...(e.children?.map((c) => c.labelKey) ?? []),
+    ]);
+
+    for (const [name, messages] of [["fr", fr], ["en", en]] as const) {
+      const nav = messages.nav as Record<string, string | undefined>;
+      for (const key of labelKeys) {
+        expect(nav[key], `${name}: nav.${key} is missing`).toBeTruthy();
+      }
+    }
   });
 
   it("orders entries program → speakers → sponsors → venue → blog", () => {

--- a/src/frontend/src/lib/nav.ts
+++ b/src/frontend/src/lib/nav.ts
@@ -26,6 +26,15 @@ const JOB_OFFERS_CHILD: NavEntry = {
   labelKey: "jobOffers",
   href: "/offres-emploi-partenaires",
 };
+// The hall of fame hangs under Speakers (#369), the way the job offers hang
+// under Sponsors. It spans every edition rather than the current one, so it
+// rides on the parent's condition: no speakers announced, no menu, and the
+// footer link — which is always there — remains the way in.
+const HALL_OF_FAME_CHILD: NavEntry = {
+  key: "hall-of-fame",
+  labelKey: "hallOfFame",
+  href: "/hall-of-fame",
+};
 const BLOG_ENTRY: NavEntry = { key: "blog", labelKey: "blog", href: "/actualites" };
 // Venue & practical-info page (#109). Shown only once the edition has map
 // coordinates or a written transports/parking section (hasVenueInfo).
@@ -53,7 +62,7 @@ export function getPublicNavEntries(edition: Edition | null): NavEntry[] {
     entries.push(CONFERENCES_ENTRY);
   }
 
-  if (edition?.hasSpeakers) entries.push(SPEAKERS_ENTRY);
+  if (edition?.hasSpeakers) entries.push({ ...SPEAKERS_ENTRY, children: [HALL_OF_FAME_CHILD] });
   if (edition?.hasSponsors) {
     entries.push(
       edition.hasJobOffers ? { ...SPONSORS_ENTRY, children: [JOB_OFFERS_CHILD] } : SPONSORS_ENTRY,


### PR DESCRIPTION
Quatre correctifs indépendants, réunis parce qu'ils visent la même mise en production.

| Issue | Ce que ça change |
|---|---|
| **#426** | `/sitemap.xml` n'est plus prérendu : le build tourne sans backend, donc la version figée ne listait que les routes statiques |
| **#428** | Six écrans d'admin annonçaient « Modifications enregistrées. » quand la requête n'avait jamais atteint le backend |
| **#381** | Deux titres répétaient la marque, dont un qui affichait deux années différentes |
| **#369** | Le hall of fame devient atteignable depuis le header, sous Speakers |

## Plan de test

### #426 — mesuré, avec témoin

Deux builds faits sans backend joignable, puis `next start` contre un backend local,
première requête sur `/sitemap.xml` :

| | Type de route | URLs en 1ʳᵉ requête |
|---|---|---|
| Sans le correctif | `○ /sitemap.xml` | **28** — les routes statiques seules |
| Avec le correctif | `ƒ /sitemap.xml` | **122** — sponsors, conférences, speakers, actualités |

Le premier essai du témoin était faux : le serveur n'avait pas démarré (`EADDRINUSE`) et
je mesurais encore l'ancien. Refait sur un port libre.

Vérifié aussi ce que devient une panne backend, parce que le commentaire que j'avais
écrit se révélait inexact : le cache de fetch garde son heure, donc une coupure sert le
**dernier sitemap valide**, pas un tronqué. Seuls un cache froid *et* un backend mort
donnent un 500 — corrigé dans le commentaire du code.

`robots.txt` a été vérifié et reste statique à raison : il ne lit que des variables
d'environnement.

### #428 — test rouge d'abord

Le nouveau test échoue sur le code d'avant (`Unable to find … "Échec de
l'enregistrement. Réessayez."`) et passe ensuite. Un second test vérifie qu'un
enregistrement qui aboutit confirme toujours.

### #381 — titres rendus, avant / après

Relevés sur le stack local :

| Page | Avant | Après |
|---|---|---|
| `/fr/replays` | 83 car., marque en double | **64 car.** |
| `/en/replays` | 72 car. | **53 car.** |
| `/fr/editions/2025` | « DevFest Toulouse 2025 — DevFest Toulouse 2026 » | **« DevFest Toulouse 2025 »** |

64 caractères reste au-dessus de la cible de ~60 posée par l'issue : la formulation
éditoriale existante a été conservée telle quelle, seule la marque est retirée.

### #369 — structure et rendu

Test unitaire sur `getPublicNavEntries` (rouge d'abord), et sur la page rendue le lien
`/hall-of-fame` passe de 2 à 6 occurrences — le footer, plus les navigations desktop et
mobile.

### Global

**134 tests / 21 fichiers au vert.** `tsc --noEmit` et ESLint propres.

## Ce qui n'a pas été vérifié

**Le #428 n'a pas été rejoué au navigateur sur le code corrigé** — la MCP Chrome s'est
déconnectée en cours de session. Le défaut, lui, a bien été observé en direct sur la
beta (PUT en `ERR_INTERNET_DISCONNECTED`, message de succès affiché), et le test rend le
composant réel avec la valeur exacte que renvoie `adminFetch`. Il reste qu'aucune
exécution unique ne couvre la chaîne de bout en bout sur le code corrigé.

Quatre des six écrans (conférence, offre de sponsoring, catégorie, traduction d'article)
sont corrigés d'après lecture du code : seules les fiches sponsor et speaker avaient été
reproduites au navigateur.

Le sous-menu du #369 a été vérifié dans le HTML servi, **pas au survol** : le déroulé
tient à `group-hover`/`group-focus-within` dans `Header.tsx`, inchangé ici, et déjà en
service pour les offres d'emploi.

## Portée volontairement réduite

- **#381** ne traite que le défaut 1 (les titres). L'issue prévoit ce découpage : « le
  titre de /replays étant visible en production et corrigeable en une ligne, il peut
  partir en correctif rapide sans attendre le reste. » Les métadonnées de la page
  d'accueil et la réécriture des descriptions FR restent à faire.
- L'issue affirme que `replays.title` n'est utilisé nulle part et propose de le
  supprimer : **c'est faux**, la clé sert au fil d'Ariane
  ([`replays/page.tsx:52`](src/frontend/src/app/[locale]/replays/page.tsx#L52)). Elle est
  conservée.
- **#369** : le hall of fame n'apparaît dans le header que si l'édition courante a des
  speakers, alors que la page couvre toutes les éditions. Choix assumé et commenté ; le
  lien du footer, lui, est inconditionnel.

## Trouvé en chemin, non traité ici

- `manifest.webmanifest` a le même gel que le sitemap : prérendu au build sans backend,
  il retombe sur le logo embarqué et ignore la favicon configurée en admin jusqu'à sa
  revalidation. Conséquence cosmétique et auto-résolue — les navigateurs le demandent à
  chaque visite, contrairement au sitemap. Laissé en ISR exprès : le passer en dynamique
  le ferait rendre à chaque visiteur.
- `seed-dev.ts` n'applique **jamais** les mots de passe documentés dans CLAUDE.md sur une
  base neuve : il appelle `seed.ts` d'abord, qui crée les comptes avec un mot de passe
  aléatoire, puis constate qu'ils existent et passe son tour.

Refs #426
Refs #428
Refs #381
Refs #369
