### PR TITLE
Programme — la grille horaire publique

### DIFF
--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -728,36 +728,115 @@ async function seedDev() {
       speakers: { connect: [{ id: speakerJean.id }] },
     },
   });
-  console.log("Talks created: 2");
+  // --- Schedule (#105, rendered by #106) ---
+  //
+  // A day dense enough for the grid to be worth looking at: six session slots
+  // across four rooms. Diagora holds eight, and four staying empty is the case
+  // the endpoint derives its columns for — a venue's room list is not a grid.
+  //
+  // Times are UTC, an hour behind the November wall clock in Toulouse, and fit
+  // between the off-session moments of the 2026 sponsor guide below.
+  const sessions = [
+    { slug: "observabilite-opentelemetry", title: "Observabilité : OpenTelemetry en pratique",
+      description: "Instrumenter une application sans se noyer dans les traces.",
+      format: "CONFERENCE", level: "CONFIRME", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Amphithéâtre", start: "08:50", end: "09:30" },
+    { slug: "design-system-tailwind", title: "Un design system qui survit à ses auteurs",
+      description: "Tokens, composants et conventions : ce qui tient dans la durée.",
+      format: "CONFERENCE", level: "INTERMEDIAIRE", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Agora 1", start: "08:50", end: "09:30" },
+    { slug: "postgres-plan-execution", title: "Postgres : lire un plan d'exécution",
+      description: "EXPLAIN ANALYZE, ligne par ligne, sur des requêtes réelles.",
+      format: "CONFERENCE", level: "CONFIRME", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Hémicycle", start: "08:50", end: "09:30" },
+    { slug: "accessibilite-par-ou-commencer", title: "Accessibilité : par où commencer",
+      description: "Les quelques gestes qui changent tout, avant l'audit complet.",
+      format: "QUICKIE", level: "DEBUTANT", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Pastel", start: "08:50", end: "09:10" },
+    { slug: "terraform-sans-douleur", title: "Terraform sans douleur",
+      description: "Modules, états partagés et revues : industrialiser sans se figer.",
+      format: "CONFERENCE", level: "INTERMEDIAIRE", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Amphithéâtre", start: "10:00", end: "10:40" },
+    { slug: "server-actions-limites", title: "Server Actions : jusqu'où aller",
+      description: "Ce que les Server Actions résolvent, et ce qu'elles compliquent.",
+      format: "CONFERENCE", level: "CONFIRME", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Agora 1", start: "10:00", end: "10:40" },
+    { slug: "edge-computing-really-buys", title: "Edge computing: what it actually buys you",
+      description: "Measuring the latency you gain, and the complexity you pay.",
+      format: "CONFERENCE", level: "INTERMEDIAIRE", language: "en", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Hémicycle", start: "10:55", end: "11:35" },
+    { slug: "web-components-renouveau", title: "Web Components : le renouveau",
+      description: "Les nouvelles API navigateur qui les rendent enfin utilisables.",
+      format: "QUICKIE", level: "INTERMEDIAIRE", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Pastel", start: "10:55", end: "11:15" },
+    { slug: "finops-reprendre-la-main", title: "FinOps : reprendre la main sur la facture",
+      description: "Attribuer les coûts, puis décider — dans cet ordre.",
+      format: "CONFERENCE", level: "INTERMEDIAIRE", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Amphithéâtre", start: "13:15", end: "13:55" },
+    { slug: "tests-end-to-end-playwright", title: "Tests end-to-end : arrêter de les subir",
+      description: "Écrire des tests qui échouent pour une bonne raison seulement.",
+      format: "CONFERENCE", level: "INTERMEDIAIRE", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Agora 1", start: "13:15", end: "13:55" },
+    { slug: "vos-secrets-sont-en-clair", title: "Vos secrets sont en clair (et vous l'ignorez)",
+      description: "Là où les jetons finissent vraiment : logs, images, tickets.",
+      format: "CONFERENCE", level: "CONFIRME", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Amphithéâtre", start: "14:10", end: "14:50" },
+    { slug: "islands-architecture-production", title: "Islands architecture in production",
+      description: "Shipping less JavaScript without giving up interactivity.",
+      format: "CONFERENCE", level: "CONFIRME", language: "en", category: catWeb.id,
+      speaker: speakerJean.id, room: "Agora 1", start: "14:10", end: "14:50" },
+    { slug: "green-it-mesurer-avant", title: "Green IT : mesurer avant d'optimiser",
+      description: "Ce qu'on croit économiser, et ce qu'on économise vraiment.",
+      format: "CONFERENCE", level: "DEBUTANT", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Hémicycle", start: "15:30", end: "16:10" },
+    { slug: "typescript-types-avances", title: "TypeScript : les types avancés sans peur",
+      description: "Génériques, inférence et types conditionnels, pas à pas.",
+      format: "CONFERENCE", level: "INTERMEDIAIRE", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Agora 1", start: "15:30", end: "16:10" },
+  ] as const;
 
-  // --- Schedule (#105) ---
-  // Both talks get an hour and a room so the "Programme" menu shows up (#203)
-  // and the grid has something to draw. Times follow the 2026 day plan of the
-  // sponsor guide; the dates are UTC, an hour behind the local schedule.
-  const amphitheatre = await prisma.room.findUnique({
-    where: { venueId_name: { venueId: diagora.id, name: "Amphithéâtre" } },
-  });
-  const hemicycle = await prisma.room.findUnique({
-    where: { venueId_name: { venueId: diagora.id, name: "Hémicycle" } },
-  });
-  await prisma.talk.update({
-    where: { editionId_slug: { editionId: edition.id, slug: "kubernetes-en-production" } },
-    data: {
-      roomId: amphitheatre?.id,
-      roomLabel: amphitheatre?.name,
-      startsAt: new Date("2026-11-19T08:00:00Z"),
-      endsAt: new Date("2026-11-19T08:40:00Z"),
-    },
-  });
-  await prisma.talk.update({
-    where: { editionId_slug: { editionId: edition.id, slug: "react-server-components" } },
-    data: {
-      roomId: hemicycle?.id,
-      roomLabel: hemicycle?.name,
-      startsAt: new Date("2026-11-19T08:00:00Z"),
-      endsAt: new Date("2026-11-19T08:15:00Z"),
-    },
-  });
+  const roomsByName = new Map(
+    (await prisma.room.findMany({ where: { venueId: diagora.id } })).map((r) => [r.name, r]),
+  );
+  const placedAt = (time: string) => new Date(`2026-11-19T${time}:00Z`);
+
+  for (const session of sessions) {
+    const room = roomsByName.get(session.room);
+    await prisma.talk.create({
+      data: {
+        slug: session.slug, title: session.title, description: session.description,
+        format: session.format, level: session.level, language: session.language,
+        publicationStatus: "PUBLISHED", editionId: edition.id, categoryId: session.category,
+        speakers: { connect: [{ id: session.speaker }] },
+        roomId: room?.id,
+        // Frozen at placement time (#375): renaming the room in 2027 must not
+        // rewrite what the 2026 grid says.
+        roomLabel: room?.name,
+        startsAt: placedAt(session.start),
+        endsAt: placedAt(session.end),
+      },
+    });
+  }
+
+  // The two talks created above get their slot too — one of them is the only
+  // English quickie, and both are the ones the speaker-edit fixtures point at.
+  const placements = [
+    { slug: "kubernetes-en-production", room: "Amphithéâtre", start: "10:55", end: "11:35" },
+    { slug: "react-server-components", room: "Pastel", start: "13:15", end: "13:35" },
+  ];
+  for (const placement of placements) {
+    const room = roomsByName.get(placement.room);
+    await prisma.talk.update({
+      where: { editionId_slug: { editionId: edition.id, slug: placement.slug } },
+      data: {
+        roomId: room?.id,
+        roomLabel: room?.name,
+        startsAt: placedAt(placement.start),
+        endsAt: placedAt(placement.end),
+      },
+    });
+  }
+  console.log(`Talks created: ${sessions.length + 2}`);
 
   // Everything that is not a session. Lunch is the one that matters for the
   // grid: it spans every room, and in 2026 no quickie runs under it.

--- a/src/backend/src/lib/revalidate.ts
+++ b/src/backend/src/lib/revalidate.ts
@@ -70,6 +70,8 @@ export function revalidateVenue(): Promise<void> {
   return revalidatePaths([
     ...bilingualPaths(""),
     ...bilingualPaths("/lieu"),
+    // Renaming a room changes the grid's column headers (#106).
+    ...bilingualPaths("/programme"),
   ]);
 }
 
@@ -118,6 +120,10 @@ export function revalidateConferences(): Promise<void> {
   return revalidatePaths([
     ...bilingualPaths(""),
     ...bilingualPaths("/conferences"),
+    // The grid (#106) reads the same talks, plus the off-session entries the
+    // schedule screens write. Placing a session must show there immediately —
+    // the organisers publish the planning right up to the day before.
+    ...bilingualPaths("/programme"),
   ]);
 }
 

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -357,6 +357,19 @@
     "cta": "View offer",
     "offersAt": "Offers at {name}"
   },
+  "programme": {
+    "title": "Schedule",
+    "pageTitle": "Schedule — the full grid",
+    "description": "The DevFest Toulouse {year} schedule: every session, room by room.",
+    "heading": "DevFest Toulouse {year} schedule",
+    "home": "Home",
+    "intro": "The day, room by room. Click a session to read its details.",
+    "timeColumn": "Time",
+    "roomTba": "Room to be confirmed",
+    "allSessions": "See every session as a list",
+    "comingSoonTitle": "The schedule is on its way",
+    "comingSoonBody": "The DevFest Toulouse {year} sessions are still being placed. The grid will be published here as soon as it is final."
+  },
   "venue": {
     "pageTitle": "Venue & practical info",
     "description": "How to reach DevFest Toulouse, where to park and how to get around.",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -357,6 +357,19 @@
     "cta": "Voir l'offre",
     "offersAt": "Offres chez {name}"
   },
+  "programme": {
+    "title": "Programme",
+    "pageTitle": "Programme — la grille horaire",
+    "description": "La grille horaire du DevFest Toulouse {year} : toutes les sessions, salle par salle.",
+    "heading": "Programme du DevFest Toulouse {year}",
+    "home": "Accueil",
+    "intro": "Le programme de la journée, salle par salle. Cliquez sur une session pour en lire le détail.",
+    "timeColumn": "Horaire",
+    "roomTba": "Salle à préciser",
+    "allSessions": "Voir toutes les sessions en liste",
+    "comingSoonTitle": "La grille horaire arrive bientôt",
+    "comingSoonBody": "Les sessions du DevFest Toulouse {year} sont en cours de placement. La grille sera publiée ici dès qu'elle sera figée."
+  },
   "venue": {
     "pageTitle": "Lieu & infos pratiques",
     "description": "Comment venir au DevFest Toulouse, se garer et s'orienter sur place.",

--- a/src/frontend/src/app/[locale]/programme/page.tsx
+++ b/src/frontend/src/app/[locale]/programme/page.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from "next";
+import { getLocale, getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+
+import { Link } from "@/i18n/navigation";
+import { getCurrentEdition, getEditionSchedule } from "@/lib/api";
+import Breadcrumb from "@/components/Breadcrumb";
+import ScheduleGrid from "@/components/programme/ScheduleGrid";
+import ScheduleAgenda from "@/components/programme/ScheduleAgenda";
+import { buildScheduleRows } from "@/lib/schedule";
+import type { TalkFormat } from "@/lib/types";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  const t = await getTranslations("programme");
+  const edition = await getCurrentEdition();
+  const year = edition?.year ?? new Date().getFullYear();
+
+  return {
+    title: t("pageTitle"),
+    description: t("description", { year }),
+    alternates: {
+      canonical: `/${locale}/programme`,
+      languages: { fr: "/fr/programme", en: "/en/programme", "x-default": "/fr/programme" },
+    },
+  };
+}
+
+const TALK_FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"];
+
+export default async function ProgrammePage() {
+  const locale = await getLocale();
+  const t = await getTranslations("programme");
+  const tc = await getTranslations("conferences");
+  const edition = await getCurrentEdition();
+
+  if (!edition) notFound();
+
+  const schedule = await getEditionSchedule(edition.year);
+  const rows = schedule ? buildScheduleRows(schedule) : [];
+
+  const formatLabels = Object.fromEntries(
+    TALK_FORMATS.map((format) => [format, tc(`format.${format}`)]),
+  );
+
+  const breadcrumbItems = [
+    { label: t("home"), href: `/${locale}` },
+    { label: t("title"), href: `/${locale}/programme` },
+  ];
+
+  return (
+    <div className="px-6 py-8 lg:py-12">
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumb items={breadcrumbItems} />
+
+        <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
+          {t("heading", { year: edition.year })}
+        </h1>
+
+        {/* An edition with rooms but no session placed yet still lands here from
+            a shared link: it says "soon" rather than 404, because a 404 cached
+            for an hour outlives the state that caused it (#345). */}
+        {rows.length === 0 ? (
+          <div className="mt-8 rounded-3xl bg-blanc p-8 shadow-card">
+            <h2 className="text-2xl font-bold text-noir lg:text-3xl">{t("comingSoonTitle")}</h2>
+            <p className="mt-4 text-lg leading-relaxed text-gris">
+              {t("comingSoonBody", { year: edition.year })}
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="mt-4 text-lg text-gris">{t("intro")}</p>
+
+            <div className="mt-8">
+              <ScheduleGrid
+                rows={rows}
+                rooms={schedule!.rooms}
+                locale={locale}
+                formatLabels={formatLabels}
+                labels={{ timeColumn: t("timeColumn"), roomTba: t("roomTba") }}
+              />
+              <ScheduleAgenda
+                rows={rows}
+                rooms={schedule!.rooms}
+                locale={locale}
+                formatLabels={formatLabels}
+                labels={{ roomTba: t("roomTba") }}
+              />
+            </div>
+
+            {/* The searchable list is the other way in (#107) — the grid answers
+                "when and where", the list answers "what is there on my topic". */}
+            <Link
+              href="/conferences"
+              className="mt-8 inline-flex items-center gap-2 rounded-[12px] bg-bismarck px-4 py-2 text-sm font-bold text-blanc hover:bg-bismarck/90"
+            >
+              {t("allSessions")}
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/app/sitemap.ts
+++ b/src/frontend/src/app/sitemap.ts
@@ -111,6 +111,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // it unconditionally would put a 404 in the sitemap.
   if (featured?.hasVenueInfo) fullyTranslatedRoutes.push("/lieu");
 
+  // /programme renders a "coming soon" card rather than 404ing before the grid
+  // is placed (#106), so listing it early would only index an empty page.
+  if (featured?.isScheduleReady) fullyTranslatedRoutes.push("/programme");
+
   const entries: MetadataRoute.Sitemap = [];
 
   // Routes available in both locales. These are code-backed pages with no row

--- a/src/frontend/src/components/admin/edition-detail/ScheduleTab.tsx
+++ b/src/frontend/src/components/admin/edition-detail/ScheduleTab.tsx
@@ -6,7 +6,7 @@ import { adminFetch, humanError } from "@/lib/admin-api";
 import LoadingSpinner from "@/components/admin/LoadingSpinner";
 import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
 import ConfirmDialog from "@/components/admin/ConfirmDialog";
-import { isoToLocalTime, localInputToIso } from "@/lib/datetime";
+import { formatEventTime, localInputToIso } from "@/lib/datetime";
 import type { ScheduleEntry } from "@/lib/types";
 
 interface ScheduleTabProps {
@@ -116,7 +116,7 @@ export default function ScheduleTab({ editionId, venueId }: ScheduleTabProps) {
             <li key={entry.id} className="flex flex-wrap items-center justify-between gap-3 rounded-[12px] bg-blanc shadow-card px-4 py-3">
               <span className="text-base text-noir">
                 <span className="text-gris">
-                  {isoToLocalTime(entry.startsAt)} – {isoToLocalTime(entry.endsAt)}
+                  {formatEventTime(entry.startsAt)} – {formatEventTime(entry.endsAt)}
                 </span>{" "}
                 {entry.labelFr}
                 <span className="text-gris"> · {KIND_LABELS[entry.kind]}</span>

--- a/src/frontend/src/components/programme/ScheduleAgenda.tsx
+++ b/src/frontend/src/components/programme/ScheduleAgenda.tsx
@@ -1,0 +1,57 @@
+import type { ScheduleRow } from "@/lib/schedule";
+import type { ScheduleRoom } from "@/lib/types";
+import { formatEventTime } from "@/lib/datetime";
+import { localizedField } from "@/lib/i18n-helpers";
+import SessionCard from "./SessionCard";
+
+interface ScheduleAgendaProps {
+  rows: ScheduleRow[];
+  rooms: ScheduleRoom[];
+  locale: string;
+  formatLabels: Record<string, string>;
+  labels: { roomTba: string };
+}
+
+// The same schedule read on a phone (#106): one column, chronological, each
+// session carrying its room since there is no column to say it.
+export default function ScheduleAgenda({
+  rows,
+  rooms,
+  locale,
+  formatLabels,
+  labels,
+}: ScheduleAgendaProps) {
+  return (
+    <div className="space-y-6 lg:hidden">
+      {rows.map((row) =>
+        row.type === "band" ? (
+          <div key={row.key} className="rounded-2xl bg-blanc-casse px-4 py-3">
+            <p className="text-sm font-bold text-noir">
+              {localizedField(row.entry, "label", locale)}
+            </p>
+            <p className="mt-1 text-xs text-gris">
+              {formatEventTime(row.entry.startsAt)} – {formatEventTime(row.entry.endsAt)}
+            </p>
+          </div>
+        ) : (
+          <section key={row.key}>
+            <h2 className="text-lg font-bold text-noir">{formatEventTime(row.startsAt)}</h2>
+            <div className="mt-3 space-y-3">
+              {row.cells.flatMap((talks, index) =>
+                talks.map((talk) => (
+                  <SessionCard
+                    key={talk.slug}
+                    talk={talk}
+                    locale={locale}
+                    formatLabels={formatLabels}
+                    roomName={rooms[index]?.name || labels.roomTba}
+                  />
+                )),
+              )}
+            </div>
+          </section>
+        ),
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/programme/ScheduleGrid.tsx
+++ b/src/frontend/src/components/programme/ScheduleGrid.tsx
@@ -1,0 +1,89 @@
+import type { ScheduleRow } from "@/lib/schedule";
+import type { ScheduleRoom } from "@/lib/types";
+import { formatEventTime } from "@/lib/datetime";
+import { localizedField } from "@/lib/i18n-helpers";
+import SessionCard from "./SessionCard";
+
+interface ScheduleGridProps {
+  rows: ScheduleRow[];
+  rooms: ScheduleRoom[];
+  locale: string;
+  formatLabels: Record<string, string>;
+  labels: { timeColumn: string; roomTba: string };
+}
+
+// The desktop grid (#106): rooms across, start times down.
+//
+// A real table, because that is what this is — the room headers and the time
+// headers are what a screen reader needs to announce a cell. The mobile agenda
+// renders the same data as a linear list; only one of the two is ever in the
+// accessibility tree, since the other is `display: none`.
+export default function ScheduleGrid({
+  rows,
+  rooms,
+  locale,
+  formatLabels,
+  labels,
+}: ScheduleGridProps) {
+  return (
+    // The grid outgrows the viewport as soon as there are five rooms, so it
+    // scrolls inside its own box rather than pushing the page sideways.
+    <div className="hidden overflow-x-auto lg:block">
+      <table className="w-full min-w-[64rem] border-separate border-spacing-2">
+        <thead>
+          <tr>
+            <th scope="col" className="w-24 text-left text-sm font-bold text-gris">
+              {labels.timeColumn}
+            </th>
+            {rooms.map((room) => (
+              <th
+                key={room.id ?? `label:${room.name}`}
+                scope="col"
+                className="rounded-2xl bg-blanc-casse px-3 py-2 text-left text-sm font-bold text-noir"
+              >
+                {room.name || labels.roomTba}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) =>
+            row.type === "band" ? (
+              <tr key={row.key}>
+                <td
+                  colSpan={rooms.length + 1}
+                  className="rounded-2xl bg-blanc-casse px-4 py-3 text-sm font-bold text-noir"
+                >
+                  <span className="text-gris">
+                    {formatEventTime(row.entry.startsAt)} – {formatEventTime(row.entry.endsAt)}
+                  </span>
+                  <span className="ml-3">{localizedField(row.entry, "label", locale)}</span>
+                </td>
+              </tr>
+            ) : (
+              <tr key={row.key}>
+                <th scope="row" className="align-top text-left text-sm font-bold text-noir">
+                  {formatEventTime(row.startsAt)}
+                </th>
+                {row.cells.map((talks, index) => (
+                  <td key={rooms[index]?.id ?? index} className="align-top">
+                    <div className="flex h-full flex-col gap-2">
+                      {talks.map((talk) => (
+                        <SessionCard
+                          key={talk.slug}
+                          talk={talk}
+                          locale={locale}
+                          formatLabels={formatLabels}
+                        />
+                      ))}
+                    </div>
+                  </td>
+                ))}
+              </tr>
+            ),
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/frontend/src/components/programme/SessionCard.tsx
+++ b/src/frontend/src/components/programme/SessionCard.tsx
@@ -1,0 +1,56 @@
+import { Link } from "@/i18n/navigation";
+
+import type { ScheduleTalk } from "@/lib/schedule";
+import { localizedField } from "@/lib/i18n-helpers";
+import { formatEventTime } from "@/lib/datetime";
+
+interface SessionCardProps {
+  talk: ScheduleTalk;
+  locale: string;
+  // Pre-resolved labels: the page owns the translation namespaces, so this stays
+  // a plain server component — same arrangement as ConferencesList.
+  formatLabels: Record<string, string>;
+  /** Shown on the mobile agenda, where there is no column to say which room. */
+  roomName?: string;
+}
+
+// One session inside the grid (#106). The whole card is the link to its detail
+// page, so the target is comfortable on a touch screen.
+export default function SessionCard({ talk, locale, formatLabels, roomName }: SessionCardProps) {
+  const categoryName = talk.category ? localizedField(talk.category, "name", locale) : null;
+  const endsAt = talk.endsAt ? formatEventTime(talk.endsAt) : null;
+
+  return (
+    <Link
+      href={`/conferences/${talk.slug}`}
+      className="flex h-full flex-col rounded-2xl bg-blanc p-3 shadow-card transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
+    >
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="rounded-full bg-bleu/10 px-2 py-0.5 text-xs font-bold text-bleu">
+          {formatLabels[talk.format]}
+        </span>
+        {categoryName && (
+          <span
+            className="rounded-full px-2 py-0.5 text-xs font-bold"
+            style={{ backgroundColor: `${talk.category!.color}20`, color: talk.category!.color }}
+          >
+            {categoryName}
+          </span>
+        )}
+      </div>
+
+      {/* The title is not localized (#293) — a talk is given in one language. */}
+      <p className="mt-2 text-sm font-bold leading-snug text-noir">{talk.title}</p>
+
+      {talk.speakers.length > 0 && (
+        <p className="mt-1 text-xs text-gris">{talk.speakers.map((s) => s.name).join(", ")}</p>
+      )}
+
+      <p className="mt-auto pt-2 text-xs text-gris">
+        {formatEventTime(talk.startsAt)}
+        {endsAt ? ` – ${endsAt}` : ""}
+        {roomName ? ` · ${roomName}` : ""}
+      </p>
+    </Link>
+  );
+}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   EditionSpeaker,
   EditionTalk,
   EditionTalkDetail,
+  EditionSchedule,
   Replay,
   ReplayFilters,
   EcosystemPartner,
@@ -260,6 +261,13 @@ export async function getEditionSpeakers(year: number): Promise<EditionSpeaker[]
 
 export async function getEditionTalks(year: number): Promise<EditionTalk[]> {
   return (await fetchAPI<EditionTalk[]>(`/api/editions/${year}/talks`)) || [];
+}
+
+// The grid of one year (#106): scheduled talks, the rooms they use, and the
+// moments around them. Null when the year has no edition — the page 404s, the
+// same way /lieu does when there is nothing to show.
+export async function getEditionSchedule(year: number): Promise<EditionSchedule | null> {
+  return fetchAPI<EditionSchedule>(`/api/editions/${year}/schedule`);
 }
 
 // Sponsors of a past edition (#370). Same payload as getSponsors() — the values

--- a/src/frontend/src/lib/datetime.test.ts
+++ b/src/frontend/src/lib/datetime.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
-import { isoToLocalInput, localInputToIso, isoToLocalTime } from "./datetime";
+import { isoToLocalInput, localInputToIso, formatEventTime } from "./datetime";
 
 // The bug these lock down (#105): the talk editor loaded `startsAt` by slicing
 // the ISO string, which handed the datetime-local input a UTC wall-clock. The
 // input reads local, so saving converted it a second time and the start moved
 // back by the timezone offset — an hour, every save, silently.
 //
-// Nothing pins a timezone for these tests, and pinning one would weaken them:
-// in UTC the old sliced version passes. So nothing is asserted against a
-// literal local string — only that loading then saving changes nothing, which
-// has to hold in every zone, CI's included.
+// The round-trip assertions below never name a literal local hour: loading then
+// saving must change nothing, and that has to hold in every zone. The suite
+// runs on `TZ=Europe/Paris` (vitest.config.ts) because the sliced version does
+// pass under a zero offset, so a UTC runner could not tell the two apart.
 
 describe("datetime-local round trip", () => {
   it("returns the same instant after a load/save cycle", () => {
@@ -40,7 +40,35 @@ describe("datetime-local round trip", () => {
     expect(localInputToIso("pas une date")).toBeNull();
   });
 
-  it("reads a schedule time as hours and minutes", () => {
-    expect(isoToLocalTime("2026-11-19T08:00:00.000Z")).toMatch(/^\d{2}:\d{2}$/);
+});
+
+describe("schedule times (#106)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("reads a session time as hours and minutes, on the Toulouse clock", () => {
+    expect(formatEventTime("2026-11-19T08:50:00.000Z")).toBe("09:50");
+  });
+
+  it("says Toulouse time even when the server itself runs on UTC", async () => {
+    // This is not hypothetical: the frontend container has no TZ, so the grid
+    // is rendered by a process on UTC and printed 08:50 for the session the
+    // signage calls 09:50. The zone has to be in the formatter, not inherited.
+    vi.resetModules();
+    vi.stubEnv("TZ", "UTC");
+    const { formatEventTime: onUtcServer } = await import("./datetime");
+
+    expect(onUtcServer("2026-11-19T08:50:00.000Z")).toBe("09:50");
+  });
+
+  it("follows summer time — the offset is not a constant", () => {
+    // A June rehearsal or a spring meetup runs on CEST (+2), not CET (+1).
+    expect(formatEventTime("2026-06-18T08:50:00.000Z")).toBe("10:50");
+  });
+
+  it("treats an unparseable value as empty rather than printing NaN", () => {
+    expect(formatEventTime("pas une date")).toBe("");
   });
 });

--- a/src/frontend/src/lib/datetime.ts
+++ b/src/frontend/src/lib/datetime.ts
@@ -29,7 +29,27 @@ export function localInputToIso(value: string): string | null {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
-/** UTC instant → `09:00`, for reading a schedule at a glance. */
-export function isoToLocalTime(iso: string): string {
-  return isoToLocalInput(iso).slice(11);
+/**
+ * The zone the schedule speaks in.
+ *
+ * Not the reader's, and above all not the server's: the grid is rendered on a
+ * container that runs on UTC, so formatting "locally" printed 08:50 for a
+ * session the signage calls 09:50. A time on a schedule is a place, not a
+ * moment relative to whoever is looking (#106).
+ */
+export const EVENT_TIME_ZONE = "Europe/Paris";
+
+// 24-hour in both locales: it is what the programme, the badges and the room
+// signage print, and an English visitor reading 3:15 PM would have to convert
+// back to match them.
+const eventTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
+  timeZone: EVENT_TIME_ZONE,
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+/** UTC instant → `09:50` in Toulouse, whatever the machine formatting it. */
+export function formatEventTime(iso: string): string {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "" : eventTimeFormatter.format(date);
 }

--- a/src/frontend/src/lib/nav.test.ts
+++ b/src/frontend/src/lib/nav.test.ts
@@ -47,6 +47,9 @@ describe("getPublicNavEntries", () => {
     const entries = getPublicNavEntries(edition({ isScheduleReady: true, isProgramPublished: true }));
     const program = entries.find((e) => e.key === "program");
     expect(program).toBeDefined();
+    // The parent is the grid itself since #106 — it pointed at /conferences
+    // while the page did not exist yet.
+    expect(program?.href).toBe("/programme");
     expect(program?.children?.map((c) => c.key)).toEqual(["conferences"]);
     // Not also a flat conferences entry — schedule-ready supersedes it.
     expect(keys(entries)).not.toContain("conferences");

--- a/src/frontend/src/lib/nav.ts
+++ b/src/frontend/src/lib/nav.ts
@@ -49,13 +49,11 @@ export function getPublicNavEntries(edition: Edition | null): NavEntry[] {
   const entries: NavEntry[] = [];
 
   if (edition?.isScheduleReady) {
-    // The schedule (planning) page lives at /programme and is built in Lot 3.
-    // Until it exists, the parent points to /conferences so the menu never
-    // leads to a 404; flip this href to /programme when the page ships.
+    // The grid itself (#106), with the searchable list nested under it.
     entries.push({
       key: "program",
       labelKey: "program",
-      href: "/conferences",
+      href: "/programme",
       children: [CONFERENCES_ENTRY],
     });
   } else if (edition?.isProgramPublished) {

--- a/src/frontend/src/lib/schedule.test.ts
+++ b/src/frontend/src/lib/schedule.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+
+import { buildScheduleRows } from "./schedule";
+import type { EditionSchedule } from "./types";
+
+const AMPHI = { id: 1, name: "Amphithéâtre", sortOrder: 0 };
+const HEMI = { id: 2, name: "Hémicycle", sortOrder: 1 };
+
+function talk(over: Partial<EditionSchedule["talks"][number]>): EditionSchedule["talks"][number] {
+  return {
+    slug: "t",
+    title: "Talk",
+    format: "CONFERENCE",
+    level: null,
+    language: "fr",
+    category: null,
+    speakers: [],
+    room: AMPHI.name,
+    roomId: AMPHI.id,
+    startsAt: "2026-11-19T08:00:00.000Z",
+    endsAt: "2026-11-19T08:40:00.000Z",
+    ...over,
+  };
+}
+
+function schedule(over: Partial<EditionSchedule> = {}): EditionSchedule {
+  return { year: 2026, rooms: [AMPHI, HEMI], talks: [], entries: [], ...over };
+}
+
+describe("buildScheduleRows", () => {
+  it("puts each talk in its room's column", () => {
+    const rows = buildScheduleRows(
+      schedule({
+        talks: [
+          talk({ slug: "a" }),
+          talk({ slug: "b", room: HEMI.name, roomId: HEMI.id }),
+        ],
+      }),
+    );
+
+    expect(rows).toHaveLength(1);
+    const slot = rows[0];
+    if (slot.type !== "slot") throw new Error("expected a slot row");
+    expect(slot.cells[0].map((t) => t.slug)).toEqual(["a"]);
+    expect(slot.cells[1].map((t) => t.slug)).toEqual(["b"]);
+  });
+
+  it("groups talks that start at the same moment into one row", () => {
+    const rows = buildScheduleRows(
+      schedule({
+        talks: [
+          talk({ slug: "a" }),
+          talk({ slug: "b", room: HEMI.name, roomId: HEMI.id }),
+          talk({ slug: "c", startsAt: "2026-11-19T09:00:00.000Z" }),
+        ],
+      }),
+    );
+
+    expect(rows.map((r) => r.startsAt)).toEqual([
+      "2026-11-19T08:00:00.000Z",
+      "2026-11-19T09:00:00.000Z",
+    ]);
+  });
+
+  it("does not let a break hide the sessions running under it", () => {
+    // The 2025 case: lunch spans 12:45–14:15 and quickies play inside it. The
+    // band is a row like any other — it never swallows the slot.
+    const rows = buildScheduleRows(
+      schedule({
+        talks: [talk({ slug: "quickie", startsAt: "2026-11-19T12:55:00.000Z" })],
+        entries: [
+          {
+            id: 7,
+            kind: "MEAL",
+            labelFr: "Déjeuner",
+            labelEn: "Lunch",
+            startsAt: "2026-11-19T12:45:00.000Z",
+            endsAt: "2026-11-19T14:15:00.000Z",
+            roomId: null,
+            room: null,
+          },
+        ],
+      }),
+    );
+
+    expect(rows.map((r) => r.type)).toEqual(["band", "slot"]);
+  });
+
+  it("keeps a talk whose room no longer exists, on its frozen label", () => {
+    // A room deleted after the grid was published (#375): the column carries no
+    // id, only the label the signage had that year.
+    const ghost = { id: null, name: "Salle Pastel", sortOrder: 0 };
+    const rows = buildScheduleRows(
+      schedule({
+        rooms: [ghost],
+        talks: [talk({ slug: "old", roomId: null, room: "Salle Pastel" })],
+      }),
+    );
+
+    const slot = rows[0];
+    if (slot.type !== "slot") throw new Error("expected a slot row");
+    expect(slot.cells[0].map((t) => t.slug)).toEqual(["old"]);
+  });
+});

--- a/src/frontend/src/lib/schedule.ts
+++ b/src/frontend/src/lib/schedule.ts
@@ -1,0 +1,83 @@
+import type { EditionSchedule, ScheduleEntry } from "./types";
+
+// Turning the flat payload of /api/editions/:year/schedule into the rows a grid
+// draws (#106).
+//
+// The rows are the distinct start times, not a fixed rhythm: every room starts
+// its sessions at the same moments (checked against the 2025 agenda), so a
+// `DISTINCT startsAt` is the row list — no need for a time-slot entity.
+//
+// Off-session entries — breaks, lunch, the party — are rows of their own,
+// spanning every column. They do *not* reserve their time range: in 2025 lunch
+// ran from 12:45 to 14:15 while quickies played at 12:55 and 13:50. So a band
+// and sessions can share a moment, and the band never hides them.
+
+export type ScheduleTalk = EditionSchedule["talks"][number];
+
+export interface ScheduleSlotRow {
+  type: "slot";
+  key: string;
+  startsAt: string;
+  /** One bucket per room, in column order. Normally 0 or 1 talk each. */
+  cells: ScheduleTalk[][];
+}
+
+export interface ScheduleBandRow {
+  type: "band";
+  key: string;
+  startsAt: string;
+  entry: ScheduleEntry;
+}
+
+export type ScheduleRow = ScheduleSlotRow | ScheduleBandRow;
+
+/**
+ * How a talk is matched to its column.
+ *
+ * A room deleted after the fact, or a talk placed before the room existed,
+ * leaves the id null and only the frozen label (#375) to go on — the endpoint
+ * builds its column list the same way, so the two agree by construction.
+ */
+function roomKey(id: number | null, name: string | null): string {
+  return id != null ? `id:${id}` : `label:${name ?? ""}`;
+}
+
+export function buildScheduleRows(schedule: EditionSchedule): ScheduleRow[] {
+  const columns = schedule.rooms.map((room) => roomKey(room.id, room.name));
+
+  const slots = new Map<string, ScheduleSlotRow>();
+  for (const talk of schedule.talks) {
+    let slot = slots.get(talk.startsAt);
+    if (!slot) {
+      slot = {
+        type: "slot",
+        key: `slot:${talk.startsAt}`,
+        startsAt: talk.startsAt,
+        cells: columns.map(() => []),
+      };
+      slots.set(talk.startsAt, slot);
+    }
+    const column = columns.indexOf(roomKey(talk.roomId, talk.room));
+    // A talk whose column is missing would vanish from the grid; the endpoint
+    // derives the columns from these very talks, so this cannot happen — but
+    // dropping one silently is the kind of failure nobody notices, so it lands
+    // in the first column rather than nowhere.
+    slot.cells[column === -1 ? 0 : column].push(talk);
+  }
+
+  // The model lets an entry name a room; no screen writes one today, so every
+  // entry spans the grid.
+  const bands: ScheduleBandRow[] = schedule.entries.map((entry) => ({
+    type: "band",
+    key: `entry:${entry.id}`,
+    startsAt: entry.startsAt,
+    entry,
+  }));
+
+  // Equal times put the band first: "coffee break" then whatever runs during it.
+  return [...bands, ...[...slots.values()]].sort(
+    (a, b) =>
+      a.startsAt.localeCompare(b.startsAt) ||
+      (a.type === b.type ? 0 : a.type === "band" ? -1 : 1),
+  );
+}


### PR DESCRIPTION
La grille horaire publique, celle que #105 avait rendue saisissable sans que personne puisse la lire. Les filtres et la recherche existent déjà (#107) ; l'export agenda reste #108.

## L'énoncé de l'issue était périmé

Elle décrit `/conferences` comme un placeholder « Fonctionnalité à venir » et range les filtres en hors-scope, « issue séparée ». Les deux ont été livrés depuis : la page rend une liste filtrable (#107, #246, #256). Ce qui manquait vraiment, c'est la lecture **par salle et par créneau** — le « quand et où », que la liste ne donne pas.

D'où le choix : une page de plus, pas une refonte de l'existante. [nav.ts](src/frontend/src/lib/nav.ts) l'avait d'ailleurs anticipé depuis #203 — le menu « Programme » pointait sur `/conferences` avec un commentaire disant de basculer sur `/programme` le jour où la page existerait. C'est fait.

## Ce qui change

- **`/programme`** dans les deux langues : salles en colonnes, heures de début en lignes, chaque session cliquable vers son détail.
- **Grille sur desktop, agenda chronologique sur mobile** — deux rendus, un seul dans l'arbre d'accessibilité à la fois (`display: none` retire l'autre).
- **Purge de cache** : placer une session vide `/programme` en même temps que `/conferences`, et renommer une salle aussi — c'est un en-tête de colonne.
- **Le seed remplit une vraie journée** : six créneaux sur quatre des huit salles de Diagora. Les quatre salles vides sont précisément le cas pour lequel l'endpoint déduit ses colonnes des sessions programmées.

## Un défaut que les suites ne pouvaient pas voir

**La grille affichait l'heure UTC.** Le conteneur frontend n'a pas de `TZ` : formater « en heure locale » donne l'heure de la machine qui rend la page, pas celle de Toulouse. La page annonçait 08:50 pour la session que la signalétique appelle 09:50.

Le point qui compte pour la suite : **la suite tourne sur `TZ=Europe/Paris`** — épinglé en #105 pour attraper le bug inverse — donc toute assertion écrite contre une heure locale passe avec la version fautive. Le garde-fou charge le module sous un process en UTC ; c'est la seule forme de test qui distingue les deux. Vérifié en réintroduisant le bug : ce test rougit (`08:50` au lieu de `09:50`), les sept autres restent verts.

Corollaire non traité : la **saisie** admin lit toujours l'heure du navigateur. Pour une organisation à Toulouse c'est équivalent ; pour quelqu'un qui saisit depuis un autre fuseau, ça ne l'est pas. À traiter séparément si le cas se présente.

## Ce que l'agenda 2025 avait tranché, et qui se voit ici

Les lignes sont les `startsAt` distincts, pas un rythme fixe : toutes les salles démarrent ensemble. Et une entrée hors-session **ne réserve pas sa plage** — en 2025 des quickies jouaient pendant le déjeuner. Une bande qui avale son créneau les aurait masqués. Test de non-régression inclus.

## Plan de test

**Vérifié**

- Suites : frontend 147/147, backend 652/653.
- `tsc` et `eslint` propres des deux côtés.
- Navigateur (Chrome DevTools MCP) : `/fr/programme` et `/en/programme`, grille desktop complète, agenda mobile (390 × 844), libellés hors-session traduits, titres de sessions laissés dans leur langue (#293).
- Heures rendues après correctif : accueil 07:30–08:45, keynote 09:00–09:45, sessions à partir de 09:50 — le plan du guide 2026.
- Console propre, hors l'avertissement `next/image` sur le logo, présent sur tout le site.

**Non vérifié**

- **Le cas « bientôt » n'a pas été vu en navigateur** : la page rend une carte d'attente quand aucune session n'est placée, plutôt qu'un 404 qui resterait en cache une heure (#345). Le chemin est couvert côté backend (grille vide), pas côté rendu.
- **Rien n'a été rejoué sur des données de production**, où aucune session n'est encore programmée : la page y affichera la carte d'attente et le menu « Programme » restera absent tant que `isScheduleReady` est faux.
- L'échec backend restant (1/653) est l'artefact connu de `stat-icons.test.ts`. Une exécution complète a par ailleurs sorti un 500 isolé sur `public-hall-of-fame` ; rejoué seul puis en suite complète, il ne se reproduit pas — collision de fixtures, le motif de #292.
- Pas de balisage Schema.org sur la grille. `Event` par session vaudrait le coup, mais c'est un chantier SEO à part.

Refs #106
