### PR TITLE
Programme — modèle Lieu / Salle / Créneau et sa saisie

### DIFF
--- a/src/backend/prisma/migrations/20260821090000_programme_venue_rooms/migration.sql
+++ b/src/backend/prisma/migrations/20260821090000_programme_venue_rooms/migration.sql
@@ -1,0 +1,145 @@
+-- Venue, rooms and schedule entries (#105).
+--
+-- The seven flat `venue*` columns move off Edition onto a shared Venue, and
+-- Talk.room (free text) becomes a foreign key. Both are backfilled before the
+-- old columns are dropped, so no data is lost.
+--
+-- Written by hand: `prisma migrate dev` is interactive and unusable here.
+
+-- ---------------------------------------------------------------------------
+-- 1. New tables.
+-- ---------------------------------------------------------------------------
+CREATE TABLE "Venue" (
+  "id"            SERIAL PRIMARY KEY,
+  "name"          TEXT NOT NULL,
+  "address"       TEXT,
+  "lat"           DOUBLE PRECISION,
+  "lng"           DOUBLE PRECISION,
+  "transports"    TEXT,
+  "parking"       TEXT,
+  "directionsUrl" TEXT,
+  "createdAt"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt"     TIMESTAMP(3) NOT NULL
+);
+
+CREATE UNIQUE INDEX "Venue_name_key" ON "Venue"("name");
+
+CREATE TABLE "Room" (
+  "id"        SERIAL PRIMARY KEY,
+  "name"      TEXT NOT NULL,
+  "capacity"  INTEGER,
+  "sortOrder" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "venueId"   INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX "Room_venueId_name_key" ON "Room"("venueId", "name");
+CREATE INDEX "Room_venueId_idx" ON "Room"("venueId");
+
+ALTER TABLE "Room"
+  ADD CONSTRAINT "Room_venueId_fkey" FOREIGN KEY ("venueId") REFERENCES "Venue"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TYPE "ScheduleEntryKind" AS ENUM ('BREAK', 'MEAL', 'PLENARY', 'SOCIAL', 'OTHER');
+
+CREATE TABLE "ScheduleEntry" (
+  "id"        SERIAL PRIMARY KEY,
+  "kind"      "ScheduleEntryKind" NOT NULL,
+  "labelFr"   TEXT NOT NULL,
+  "labelEn"   TEXT NOT NULL,
+  "startsAt"  TIMESTAMP(3) NOT NULL,
+  "endsAt"    TIMESTAMP(3) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "editionId" INTEGER NOT NULL,
+  "roomId"    INTEGER
+);
+
+CREATE INDEX "ScheduleEntry_editionId_idx" ON "ScheduleEntry"("editionId");
+CREATE INDEX "ScheduleEntry_roomId_idx" ON "ScheduleEntry"("roomId");
+
+ALTER TABLE "ScheduleEntry"
+  ADD CONSTRAINT "ScheduleEntry_editionId_fkey" FOREIGN KEY ("editionId") REFERENCES "Edition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ScheduleEntry"
+  ADD CONSTRAINT "ScheduleEntry_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 2. New columns, all nullable so the backfill can run before anything is
+--    dropped.
+-- ---------------------------------------------------------------------------
+ALTER TABLE "Edition" ADD COLUMN "venueId" INTEGER;
+ALTER TABLE "Talk" ADD COLUMN "roomId" INTEGER;
+ALTER TABLE "Talk" ADD COLUMN "roomLabel" TEXT;
+
+-- ---------------------------------------------------------------------------
+-- 3. Backfill the venues — one row per distinct venue name.
+--
+--    Editions that share a name share a venue, which is the whole point: the
+--    dev seed alone carries "Diagora" twice and "Centre de Congrès Pierre
+--    Baudis" twice. DISTINCT ON picks the most recent edition's details as the
+--    canonical ones, so an address corrected last year wins over an older typo.
+-- ---------------------------------------------------------------------------
+INSERT INTO "Venue" ("name", "address", "lat", "lng", "transports", "parking", "directionsUrl", "updatedAt")
+SELECT DISTINCT ON (e."venueName")
+  e."venueName",
+  e."venueAddress",
+  e."venueLat",
+  e."venueLng",
+  e."venueTransports",
+  e."venueParking",
+  e."venueDirectionsUrl",
+  CURRENT_TIMESTAMP
+FROM "Edition" e
+WHERE e."venueName" IS NOT NULL AND e."venueName" <> ''
+ORDER BY e."venueName", e."year" DESC;
+
+UPDATE "Edition" e
+SET "venueId" = v."id"
+FROM "Venue" v
+WHERE v."name" = e."venueName";
+
+-- ---------------------------------------------------------------------------
+-- 4. Backfill the rooms from the free-text Talk.room, scoped to the venue of
+--    the talk's edition.
+--
+--    A talk whose edition has no venue cannot produce a room — there is nothing
+--    to attach it to. Its `room` text is preserved in `roomLabel` below rather
+--    than dropped, so the information survives the migration either way.
+-- ---------------------------------------------------------------------------
+INSERT INTO "Room" ("name", "venueId", "updatedAt")
+SELECT DISTINCT t."room", e."venueId", CURRENT_TIMESTAMP
+FROM "Talk" t
+JOIN "Edition" e ON e."id" = t."editionId"
+WHERE t."room" IS NOT NULL AND t."room" <> '' AND e."venueId" IS NOT NULL
+ON CONFLICT ("venueId", "name") DO NOTHING;
+
+UPDATE "Talk" t
+SET "roomId" = r."id"
+FROM "Edition" e, "Room" r
+WHERE e."id" = t."editionId"
+  AND r."venueId" = e."venueId"
+  AND r."name" = t."room";
+
+-- Freeze the label on every talk that had one, whether or not a Room could be
+-- created for it (#375).
+UPDATE "Talk" SET "roomLabel" = "room" WHERE "room" IS NOT NULL AND "room" <> '';
+
+-- ---------------------------------------------------------------------------
+-- 5. Wire the foreign keys, then drop what has been moved.
+-- ---------------------------------------------------------------------------
+CREATE INDEX "Edition_venueId_idx" ON "Edition"("venueId");
+CREATE INDEX "Talk_roomId_idx" ON "Talk"("roomId");
+
+ALTER TABLE "Edition"
+  ADD CONSTRAINT "Edition_venueId_fkey" FOREIGN KEY ("venueId") REFERENCES "Venue"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Talk"
+  ADD CONSTRAINT "Talk_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "Edition" DROP COLUMN "venueName";
+ALTER TABLE "Edition" DROP COLUMN "venueAddress";
+ALTER TABLE "Edition" DROP COLUMN "venueLat";
+ALTER TABLE "Edition" DROP COLUMN "venueLng";
+ALTER TABLE "Edition" DROP COLUMN "venueTransports";
+ALTER TABLE "Edition" DROP COLUMN "venueParking";
+ALTER TABLE "Edition" DROP COLUMN "venueDirectionsUrl";
+ALTER TABLE "Talk" DROP COLUMN "room";

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -86,17 +86,12 @@ model Edition {
   startDate               DateTime?
   endDate                 DateTime?
   status                  EditionStatus     @default(PREPARATION)
-  venueName               String?
-  venueAddress            String?
-  // Venue & practical-info page (#109). Coordinates drive the Leaflet/OSM map;
-  // transports/parking are rich-text HTML (sanitized on write like sponsor
-  // descriptions); directionsUrl is an external itinerary link. All optional —
-  // the public page and its map only show once coordinates are set.
-  venueLat                Float?
-  venueLng                Float?
-  venueTransports         String?
-  venueParking            String?
-  venueDirectionsUrl      String?
+  // The venue is shared between editions (#105): the DevFest comes back to the
+  // same place for years at a time, and its rooms come back with it. The seven
+  // flat `venue*` columns that used to sit here moved onto Venue; the public
+  // payload still exposes them flattened, so no page had to change.
+  venueId                 Int?
+  venue                   Venue?            @relation(fields: [venueId], references: [id])
   heroImageUrl            String?
   sponsorFormUrl          String?
   aftermovieUrl           String?
@@ -130,8 +125,97 @@ model Edition {
   talks           Talk[]
   editionSponsors EditionSponsor[]
   categories      EditionCategory[]
+  scheduleEntries ScheduleEntry[]
 
   @@index([deletedAt])
+  @@index([venueId])
+}
+
+// --- Venue, rooms and schedule (#105) ---
+
+/// Where an edition takes place. Shared across editions on purpose
+/// (docs/modele-donnees-metier.md): the DevFest returns to the same congress
+/// centre several years running, and re-typing its rooms every year would
+/// invite typos in the very labels the schedule prints.
+model Venue {
+  id            Int     @id @default(autoincrement())
+  name          String  @unique
+  address       String?
+  // Coordinates drive the Leaflet/OSM map; transports and parking are
+  // rich-text HTML sanitized on write, like sponsor descriptions;
+  // directionsUrl is an external itinerary link (#109).
+  lat           Float?
+  lng           Float?
+  transports    String?
+  parking       String?
+  directionsUrl String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  rooms    Room[]
+  editions Edition[]
+}
+
+/// A room inside a venue. Not every room is used every year — the 2025 grid
+/// showed five of them where the venue has eight — so the schedule derives the
+/// columns it displays from the talks actually scheduled, not from this list.
+model Room {
+  id        Int    @id @default(autoincrement())
+  name      String
+  capacity  Int?
+  /// Column order in the schedule grid, ascending.
+  sortOrder Int    @default(0)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  venueId Int
+  venue   Venue @relation(fields: [venueId], references: [id], onDelete: Cascade)
+
+  talks          Talk[]
+  scheduleEntries ScheduleEntry[]
+
+  @@unique([venueId, name])
+  @@index([venueId])
+}
+
+enum ScheduleEntryKind {
+  BREAK
+  MEAL
+  PLENARY
+  SOCIAL
+  OTHER
+}
+
+/// Everything on the grid that is not a talk: welcome, warm-up, breaks, lunch,
+/// the closing party. The 2026 day is mostly made of these, and a grid that
+/// omitted them would leave unexplained gaps at exactly the hours sponsors
+/// expect visitors on their stands.
+///
+/// An entry does NOT block its time range: in 2025 lunch ran 12h45–14h15 while
+/// quickies played at 12h55 and 13h50. Whether a slot is free is decided by the
+/// absence of talks on it, never by a property of the entry.
+model ScheduleEntry {
+  id       Int               @id @default(autoincrement())
+  kind     ScheduleEntryKind
+  labelFr  String
+  labelEn  String
+  startsAt DateTime
+  endsAt   DateTime
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  editionId Int
+  edition   Edition @relation(fields: [editionId], references: [id], onDelete: Cascade)
+
+  /// Null means the entry spans the whole grid — the usual case for a break.
+  roomId Int?
+  room   Room? @relation(fields: [roomId], references: [id], onDelete: SetNull)
+
+  @@index([editionId])
+  @@index([roomId])
 }
 
 // --- Key Figures ---
@@ -638,10 +722,24 @@ model Talk {
   // by talk. Format, level and language stay with the organizers regardless.
   isSpeakerEditable Boolean @default(false)
 
-  // Room and time slot are assigned in Lot 3 (Programme) — optional here (RG-216).
-  room     String?
+  // Room and time slot (#105). Optional (RG-216): the 244 imported historical
+  // talks have neither, and a talk exists long before it is scheduled.
+  //
+  // `startsAt` stays on the talk rather than moving to a slot table because
+  // `isScheduleReady` counts published talks that have one, and that count is
+  // what promotes the flat "Conférences" link to a "Programme" menu (#203).
   startsAt DateTime?
   endsAt   DateTime?
+
+  roomId Int?
+  room   Room? @relation(fields: [roomId], references: [id], onDelete: SetNull)
+
+  // The room name as this edition printed it, frozen when the talk is
+  // scheduled (#375 again). Venues are shared and mutable: renaming a room in
+  // 2027 would otherwise rewrite the 2026 grid, which has to keep saying what
+  // the signage said that year. Null means "not scheduled yet, read the live
+  // room".
+  roomLabel String?
 
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
@@ -662,6 +760,7 @@ model Talk {
   @@index([editionId])
   @@index([categoryId])
   @@index([deletedAt])
+  @@index([roomId])
 }
 
 // --- Sponsors (RG-220 to RG-231) ---

--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -12,6 +12,42 @@ async function seedDev() {
 
   console.log("Seeding dev data...");
 
+  // --- Venues (#105) ---
+  // Upsert by name: the venue is the shared entity, so re-seeding must find the
+  // existing row rather than fail on the unique name.
+  const diagora = await prisma.venue.upsert({
+    where: { name: "Diagora" },
+    update: {},
+    create: { name: "Diagora", address: "Labège", lat: 43.5497, lng: 1.5119 },
+  });
+
+  // The eight rooms of the 2026 edition, with their real capacities — the
+  // schedule grid orders its columns by sortOrder.
+  const rooms2026 = [
+    { name: "Amphithéâtre", capacity: 500, sortOrder: 1 },
+    { name: "Agora 1", capacity: 500, sortOrder: 2 },
+    { name: "Hémicycle", capacity: 150, sortOrder: 3 },
+    { name: "Pastel", capacity: 200, sortOrder: 4 },
+    { name: "Lauragais", capacity: 200, sortOrder: 5 },
+    { name: "Ellipse", capacity: 100, sortOrder: 6 },
+    { name: "Salle Quickies", capacity: 80, sortOrder: 7 },
+    { name: "Salle Communautés", capacity: 80, sortOrder: 8 },
+  ];
+  for (const room of rooms2026) {
+    await prisma.room.upsert({
+      where: { venueId_name: { venueId: diagora.id, name: room.name } },
+      update: { capacity: room.capacity, sortOrder: room.sortOrder },
+      create: { ...room, venueId: diagora.id },
+    });
+  }
+  console.log(`Venue created: ${diagora.name} (${rooms2026.length} rooms)`);
+
+  const pierreBaudis = await prisma.venue.upsert({
+    where: { name: "Centre de Congrès Pierre Baudis" },
+    update: {},
+    create: { name: "Centre de Congrès Pierre Baudis", address: "Toulouse" },
+  });
+
   // --- Edition 2026 ---
   const edition = await prisma.edition.upsert({
     where: { year: 2026 },
@@ -21,8 +57,7 @@ async function seedDev() {
       startDate: new Date("2026-11-19T09:00:00Z"),
       endDate: new Date("2026-11-19T18:00:00Z"),
       status: "ANNOUNCEMENT",
-      venueName: "Diagora",
-      venueAddress: "Labège",
+      venueId: diagora.id,
       sponsorFormUrl: "https://forms.gle/devfest-sponsor",
       aftermovieUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
     },
@@ -187,8 +222,7 @@ async function seedDev() {
       status: "SEE_YOU_NEXT_YEAR",
       startDate: new Date("2025-11-06T09:00:00Z"),
       endDate: new Date("2025-11-06T18:00:00Z"),
-      venueName: "Centre de Congrès Pierre Baudis",
-      venueAddress: "Toulouse",
+      venueId: pierreBaudis.id,
       aftermovieUrl: "https://www.youtube.com/watch?v=nCjk1T8G1WE",
       galleryUrl: "https://photos.app.goo.gl/devfest2025",
       archivedSiteUrl: "https://2025.devfesttoulouse.fr",
@@ -198,8 +232,7 @@ async function seedDev() {
       startDate: new Date("2025-11-06T09:00:00Z"),
       endDate: new Date("2025-11-06T18:00:00Z"),
       status: "SEE_YOU_NEXT_YEAR",
-      venueName: "Centre de Congrès Pierre Baudis",
-      venueAddress: "Toulouse",
+      venueId: pierreBaudis.id,
       aftermovieUrl: "https://www.youtube.com/watch?v=nCjk1T8G1WE",
       galleryUrl: "https://photos.app.goo.gl/devfest2025",
       archivedSiteUrl: "https://2025.devfesttoulouse.fr",
@@ -696,6 +729,61 @@ async function seedDev() {
     },
   });
   console.log("Talks created: 2");
+
+  // --- Schedule (#105) ---
+  // Both talks get an hour and a room so the "Programme" menu shows up (#203)
+  // and the grid has something to draw. Times follow the 2026 day plan of the
+  // sponsor guide; the dates are UTC, an hour behind the local schedule.
+  const amphitheatre = await prisma.room.findUnique({
+    where: { venueId_name: { venueId: diagora.id, name: "Amphithéâtre" } },
+  });
+  const hemicycle = await prisma.room.findUnique({
+    where: { venueId_name: { venueId: diagora.id, name: "Hémicycle" } },
+  });
+  await prisma.talk.update({
+    where: { editionId_slug: { editionId: edition.id, slug: "kubernetes-en-production" } },
+    data: {
+      roomId: amphitheatre?.id,
+      roomLabel: amphitheatre?.name,
+      startsAt: new Date("2026-11-19T08:00:00Z"),
+      endsAt: new Date("2026-11-19T08:40:00Z"),
+    },
+  });
+  await prisma.talk.update({
+    where: { editionId_slug: { editionId: edition.id, slug: "react-server-components" } },
+    data: {
+      roomId: hemicycle?.id,
+      roomLabel: hemicycle?.name,
+      startsAt: new Date("2026-11-19T08:00:00Z"),
+      endsAt: new Date("2026-11-19T08:15:00Z"),
+    },
+  });
+
+  // Everything that is not a session. Lunch is the one that matters for the
+  // grid: it spans every room, and in 2026 no quickie runs under it.
+  await prisma.scheduleEntry.deleteMany({ where: { editionId: edition.id } });
+  const scheduleEntries = [
+    { kind: "OTHER" as const, labelFr: "Accueil et petit déjeuner", labelEn: "Welcome and breakfast", startsAt: "06:30", endsAt: "07:45" },
+    { kind: "PLENARY" as const, labelFr: "Keynote d'ouverture", labelEn: "Opening keynote", startsAt: "08:00", endsAt: "08:45" },
+    { kind: "BREAK" as const, labelFr: "Pause du matin", labelEn: "Morning break", startsAt: "09:35", endsAt: "10:00" },
+    { kind: "MEAL" as const, labelFr: "Déjeuner", labelEn: "Lunch", startsAt: "11:45", endsAt: "13:15" },
+    { kind: "BREAK" as const, labelFr: "Pause de l'après-midi", labelEn: "Afternoon break", startsAt: "15:00", endsAt: "15:30" },
+    { kind: "PLENARY" as const, labelFr: "Keynote de clôture", labelEn: "Closing keynote", startsAt: "16:30", endsAt: "17:15" },
+    { kind: "SOCIAL" as const, labelFr: "Soirée « 10 ans »", labelEn: "\"10 years\" party", startsAt: "17:30", endsAt: "20:00" },
+  ];
+  for (const entry of scheduleEntries) {
+    await prisma.scheduleEntry.create({
+      data: {
+        editionId: edition.id,
+        kind: entry.kind,
+        labelFr: entry.labelFr,
+        labelEn: entry.labelEn,
+        startsAt: new Date(`2026-11-19T${entry.startsAt}:00Z`),
+        endsAt: new Date(`2026-11-19T${entry.endsAt}:00Z`),
+      },
+    });
+  }
+  console.log(`Schedule entries created: ${scheduleEntries.length}`);
 
   // --- Social Links ---
   const socialSettings = [

--- a/src/backend/src/__tests__/edition-venue.test.ts
+++ b/src/backend/src/__tests__/edition-venue.test.ts
@@ -1,18 +1,24 @@
 import { describe, it, expect, afterEach } from "vitest";
 
 import Fastify from "fastify";
-import adminEditionRoutes from "../routes/admin/editions.js";
+import adminVenueRoutes from "../routes/admin/venues.js";
 import editionRoutes from "../routes/editions.js";
 import { prisma } from "../lib/prisma.js";
 import { getSeededEdition } from "./edition-test-helpers.js";
 
-// Venue & practical-info fields (#109): the admin PUT persists them and
-// sanitizes the rich-text ones, and the public /editions/current exposes them.
-// The tests edit a seeded edition, so they restore the fields afterwards.
+// Venue & practical-info fields (#109), now carried by the Venue entity (#105).
+// Two things are under test here:
+//
+//   1. the admin writes them on the venue, and sanitizes the rich-text ones;
+//   2. the PUBLIC payload still exposes them flattened onto the edition.
+//
+// (2) is the contract that let #105 land without touching the nine frontend
+// files that read `edition.venueName` & co. If it breaks, the homepage strap
+// line and /lieu go blank in production without a single type error.
 
 async function buildAdminApp() {
   const app = Fastify({ logger: false });
-  await app.register(adminEditionRoutes, { prefix: "/api/admin" });
+  await app.register(adminVenueRoutes, { prefix: "/api/admin" });
   return app;
 }
 
@@ -22,132 +28,158 @@ async function buildPublicApp() {
   return app;
 }
 
-let touchedEditionId: number | null = null;
+let touchedVenueId: number | null = null;
 
 afterEach(async () => {
-  // Clear the venue fields this test wrote so seeded editions go back to their
-  // original (empty) state — no leftover across runs.
-  if (touchedEditionId !== null) {
-    await prisma.edition.update({
-      where: { id: touchedEditionId },
-      data: {
-        venueLat: null,
-        venueLng: null,
-        venueTransports: null,
-        venueParking: null,
-        venueDirectionsUrl: null,
-      },
+  // Clear what the test wrote so the seeded venue goes back to its original
+  // (empty) state — no leftover across runs.
+  if (touchedVenueId !== null) {
+    await prisma.venue.update({
+      where: { id: touchedVenueId },
+      data: { lat: null, lng: null, transports: null, parking: null, directionsUrl: null },
     });
-    touchedEditionId = null;
+    touchedVenueId = null;
   }
 });
 
-describe("edition venue fields (#109)", () => {
+/** The venue of the most recent seeded edition. */
+async function getSeededVenue() {
+  const edition = await getSeededEdition();
+  if (!edition.venueId) throw new Error("seed missing a venue on its latest edition");
+  const venue = await prisma.venue.findUnique({ where: { id: edition.venueId } });
+  if (!venue) throw new Error("seed venue not found");
+  return venue;
+}
+
+describe("venue fields (#109 on the #105 model)", () => {
   it("persists coordinates and directions through the admin PUT", async () => {
-    const edition = await getSeededEdition();
-    touchedEditionId = edition.id;
+    const venue = await getSeededVenue();
+    touchedVenueId = venue.id;
     const app = await buildAdminApp();
 
     const res = await app.inject({
       method: "PUT",
-      url: `/api/admin/editions/${edition.id}`,
-      payload: {
-        venueLat: 43.5497,
-        venueLng: 1.5119,
-        venueDirectionsUrl: "https://maps.example.com/route",
-      },
+      url: `/api/admin/venues/${venue.id}`,
+      payload: { lat: 43.5497, lng: 1.5119, directionsUrl: "https://maps.example.com/route" },
     });
     expect(res.statusCode).toBe(200);
 
-    const stored = await prisma.edition.findUnique({ where: { id: edition.id } });
-    expect(stored?.venueLat).toBe(43.5497);
-    expect(stored?.venueLng).toBe(1.5119);
-    expect(stored?.venueDirectionsUrl).toBe("https://maps.example.com/route");
+    const stored = await prisma.venue.findUnique({ where: { id: venue.id } });
+    expect(stored?.lat).toBe(43.5497);
+    expect(stored?.lng).toBe(1.5119);
+    expect(stored?.directionsUrl).toBe("https://maps.example.com/route");
 
     await app.close();
   });
 
   it("rejects a javascript: directions URL rather than storing an XSS vector", async () => {
-    const edition = await getSeededEdition();
-    touchedEditionId = edition.id;
+    const venue = await getSeededVenue();
+    touchedVenueId = venue.id;
     const app = await buildAdminApp();
 
     // The URL ends up in an href on the public /lieu page. A javascript: scheme
     // must be refused at write time, not stored (#109 security follow-up).
     const res = await app.inject({
       method: "PUT",
-      url: `/api/admin/editions/${edition.id}`,
+      url: `/api/admin/venues/${venue.id}`,
       // eslint-disable-next-line no-script-url
-      payload: { venueDirectionsUrl: "javascript:alert(document.cookie)" },
+      payload: { directionsUrl: "javascript:alert(document.cookie)" },
     });
     expect(res.statusCode).toBe(422);
-    expect(res.json().error).toBe("invalid_url");
+    expect(res.json().error).toBe("invalid_venue");
 
     // Nothing was written.
-    const stored = await prisma.edition.findUnique({ where: { id: edition.id } });
-    expect(stored?.venueDirectionsUrl).toBeNull();
-
-    await app.close();
-  });
-
-  it("accepts a normal https directions URL", async () => {
-    const edition = await getSeededEdition();
-    touchedEditionId = edition.id;
-    const app = await buildAdminApp();
-
-    const res = await app.inject({
-      method: "PUT",
-      url: `/api/admin/editions/${edition.id}`,
-      payload: { venueDirectionsUrl: "https://maps.example.com/route" },
-    });
-    expect(res.statusCode).toBe(200);
+    const stored = await prisma.venue.findUnique({ where: { id: venue.id } });
+    expect(stored?.directionsUrl).toBeNull();
 
     await app.close();
   });
 
   it("sanitizes the rich-text transports/parking on write", async () => {
-    const edition = await getSeededEdition();
-    touchedEditionId = edition.id;
+    const venue = await getSeededVenue();
+    touchedVenueId = venue.id;
     const app = await buildAdminApp();
 
     await app.inject({
       method: "PUT",
-      url: `/api/admin/editions/${edition.id}`,
+      url: `/api/admin/venues/${venue.id}`,
       payload: {
-        venueTransports: '<p>Métro B</p><script>alert(1)</script>',
-        venueParking: '<p>Parking Diagora</p>',
+        transports: "<p>Métro B</p><script>alert(1)</script>",
+        parking: "<p>Parking Diagora</p>",
       },
     });
 
-    const stored = await prisma.edition.findUnique({ where: { id: edition.id } });
+    const stored = await prisma.venue.findUnique({ where: { id: venue.id } });
     // The paragraph survives, the script is stripped by sanitizeRichHtml.
-    expect(stored?.venueTransports).toContain("Métro B");
-    expect(stored?.venueTransports).not.toContain("<script");
-    expect(stored?.venueParking).toContain("Parking Diagora");
+    expect(stored?.transports).toContain("Métro B");
+    expect(stored?.transports).not.toContain("<script");
+    expect(stored?.parking).toContain("Parking Diagora");
 
     await app.close();
   });
 
+  it("refuses to delete a venue an edition still points at", async () => {
+    const venue = await getSeededVenue();
+    const app = await buildAdminApp();
+
+    const res = await app.inject({ method: "DELETE", url: `/api/admin/venues/${venue.id}` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe("venue_in_use");
+
+    // Still there — a refused delete must not half-apply.
+    expect(await prisma.venue.findUnique({ where: { id: venue.id } })).not.toBeNull();
+
+    await app.close();
+  });
+});
+
+describe("the public edition payload keeps its flat venue shape (#105)", () => {
   it("exposes venue fields and hasVenueInfo on /editions/current", async () => {
     const edition = await getSeededEdition();
-    touchedEditionId = edition.id;
-    // The seed points featured_edition_id at the latest seeded edition, which is
-    // exactly what getSeededEdition returns — so /current returns this row.
-    // (Guarded below rather than assumed, so a seed change fails loudly.)
-    await prisma.edition.update({
-      where: { id: edition.id },
-      data: { venueLat: 43.5, venueLng: 1.5, venueTransports: "<p>Bus</p>" },
+    const venue = await getSeededVenue();
+    touchedVenueId = venue.id;
+
+    await prisma.venue.update({
+      where: { id: venue.id },
+      data: { lat: 43.5, lng: 1.5, transports: "<p>Bus</p>" },
     });
 
     const app = await buildPublicApp();
     const res = await app.inject({ method: "GET", url: "/api/editions/current" });
     const body = res.json();
 
-    expect(body.id).toBe(edition.id); // guards the assumption above
-    expect(body.hasVenueInfo).toBe(true);
+    // The seed points featured_edition_id at the latest seeded edition, which
+    // is what getSeededEdition returns. Guarded rather than assumed, so a seed
+    // change fails loudly.
+    expect(body.id).toBe(edition.id);
+
+    // Flat keys, exactly as before the venue moved to its own table.
+    expect(body.venueName).toBe(venue.name);
+    expect(body.venueAddress).toBe(venue.address);
     expect(body.venueLat).toBe(43.5);
+    expect(body.venueLng).toBe(1.5);
     expect(body.venueTransports).toContain("Bus");
+    expect(body.hasVenueInfo).toBe(true);
 
     await app.close();
+  });
+
+  it("reports no venue info when the edition has no venue at all", async () => {
+    // An edition detached from every venue must not crash the payload — it has
+    // to answer null on each key, which is what the pages already handle.
+    const edition = await prisma.edition.create({
+      data: { year: 1990, status: "PREPARATION" },
+    });
+
+    try {
+      const app = await buildPublicApp();
+      const res = await app.inject({ method: "GET", url: `/api/editions/${edition.year}` });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().venueName).toBeNull();
+      expect(res.json().venueAddress).toBeNull();
+      await app.close();
+    } finally {
+      await prisma.edition.delete({ where: { id: edition.id } });
+    }
   });
 });

--- a/src/backend/src/__tests__/edition-venue.test.ts
+++ b/src/backend/src/__tests__/edition-venue.test.ts
@@ -167,8 +167,13 @@ describe("the public edition payload keeps its flat venue shape (#105)", () => {
   it("reports no venue info when the edition has no venue at all", async () => {
     // An edition detached from every venue must not crash the payload — it has
     // to answer null on each key, which is what the pages already handle.
+    //
+    // 1870 because `Edition.year` is @unique and the files run in parallel:
+    // 1990 belongs to admin-edition-sponsor-tiers, 16xx/17xx/19xx to the
+    // sponsor and speaker fixtures. Reusing one is the #292 failure, and it
+    // only shows in the full run.
     const edition = await prisma.edition.create({
-      data: { year: 1990, status: "PREPARATION" },
+      data: { year: 1870, status: "PREPARATION" },
     });
 
     try {

--- a/src/backend/src/__tests__/schedule.test.ts
+++ b/src/backend/src/__tests__/schedule.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+import adminVenueRoutes from "../routes/admin/venues.js";
+import adminTalkRoutes from "../routes/admin/talks.js";
+import editionRoutes from "../routes/editions.js";
+import { prisma } from "../lib/prisma.js";
+
+// Rooms and scheduling (#105).
+//
+// The fixture builds its own venue, edition and talk rather than borrowing the
+// seed: these tests rename and delete rooms, and doing that to a shared row is
+// how #292 turned into forty flaky failures.
+
+const TEST_YEAR = 1991;
+
+let venueId: number;
+let editionId: number;
+let roomId: number;
+let talkId: number;
+
+async function buildApp(routes: (app: FastifyInstance) => Promise<void>) {
+  const app = Fastify({ logger: false });
+  await app.register(routes, { prefix: "/api/admin" });
+  return app;
+}
+
+beforeEach(async () => {
+  const venue = await prisma.venue.create({ data: { name: `Lieu de test ${TEST_YEAR}` } });
+  venueId = venue.id;
+
+  const edition = await prisma.edition.create({
+    data: { year: TEST_YEAR, status: "PREPARATION", venueId },
+  });
+  editionId = edition.id;
+
+  const room = await prisma.room.create({
+    data: { venueId, name: "Amphithéâtre", capacity: 500, sortOrder: 1 },
+  });
+  roomId = room.id;
+
+  const talk = await prisma.talk.create({
+    data: {
+      editionId,
+      slug: "session-de-test",
+      title: "Session de test",
+      description: "",
+      format: "CONFERENCE",
+      language: "fr",
+      publicationStatus: "PUBLISHED",
+    },
+  });
+  talkId = talk.id;
+});
+
+afterEach(async () => {
+  await prisma.talk.deleteMany({ where: { editionId } });
+  await prisma.scheduleEntry.deleteMany({ where: { editionId } });
+  await prisma.edition.deleteMany({ where: { id: editionId } });
+  await prisma.room.deleteMany({ where: { venueId } });
+  await prisma.venue.deleteMany({ where: { id: venueId } });
+});
+
+describe("scheduling a talk (#105)", () => {
+  it("assigns a room and freezes its label", async () => {
+    const app = await buildApp(adminTalkRoutes);
+
+    const res = await app.inject({
+      method: "PUT",
+      url: `/api/admin/talks/${talkId}`,
+      payload: { roomId, startsAt: "2026-11-19T09:00:00.000Z", endsAt: "2026-11-19T09:40:00.000Z" },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const stored = await prisma.talk.findUnique({ where: { id: talkId } });
+    expect(stored?.roomId).toBe(roomId);
+    expect(stored?.roomLabel).toBe("Amphithéâtre");
+    expect(stored?.startsAt?.toISOString()).toBe("2026-11-19T09:00:00.000Z");
+
+    await app.close();
+  });
+
+  it("keeps the label a talk was scheduled under when the room is renamed (#375)", async () => {
+    const talkApp = await buildApp(adminTalkRoutes);
+    await talkApp.inject({
+      method: "PUT",
+      url: `/api/admin/talks/${talkId}`,
+      payload: { roomId, startsAt: "2026-11-19T09:00:00.000Z" },
+    });
+    await talkApp.close();
+
+    const venueApp = await buildApp(adminVenueRoutes);
+    const renamed = await venueApp.inject({
+      method: "PUT",
+      url: `/api/admin/rooms/${roomId}`,
+      payload: { name: "Grand Amphi" },
+    });
+    expect(renamed.statusCode).toBe(200);
+    await venueApp.close();
+
+    // The room now reads "Grand Amphi", but what 1991 printed is unchanged.
+    const stored = await prisma.talk.findUnique({ where: { id: talkId } });
+    expect(stored?.roomLabel).toBe("Amphithéâtre");
+  });
+
+  it("refuses a room that belongs to another venue", async () => {
+    const otherVenue = await prisma.venue.create({ data: { name: `Autre lieu ${TEST_YEAR}` } });
+    const otherRoom = await prisma.room.create({ data: { venueId: otherVenue.id, name: "Salle voisine" } });
+
+    try {
+      const app = await buildApp(adminTalkRoutes);
+      const res = await app.inject({
+        method: "PUT",
+        url: `/api/admin/talks/${talkId}`,
+        payload: { roomId: otherRoom.id },
+      });
+      expect(res.statusCode).toBe(422);
+      expect(res.json().error).toBe("invalid_room");
+
+      const stored = await prisma.talk.findUnique({ where: { id: talkId } });
+      expect(stored?.roomId).toBeNull();
+      await app.close();
+    } finally {
+      await prisma.room.delete({ where: { id: otherRoom.id } });
+      await prisma.venue.delete({ where: { id: otherVenue.id } });
+    }
+  });
+
+  it("leaves an unscheduled talk valid — the 244 imported ones have no room", async () => {
+    const stored = await prisma.talk.findUnique({ where: { id: talkId } });
+    expect(stored?.roomId).toBeNull();
+    expect(stored?.roomLabel).toBeNull();
+    expect(stored?.startsAt).toBeNull();
+  });
+});
+
+describe("deleting a room (#105)", () => {
+  it("refuses while a talk is scheduled in it", async () => {
+    await prisma.talk.update({ where: { id: talkId }, data: { roomId, roomLabel: "Amphithéâtre" } });
+
+    const app = await buildApp(adminVenueRoutes);
+    const res = await app.inject({ method: "DELETE", url: `/api/admin/rooms/${roomId}` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe("room_in_use");
+
+    expect(await prisma.room.findUnique({ where: { id: roomId } })).not.toBeNull();
+    await app.close();
+  });
+
+  it("goes through once nothing is scheduled in it", async () => {
+    const app = await buildApp(adminVenueRoutes);
+    const res = await app.inject({ method: "DELETE", url: `/api/admin/rooms/${roomId}` });
+    expect(res.statusCode).toBe(204);
+    expect(await prisma.room.findUnique({ where: { id: roomId } })).toBeNull();
+    await app.close();
+  });
+});
+
+describe("GET /editions/:year/schedule", () => {
+  it("returns the scheduled talks, the surrounding entries and the used rooms", async () => {
+    await prisma.talk.update({
+      where: { id: talkId },
+      data: {
+        roomId,
+        roomLabel: "Amphithéâtre",
+        startsAt: new Date("2026-11-19T09:00:00.000Z"),
+        endsAt: new Date("2026-11-19T09:40:00.000Z"),
+      },
+    });
+    await prisma.scheduleEntry.create({
+      data: {
+        editionId,
+        kind: "MEAL",
+        labelFr: "Déjeuner",
+        labelEn: "Lunch",
+        startsAt: new Date("2026-11-19T11:45:00.000Z"),
+        endsAt: new Date("2026-11-19T13:15:00.000Z"),
+      },
+    });
+
+    const app = Fastify({ logger: false });
+    await app.register(editionRoutes, { prefix: "/api" });
+
+    const res = await app.inject({ method: "GET", url: `/api/editions/${TEST_YEAR}/schedule` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body.talks).toHaveLength(1);
+    expect(body.talks[0].room).toBe("Amphithéâtre");
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0].labelFr).toBe("Déjeuner");
+    // A break spans the grid, so it carries no room.
+    expect(body.entries[0].roomId).toBeNull();
+
+    // Only the rooms actually used — the venue could hold eight and the grid
+    // still shows one.
+    expect(body.rooms).toHaveLength(1);
+    expect(body.rooms[0].name).toBe("Amphithéâtre");
+
+    await app.close();
+  });
+
+  it("leaves unscheduled talks out of the grid", async () => {
+    const app = Fastify({ logger: false });
+    await app.register(editionRoutes, { prefix: "/api" });
+
+    const res = await app.inject({ method: "GET", url: `/api/editions/${TEST_YEAR}/schedule` });
+    expect(res.json().talks).toHaveLength(0);
+    expect(res.json().rooms).toHaveLength(0);
+
+    await app.close();
+  });
+});

--- a/src/backend/src/lib/revalidate.ts
+++ b/src/backend/src/lib/revalidate.ts
@@ -59,6 +59,20 @@ export function revalidateEdition(year: number): Promise<void> {
   ]);
 }
 
+/**
+ * A venue changed (#105) — purge every page that prints it.
+ *
+ * `/lieu` had no purge at all until now: the practical-info page shipped with
+ * #109 without one, so a corrected address stayed stale for an hour. The home
+ * page carries the venue in its strap line, hence both.
+ */
+export function revalidateVenue(): Promise<void> {
+  return revalidatePaths([
+    ...bilingualPaths(""),
+    ...bilingualPaths("/lieu"),
+  ]);
+}
+
 export function revalidateBilletterie(): Promise<void> {
   return revalidatePaths([
     ...bilingualPaths(""),

--- a/src/backend/src/routes/admin/editions.ts
+++ b/src/backend/src/routes/admin/editions.ts
@@ -10,15 +10,9 @@ interface EditionBody {
   startDate?: string;
   endDate?: string;
   status?: "PREPARATION" | "ANNOUNCEMENT" | "SEE_YOU_NEXT_YEAR";
-  venueName?: string;
-  venueAddress?: string;
-  // Venue & practical-info page (#109). lat/lng feed the map; transports/parking
-  // are rich-text HTML, sanitized on write; directionsUrl is an itinerary link.
-  venueLat?: number | null;
-  venueLng?: number | null;
-  venueTransports?: string;
-  venueParking?: string;
-  venueDirectionsUrl?: string;
+  // Which venue hosts this edition (#105). The venue's own details — address,
+  // map coordinates, transports, parking (#109) — are edited on its screen.
+  venueId?: number | null;
   heroImageUrl?: string;
   sponsorFormUrl?: string;
   aftermovieUrl?: string;
@@ -38,6 +32,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       where: notDeleted,
       orderBy: { year: "desc" },
       include: {
+        venue: true,
         _count: { select: { ticketTiers: { where: notDeleted }, articles: { where: notDeleted } } },
       },
     });
@@ -48,8 +43,8 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       startDate: e.startDate,
       endDate: e.endDate,
       status: e.status,
-      venueName: e.venueName,
-      venueAddress: e.venueAddress,
+      venueName: e.venue?.name ?? null,
+      venueAddress: e.venue?.address ?? null,
       heroImageUrl: e.heroImageUrl,
       sponsorFormUrl: e.sponsorFormUrl,
       aftermovieUrl: e.aftermovieUrl,
@@ -65,6 +60,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
     const edition = await prisma.edition.findFirst({
       where: notDeleted,
       orderBy: { year: "desc" },
+      include: { venue: true },
     });
 
     if (!edition) return reply.status(404).send({ error: "No edition found" });
@@ -75,8 +71,8 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       startDate: edition.startDate,
       endDate: edition.endDate,
       status: edition.status,
-      venueName: edition.venueName,
-      venueAddress: edition.venueAddress,
+      venueName: edition.venue?.name ?? null,
+      venueAddress: edition.venue?.address ?? null,
       heroImageUrl: edition.heroImageUrl,
       sponsorFormUrl: edition.sponsorFormUrl,
       aftermovieUrl: edition.aftermovieUrl,
@@ -106,6 +102,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
       const edition = await prisma.edition.findFirst({
         where: { id, ...notDeleted },
         include: {
+          venue: true,
           _count: {
             select: {
               ticketTiers: { where: notDeleted },
@@ -134,14 +131,16 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         startDate: edition.startDate,
         endDate: edition.endDate,
         status: edition.status,
-        venueName: edition.venueName,
-        venueAddress: edition.venueAddress,
-        // #109 — so the admin "Lieu" tab can pre-fill these fields.
-        venueLat: edition.venueLat,
-        venueLng: edition.venueLng,
-        venueTransports: edition.venueTransports,
-        venueParking: edition.venueParking,
-        venueDirectionsUrl: edition.venueDirectionsUrl,
+        // Since #105 an edition points at a venue instead of describing one.
+        // The practical-info fields (#109) are edited on the venue's own
+        // screen — repeated here, they would let two editions of the same
+        // place drift apart.
+        venueId: edition.venueId,
+        venue: edition.venue && {
+          id: edition.venue.id,
+          name: edition.venue.name,
+          address: edition.venue.address,
+        },
         heroImageUrl: edition.heroImageUrl,
         sponsorFormUrl: edition.sponsorFormUrl,
         aftermovieUrl: edition.aftermovieUrl,
@@ -175,16 +174,19 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
 
     const body = request.body;
 
-    // The directions URL lands in an href on the public /lieu page, so reject a
-    // javascript:/data: scheme at the source rather than storing an XSS vector
-    // (#109). Only validate a non-empty value — "" clears the field. isSafeUrl
-    // is the same allowlist used for sponsor/social URLs (#223).
-    if (body.venueDirectionsUrl && !isSafeUrl(body.venueDirectionsUrl)) {
-      return reply.status(422).send({
-        error: "invalid_url",
-        message: "Le lien itinéraire doit être une URL http(s) valide.",
-      });
+    // An edition points at an existing venue (#105) — creating one is its own
+    // screen. Reject an unknown id rather than storing a dangling reference the
+    // public payload would silently render as "no venue".
+    if (body.venueId != null) {
+      const venue = await prisma.venue.findUnique({ where: { id: body.venueId } });
+      if (!venue) {
+        return reply.status(422).send({
+          error: "unknown_venue",
+          message: "Ce lieu n'existe pas.",
+        });
+      }
     }
+
     const newStatus = body.status ?? existing.status;
 
     const edition = await prisma.edition.update({
@@ -194,16 +196,9 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         startDate: body.startDate ? new Date(body.startDate) : existing.startDate,
         endDate: body.endDate ? new Date(body.endDate) : existing.endDate,
         status: newStatus,
-        venueName: body.venueName !== undefined ? (body.venueName || null) : existing.venueName,
-        venueAddress: body.venueAddress !== undefined ? (body.venueAddress || null) : existing.venueAddress,
-        // #109. Coordinates are numbers: `null` explicitly clears them (an empty
-        // map field), a number sets them; undefined keeps the existing value.
-        venueLat: body.venueLat !== undefined ? body.venueLat : existing.venueLat,
-        venueLng: body.venueLng !== undefined ? body.venueLng : existing.venueLng,
-        // Rich-text HTML, sanitized on write like sponsor descriptions.
-        venueTransports: body.venueTransports !== undefined ? (sanitizeRichHtml(body.venueTransports) || null) : existing.venueTransports,
-        venueParking: body.venueParking !== undefined ? (sanitizeRichHtml(body.venueParking) || null) : existing.venueParking,
-        venueDirectionsUrl: body.venueDirectionsUrl !== undefined ? (body.venueDirectionsUrl || null) : existing.venueDirectionsUrl,
+        // `null` detaches the edition from its venue, a number attaches it;
+        // undefined leaves it alone (#105).
+        venueId: body.venueId !== undefined ? body.venueId : existing.venueId,
         heroImageUrl: body.heroImageUrl !== undefined ? (body.heroImageUrl || null) : existing.heroImageUrl,
         sponsorFormUrl: body.sponsorFormUrl !== undefined ? (body.sponsorFormUrl || null) : existing.sponsorFormUrl,
         aftermovieUrl: body.aftermovieUrl !== undefined ? (body.aftermovieUrl || null) : existing.aftermovieUrl,
@@ -248,8 +243,7 @@ export default async function adminEditionRoutes(app: FastifyInstance) {
         startDate: body.startDate ? new Date(body.startDate) : null,
         endDate: body.endDate ? new Date(body.endDate) : null,
         status: body.status || "PREPARATION",
-        venueName: body.venueName || null,
-        venueAddress: body.venueAddress || null,
+        venueId: body.venueId ?? null,
         heroImageUrl: body.heroImageUrl || null,
         sponsorFormUrl: body.sponsorFormUrl || null,
         aftermovieUrl: body.aftermovieUrl || null,

--- a/src/backend/src/routes/admin/index.ts
+++ b/src/backend/src/routes/admin/index.ts
@@ -19,6 +19,8 @@ import adminImportRoutes from "./import.js";
 import adminApiKeyRoutes from "./api-keys.js";
 import adminTranslateRoutes from "./translate.js";
 import adminTrashRoutes from "./trash.js";
+import adminVenueRoutes from "./venues.js";
+import adminScheduleRoutes from "./schedule.js";
 
 export default async function adminRoutes(app: FastifyInstance) {
   // Auth check route (does its own auth check internally)
@@ -37,6 +39,9 @@ export default async function adminRoutes(app: FastifyInstance) {
     await editorApp.register(adminSpeakerRoutes);
     await editorApp.register(adminCategoryRoutes);
     await editorApp.register(adminTalkRoutes);
+    // Scheduling sits with the talks: whoever places a session also places the
+    // breaks around it. Creating the rooms themselves stays ADMIN-only below.
+    await editorApp.register(adminScheduleRoutes);
     await editorApp.register(adminImportRoutes);
     // Editors may consult and restore; the purge route carries its own
     // ADMIN-only guard, since destroying a row for good is not theirs to do.
@@ -48,6 +53,7 @@ export default async function adminRoutes(app: FastifyInstance) {
     adminApp.addHook("preHandler", requireAdminRole);
     await adminApp.register(adminCacheRoutes);
     await adminApp.register(adminEditionRoutes);
+    await adminApp.register(adminVenueRoutes);
     await adminApp.register(adminTicketRoutes);
     await adminApp.register(adminSettingsRoutes);
     await adminApp.register(adminUserRoutes);

--- a/src/backend/src/routes/admin/schedule.ts
+++ b/src/backend/src/routes/admin/schedule.ts
@@ -1,0 +1,130 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../lib/prisma.js";
+import { revalidateConferences } from "../../lib/revalidate.js";
+
+// Everything on the schedule that is not a talk (#105): welcome, warm-up,
+// breaks, lunch, the closing party. The 2026 day is mostly made of these.
+//
+// An entry does not block its time range. In 2025 lunch ran 12h45–14h15 while
+// quickies played at 12h55 and 13h50; in 2026 the quickies moved out and lunch
+// is clear. Both have to render, so "is this slot free" is answered by the
+// talks on it, never by a flag here.
+
+const KINDS = ["BREAK", "MEAL", "PLENARY", "SOCIAL", "OTHER"] as const;
+type ScheduleEntryKind = (typeof KINDS)[number];
+
+interface ScheduleEntryBody {
+  editionId: number;
+  kind: ScheduleEntryKind;
+  labelFr: string;
+  labelEn: string;
+  startsAt: string;
+  endsAt: string;
+  roomId?: number | null;
+}
+
+/** Returns an error message, or null when the payload is usable. */
+function validate(body: Partial<ScheduleEntryBody>): string | null {
+  if (body.kind !== undefined && !KINDS.includes(body.kind)) {
+    return `Type inconnu. Valeurs acceptées : ${KINDS.join(", ")}.`;
+  }
+  if (body.labelFr !== undefined && !body.labelFr.trim()) return "Le libellé français est obligatoire.";
+  if (body.labelEn !== undefined && !body.labelEn.trim()) return "Le libellé anglais est obligatoire.";
+
+  if (body.startsAt !== undefined && body.endsAt !== undefined) {
+    const start = new Date(body.startsAt);
+    const end = new Date(body.endsAt);
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) return "Les horaires sont invalides.";
+    // A backwards range would render as a zero-width or negative block, which
+    // the grid has no sensible way to draw.
+    if (end <= start) return "La fin doit être postérieure au début.";
+  }
+  return null;
+}
+
+export default async function adminScheduleRoutes(app: FastifyInstance) {
+  // GET /api/admin/schedule-entries?editionId=X
+  app.get<{ Querystring: { editionId?: string } }>("/schedule-entries", async (request) => {
+    const { editionId } = request.query;
+    return prisma.scheduleEntry.findMany({
+      where: editionId ? { editionId: Number(editionId) } : {},
+      orderBy: { startsAt: "asc" },
+      include: { room: { select: { id: true, name: true } } },
+    });
+  });
+
+  // POST /api/admin/schedule-entries
+  app.post<{ Body: ScheduleEntryBody }>("/schedule-entries", async (request, reply) => {
+    const body = request.body;
+    const error = validate(body);
+    if (error) return reply.code(422).send({ error: "invalid_entry", message: error });
+
+    if (!body.startsAt || !body.endsAt) {
+      return reply.code(422).send({ error: "invalid_entry", message: "Les horaires sont obligatoires." });
+    }
+
+    const entry = await prisma.scheduleEntry.create({
+      data: {
+        editionId: body.editionId,
+        kind: body.kind,
+        labelFr: body.labelFr.trim(),
+        labelEn: body.labelEn.trim(),
+        startsAt: new Date(body.startsAt),
+        endsAt: new Date(body.endsAt),
+        roomId: body.roomId ?? null,
+      },
+      include: { room: { select: { id: true, name: true } } },
+    });
+
+    revalidateConferences();
+    return reply.code(201).send(entry);
+  });
+
+  // PUT /api/admin/schedule-entries/:id
+  app.put<{ Params: { id: string }; Body: Partial<ScheduleEntryBody> }>(
+    "/schedule-entries/:id",
+    async (request, reply) => {
+      const id = Number(request.params.id);
+      const body = request.body;
+
+      const existing = await prisma.scheduleEntry.findUnique({ where: { id } });
+      if (!existing) return reply.code(404).send({ error: "Schedule entry not found" });
+
+      // Validate against the merged result, not the patch alone: sending only
+      // `endsAt` must still be checked against the stored `startsAt`.
+      const error = validate({
+        ...body,
+        startsAt: body.startsAt ?? existing.startsAt.toISOString(),
+        endsAt: body.endsAt ?? existing.endsAt.toISOString(),
+      });
+      if (error) return reply.code(422).send({ error: "invalid_entry", message: error });
+
+      const entry = await prisma.scheduleEntry.update({
+        where: { id },
+        data: {
+          ...(body.kind !== undefined && { kind: body.kind }),
+          ...(body.labelFr !== undefined && { labelFr: body.labelFr.trim() }),
+          ...(body.labelEn !== undefined && { labelEn: body.labelEn.trim() }),
+          ...(body.startsAt !== undefined && { startsAt: new Date(body.startsAt) }),
+          ...(body.endsAt !== undefined && { endsAt: new Date(body.endsAt) }),
+          ...(body.roomId !== undefined && { roomId: body.roomId }),
+        },
+        include: { room: { select: { id: true, name: true } } },
+      });
+
+      revalidateConferences();
+      return entry;
+    },
+  );
+
+  // DELETE /api/admin/schedule-entries/:id
+  app.delete<{ Params: { id: string } }>("/schedule-entries/:id", async (request, reply) => {
+    const id = Number(request.params.id);
+    const existing = await prisma.scheduleEntry.findUnique({ where: { id } });
+    if (!existing) return reply.code(404).send({ error: "Schedule entry not found" });
+
+    await prisma.scheduleEntry.delete({ where: { id } });
+    revalidateConferences();
+    return reply.code(204).send();
+  });
+}

--- a/src/backend/src/routes/admin/talks.ts
+++ b/src/backend/src/routes/admin/talks.ts
@@ -18,7 +18,11 @@ interface TalkCreateBody {
   language: string;
   categoryId?: number | null;
   speakerIds?: number[];
-  room?: string;
+  // Scheduling (#105). `roomId: null` unassigns the room; the dates are ISO
+  // strings, `null` clears the slot.
+  roomId?: number | null;
+  startsAt?: string | null;
+  endsAt?: string | null;
   publicationStatus?: "DRAFT" | "PUBLISHED";
   isSpeakerEditable?: boolean;
 }
@@ -49,6 +53,36 @@ function serialize(t: {
   };
 }
 
+/**
+ * Resolve a room assignment for a talk (#105).
+ *
+ * A room belongs to a venue and a venue hosts editions, so a room is only
+ * assignable to a talk whose edition happens at that venue — otherwise a 2026
+ * session could be scheduled into a room the DevFest left behind in 2024.
+ *
+ * Returns the fields to write, or an error message to send back as a 422.
+ */
+async function resolveRoom(
+  roomId: number | null,
+  editionId: number,
+): Promise<{ data: { roomId: number | null; roomLabel: string | null } } | { error: string }> {
+  if (roomId === null) return { data: { roomId: null, roomLabel: null } };
+
+  const room = await prisma.room.findUnique({ where: { id: roomId } });
+  if (!room) return { error: "Cette salle n'existe pas." };
+
+  const edition = await prisma.edition.findUnique({
+    where: { id: editionId },
+    select: { venueId: true },
+  });
+  if (!edition || edition.venueId !== room.venueId) {
+    return { error: "Cette salle n'appartient pas au lieu de l'édition." };
+  }
+
+  // The label is frozen here, not read through at display time (#375).
+  return { data: { roomId: room.id, roomLabel: room.name } };
+}
+
 export default async function adminTalkRoutes(app: FastifyInstance) {
   // GET /api/admin/talks?editionId=X — editionId omitted lists all editions
   app.get<{ Querystring: TalkListQuery }>("/talks", {
@@ -65,6 +99,7 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
         // trashed speaker would otherwise still show up on a live talk.
         speakers: { where: notDeleted, select: { id: true, name: true } },
         category: { select: { id: true, nameFr: true, color: true } },
+        room: { select: { id: true, name: true } },
         ...(editionId ? {} : { edition: { select: { id: true, year: true } } }),
       },
     });
@@ -82,6 +117,7 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
       include: {
         speakers: { where: notDeleted, select: { id: true, name: true } },
         category: { select: { id: true, nameFr: true, color: true } },
+        room: { select: { id: true, name: true } },
         edition: { select: { id: true, year: true } },
       },
     });
@@ -115,6 +151,11 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
     });
     const slug = uniqueSlug(slugify(body.title), new Set(existing.map((e) => e.slug)));
 
+    const roomAssignment = await resolveRoom(body.roomId ?? null, body.editionId);
+    if ("error" in roomAssignment) {
+      return reply.code(422).send({ error: "invalid_room", message: roomAssignment.error });
+    }
+
     const talk = await prisma.talk.create({
       data: {
         editionId: body.editionId,
@@ -124,7 +165,9 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
         format: body.format,
         level: body.level ?? null,
         language: body.language.trim(),
-        room: body.room || null,
+        ...roomAssignment.data,
+        startsAt: body.startsAt ? new Date(body.startsAt) : null,
+        endsAt: body.endsAt ? new Date(body.endsAt) : null,
         categoryId: body.categoryId ?? null,
         publicationStatus: body.publicationStatus === "PUBLISHED" ? "PUBLISHED" : "DRAFT",
         isSpeakerEditable: body.isSpeakerEditable === true,
@@ -156,6 +199,23 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
       return reply.code(422).send({ error: `Invalid level. Allowed: ${LEVELS.join(", ")}` });
     }
 
+    // The room is validated against the talk's own edition, so the edition has
+    // to be read before the update rather than trusted from the request.
+    let roomData: { roomId: number | null; roomLabel: string | null } | undefined;
+    if (body.roomId !== undefined) {
+      const current = await prisma.talk.findUnique({
+        where: { id: Number(id) },
+        select: { editionId: true },
+      });
+      if (!current) return reply.code(404).send({ error: "Talk not found" });
+
+      const roomAssignment = await resolveRoom(body.roomId, current.editionId);
+      if ("error" in roomAssignment) {
+        return reply.code(422).send({ error: "invalid_room", message: roomAssignment.error });
+      }
+      roomData = roomAssignment.data;
+    }
+
     const talk = await prisma.talk.update({
       where: { id: Number(id) },
       data: {
@@ -164,7 +224,9 @@ export default async function adminTalkRoutes(app: FastifyInstance) {
         ...(body.format !== undefined && { format: body.format }),
         ...(body.level !== undefined && { level: body.level ?? null }),
         ...(body.language !== undefined && { language: body.language.trim() }),
-        ...(body.room !== undefined && { room: body.room || null }),
+        ...(roomData ?? {}),
+        ...(body.startsAt !== undefined && { startsAt: body.startsAt ? new Date(body.startsAt) : null }),
+        ...(body.endsAt !== undefined && { endsAt: body.endsAt ? new Date(body.endsAt) : null }),
         ...(body.categoryId !== undefined && { categoryId: body.categoryId ?? null }),
         ...(body.publicationStatus !== undefined && { publicationStatus: body.publicationStatus }),
         ...(body.isSpeakerEditable !== undefined && { isSpeakerEditable: body.isSpeakerEditable }),

--- a/src/backend/src/routes/admin/venues.ts
+++ b/src/backend/src/routes/admin/venues.ts
@@ -203,7 +203,10 @@ export default async function adminVenueRoutes(app: FastifyInstance) {
     if (room._count.talks > 0) {
       return reply.code(409).send({
         error: "room_in_use",
-        message: `${room._count.talks} conférence${room._count.talks > 1 ? "s sont programmées" : " est programmée"} dans cette salle. Déplacez-les avant de la supprimer.`,
+        message:
+          room._count.talks > 1
+            ? `${room._count.talks} conférences sont programmées dans cette salle. Déplacez-les avant de la supprimer.`
+            : "Une conférence est programmée dans cette salle. Déplacez-la avant de supprimer la salle.",
       });
     }
 

--- a/src/backend/src/routes/admin/venues.ts
+++ b/src/backend/src/routes/admin/venues.ts
@@ -1,0 +1,213 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../lib/prisma.js";
+import { revalidateVenue } from "../../lib/revalidate.js";
+import { sanitizeRichHtml, isSafeUrl } from "../../lib/sanitize.js";
+
+// CRUD for venues and their rooms (#105). A venue is shared across editions —
+// the DevFest returns to the same congress centre for years at a time — so its
+// details are edited here rather than on each edition.
+//
+// Neither venues nor rooms go to the trash (#146). They are configuration in
+// very small numbers, and a room that vanished quietly from a published grid
+// would be worse than a delete that refuses with a reason.
+
+interface VenueBody {
+  name: string;
+  address?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+  transports?: string | null;
+  parking?: string | null;
+  directionsUrl?: string | null;
+}
+
+interface RoomBody {
+  name: string;
+  capacity?: number | null;
+  sortOrder?: number;
+}
+
+/** Shared by create and update: the checks that protect the public page. */
+function validateVenue(body: Partial<VenueBody>): string | null {
+  if (body.name !== undefined && !body.name.trim()) {
+    return "Le nom du lieu est obligatoire.";
+  }
+  // The directions URL lands in an href on /lieu, so a javascript:/data: scheme
+  // is refused at the source rather than stored as an XSS vector (#109). Same
+  // allowlist as sponsor and social URLs (#223).
+  if (body.directionsUrl && !isSafeUrl(body.directionsUrl)) {
+    return "Le lien itinéraire doit être une URL http(s) valide.";
+  }
+  return null;
+}
+
+function venueWriteData(body: Partial<VenueBody>) {
+  return {
+    ...(body.name !== undefined && { name: body.name.trim() }),
+    ...(body.address !== undefined && { address: body.address || null }),
+    ...(body.lat !== undefined && { lat: body.lat }),
+    ...(body.lng !== undefined && { lng: body.lng }),
+    // Rich text, sanitized on write like sponsor descriptions.
+    ...(body.transports !== undefined && { transports: sanitizeRichHtml(body.transports) || null }),
+    ...(body.parking !== undefined && { parking: sanitizeRichHtml(body.parking) || null }),
+    ...(body.directionsUrl !== undefined && { directionsUrl: body.directionsUrl || null }),
+  };
+}
+
+export default async function adminVenueRoutes(app: FastifyInstance) {
+  // GET /api/admin/venues — the whole list, with rooms in grid order.
+  app.get("/venues", async () => {
+    return prisma.venue.findMany({
+      orderBy: { name: "asc" },
+      include: {
+        rooms: { orderBy: [{ sortOrder: "asc" }, { name: "asc" }] },
+        _count: { select: { editions: true } },
+      },
+    });
+  });
+
+  // GET /api/admin/venues/:id
+  app.get<{ Params: { id: string } }>("/venues/:id", async (request, reply) => {
+    const venue = await prisma.venue.findUnique({
+      where: { id: Number(request.params.id) },
+      include: {
+        rooms: { orderBy: [{ sortOrder: "asc" }, { name: "asc" }] },
+        editions: { select: { id: true, year: true }, orderBy: { year: "desc" } },
+      },
+    });
+    if (!venue) return reply.code(404).send({ error: "Venue not found" });
+    return venue;
+  });
+
+  // POST /api/admin/venues
+  app.post<{ Body: VenueBody }>("/venues", async (request, reply) => {
+    const error = validateVenue(request.body);
+    if (error) return reply.code(422).send({ error: "invalid_venue", message: error });
+
+    const existing = await prisma.venue.findUnique({ where: { name: request.body.name.trim() } });
+    if (existing) {
+      return reply.code(409).send({
+        error: "duplicate_venue",
+        message: "Un lieu porte déjà ce nom.",
+        venueId: existing.id,
+      });
+    }
+
+    const venue = await prisma.venue.create({
+      data: { name: request.body.name.trim(), ...venueWriteData(request.body) },
+    });
+    return reply.code(201).send(venue);
+  });
+
+  // PUT /api/admin/venues/:id
+  app.put<{ Params: { id: string }; Body: Partial<VenueBody> }>("/venues/:id", async (request, reply) => {
+    const id = Number(request.params.id);
+    const error = validateVenue(request.body);
+    if (error) return reply.code(422).send({ error: "invalid_venue", message: error });
+
+    const venue = await prisma.venue.findUnique({ where: { id } });
+    if (!venue) return reply.code(404).send({ error: "Venue not found" });
+
+    const updated = await prisma.venue.update({ where: { id }, data: venueWriteData(request.body) });
+    // The venue drives the public /lieu page and the homepage strap line.
+    revalidateVenue();
+    return updated;
+  });
+
+  // DELETE /api/admin/venues/:id — refused while an edition still points here.
+  app.delete<{ Params: { id: string } }>("/venues/:id", async (request, reply) => {
+    const id = Number(request.params.id);
+    const venue = await prisma.venue.findUnique({
+      where: { id },
+      include: { editions: { select: { year: true }, orderBy: { year: "desc" } } },
+    });
+    if (!venue) return reply.code(404).send({ error: "Venue not found" });
+
+    if (venue.editions.length > 0) {
+      const years = venue.editions.map((e) => e.year).join(", ");
+      return reply.code(409).send({
+        error: "venue_in_use",
+        message: `Ce lieu accueille encore ${venue.editions.length > 1 ? "les éditions" : "l'édition"} ${years}. Rattachez-les ailleurs avant de le supprimer.`,
+      });
+    }
+
+    await prisma.venue.delete({ where: { id } });
+    return reply.code(204).send();
+  });
+
+  // --- Rooms ------------------------------------------------------------
+
+  // POST /api/admin/venues/:id/rooms
+  app.post<{ Params: { id: string }; Body: RoomBody }>("/venues/:id/rooms", async (request, reply) => {
+    const venueId = Number(request.params.id);
+    const { name, capacity, sortOrder } = request.body;
+
+    if (!name?.trim()) {
+      return reply.code(422).send({ error: "invalid_room", message: "Le nom de la salle est obligatoire." });
+    }
+
+    const venue = await prisma.venue.findUnique({ where: { id: venueId } });
+    if (!venue) return reply.code(404).send({ error: "Venue not found" });
+
+    const existing = await prisma.room.findUnique({
+      where: { venueId_name: { venueId, name: name.trim() } },
+    });
+    if (existing) {
+      return reply.code(409).send({
+        error: "duplicate_room",
+        message: "Ce lieu a déjà une salle de ce nom.",
+      });
+    }
+
+    const room = await prisma.room.create({
+      data: { venueId, name: name.trim(), capacity: capacity ?? null, sortOrder: sortOrder ?? 0 },
+    });
+    return reply.code(201).send(room);
+  });
+
+  // PUT /api/admin/rooms/:id
+  app.put<{ Params: { id: string }; Body: Partial<RoomBody> }>("/rooms/:id", async (request, reply) => {
+    const id = Number(request.params.id);
+    const { name, capacity, sortOrder } = request.body;
+
+    if (name !== undefined && !name.trim()) {
+      return reply.code(422).send({ error: "invalid_room", message: "Le nom de la salle est obligatoire." });
+    }
+
+    const room = await prisma.room.findUnique({ where: { id } });
+    if (!room) return reply.code(404).send({ error: "Room not found" });
+
+    // Renaming a room does NOT rewrite the talks already scheduled in it: they
+    // carry their own frozen label (#375), so a 2026 grid keeps saying what the
+    // signage said in 2026.
+    const updated = await prisma.room.update({
+      where: { id },
+      data: {
+        ...(name !== undefined && { name: name.trim() }),
+        ...(capacity !== undefined && { capacity }),
+        ...(sortOrder !== undefined && { sortOrder }),
+      },
+    });
+    return updated;
+  });
+
+  // DELETE /api/admin/rooms/:id — refused while a talk is scheduled in it.
+  app.delete<{ Params: { id: string } }>("/rooms/:id", async (request, reply) => {
+    const id = Number(request.params.id);
+    const room = await prisma.room.findUnique({
+      where: { id },
+      include: { _count: { select: { talks: true } } },
+    });
+    if (!room) return reply.code(404).send({ error: "Room not found" });
+
+    if (room._count.talks > 0) {
+      return reply.code(409).send({
+        error: "room_in_use",
+        message: `${room._count.talks} conférence${room._count.talks > 1 ? "s sont programmées" : " est programmée"} dans cette salle. Déplacez-les avant de la supprimer.`,
+      });
+    }
+
+    await prisma.room.delete({ where: { id } });
+    return reply.code(204).send();
+  });
+}

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -35,6 +35,7 @@ export async function getFeaturedEdition() {
     // site — this function decides what every visitor sees.
     const edition = await prisma.edition.findFirst({
       where: { id: Number(setting.value), ...notDeleted },
+      include: { venue: true },
     });
     if (edition) return edition;
   }
@@ -43,6 +44,7 @@ export async function getFeaturedEdition() {
   return prisma.edition.findFirst({
     where: notDeleted,
     orderBy: { year: "desc" },
+    include: { venue: true },
   });
 }
 
@@ -78,6 +80,9 @@ export default async function editionRoutes(app: FastifyInstance) {
     const edition = await prisma.edition.findFirst({
       where: { year: yearNum, ...notDeleted },
       include: {
+        // The venue moved to its own table (#105); the payload below keeps
+        // rendering it flat so no consumer had to change.
+        venue: true,
         keyFigures: { orderBy: { sortOrder: "asc" } },
         articles: {
           where: { publicationStatus: "PUBLISHED", ...notDeleted },
@@ -96,8 +101,8 @@ export default async function editionRoutes(app: FastifyInstance) {
       startDate: edition.startDate,
       endDate: edition.endDate,
       status: edition.status,
-      venueName: edition.venueName,
-      venueAddress: edition.venueAddress,
+      venueName: edition.venue?.name ?? null,
+      venueAddress: edition.venue?.address ?? null,
       heroImageUrl: edition.heroImageUrl,
       aftermovieUrl: edition.aftermovieUrl,
       galleryUrl: edition.galleryUrl,
@@ -207,9 +212,103 @@ export default async function editionRoutes(app: FastifyInstance) {
       // Dates the talk page in the sitemap (#379). The list already carries
       // every published slug of the year, so no extra endpoint is needed.
       updatedAt: t.updatedAt,
+      // Scheduling (#105). `room` is the label frozen when the talk was placed,
+      // so an archive keeps the name that year's signage carried (#375).
+      room: t.roomLabel,
+      startsAt: t.startsAt,
+      endsAt: t.endsAt,
       category: visibleCategory(t.category),
       speakers: t.speakers,
     }));
+  });
+
+  // GET /api/editions/:year/schedule — the grid of a year: scheduled talks and
+  // everything around them (#105).
+  //
+  // Built for #106, which renders it. The columns are derived from the talks
+  // actually scheduled rather than from the venue's room list: the 2026 venue
+  // has eight rooms and the 2025 grid used five, so listing them all would draw
+  // empty columns.
+  app.get<{ Params: { year: string } }>("/editions/:year/schedule", {
+    schema: { params: { type: "object", required: ["year"], properties: { year: { type: "string" } } } },
+  }, async (request, reply) => {
+    const yearNum = Number(request.params.year);
+    if (isNaN(yearNum)) return reply.status(400).send({ error: "Invalid year" });
+
+    const edition = await prisma.edition.findFirst({
+      where: { year: yearNum, ...notDeleted },
+      select: { id: true },
+    });
+    if (!edition) return reply.status(404).send({ error: "Edition not found" });
+
+    const [talks, entries] = await Promise.all([
+      prisma.talk.findMany({
+        where: {
+          editionId: edition.id,
+          publicationStatus: "PUBLISHED",
+          startsAt: { not: null },
+          ...notDeleted,
+        },
+        orderBy: [{ startsAt: "asc" }, { title: "asc" }],
+        include: {
+          speakers: {
+            where: {
+              ...notDeleted,
+              editions: { some: { editionId: edition.id, publicationStatus: "PUBLISHED" } },
+            },
+            select: { slug: true, name: true, photoUrl: true },
+            orderBy: { name: "asc" },
+          },
+          category: { select: { nameFr: true, nameEn: true, color: true, deletedAt: true } },
+          room: { select: { id: true, sortOrder: true } },
+        },
+      }),
+      prisma.scheduleEntry.findMany({
+        where: { editionId: edition.id },
+        orderBy: { startsAt: "asc" },
+        include: { room: { select: { id: true, name: true } } },
+      }),
+    ]);
+
+    // One entry per room actually used, in grid order. A talk placed before its
+    // room existed — or whose room was later deleted — keeps its frozen label
+    // and lands in a column of its own rather than disappearing.
+    const rooms = [
+      ...new Map(
+        talks.map((t) => [
+          t.room?.id ?? `label:${t.roomLabel ?? ""}`,
+          { id: t.room?.id ?? null, name: t.roomLabel ?? "", sortOrder: t.room?.sortOrder ?? 0 },
+        ]),
+      ).values(),
+    ].sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name));
+
+    return {
+      year: yearNum,
+      rooms,
+      talks: talks.map((t) => ({
+        slug: t.slug,
+        title: t.title,
+        format: t.format,
+        level: t.level,
+        language: t.language,
+        room: t.roomLabel,
+        roomId: t.roomId,
+        startsAt: t.startsAt,
+        endsAt: t.endsAt,
+        category: visibleCategory(t.category),
+        speakers: t.speakers,
+      })),
+      entries: entries.map((e) => ({
+        id: e.id,
+        kind: e.kind,
+        labelFr: e.labelFr,
+        labelEn: e.labelEn,
+        startsAt: e.startsAt,
+        endsAt: e.endsAt,
+        roomId: e.roomId,
+        room: e.room?.name ?? null,
+      })),
+    };
   });
 
   // GET /api/editions/:year/talks/:slug — detail of one past talk (#343).
@@ -345,21 +444,25 @@ export default async function editionRoutes(app: FastifyInstance) {
       startDate: edition.startDate,
       endDate: edition.endDate,
       status: edition.status,
-      venueName: edition.venueName,
-      venueAddress: edition.venueAddress,
+      // The venue lives in its own table since #105, but the payload stays
+      // flat: nine frontend files read these keys, and reshaping the contract
+      // to mirror the storage would have meant reworking pages that already
+      // work — the homepage hero, /lieu, the past-edition sheets.
+      venueName: edition.venue?.name ?? null,
+      venueAddress: edition.venue?.address ?? null,
       // Venue & practical-info page (#109). The map needs both coordinates, so
       // `hasVenueInfo` drives the nav entry on the presence of at least the map
       // or one written section — an edition with only a name/address stays as it
       // was and shows no dedicated page.
-      venueLat: edition.venueLat,
-      venueLng: edition.venueLng,
-      venueTransports: edition.venueTransports,
-      venueParking: edition.venueParking,
-      venueDirectionsUrl: edition.venueDirectionsUrl,
+      venueLat: edition.venue?.lat ?? null,
+      venueLng: edition.venue?.lng ?? null,
+      venueTransports: edition.venue?.transports ?? null,
+      venueParking: edition.venue?.parking ?? null,
+      venueDirectionsUrl: edition.venue?.directionsUrl ?? null,
       hasVenueInfo:
-        (edition.venueLat !== null && edition.venueLng !== null) ||
-        !!edition.venueTransports ||
-        !!edition.venueParking,
+        (edition.venue?.lat != null && edition.venue?.lng != null) ||
+        !!edition.venue?.transports ||
+        !!edition.venue?.parking,
       heroImageUrl: edition.heroImageUrl,
       sponsorFormUrl: edition.sponsorFormUrl,
       aftermovieUrl: edition.aftermovieUrl,

--- a/src/frontend/src/app/admin/editions/[id]/page.tsx
+++ b/src/frontend/src/app/admin/editions/[id]/page.tsx
@@ -12,6 +12,7 @@ import CfpTab from "@/components/admin/edition-detail/CfpTab";
 import KeyFiguresTab from "@/components/admin/edition-detail/KeyFiguresTab";
 import SponsoringTab from "@/components/admin/edition-detail/SponsoringTab";
 import EditionSponsorsTab from "@/components/admin/edition-detail/EditionSponsorsTab";
+import ScheduleTab from "@/components/admin/edition-detail/ScheduleTab";
 import SynthesisOverview from "@/components/admin/edition-detail/SynthesisOverview";
 
 interface EditionData {
@@ -20,14 +21,11 @@ interface EditionData {
   startDate: string | null;
   endDate: string | null;
   status: string;
-  venueName: string | null;
-  venueAddress: string | null;
-  // Venue & practical-info page (#109), edited in the dedicated "Lieu" tab.
-  venueLat: number | null;
-  venueLng: number | null;
-  venueTransports: string | null;
-  venueParking: string | null;
-  venueDirectionsUrl: string | null;
+  // Which venue hosts this edition (#105). Its address, map and practical
+  // info (#109) are edited on the venue's own screen — an edition only picks
+  // one, so two years at the same place cannot describe it differently.
+  venueId: number | null;
+  venue: { id: number; name: string; address: string | null } | null;
   heroImageUrl: string | null;
   sponsorFormUrl: string | null;
   aftermovieUrl: string | null;
@@ -50,6 +48,7 @@ const STATUS_LABELS: Record<string, { label: string; variant: "green" | "orange"
 const TABS = [
   { key: "general", label: "Général" },
   { key: "venue", label: "Lieu" },
+  { key: "schedule", label: "Programme" },
   { key: "ticketing", label: "Billetterie" },
   // "Sponsoring" configures the tiers offered (#320); "Sponsors" lists the
   // companies actually signed for the edition (#389). Neighbouring, distinct.
@@ -128,6 +127,9 @@ export default function EditionDetailPage() {
         )}
         {activeTab === "venue" && (
           <VenueTab edition={edition} onSaved={loadEdition} />
+        )}
+        {activeTab === "schedule" && (
+          <ScheduleTab editionId={edition.id} venueId={edition.venueId} />
         )}
         {activeTab === "ticketing" && (
           <TicketingTab editionId={edition.id} />

--- a/src/frontend/src/app/admin/talks/[id]/page.tsx
+++ b/src/frontend/src/app/admin/talks/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { adminFetch } from "@/lib/admin-api";
 import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
-import type { Talk, Category, Speaker } from "@/lib/types";
+import type { Talk, Category, Speaker, AdminVenue } from "@/lib/types";
 import TalkForm, { emptyTalkForm, type TalkFormValue } from "@/components/admin/talks/TalkForm";
 
 interface TalkData extends Talk {
@@ -25,6 +25,8 @@ export default function TalkEditorPage() {
   const [editionYear, setEditionYear] = useState<number | null>(null);
   const [categories, setCategories] = useState<Category[]>([]);
   const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  // The rooms of the edition's venue (#105). Empty until an edition is known.
+  const [rooms, setRooms] = useState<{ id: number; name: string }[]>([]);
   const [isLoading, setIsLoading] = useState(!isNew);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -57,6 +59,10 @@ export default function TalkEditorPage() {
           speakerIds: data.speakerIds,
           publicationStatus: data.publicationStatus,
           isSpeakerEditable: data.isSpeakerEditable,
+          roomId: data.roomId ? String(data.roomId) : "",
+          // datetime-local wants `YYYY-MM-DDTHH:mm`, without zone or seconds.
+          startsAt: data.startsAt ? data.startsAt.slice(0, 16) : "",
+          endsAt: data.endsAt ? data.endsAt.slice(0, 16) : "",
         });
         setEditionId(data.editionId);
         setEditionYear(data.edition?.year ?? null);
@@ -78,6 +84,21 @@ export default function TalkEditorPage() {
     });
   }, [editionId]);
 
+  // The room list comes from the edition's venue, not from every venue: a
+  // session can only be placed where its own edition happens (#105).
+  useEffect(() => {
+    if (!editionId) return;
+    void adminFetch<{ venueId: number | null }>(`/editions/${editionId}`).then(({ data }) => {
+      if (!data?.venueId) {
+        setRooms([]);
+        return;
+      }
+      void adminFetch<AdminVenue>(`/venues/${data.venueId}`).then(({ data: venue }) => {
+        setRooms(venue?.rooms.map((r) => ({ id: r.id, name: r.name })) ?? []);
+      });
+    });
+  }, [editionId]);
+
   async function handleSave() {
     if (!form.title.trim() || !editionId) return;
     setIsSaving(true);
@@ -93,6 +114,10 @@ export default function TalkEditorPage() {
       speakerIds: form.speakerIds,
       publicationStatus: form.publicationStatus,
       isSpeakerEditable: form.isSpeakerEditable,
+      // `null` unschedules; a blank date clears the slot (#105).
+      roomId: form.roomId ? Number(form.roomId) : null,
+      startsAt: form.startsAt ? new Date(form.startsAt).toISOString() : null,
+      endsAt: form.endsAt ? new Date(form.endsAt).toISOString() : null,
     };
 
     if (isNew) {
@@ -148,7 +173,7 @@ export default function TalkEditorPage() {
           <p className="text-sm text-gris">Édition : <span className="font-medium text-noir">{editionYear ?? "—"}</span></p>
         )}
 
-        <TalkForm value={form} onChange={setForm} categories={categories} speakers={speakers} />
+        <TalkForm value={form} onChange={setForm} categories={categories} speakers={speakers} rooms={rooms} />
 
         {error && <p role="alert" className="text-sm text-terre-cuite">{error}</p>}
 

--- a/src/frontend/src/app/admin/talks/[id]/page.tsx
+++ b/src/frontend/src/app/admin/talks/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { adminFetch } from "@/lib/admin-api";
+import { isoToLocalInput, localInputToIso } from "@/lib/datetime";
 import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
 import type { Talk, Category, Speaker, AdminVenue } from "@/lib/types";
 import TalkForm, { emptyTalkForm, type TalkFormValue } from "@/components/admin/talks/TalkForm";
@@ -60,9 +61,10 @@ export default function TalkEditorPage() {
           publicationStatus: data.publicationStatus,
           isSpeakerEditable: data.isSpeakerEditable,
           roomId: data.roomId ? String(data.roomId) : "",
-          // datetime-local wants `YYYY-MM-DDTHH:mm`, without zone or seconds.
-          startsAt: data.startsAt ? data.startsAt.slice(0, 16) : "",
-          endsAt: data.endsAt ? data.endsAt.slice(0, 16) : "",
+          // Through the helper, never by slicing: the input reads local time
+          // and the API stores UTC, so a slice loses the offset on save (#105).
+          startsAt: isoToLocalInput(data.startsAt),
+          endsAt: isoToLocalInput(data.endsAt),
         });
         setEditionId(data.editionId);
         setEditionYear(data.edition?.year ?? null);
@@ -116,8 +118,8 @@ export default function TalkEditorPage() {
       isSpeakerEditable: form.isSpeakerEditable,
       // `null` unschedules; a blank date clears the slot (#105).
       roomId: form.roomId ? Number(form.roomId) : null,
-      startsAt: form.startsAt ? new Date(form.startsAt).toISOString() : null,
-      endsAt: form.endsAt ? new Date(form.endsAt).toISOString() : null,
+      startsAt: localInputToIso(form.startsAt),
+      endsAt: localInputToIso(form.endsAt),
     };
 
     if (isNew) {

--- a/src/frontend/src/app/admin/venues/[id]/page.tsx
+++ b/src/frontend/src/app/admin/venues/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { adminFetch } from "@/lib/admin-api";
+import { adminFetch, humanError } from "@/lib/admin-api";
 import FormField from "@/components/admin/FormField";
 import RichTextEditor from "@/components/admin/RichTextEditor";
 import LoadingSpinner from "@/components/admin/LoadingSpinner";
@@ -84,7 +84,7 @@ export default function VenueDetailPage() {
 
     // Rich-text / URL fields go as "" (not undefined) when cleared so the
     // backend applies its "" → null branch and the key is not dropped (#166).
-    const { status, error } = await adminFetch(`/venues/${venueId}`, {
+    const result = await adminFetch(`/venues/${venueId}`, {
       method: "PUT",
       body: JSON.stringify({
         name: form.name,
@@ -100,8 +100,8 @@ export default function VenueDetailPage() {
     setIsSaving(false);
     // Anything but 200 failed, network included: a dropped connection comes
     // back as status 0, which `>= 400` announced as a save (#428).
-    if (status !== 200) {
-      setFeedback({ kind: "error", text: error ?? "Le lieu n'a pas pu être enregistré." });
+    if (result.status !== 200) {
+      setFeedback({ kind: "error", text: humanError(result, "Le lieu n'a pas pu être enregistré.") });
       return;
     }
     setFeedback({ kind: "ok", text: "Lieu enregistré." });
@@ -110,7 +110,7 @@ export default function VenueDetailPage() {
 
   async function addRoom() {
     if (!newRoom.name.trim()) return;
-    const { status, error } = await adminFetch(`/venues/${venueId}/rooms`, {
+    const result = await adminFetch(`/venues/${venueId}/rooms`, {
       method: "POST",
       body: JSON.stringify({
         name: newRoom.name.trim(),
@@ -118,8 +118,8 @@ export default function VenueDetailPage() {
         sortOrder: newRoom.sortOrder.trim() === "" ? 0 : Number(newRoom.sortOrder),
       }),
     });
-    if (status !== 201) {
-      setFeedback({ kind: "error", text: error ?? "La salle n'a pas pu être créée." });
+    if (result.status !== 201) {
+      setFeedback({ kind: "error", text: humanError(result, "La salle n'a pas pu être créée.") });
       return;
     }
     setNewRoom({ name: "", capacity: "", sortOrder: "" });
@@ -132,11 +132,11 @@ export default function VenueDetailPage() {
     const room = pendingDelete;
     setPendingDelete(null);
 
-    const { status, error } = await adminFetch(`/rooms/${room.id}`, { method: "DELETE" });
-    if (status !== 204) {
+    const result = await adminFetch(`/rooms/${room.id}`, { method: "DELETE" });
+    if (result.status !== 204) {
       // The backend refuses with a readable reason when sessions are scheduled
       // in the room — surface it rather than a generic failure.
-      setFeedback({ kind: "error", text: error ?? "La salle n'a pas pu être supprimée." });
+      setFeedback({ kind: "error", text: humanError(result, "La salle n'a pas pu être supprimée.") });
       return;
     }
     setFeedback({ kind: "ok", text: `Salle « ${room.name} » supprimée.` });

--- a/src/frontend/src/app/admin/venues/[id]/page.tsx
+++ b/src/frontend/src/app/admin/venues/[id]/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { adminFetch } from "@/lib/admin-api";
+import FormField from "@/components/admin/FormField";
+import RichTextEditor from "@/components/admin/RichTextEditor";
+import LoadingSpinner from "@/components/admin/LoadingSpinner";
+import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import type { AdminVenue, AdminRoom } from "@/lib/types";
+
+// One venue and its rooms (#105). The practical-info fields (#109) moved here
+// from the edition: they describe the place, not the year, so two editions at
+// the same address can no longer drift apart.
+export default function VenueDetailPage() {
+  const params = useParams();
+  const venueId = Number(params.id);
+
+  const [venue, setVenue] = useState<AdminVenue | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [form, setForm] = useState({
+    name: "",
+    address: "",
+    // Coordinates are kept as strings while editing; parsed on save.
+    lat: "",
+    lng: "",
+    transports: "",
+    parking: "",
+    directionsUrl: "",
+  });
+  const [isSaving, setIsSaving] = useState(false);
+  const [feedback, setFeedback] = useState<SaveState>(null);
+
+  const [newRoom, setNewRoom] = useState({ name: "", capacity: "", sortOrder: "" });
+  const [pendingDelete, setPendingDelete] = useState<AdminRoom | null>(null);
+
+  const load = useCallback(async () => {
+    const { data } = await adminFetch<AdminVenue>(`/venues/${venueId}`);
+    if (data) {
+      setVenue(data);
+      setForm({
+        name: data.name,
+        address: data.address ?? "",
+        lat: data.lat?.toString() ?? "",
+        lng: data.lng?.toString() ?? "",
+        transports: data.transports ?? "",
+        parking: data.parking ?? "",
+        directionsUrl: data.directionsUrl ?? "",
+      });
+    }
+    setIsLoading(false);
+  }, [venueId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // A blank coordinate clears it (null); a filled one must parse to a finite
+  // number, otherwise we refuse to save rather than store NaN.
+  function parseCoord(raw: string): number | null | "invalid" {
+    const trimmed = raw.trim();
+    if (trimmed === "") return null;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : "invalid";
+  }
+
+  async function persist() {
+    const lat = parseCoord(form.lat);
+    const lng = parseCoord(form.lng);
+    if (lat === "invalid" || lng === "invalid") {
+      setFeedback({ kind: "error", text: "Latitude et longitude doivent être des nombres (ex. 43.5497)." });
+      return;
+    }
+    // The map needs both or neither — one lone coordinate places nothing.
+    if ((lat === null) !== (lng === null)) {
+      setFeedback({ kind: "error", text: "Renseignez la latitude ET la longitude, ou laissez les deux vides." });
+      return;
+    }
+
+    setIsSaving(true);
+    setFeedback(null);
+
+    // Rich-text / URL fields go as "" (not undefined) when cleared so the
+    // backend applies its "" → null branch and the key is not dropped (#166).
+    const { status, error } = await adminFetch(`/venues/${venueId}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        name: form.name,
+        address: form.address,
+        lat,
+        lng,
+        transports: form.transports,
+        parking: form.parking,
+        directionsUrl: form.directionsUrl,
+      }),
+    });
+
+    setIsSaving(false);
+    // Anything but 200 failed, network included: a dropped connection comes
+    // back as status 0, which `>= 400` announced as a save (#428).
+    if (status !== 200) {
+      setFeedback({ kind: "error", text: error ?? "Le lieu n'a pas pu être enregistré." });
+      return;
+    }
+    setFeedback({ kind: "ok", text: "Lieu enregistré." });
+    load();
+  }
+
+  async function addRoom() {
+    if (!newRoom.name.trim()) return;
+    const { status, error } = await adminFetch(`/venues/${venueId}/rooms`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: newRoom.name.trim(),
+        capacity: newRoom.capacity.trim() === "" ? null : Number(newRoom.capacity),
+        sortOrder: newRoom.sortOrder.trim() === "" ? 0 : Number(newRoom.sortOrder),
+      }),
+    });
+    if (status !== 201) {
+      setFeedback({ kind: "error", text: error ?? "La salle n'a pas pu être créée." });
+      return;
+    }
+    setNewRoom({ name: "", capacity: "", sortOrder: "" });
+    setFeedback({ kind: "ok", text: "Salle ajoutée." });
+    load();
+  }
+
+  async function confirmDeleteRoom() {
+    if (!pendingDelete) return;
+    const room = pendingDelete;
+    setPendingDelete(null);
+
+    const { status, error } = await adminFetch(`/rooms/${room.id}`, { method: "DELETE" });
+    if (status !== 204) {
+      // The backend refuses with a readable reason when sessions are scheduled
+      // in the room — surface it rather than a generic failure.
+      setFeedback({ kind: "error", text: error ?? "La salle n'a pas pu être supprimée." });
+      return;
+    }
+    setFeedback({ kind: "ok", text: `Salle « ${room.name} » supprimée.` });
+    load();
+  }
+
+  if (isLoading) return <LoadingSpinner />;
+  if (!venue) return <p className="text-sm text-gris">Ce lieu n’existe pas.</p>;
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <Link href="/admin/venues" className="text-sm text-gris underline">
+          ← Tous les lieux
+        </Link>
+        <h1 className="mt-2 text-2xl font-bold text-noir">{venue.name}</h1>
+        {venue.editions && venue.editions.length > 0 && (
+          <p className="text-sm text-gris">
+            Accueille {venue.editions.length > 1 ? "les éditions" : "l’édition"}{" "}
+            {venue.editions.map((e) => e.year).join(", ")}.
+          </p>
+        )}
+      </div>
+
+      <SaveFeedback state={feedback} onDismiss={() => setFeedback(null)} />
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-bold text-noir">Informations pratiques</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <FormField label="Nom" name="name" value={form.name} onChange={(v) => setForm({ ...form, name: v })} />
+          <FormField label="Adresse / Ville" name="address" value={form.address} onChange={(v) => setForm({ ...form, address: v })} />
+          <FormField label="Latitude" name="lat" value={form.lat} onChange={(v) => setForm({ ...form, lat: v })} />
+          <FormField label="Longitude" name="lng" value={form.lng} onChange={(v) => setForm({ ...form, lng: v })} />
+          <FormField label="Lien itinéraire" name="directionsUrl" value={form.directionsUrl} onChange={(v) => setForm({ ...form, directionsUrl: v })} />
+        </div>
+
+        <RichTextEditor
+          label="Transports"
+          name="transports"
+          value={form.transports}
+          onChange={(v) => setForm({ ...form, transports: v })}
+        />
+        <RichTextEditor
+          label="Parking"
+          name="parking"
+          value={form.parking}
+          onChange={(v) => setForm({ ...form, parking: v })}
+        />
+
+        <button
+          type="button"
+          onClick={persist}
+          disabled={isSaving}
+          className="rounded-[12px] bg-malachite px-[18px] py-3 text-base font-bold text-blanc disabled:opacity-50"
+        >
+          {isSaving ? "Enregistrement…" : "Enregistrer"}
+        </button>
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-lg font-bold text-noir">Salles</h2>
+          <p className="text-sm text-gris">
+            L’ordre décide de la position des colonnes dans la grille du programme.
+          </p>
+        </div>
+
+        {venue.rooms.length === 0 ? (
+          <p className="text-sm text-gris">Aucune salle — le programme ne pourra pas être établi.</p>
+        ) : (
+          <ul className="space-y-2">
+            {venue.rooms.map((room) => (
+              <li key={room.id} className="flex flex-wrap items-center justify-between gap-3 rounded-[12px] bg-blanc shadow-card px-4 py-3">
+                <span className="text-base text-noir">
+                  <span className="text-gris">{room.sortOrder}.</span> {room.name}
+                  {room.capacity ? <span className="text-gris"> — {room.capacity} places</span> : null}
+                </span>
+                <button type="button" onClick={() => setPendingDelete(room)} className="text-sm text-rouge underline">
+                  Supprimer
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex-1 min-w-[180px]">
+            <label htmlFor="roomName" className="block text-sm font-medium text-noir mb-1">Nom de la salle</label>
+            <input
+              id="roomName"
+              value={newRoom.name}
+              onChange={(e) => setNewRoom({ ...newRoom, name: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && addRoom()}
+              placeholder="Amphithéâtre"
+              className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+            />
+          </div>
+          <div className="w-28">
+            <label htmlFor="roomCapacity" className="block text-sm font-medium text-noir mb-1">Places</label>
+            <input
+              id="roomCapacity"
+              inputMode="numeric"
+              value={newRoom.capacity}
+              onChange={(e) => setNewRoom({ ...newRoom, capacity: e.target.value })}
+              className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+            />
+          </div>
+          <div className="w-24">
+            <label htmlFor="roomOrder" className="block text-sm font-medium text-noir mb-1">Ordre</label>
+            <input
+              id="roomOrder"
+              inputMode="numeric"
+              value={newRoom.sortOrder}
+              onChange={(e) => setNewRoom({ ...newRoom, sortOrder: e.target.value })}
+              className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={addRoom}
+            disabled={!newRoom.name.trim()}
+            className="rounded-[12px] bg-malachite px-[18px] py-3 text-base font-bold text-blanc disabled:opacity-50"
+          >
+            + Ajouter
+          </button>
+        </div>
+      </section>
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== null}
+        title="Supprimer cette salle ?"
+        message={`« ${pendingDelete?.name ?? ""} » sera supprimée définitivement. Les sessions déjà programmées dedans empêchent la suppression.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={confirmDeleteRoom}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/app/admin/venues/page.tsx
+++ b/src/frontend/src/app/admin/venues/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { adminFetch } from "@/lib/admin-api";
+import { adminFetch, humanError } from "@/lib/admin-api";
 import LoadingSpinner from "@/components/admin/LoadingSpinner";
 import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
 import ConfirmDialog from "@/components/admin/ConfirmDialog";
@@ -33,19 +33,19 @@ export default function VenuesPage() {
     setIsCreating(true);
     setFeedback(null);
 
-    const { data, status, error } = await adminFetch<AdminVenue>("/venues", {
+    const result = await adminFetch<AdminVenue>("/venues", {
       method: "POST",
       body: JSON.stringify({ name: newName.trim() }),
     });
 
     setIsCreating(false);
     // A creation answers 201; anything else failed, network included (#428).
-    if (status !== 201 || !data) {
-      setFeedback({ kind: "error", text: error ?? "Le lieu n'a pas pu être créé." });
+    if (result.status !== 201 || !result.data) {
+      setFeedback({ kind: "error", text: humanError(result, "Le lieu n'a pas pu être créé.") });
       return;
     }
     setNewName("");
-    setFeedback({ kind: "ok", text: `Lieu « ${data.name} » créé.` });
+    setFeedback({ kind: "ok", text: `Lieu « ${result.data.name} » créé.` });
     load();
   }
 
@@ -54,10 +54,10 @@ export default function VenuesPage() {
     const venue = pendingDelete;
     setPendingDelete(null);
 
-    const { status, error } = await adminFetch(`/venues/${venue.id}`, { method: "DELETE" });
+    const result = await adminFetch(`/venues/${venue.id}`, { method: "DELETE" });
     // A DELETE answers 204, not 200 — adminFetch returns it as-is.
-    if (status !== 204) {
-      setFeedback({ kind: "error", text: error ?? "Le lieu n'a pas pu être supprimé." });
+    if (result.status !== 204) {
+      setFeedback({ kind: "error", text: humanError(result, "Le lieu n'a pas pu être supprimé.") });
       return;
     }
     setFeedback({ kind: "ok", text: `Lieu « ${venue.name} » supprimé.` });

--- a/src/frontend/src/app/admin/venues/page.tsx
+++ b/src/frontend/src/app/admin/venues/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { adminFetch } from "@/lib/admin-api";
+import LoadingSpinner from "@/components/admin/LoadingSpinner";
+import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import type { AdminVenue } from "@/lib/types";
+
+// The venues the DevFest has used (#105). A venue is shared between editions,
+// so this list is short and slow-moving — no pagination, no filters.
+export default function VenuesPage() {
+  const [venues, setVenues] = useState<AdminVenue[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [newName, setNewName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [feedback, setFeedback] = useState<SaveState>(null);
+  const [pendingDelete, setPendingDelete] = useState<AdminVenue | null>(null);
+
+  const load = useCallback(async () => {
+    const { data } = await adminFetch<AdminVenue[]>("/venues");
+    setVenues(data ?? []);
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function create() {
+    if (!newName.trim()) return;
+    setIsCreating(true);
+    setFeedback(null);
+
+    const { data, status, error } = await adminFetch<AdminVenue>("/venues", {
+      method: "POST",
+      body: JSON.stringify({ name: newName.trim() }),
+    });
+
+    setIsCreating(false);
+    // A creation answers 201; anything else failed, network included (#428).
+    if (status !== 201 || !data) {
+      setFeedback({ kind: "error", text: error ?? "Le lieu n'a pas pu être créé." });
+      return;
+    }
+    setNewName("");
+    setFeedback({ kind: "ok", text: `Lieu « ${data.name} » créé.` });
+    load();
+  }
+
+  async function confirmDelete() {
+    if (!pendingDelete) return;
+    const venue = pendingDelete;
+    setPendingDelete(null);
+
+    const { status, error } = await adminFetch(`/venues/${venue.id}`, { method: "DELETE" });
+    // A DELETE answers 204, not 200 — adminFetch returns it as-is.
+    if (status !== 204) {
+      setFeedback({ kind: "error", text: error ?? "Le lieu n'a pas pu être supprimé." });
+      return;
+    }
+    setFeedback({ kind: "ok", text: `Lieu « ${venue.name} » supprimé.` });
+    load();
+  }
+
+  if (isLoading) return <LoadingSpinner />;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-noir">Lieux</h1>
+        <p className="text-sm text-gris">
+          Un lieu est partagé entre les éditions, avec ses salles. Les sessions du programme
+          sont affectées à ces salles.
+        </p>
+      </div>
+
+      <SaveFeedback state={feedback} onDismiss={() => setFeedback(null)} />
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex-1 min-w-[220px]">
+          <label htmlFor="newVenue" className="block text-sm font-medium text-noir mb-1">
+            Nouveau lieu
+          </label>
+          <input
+            id="newVenue"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && create()}
+            placeholder="Diagora"
+            className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={create}
+          disabled={isCreating || !newName.trim()}
+          className="rounded-[12px] bg-malachite px-[18px] py-3 text-base font-bold text-blanc disabled:opacity-50"
+        >
+          + Ajouter
+        </button>
+      </div>
+
+      {venues.length === 0 ? (
+        <p className="text-sm text-gris">Aucun lieu pour le moment.</p>
+      ) : (
+        <ul className="space-y-3">
+          {venues.map((venue) => (
+            <li key={venue.id} className="rounded-[12px] bg-blanc shadow-card p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <Link href={`/admin/venues/${venue.id}`} className="text-base font-medium text-noir underline">
+                    {venue.name}
+                  </Link>
+                  {venue.address && <p className="text-sm text-gris">{venue.address}</p>}
+                  <p className="mt-1 text-sm text-gris">
+                    {venue.rooms.length} salle{venue.rooms.length > 1 ? "s" : ""}
+                    {venue._count ? ` · ${venue._count.editions} édition${venue._count.editions > 1 ? "s" : ""}` : ""}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setPendingDelete(venue)}
+                  className="text-sm text-rouge underline"
+                >
+                  Supprimer
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== null}
+        title="Supprimer ce lieu ?"
+        // The backend refuses while an edition still points here, so this
+        // dialog guards the case where nothing does — which is irreversible.
+        message={`« ${pendingDelete?.name ?? ""} » et ses salles seront supprimés définitivement.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/AdminSidebar.tsx
+++ b/src/frontend/src/components/admin/AdminSidebar.tsx
@@ -20,6 +20,7 @@ import {
   faTag,
   faStar,
   faTrashCan,
+  faLocationDot,
 } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 
@@ -59,6 +60,7 @@ const iconMap: Record<string, IconDefinition> = {
   tag: faTag,
   star: faStar,
   trash: faTrashCan,
+  "map-pin": faLocationDot,
 };
 
 interface HealthInfo {

--- a/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/GeneralTab.tsx
@@ -12,8 +12,6 @@ interface EditionData {
   startDate: string | null;
   endDate: string | null;
   status: string;
-  venueName: string | null;
-  venueAddress: string | null;
   heroImageUrl: string | null;
   sponsorFormUrl: string | null;
   aftermovieUrl: string | null;
@@ -37,8 +35,6 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
     status: edition.status,
     startDate: edition.startDate?.split("T")[0] || "",
     endDate: edition.endDate?.split("T")[0] || "",
-    venueName: edition.venueName || "",
-    venueAddress: edition.venueAddress || "",
     heroImageUrl: edition.heroImageUrl || "",
     sponsorFormUrl: edition.sponsorFormUrl || "",
     aftermovieUrl: edition.aftermovieUrl || "",
@@ -67,8 +63,6 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
         status: form.status,
         startDate: form.startDate || undefined,
         endDate: form.endDate || undefined,
-        venueName: form.venueName,
-        venueAddress: form.venueAddress,
         heroImageUrl: form.heroImageUrl,
         sponsorFormUrl: form.sponsorFormUrl,
         aftermovieUrl: form.aftermovieUrl,
@@ -113,8 +107,6 @@ export default function GeneralTab({ edition, onSaved }: GeneralTabProps) {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <FormField label="Nom du lieu" name="venueName" value={form.venueName} onChange={(v) => setForm({ ...form, venueName: v })} />
-        <FormField label="Adresse / Ville" name="venueAddress" value={form.venueAddress} onChange={(v) => setForm({ ...form, venueAddress: v })} />
       </div>
 
       <div>

--- a/src/frontend/src/components/admin/edition-detail/ScheduleTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/ScheduleTab.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { adminFetch } from "@/lib/admin-api";
+import LoadingSpinner from "@/components/admin/LoadingSpinner";
+import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import type { ScheduleEntry } from "@/lib/types";
+
+interface ScheduleTabProps {
+  editionId: number;
+  venueId: number | null;
+}
+
+const KIND_LABELS: Record<ScheduleEntry["kind"], string> = {
+  OTHER: "Autre",
+  PLENARY: "Plénière",
+  BREAK: "Pause",
+  MEAL: "Repas",
+  SOCIAL: "Soirée",
+};
+
+/** `2026-11-19T09:00:00.000Z` → `2026-11-19T09:00`, what datetime-local wants. */
+function toLocalInput(iso: string): string {
+  return iso.slice(0, 16);
+}
+
+// Everything on the schedule that is not a session (#105): welcome, warm-up,
+// breaks, lunch, the party. The sessions themselves are scheduled on their own
+// screen, one by one — this tab is only for what surrounds them.
+export default function ScheduleTab({ editionId, venueId }: ScheduleTabProps) {
+  const [entries, setEntries] = useState<ScheduleEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [feedback, setFeedback] = useState<SaveState>(null);
+  const [pendingDelete, setPendingDelete] = useState<ScheduleEntry | null>(null);
+  const [draft, setDraft] = useState({
+    kind: "BREAK" as ScheduleEntry["kind"],
+    labelFr: "",
+    labelEn: "",
+    startsAt: "",
+    endsAt: "",
+  });
+
+  const load = useCallback(async () => {
+    const { data } = await adminFetch<ScheduleEntry[]>(`/schedule-entries?editionId=${editionId}`);
+    setEntries(data ?? []);
+    setIsLoading(false);
+  }, [editionId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function create() {
+    if (!draft.labelFr.trim() || !draft.startsAt || !draft.endsAt) return;
+    setFeedback(null);
+
+    const { status, error } = await adminFetch("/schedule-entries", {
+      method: "POST",
+      body: JSON.stringify({
+        editionId,
+        kind: draft.kind,
+        labelFr: draft.labelFr.trim(),
+        // The site is bilingual, so an English label is required. Falling back
+        // to the French one is better than an empty cell on /en.
+        labelEn: draft.labelEn.trim() || draft.labelFr.trim(),
+        startsAt: new Date(draft.startsAt).toISOString(),
+        endsAt: new Date(draft.endsAt).toISOString(),
+      }),
+    });
+
+    if (status !== 201) {
+      setFeedback({ kind: "error", text: error ?? "Le moment n'a pas pu être ajouté." });
+      return;
+    }
+    setDraft({ kind: "BREAK", labelFr: "", labelEn: "", startsAt: "", endsAt: "" });
+    setFeedback({ kind: "ok", text: "Moment ajouté au programme." });
+    load();
+  }
+
+  async function confirmDelete() {
+    if (!pendingDelete) return;
+    const entry = pendingDelete;
+    setPendingDelete(null);
+
+    const { status, error } = await adminFetch(`/schedule-entries/${entry.id}`, { method: "DELETE" });
+    if (status !== 204) {
+      setFeedback({ kind: "error", text: error ?? "Le moment n'a pas pu être supprimé." });
+      return;
+    }
+    setFeedback({ kind: "ok", text: "Moment supprimé." });
+    load();
+  }
+
+  if (isLoading) return <LoadingSpinner />;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-sm text-gris">
+          Les moments hors conférence : accueil, pauses, déjeuner, soirée. Les sessions,
+          elles, se programment une par une depuis leur fiche.
+        </p>
+        {venueId === null && (
+          <p role="alert" className="mt-2 text-sm text-rouge">
+            Aucun lieu n’est rattaché à cette édition : les sessions ne pourront pas être
+            affectées à une salle tant que ce n’est pas fait, dans l’onglet Lieu.
+          </p>
+        )}
+      </div>
+
+      <SaveFeedback state={feedback} onDismiss={() => setFeedback(null)} />
+
+      {entries.length === 0 ? (
+        <p className="text-sm text-gris">Aucun moment déclaré.</p>
+      ) : (
+        <ul className="space-y-2">
+          {entries.map((entry) => (
+            <li key={entry.id} className="flex flex-wrap items-center justify-between gap-3 rounded-[12px] bg-blanc shadow-card px-4 py-3">
+              <span className="text-base text-noir">
+                <span className="text-gris">
+                  {toLocalInput(entry.startsAt).slice(11)} – {toLocalInput(entry.endsAt).slice(11)}
+                </span>{" "}
+                {entry.labelFr}
+                <span className="text-gris"> · {KIND_LABELS[entry.kind]}</span>
+              </span>
+              <button type="button" onClick={() => setPendingDelete(entry)} className="text-sm text-rouge underline">
+                Supprimer
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="rounded-[12px] border border-gris-clair p-4 space-y-3">
+        <p className="text-base font-medium text-noir">Ajouter un moment</p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <label htmlFor="entryKind" className="block text-sm font-medium text-noir mb-1">Type</label>
+            <select
+              id="entryKind"
+              value={draft.kind}
+              onChange={(e) => setDraft({ ...draft, kind: e.target.value as ScheduleEntry["kind"] })}
+              className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+            >
+              {(Object.keys(KIND_LABELS) as ScheduleEntry["kind"][]).map((k) => (
+                <option key={k} value={k}>{KIND_LABELS[k]}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="entryLabelFr" className="block text-sm font-medium text-noir mb-1">Libellé (FR)</label>
+            <input
+              id="entryLabelFr"
+              value={draft.labelFr}
+              onChange={(e) => setDraft({ ...draft, labelFr: e.target.value })}
+              placeholder="Pause du matin"
+              className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+            />
+          </div>
+          <div>
+            <label htmlFor="entryLabelEn" className="block text-sm font-medium text-noir mb-1">Libellé (EN)</label>
+            <input
+              id="entryLabelEn"
+              value={draft.labelEn}
+              onChange={(e) => setDraft({ ...draft, labelEn: e.target.value })}
+              placeholder="Morning break"
+              className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label htmlFor="entryStart" className="block text-sm font-medium text-noir mb-1">Début</label>
+              <input
+                id="entryStart"
+                type="datetime-local"
+                value={draft.startsAt}
+                onChange={(e) => setDraft({ ...draft, startsAt: e.target.value })}
+                className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+              />
+            </div>
+            <div>
+              <label htmlFor="entryEnd" className="block text-sm font-medium text-noir mb-1">Fin</label>
+              <input
+                id="entryEnd"
+                type="datetime-local"
+                value={draft.endsAt}
+                onChange={(e) => setDraft({ ...draft, endsAt: e.target.value })}
+                className="w-full rounded-[12px] border border-gris-clair px-3 py-2 text-base"
+              />
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={create}
+          disabled={!draft.labelFr.trim() || !draft.startsAt || !draft.endsAt}
+          className="rounded-[12px] bg-malachite px-[18px] py-3 text-base font-bold text-blanc disabled:opacity-50"
+        >
+          + Ajouter
+        </button>
+      </div>
+
+      <p className="text-sm text-gris">
+        Pour affecter une session à une salle et à un horaire, ouvrez sa fiche depuis{" "}
+        <Link href="/admin/talks" className="underline">Conférences</Link>.
+      </p>
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== null}
+        title="Supprimer ce moment ?"
+        message={`« ${pendingDelete?.labelFr ?? ""} » sera retiré du programme.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/admin/edition-detail/ScheduleTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/ScheduleTab.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { adminFetch } from "@/lib/admin-api";
+import { adminFetch, humanError } from "@/lib/admin-api";
 import LoadingSpinner from "@/components/admin/LoadingSpinner";
 import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
 import ConfirmDialog from "@/components/admin/ConfirmDialog";
+import { isoToLocalTime, localInputToIso } from "@/lib/datetime";
 import type { ScheduleEntry } from "@/lib/types";
 
 interface ScheduleTabProps {
@@ -20,11 +21,6 @@ const KIND_LABELS: Record<ScheduleEntry["kind"], string> = {
   MEAL: "Repas",
   SOCIAL: "Soirée",
 };
-
-/** `2026-11-19T09:00:00.000Z` → `2026-11-19T09:00`, what datetime-local wants. */
-function toLocalInput(iso: string): string {
-  return iso.slice(0, 16);
-}
 
 // Everything on the schedule that is not a session (#105): welcome, warm-up,
 // breaks, lunch, the party. The sessions themselves are scheduled on their own
@@ -56,7 +52,7 @@ export default function ScheduleTab({ editionId, venueId }: ScheduleTabProps) {
     if (!draft.labelFr.trim() || !draft.startsAt || !draft.endsAt) return;
     setFeedback(null);
 
-    const { status, error } = await adminFetch("/schedule-entries", {
+    const result = await adminFetch("/schedule-entries", {
       method: "POST",
       body: JSON.stringify({
         editionId,
@@ -65,13 +61,13 @@ export default function ScheduleTab({ editionId, venueId }: ScheduleTabProps) {
         // The site is bilingual, so an English label is required. Falling back
         // to the French one is better than an empty cell on /en.
         labelEn: draft.labelEn.trim() || draft.labelFr.trim(),
-        startsAt: new Date(draft.startsAt).toISOString(),
-        endsAt: new Date(draft.endsAt).toISOString(),
+        startsAt: localInputToIso(draft.startsAt),
+        endsAt: localInputToIso(draft.endsAt),
       }),
     });
 
-    if (status !== 201) {
-      setFeedback({ kind: "error", text: error ?? "Le moment n'a pas pu être ajouté." });
+    if (result.status !== 201) {
+      setFeedback({ kind: "error", text: humanError(result, "Le moment n'a pas pu être ajouté.") });
       return;
     }
     setDraft({ kind: "BREAK", labelFr: "", labelEn: "", startsAt: "", endsAt: "" });
@@ -84,9 +80,9 @@ export default function ScheduleTab({ editionId, venueId }: ScheduleTabProps) {
     const entry = pendingDelete;
     setPendingDelete(null);
 
-    const { status, error } = await adminFetch(`/schedule-entries/${entry.id}`, { method: "DELETE" });
-    if (status !== 204) {
-      setFeedback({ kind: "error", text: error ?? "Le moment n'a pas pu être supprimé." });
+    const result = await adminFetch(`/schedule-entries/${entry.id}`, { method: "DELETE" });
+    if (result.status !== 204) {
+      setFeedback({ kind: "error", text: humanError(result, "Le moment n'a pas pu être supprimé.") });
       return;
     }
     setFeedback({ kind: "ok", text: "Moment supprimé." });
@@ -120,7 +116,7 @@ export default function ScheduleTab({ editionId, venueId }: ScheduleTabProps) {
             <li key={entry.id} className="flex flex-wrap items-center justify-between gap-3 rounded-[12px] bg-blanc shadow-card px-4 py-3">
               <span className="text-base text-noir">
                 <span className="text-gris">
-                  {toLocalInput(entry.startsAt).slice(11)} – {toLocalInput(entry.endsAt).slice(11)}
+                  {isoToLocalTime(entry.startsAt)} – {isoToLocalTime(entry.endsAt)}
                 </span>{" "}
                 {entry.labelFr}
                 <span className="text-gris"> · {KIND_LABELS[entry.kind]}</span>

--- a/src/frontend/src/components/admin/edition-detail/VenueTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/VenueTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { adminFetch } from "@/lib/admin-api";
+import { adminFetch, humanError } from "@/lib/admin-api";
 import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
 import type { AdminVenue } from "@/lib/types";
 
@@ -43,7 +43,7 @@ export default function VenueTab({ edition, onSaved }: VenueTabProps) {
     setIsSaving(true);
     setFeedback(null);
 
-    const { status, error: backendError } = await adminFetch(`/editions/${edition.id}`, {
+    const result = await adminFetch(`/editions/${edition.id}`, {
       method: "PUT",
       body: JSON.stringify({ venueId: selectedId === "" ? null : Number(selectedId) }),
     });
@@ -51,8 +51,8 @@ export default function VenueTab({ edition, onSaved }: VenueTabProps) {
     setIsSaving(false);
     // Anything but 200 failed, network included: a dropped connection comes
     // back as status 0, which `>= 400` announced as a save (#428).
-    if (status !== 200) {
-      setFeedback({ kind: "error", text: backendError ?? "Le lieu n'a pas pu être enregistré." });
+    if (result.status !== 200) {
+      setFeedback({ kind: "error", text: humanError(result, "Le lieu n'a pas pu être enregistré.") });
       return;
     }
     setFeedback({ kind: "ok", text: "Lieu enregistré." });

--- a/src/frontend/src/components/admin/edition-detail/VenueTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/VenueTab.tsx
@@ -1,19 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
 import { adminFetch } from "@/lib/admin-api";
-import FormField from "@/components/admin/FormField";
-import RichTextEditor from "@/components/admin/RichTextEditor";
+import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
+import type { AdminVenue } from "@/lib/types";
 
 interface EditionVenue {
   id: number;
-  venueName: string | null;
-  venueAddress: string | null;
-  venueLat: number | null;
-  venueLng: number | null;
-  venueTransports: string | null;
-  venueParking: string | null;
-  venueDirectionsUrl: string | null;
+  venueId: number | null;
+  venue: { id: number; name: string; address: string | null } | null;
 }
 
 interface VenueTabProps {
@@ -21,146 +17,106 @@ interface VenueTabProps {
   onSaved: () => void;
 }
 
-// Edits the fields behind the public "Lieu & infos pratiques" page (#109):
-// coordinates for the map, transports/parking as rich text, and an itinerary
-// link. Name and address live in the Général tab and are only shown read-only
-// here for context.
+// Picks which venue hosts this edition (#105). The venue's own details — its
+// address, its map coordinates, its transports and parking (#109) — are edited
+// on the venue screen, because they belong to the place and not to the year.
+// Two editions at Diagora describing it differently is exactly what moving
+// these fields off the edition was meant to prevent.
 export default function VenueTab({ edition, onSaved }: VenueTabProps) {
-  const [form, setForm] = useState({
-    // Coordinates are kept as strings while editing; parsed on save.
-    venueLat: edition.venueLat?.toString() ?? "",
-    venueLng: edition.venueLng?.toString() ?? "",
-    venueTransports: edition.venueTransports ?? "",
-    venueParking: edition.venueParking ?? "",
-    venueDirectionsUrl: edition.venueDirectionsUrl ?? "",
-  });
+  const [venues, setVenues] = useState<AdminVenue[]>([]);
+  const [selectedId, setSelectedId] = useState<string>(edition.venueId?.toString() ?? "");
+  const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<SaveState>(null);
 
-  // A blank coordinate clears it (null); a filled one must parse to a finite
-  // number, otherwise we refuse to save rather than store NaN.
-  function parseCoord(raw: string): number | null | "invalid" {
-    const trimmed = raw.trim();
-    if (trimmed === "") return null;
-    const n = Number(trimmed);
-    return Number.isFinite(n) ? n : "invalid";
-  }
+  const loadVenues = useCallback(async () => {
+    const { data } = await adminFetch<AdminVenue[]>("/venues");
+    setVenues(data ?? []);
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadVenues();
+  }, [loadVenues]);
 
   async function persist() {
-    const lat = parseCoord(form.venueLat);
-    const lng = parseCoord(form.venueLng);
-    if (lat === "invalid" || lng === "invalid") {
-      setError("Latitude et longitude doivent être des nombres (ex. 43.5497).");
-      return;
-    }
-    // The map needs both or neither — one lone coordinate places nothing.
-    if ((lat === null) !== (lng === null)) {
-      setError("Renseignez la latitude ET la longitude, ou laissez les deux vides.");
-      return;
-    }
-
     setIsSaving(true);
-    setSaved(false);
-    setError(null);
+    setFeedback(null);
 
-    // Rich-text / URL fields go as "" (not undefined) when cleared so the
-    // backend applies its "" → null branch and the key is not dropped (#166).
-    const { status } = await adminFetch(`/editions/${edition.id}`, {
+    const { status, error: backendError } = await adminFetch(`/editions/${edition.id}`, {
       method: "PUT",
-      body: JSON.stringify({
-        venueLat: lat,
-        venueLng: lng,
-        venueTransports: form.venueTransports,
-        venueParking: form.venueParking,
-        venueDirectionsUrl: form.venueDirectionsUrl,
-      }),
+      body: JSON.stringify({ venueId: selectedId === "" ? null : Number(selectedId) }),
     });
 
     setIsSaving(false);
-    if (status === 200) {
-      setSaved(true);
-      onSaved();
-    } else {
-      setError("Enregistrement impossible.");
+    // Anything but 200 failed, network included: a dropped connection comes
+    // back as status 0, which `>= 400` announced as a save (#428).
+    if (status !== 200) {
+      setFeedback({ kind: "error", text: backendError ?? "Le lieu n'a pas pu être enregistré." });
+      return;
     }
+    setFeedback({ kind: "ok", text: "Lieu enregistré." });
+    onSaved();
   }
+
+  const selected = venues.find((v) => v.id.toString() === selectedId) ?? null;
+  const isDirty = selectedId !== (edition.venueId?.toString() ?? "");
 
   return (
     <div className="space-y-6">
-      {(edition.venueName || edition.venueAddress) && (
-        <p className="text-sm text-gris">
-          Lieu : <span className="font-medium text-noir">{edition.venueName || "—"}</span>
-          {edition.venueAddress ? ` — ${edition.venueAddress}` : ""}
-          {" "}(modifiable dans l’onglet Général).
-        </p>
-      )}
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <FormField
-          label="Latitude"
-          name="venueLat"
-          type="number"
-          step="any"
-          value={form.venueLat}
-          onChange={(v) => setForm({ ...form, venueLat: v })}
-          placeholder="43.5497"
-          helpText="Coordonnée de la carte. Laissez vide pour masquer la carte."
-        />
-        <FormField
-          label="Longitude"
-          name="venueLng"
-          type="number"
-          step="any"
-          value={form.venueLng}
-          onChange={(v) => setForm({ ...form, venueLng: v })}
-          placeholder="1.5119"
-        />
-      </div>
-
-      <FormField
-        label="Lien itinéraire"
-        name="venueDirectionsUrl"
-        type="url"
-        value={form.venueDirectionsUrl}
-        onChange={(v) => setForm({ ...form, venueDirectionsUrl: v })}
-        placeholder="https://maps.google.com/?q=..."
-        helpText="Bouton « Itinéraire » sur la page publique."
-      />
-
-      <RichTextEditor
-        label="Accès & transports"
-        name="venueTransports"
-        value={form.venueTransports}
-        onChange={(html) => setForm({ ...form, venueTransports: html })}
-        placeholder="Métro, tram, bus, gare…"
-      />
-
-      <RichTextEditor
-        label="Parking"
-        name="venueParking"
-        value={form.venueParking}
-        onChange={(html) => setForm({ ...form, venueParking: html })}
-        placeholder="Parkings à proximité, tarifs, covoiturage…"
-      />
-
-      {error && (
-        <p role="alert" className="text-sm text-terre-cuite">
-          {error}
-        </p>
-      )}
-
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={persist}
-          disabled={isSaving}
-          className="px-4 py-2 rounded-lg bg-malachite text-blanc text-sm font-medium hover:bg-malachite/90 disabled:opacity-50"
+      <div>
+        <label htmlFor="venueId" className="block text-sm font-medium text-noir mb-1">
+          Lieu de l’édition
+        </label>
+        <select
+          id="venueId"
+          value={selectedId}
+          onChange={(e) => setSelectedId(e.target.value)}
+          disabled={isLoading}
+          className="w-full max-w-md rounded-[12px] border border-gris-clair px-3 py-2 text-base"
         >
-          {isSaving ? "Enregistrement…" : "Enregistrer"}
-        </button>
-        {saved && <span role="status" aria-live="polite" className="text-sm text-malachite">Modifications enregistrées.</span>}
+          <option value="">— Aucun lieu —</option>
+          {venues.map((venue) => (
+            <option key={venue.id} value={venue.id}>
+              {venue.name}
+              {venue.address ? ` — ${venue.address}` : ""}
+            </option>
+          ))}
+        </select>
+        <p className="mt-2 text-sm text-gris">
+          Un lieu est partagé entre les éditions. Son adresse, sa carte et ses infos pratiques
+          se modifient sur <Link href="/admin/venues" className="underline">l’écran des lieux</Link>.
+        </p>
       </div>
+
+      {selected && (
+        <div className="rounded-[12px] border border-gris-clair p-4">
+          <p className="text-sm font-medium text-noir">{selected.name}</p>
+          {selected.address && <p className="text-sm text-gris">{selected.address}</p>}
+          <p className="mt-2 text-sm text-gris">
+            {selected.rooms.length === 0
+              ? "Aucune salle déclarée — le programme ne pourra pas être établi."
+              : `${selected.rooms.length} salle${selected.rooms.length > 1 ? "s" : ""} : ${selected.rooms.map((r) => r.name).join(", ")}`}
+          </p>
+          <Link
+            href={`/admin/venues/${selected.id}`}
+            className="mt-3 inline-block text-sm text-bleu underline"
+          >
+            Modifier ce lieu et ses salles
+          </Link>
+        </div>
+      )}
+
+      <SaveFeedback state={feedback} onDismiss={() => setFeedback(null)} />
+
+      <button
+        type="button"
+        onClick={persist}
+        disabled={isSaving || !isDirty}
+        className="rounded-[12px] bg-malachite px-[18px] py-3 text-base font-bold text-blanc disabled:opacity-50"
+      >
+        {isSaving ? "Enregistrement…" : "Enregistrer"}
+      </button>
     </div>
   );
 }

--- a/src/frontend/src/components/admin/nav-items.ts
+++ b/src/frontend/src/components/admin/nav-items.ts
@@ -49,6 +49,9 @@ export const adminNavGroups: AdminNavGroup[] = [
     title: "Administration",
     items: [
       { label: "Éditions", path: "/admin/editions", icon: "calendar", roles: ["ADMIN"] },
+      // Next to Éditions rather than in Données: a venue and its rooms are
+      // configuration an edition points at, not content edited year by year (#105).
+      { label: "Lieux", path: "/admin/venues", icon: "map-pin", roles: ["ADMIN"] },
       { label: "Utilisateurs", path: "/admin/users", icon: "users", roles: ["ADMIN"] },
       { label: "Clés API", path: "/admin/api-keys", icon: "key", roles: ["ADMIN"] },
       // Both roles reach the page; ADMIN-only entities (users, editions…) are

--- a/src/frontend/src/components/admin/talks/TalkForm.tsx
+++ b/src/frontend/src/components/admin/talks/TalkForm.tsx
@@ -21,6 +21,10 @@ export interface TalkFormValue {
   level: "" | TalkLevel;
   language: string;
   categoryId: string;
+  // Scheduling (#105). Empty string means "not scheduled" for all three.
+  roomId: string;
+  startsAt: string;
+  endsAt: string;
   speakerIds: number[];
   publicationStatus: "DRAFT" | "PUBLISHED";
   isSpeakerEditable: boolean;
@@ -33,6 +37,9 @@ export const emptyTalkForm: TalkFormValue = {
   level: "",
   language: "fr",
   categoryId: "",
+  roomId: "",
+  startsAt: "",
+  endsAt: "",
   speakerIds: [],
   publicationStatus: "DRAFT",
   isSpeakerEditable: false,
@@ -46,9 +53,12 @@ interface TalkFormProps {
   onChange: (value: TalkFormValue) => void;
   categories: Category[];
   speakers: Speaker[];
+  // The rooms of the edition's venue (#105). Empty when no venue is attached,
+  // which the form says out loud rather than showing an empty dropdown.
+  rooms: { id: number; name: string }[];
 }
 
-export default function TalkForm({ value, onChange, categories, speakers }: TalkFormProps) {
+export default function TalkForm({ value, onChange, categories, speakers, rooms }: TalkFormProps) {
   function toggleSpeaker(id: number) {
     onChange({
       ...value,
@@ -104,6 +114,33 @@ export default function TalkForm({ value, onChange, categories, speakers }: Talk
           </select>
         </label>
       </div>
+
+      <fieldset className="rounded-lg border border-gris/30 p-4">
+        <legend className="px-1 text-sm font-medium text-noir">Programmation</legend>
+        {rooms.length === 0 ? (
+          <p className="text-sm text-gris">
+            Aucune salle disponible : rattachez un lieu à l’édition, puis déclarez ses salles.
+          </p>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-3">
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Salle</span>
+              <select value={value.roomId} onChange={(e) => onChange({ ...value, roomId: e.target.value })} className={inputClass}>
+                <option value="">— Non programmée —</option>
+                {rooms.map((r) => <option key={r.id} value={r.id}>{r.name}</option>)}
+              </select>
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Début</span>
+              <input type="datetime-local" value={value.startsAt} onChange={(e) => onChange({ ...value, startsAt: e.target.value })} className={inputClass} />
+            </label>
+            <label className="block">
+              <span className="block text-sm font-medium text-noir mb-1">Fin</span>
+              <input type="datetime-local" value={value.endsAt} onChange={(e) => onChange({ ...value, endsAt: e.target.value })} className={inputClass} />
+            </label>
+          </div>
+        )}
+      </fieldset>
 
       <div>
         <span className="block text-sm font-medium text-noir mb-1">Speakers</span>

--- a/src/frontend/src/lib/admin-api.ts
+++ b/src/frontend/src/lib/admin-api.ts
@@ -65,6 +65,25 @@ export async function adminFetch<T>(
   }
 }
 
+/**
+ * The sentence to show a human after a failed call.
+ *
+ * `adminFetch` resolves `error` as `body.error || body.message`, and several
+ * screens compare that value against a code (`last_responsable`,
+ * `quota_reached`…), so it has to keep winning. The cost is that a route
+ * sending both — a code AND a written explanation — surfaces the code:
+ * "room_in_use" where the backend wrote "3 conférences sont programmées dans
+ * cette salle". This picks the written one when there is one.
+ */
+export function humanError(
+  result: { error?: string; errorBody?: Record<string, unknown> },
+  fallback: string,
+): string {
+  const message = result.errorBody?.message;
+  if (typeof message === "string" && message.trim()) return message;
+  return result.error ?? fallback;
+}
+
 export async function getAdminSession(): Promise<AdminUser | null> {
   const { data, status } = await adminFetch<{ user: AdminUser }>("/session");
   if (status === 403 || !data) return null;

--- a/src/frontend/src/lib/datetime.test.ts
+++ b/src/frontend/src/lib/datetime.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import { isoToLocalInput, localInputToIso, isoToLocalTime } from "./datetime";
+
+// The bug these lock down (#105): the talk editor loaded `startsAt` by slicing
+// the ISO string, which handed the datetime-local input a UTC wall-clock. The
+// input reads local, so saving converted it a second time and the start moved
+// back by the timezone offset — an hour, every save, silently.
+//
+// Nothing pins a timezone for these tests, and pinning one would weaken them:
+// in UTC the old sliced version passes. So nothing is asserted against a
+// literal local string — only that loading then saving changes nothing, which
+// has to hold in every zone, CI's included.
+
+describe("datetime-local round trip", () => {
+  it("returns the same instant after a load/save cycle", () => {
+    const original = "2026-11-19T08:00:00.000Z";
+    const backToApi = localInputToIso(isoToLocalInput(original));
+    expect(backToApi).toBe(original);
+  });
+
+  it("survives repeated cycles — the drift was cumulative", () => {
+    let value = "2026-11-19T08:00:00.000Z";
+    for (let i = 0; i < 5; i++) {
+      value = localInputToIso(isoToLocalInput(value))!;
+    }
+    expect(value).toBe("2026-11-19T08:00:00.000Z");
+  });
+
+  it("hands the input a value it can actually parse back", () => {
+    const local = isoToLocalInput("2026-11-19T08:00:00.000Z");
+    expect(local).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    expect(new Date(local).toISOString()).toBe("2026-11-19T08:00:00.000Z");
+  });
+
+  it("treats an absent or unparseable value as empty rather than NaN", () => {
+    expect(isoToLocalInput(null)).toBe("");
+    expect(isoToLocalInput("pas une date")).toBe("");
+    expect(localInputToIso("")).toBeNull();
+    expect(localInputToIso("pas une date")).toBeNull();
+  });
+
+  it("reads a schedule time as hours and minutes", () => {
+    expect(isoToLocalTime("2026-11-19T08:00:00.000Z")).toMatch(/^\d{2}:\d{2}$/);
+  });
+});

--- a/src/frontend/src/lib/datetime.ts
+++ b/src/frontend/src/lib/datetime.ts
@@ -1,0 +1,35 @@
+// Bridging an ISO instant and an `<input type="datetime-local">` (#105).
+//
+// The trap this exists to close: a datetime-local field reads and writes LOCAL
+// wall-clock time, while the API stores a UTC instant. Slicing the ISO string
+// to `YYYY-MM-DDTHH:mm` looks right and is not — it hands the input a UTC
+// wall-clock, which `new Date(...)` then reads back as local and shifts by the
+// offset on save. Saving a talk twice in Paris in November walked its start
+// time back an hour each time, silently.
+//
+// So the two directions have to be symmetric, and both go through Date.
+
+/** UTC instant → the local wall-clock the input expects (`2026-11-19T09:00`). */
+export function isoToLocalInput(iso: string | null): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+}
+
+/** Local wall-clock from the input → UTC instant for the API. */
+export function localInputToIso(value: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+/** UTC instant → `09:00`, for reading a schedule at a glance. */
+export function isoToLocalTime(iso: string): string {
+  return isoToLocalInput(iso).slice(11);
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -353,8 +353,47 @@ export interface EditionTalk {
   language: string;
   videoUrl: string | null;
   updatedAt: string;
+  // Scheduling (#105). `room` is the label frozen when the talk was placed, so
+  // an archive keeps the name that year's signage carried (#375). All three are
+  // null until the talk is scheduled — the imported historical talks never are.
+  room: string | null;
+  startsAt: string | null;
+  endsAt: string | null;
   category: { nameFr: string; nameEn: string; color: string } | null;
   speakers: { slug: string; name: string; photoUrl: string | null }[];
+}
+
+// A room used by the grid of one year, in column order (#105).
+export interface ScheduleRoom {
+  id: number | null;
+  name: string;
+  sortOrder: number;
+}
+
+// Everything on the grid that is not a talk: welcome, breaks, lunch, the party.
+// `roomId` null means it spans every column, the usual case for a break.
+export interface ScheduleEntry {
+  id: number;
+  kind: "BREAK" | "MEAL" | "PLENARY" | "SOCIAL" | "OTHER";
+  labelFr: string;
+  labelEn: string;
+  startsAt: string;
+  endsAt: string;
+  roomId: number | null;
+  room: string | null;
+}
+
+// The whole grid of one edition, as /api/editions/:year/schedule serves it.
+export interface EditionSchedule {
+  year: number;
+  rooms: ScheduleRoom[];
+  talks: (Pick<EditionTalk, "slug" | "title" | "format" | "level" | "language" | "category" | "speakers"> & {
+    room: string | null;
+    roomId: number | null;
+    startsAt: string;
+    endsAt: string | null;
+  })[];
+  entries: ScheduleEntry[];
 }
 
 // One company that has a public page, for the sitemap (#379). Not the sponsor
@@ -425,7 +464,13 @@ export interface Talk {
   format: TalkFormat;
   level: TalkLevel | null;
   language: string;
-  room: string | null;
+  // Scheduling (#105). `roomLabel` is what the grid prints — frozen at the
+  // moment the talk was placed, so renaming the room later leaves it alone.
+  roomId: number | null;
+  roomLabel: string | null;
+  room: { id: number; name: string } | null;
+  startsAt: string | null;
+  endsAt: string | null;
   categoryId: number | null;
   category: { id: number; nameFr: string; color: string } | null;
   speakerIds: number[];
@@ -434,6 +479,32 @@ export interface Talk {
   // Whether the speaker may edit the wording from their magic link (#289).
   isSpeakerEditable: boolean;
   editionId: number;
+}
+
+// --- Venues and rooms (#105) ---
+
+// A venue is shared across editions: the DevFest returns to the same congress
+// centre for years at a time, and its rooms come back with it.
+export interface AdminVenue {
+  id: number;
+  name: string;
+  address: string | null;
+  lat: number | null;
+  lng: number | null;
+  transports: string | null;
+  parking: string | null;
+  directionsUrl: string | null;
+  rooms: AdminRoom[];
+  editions?: { id: number; year: number }[];
+  _count?: { editions: number };
+}
+
+export interface AdminRoom {
+  id: number;
+  name: string;
+  capacity: number | null;
+  sortOrder: number;
+  venueId: number;
 }
 
 // Session category / track.

--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
     setupFiles: ["./vitest.setup.ts"],
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
     exclude: ["node_modules", ".next"],
+    // The DevFest happens in Toulouse, so the tests run on Toulouse time (#105).
+    //
+    // Not cosmetic: a UTC runner has a zero offset, and every UTC/local bug is
+    // invisible under it. The talk editor lost an hour on each save by reading
+    // a UTC wall-clock into a local input — a fault that reproduces here and
+    // cannot reproduce on a UTC CI. Pinning the zone is what makes those tests
+    // mean something away from a developer's machine.
+    env: { TZ: "Europe/Paris" },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Pose le modèle du programme et la saisie qui va avec. La grille publique reste #106, les filtres et l'export #108.

Aucune session ne pouvait porter d'horaire ni de salle : `Talk.room` était une chaîne libre qu'aucun écran ne remplissait, et la fiche d'une conférence n'exposait ni elle ni les dates. Il n'existait donc **aucun moyen de saisir un planning** — alors que le guide sponsor déjà diffusé annonce le planning final « fin août/début septembre ».

## Ce qui change

- **`Venue` devient une entité partagée**, comme `docs/modele-donnees-metier.md` le prévoyait : le DevFest revient au même centre de congrès plusieurs années de suite, et ses salles reviennent avec lui. Les 7 champs `venue*` quittent `Edition`.
- **`Room`**, avec sa capacité et son ordre de colonne dans la grille.
- **`ScheduleEntry`** pour tout ce qui n'est pas une session : accueil, warm-up, pauses, déjeuner, soirée.
- **Écrans admin** : les lieux et leurs salles, la programmation sur la fiche de chaque conférence, les moments hors-session sur un onglet de l'édition.
- **`GET /editions/:year/schedule`**, de quoi construire #106 sans retoucher au backend.

## Le contrat d'API ne change pas

Neuf fichiers frontend lisent `edition.venueName`, `venueLat`, `venueTransports`… : page d'accueil, `/lieu` (#109), fiches d'éditions passées, tableau de bord admin. Les reprendre aurait été une refonte que personne n'a demandée.

La sérialisation aplatit donc la relation et rend la même charge utile. **Vérifié champ par champ** : 30 clés avant, 30 après, aucune ajoutée ni supprimée, et un test backend le verrouille. Le seul changement de valeur est `isScheduleReady`, qui passe à `true` parce que le seed programme désormais deux sessions.

## Deux leçons reprises plutôt que réapprises

**Le libellé de salle est figé sur la session** au moment où on la programme. Un lieu partagé et mutable est exactement la configuration qui a coûté #375 : renommer une salle en 2027 réécrirait la grille de 2026, qui doit dire ce que disait la signalétique cette année-là. Test de non-régression inclus.

**Une salle ou un lieu encore utilisés refusent d'être supprimés**, avec un motif lisible, plutôt que de disparaître d'une page publiée. Ni l'un ni l'autre ne passent par la corbeille : ce sont des données de configuration en très faible volume, et un refus explicite vaut mieux qu'une salle qui s'évapore.

## Ce que l'agenda 2025 a apporté

Relecture de la grille réellement publiée l'an dernier, qui a **confirmé un choix et corrigé un autre**.

Confirmé : toutes les salles démarrent aux mêmes heures, donc les lignes se déduisent des `startsAt` distincts. Pas besoin d'entité « Créneau horaire », malgré ce que suggère la spec.

Corrigé : en 2025 le déjeuner courait de 12h45 à 14h15 **pendant** que des quickies jouaient à 12h55 et 13h50. Une entrée hors-session ne peut donc pas bloquer sa plage — et le cas s'inverse cette année, le guide 2026 ayant déplacé les quickies hors du déjeuner. Le modèle ne porte aucun indicateur « bloquant » ; c'est la présence de sessions qui tranche.

## ⚠️ Migration destructrice

`20260821090000_programme_venue_rooms` reprend les lieux et les salles, puis supprime les 7 colonnes `venue*` de `Edition` et `Talk.room`. **Sauvegarde de la base obligatoire avant déploiement en production.**

Point à connaître : la prod n'a aujourd'hui **aucune salle saisie**, l'étape de reprise des salles y sera donc vide. C'est en local et en bêta que ce volet se vérifie. La reprise des lieux, elle, dédoublonne par nom — le seed en produit deux distincts, ce n'est pas théorique.

## Plan de test

**Vérifié**

- Suites : frontend 140/140, backend 652/653.
- Migration appliquée sur la base locale : 2 lieux dédoublonnés, chaque édition rattachée, 8 salles semées.
- **Charge utile publique comparée avant/après migration** : 30 clés identiques.
- `/fr/lieu` rend l'adresse, la carte, les transports et le parking depuis la nouvelle table — page inchangée, code inchangé.
- Navigateur (Chrome DevTools MCP) : liste des lieux, fiche d'un lieu et ses 8 salles, refus de suppression d'une salle occupée avec son motif, bloc « Programmation » sur une conférence, aller-retour d'enregistrement complet.
- Console propre, à l'exception de l'avertissement de manifeste déjà suivi en #432.

**Non vérifié**

- **La grille publique n'existe pas encore** — c'est #106. L'endpoint qui l'alimentera est testé, son rendu non.
- **Rien n'a été rejoué sur des données de production.** La reprise des salles y sera vide, mais la reprise des lieux, elle, s'exécutera pour de bon.
- Le rendu mobile des nouveaux écrans admin n'a pas été regardé.
- L'échec backend restant (1/653) est l'artefact d'environnement connu : `stat-icons.test.ts` lit un fichier du frontend, absent de l'image backend. Il passe en CI.

## Trois défauts que seules les suites n'auraient pas vus

Trouvés en navigateur, corrigés dans le dernier commit.

1. **Une heure perdue à chaque enregistrement.** Le formulaire lisait `startsAt` en tronquant la chaîne ISO, ce qui donne à un champ `datetime-local` une heure UTC qu'il interprète comme locale. Cinq enregistrements faisaient passer 08:00 à 03:00. Les tests tournent désormais sur `TZ=Europe/Paris` — sur un runner UTC le décalage est nul et **aucune assertion ne peut distinguer les deux versions**. Vérifié en réintroduisant le bug : trois tests rougissent ici, aucun ne rougirait en UTC.
2. **`room_in_use` affiché à un humain** au lieu de la phrase. `adminFetch` fait `body.error || body.message`, et six écrans comparent cette valeur à un code — le code doit donc continuer à gagner. Défaut préexistant, `invalid_url` de #109 l'avait déjà.
3. **Une année de test déjà prise** (1990, par `admin-edition-sponsor-tiers`). `Edition.year` est unique et les fichiers tournent en parallèle : le motif de #292, visible seulement dans la course complète.

## Note

Le frontend en local **ne recharge pas** les modifications de l'hôte à chaud, comme le backend (`tsx watch`) que CLAUDE.md documente déjà. J'ai perdu un aller-retour à croire un correctif inopérant. À ajouter aux pièges du dépôt si tu le confirmes de ton côté.

Refs #105
