### PR TITLE
docs: rédiger les notes de release depuis le CHANGELOG

### DIFF
--- a/.claude/skills/deploy-to-prod/SKILL.md
+++ b/.claude/skills/deploy-to-prod/SKILL.md
@@ -204,15 +204,30 @@ git show main:src/backend/src/lib/version.ts | grep APP_VERSION   # == X.Y.Z
 
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
+
+# Le corps de la release EST la section du CHANGELOG, titre `## [X.Y.Z]` retiré.
+awk '/^## \[X\.Y\.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md | sed '/./,$!d' > /tmp/notes.md
+cat >> /tmp/notes.md <<'FOOTER'
+---
+
+[Changelog complet](https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/blob/main/CHANGELOG.md) · [Diff vPREV…vX.Y.Z](https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/compare/vPREV...vX.Y.Z) · PR de promotion #NNN
+FOOTER
+
 gh release create vX.Y.Z \
   --repo GDGToulouse/Site-Devfest-Toulouse-2026 \
-  --title "vX.Y.Z" --generate-notes
+  --title "vX.Y.Z — <résumé en une demi-ligne>" --notes-file /tmp/notes.md
 ```
 
 Garde-fous :
 - Le tag **doit** être identique à `APP_VERSION` — vérifié **avant** le push.
 - **Un seul tag par version**, jamais déplacé une fois poussé.
-- `--generate-notes` compile les PR mergées depuis le tag précédent.
+- **Ne pas utiliser `--generate-notes`** : il produit une liste de PR qui répète
+  ce que le diff dit déjà, et rompt avec les releases v1.2.0 à v1.6.0. Le lecteur
+  d'une release veut savoir *ce qui change pour lui*, pas quelles branches ont été
+  mergées — c'est le travail déjà fait dans le CHANGELOG à l'étape 2.
+- Le **titre** porte un résumé, jamais le numéro seul : « v1.5.0 — Catalogue
+  sponsoring, corbeille et page Lieu ». C'est ce qui s'affiche dans la liste des
+  releases, où le numéro seul n'apprend rien.
 
 Vérifier que les `Closes` de l'étape 3 ont bien fermé les issues (le merge dans `main`
 les ferme automatiquement — si l'une est encore ouverte, le mot-clé était mal écrit) :

--- a/docs/mise-en-production.md
+++ b/docs/mise-en-production.md
@@ -302,14 +302,25 @@ git show main:src/backend/src/lib/version.ts | grep APP_VERSION
 git tag -a v1.2.3 -m "Release v1.2.3"
 git push origin v1.2.3
 
-# Publier la release avec des notes auto-générées depuis les PR mergées
+# Le corps de la release EST la section du CHANGELOG, son titre `## [1.2.3]` retiré.
+awk '/^## \[1\.2\.3\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md | sed '/./,$!d' > /tmp/notes.md
+cat >> /tmp/notes.md <<'FOOTER'
+---
+
+[Changelog complet](https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/blob/main/CHANGELOG.md) · [Diff v1.2.2…v1.2.3](https://github.com/GDGToulouse/Site-Devfest-Toulouse-2026/compare/v1.2.2...v1.2.3) · PR de promotion #NNN
+FOOTER
+
 gh release create v1.2.3 \
   --repo GDGToulouse/Site-Devfest-Toulouse-2026 \
-  --title "v1.2.3" \
-  --generate-notes
+  --title "v1.2.3 — <résumé en une demi-ligne>" \
+  --notes-file /tmp/notes.md
 ```
 
-- `--generate-notes` compile les PR mergées depuis le tag précédent.
+- **Ne pas utiliser `--generate-notes`** : la liste de PR qu'il produit répète le
+  diff et rompt avec les releases v1.2.0 à v1.6.0. La release s'adresse à qui veut
+  savoir *ce qui change pour lui* — ce texte existe déjà, c'est le CHANGELOG.
+- Le **titre** porte un résumé, jamais le numéro seul : c'est lui qu'on lit dans la
+  liste des releases.
 - Le tag doit être **identique** à `APP_VERSION` (sinon l'admin et la release
   divergent) — vérifié **avant** le push ci-dessus.
 - **Un seul tag par version.** Ne jamais déplacer un tag déjà poussé.


### PR DESCRIPTION
La procédure se contredisait : l'étape 2 disait que la section du CHANGELOG
« sert aussi de notes de release », l'étape 6 prescrivait `--generate-notes`.

Cinq releases (v1.2.0 → v1.6.0) ont suivi la première consigne. La v1.7.0 a suivi
la seconde et est sortie en liste de PR brute, sous un titre réduit au numéro —
corrigée depuis, mais la contradiction restait dans les deux fichiers.

- La skill et la doc portent désormais la forme réellement utilisée : section du
  CHANGELOG, pied de page avec le lien de comparaison et la PR de promotion, titre
  qui résume au lieu de répéter le numéro.
- Et la raison : `--generate-notes` liste les branches mergées, ce que le diff dit
  déjà, là où le lecteur veut savoir ce qui change pour lui.

## Plan de test

**Vérifié** — le snippet `awk` documenté extrait bien les 70 lignes de la section
1.7.0 du CHANGELOG réel, sans le titre `## [1.7.0]` ni les lignes vides de tête.

**Non vérifié** — la procédure complète ne sera rejouée qu'à la prochaine mise en
production.

Refs #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
