### PR TITLE
Programme — la grille tient les huit salles

### DIFF
--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -793,6 +793,42 @@ async function seedDev() {
       description: "Génériques, inférence et types conditionnels, pas à pas.",
       format: "CONFERENCE", level: "INTERMEDIAIRE", language: "fr", category: catWeb.id,
       speaker: speakerJean.id, room: "Agora 1", start: "15:30", end: "16:10" },
+    // The four rooms below exist only to fill the grid's remaining columns
+    // (#441): with four salles the layout looked fine and hid the fact that a
+    // column falls to 130 px at eight. The demo day has to reach eight, or the
+    // defect stays invisible in dev.
+    { slug: "nix-pour-les-presses", title: "Nix pour les gens pressés",
+      description: "Un environnement reproductible sans y passer le trimestre.",
+      format: "CONFERENCE", level: "CONFIRME", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Lauragais", start: "08:50", end: "09:30" },
+    { slug: "rust-cote-serveur", title: "Rust côté serveur : le prix d'entrée",
+      description: "Ce qu'on gagne, ce qu'on paie, et quand ça ne vaut pas le coup.",
+      format: "CONFERENCE", level: "CONFIRME", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Ellipse", start: "08:50", end: "09:30" },
+    { slug: "refactoring-en-binome", title: "Refactoring en binôme",
+      description: "Quinze minutes pour montrer ce qu'un pas de deux change au code.",
+      format: "QUICKIE", level: "DEBUTANT", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Salle Quickies", start: "08:50", end: "09:10" },
+    { slug: "faire-vivre-une-communaute", title: "Faire vivre une communauté locale",
+      description: "Ce qui tient une communauté au-delà du premier semestre.",
+      format: "CONFERENCE", level: "DEBUTANT", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Salle Communautés", start: "10:00", end: "10:40" },
+    { slug: "sqlite-en-production", title: "SQLite en production, vraiment ?",
+      description: "Les cas où c'est le bon choix, et ceux où c'est un piège.",
+      format: "CONFERENCE", level: "INTERMEDIAIRE", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Lauragais", start: "10:55", end: "11:35" },
+    { slug: "css-moderne-vos-hacks", title: "Le CSS moderne a rattrapé vos hacks",
+      description: "Container queries, :has(), subgrid : ce qu'on peut enfin supprimer.",
+      format: "CONFERENCE", level: "INTERMEDIAIRE", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Ellipse", start: "13:15", end: "13:55" },
+    { slug: "documenter-sans-y-passer-ses-vendredis", title: "Documenter sans y passer ses vendredis",
+      description: "Écrire le strict nécessaire, au moment où ça coûte le moins cher.",
+      format: "QUICKIE", level: "DEBUTANT", language: "fr", category: catCloud.id,
+      speaker: speakerMarie.id, room: "Salle Quickies", start: "13:15", end: "13:35" },
+    { slug: "organiser-un-meetup-qui-dure", title: "Organiser un meetup qui dure",
+      description: "Retour sur dix ans de rendez-vous mensuels, sans s'épuiser.",
+      format: "CONFERENCE", level: "DEBUTANT", language: "fr", category: catWeb.id,
+      speaker: speakerJean.id, room: "Salle Communautés", start: "14:10", end: "14:50" },
   ] as const;
 
   const roomsByName = new Map(

--- a/src/frontend/src/app/[locale]/programme/page.tsx
+++ b/src/frontend/src/app/[locale]/programme/page.tsx
@@ -28,6 +28,9 @@ export async function generateMetadata(): Promise<Metadata> {
 
 const TALK_FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"];
 
+// The width every other page of the site reads at. The grid is the exception.
+const READING_COLUMN = "mx-auto max-w-7xl";
+
 export default async function ProgrammePage() {
   const locale = await getLocale();
   const t = await getTranslations("programme");
@@ -50,7 +53,7 @@ export default async function ProgrammePage() {
 
   return (
     <div className="px-6 py-8 lg:py-12">
-      <div className="mx-auto max-w-7xl">
+      <div className={READING_COLUMN}>
         <Breadcrumb items={breadcrumbItems} />
 
         <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
@@ -68,26 +71,34 @@ export default async function ProgrammePage() {
             </p>
           </div>
         ) : (
-          <>
-            <p className="mt-4 text-lg text-gris">{t("intro")}</p>
+          <p className="mt-4 text-lg text-gris">{t("intro")}</p>
+        )}
+      </div>
 
-            <div className="mt-8">
-              <ScheduleGrid
-                rows={rows}
-                rooms={schedule!.rooms}
-                locale={locale}
-                formatLabels={formatLabels}
-                labels={{ timeColumn: t("timeColumn"), roomTba: t("roomTba") }}
-              />
-              <ScheduleAgenda
-                rows={rows}
-                rooms={schedule!.rooms}
-                locale={locale}
-                formatLabels={formatLabels}
-                labels={{ roomTba: t("roomTba") }}
-              />
-            </div>
+      {rows.length > 0 && (
+        <>
+          {/* The grid leaves the reading column (#441): eight rooms inside
+              max-w-7xl gave 130 px per column, and a wider screen changed
+              nothing at all. Everything else on the page stays aligned with
+              the rest of the site. */}
+          <div className="mx-auto mt-8 max-w-[110rem]">
+            <ScheduleGrid
+              rows={rows}
+              rooms={schedule!.rooms}
+              locale={locale}
+              formatLabels={formatLabels}
+              labels={{ timeColumn: t("timeColumn"), roomTba: t("roomTba") }}
+            />
+            <ScheduleAgenda
+              rows={rows}
+              rooms={schedule!.rooms}
+              locale={locale}
+              formatLabels={formatLabels}
+              labels={{ roomTba: t("roomTba") }}
+            />
+          </div>
 
+          <div className={READING_COLUMN}>
             {/* The searchable list is the other way in (#107) — the grid answers
                 "when and where", the list answers "what is there on my topic". */}
             <Link
@@ -96,9 +107,9 @@ export default async function ProgrammePage() {
             >
               {t("allSessions")}
             </Link>
-          </>
-        )}
-      </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/frontend/src/components/programme/ScheduleGrid.tsx
+++ b/src/frontend/src/components/programme/ScheduleGrid.tsx
@@ -18,6 +18,14 @@ interface ScheduleGridProps {
 // headers are what a screen reader needs to announce a cell. The mobile agenda
 // renders the same data as a linear list; only one of the two is ever in the
 // accessibility tree, since the other is `display: none`.
+//
+// Width is per column, not per table (#441). A single `min-width` on the table
+// only bites below its own value: at eight rooms the columns shared whatever
+// the page offered and fell to 130 px — a title over four lines, a category
+// badge cut in two. Now each room asks for MIN_COLUMN, the table grows past the
+// viewport when it must, and the wrapper scrolls.
+const MIN_COLUMN = "min-w-[180px]";
+
 export default function ScheduleGrid({
   rows,
   rooms,
@@ -26,20 +34,25 @@ export default function ScheduleGrid({
   labels,
 }: ScheduleGridProps) {
   return (
-    // The grid outgrows the viewport as soon as there are five rooms, so it
-    // scrolls inside its own box rather than pushing the page sideways.
+    // Scrolls inside its own box: the page body must never scroll sideways.
     <div className="hidden overflow-x-auto lg:block">
-      <table className="w-full min-w-[64rem] border-separate border-spacing-2">
+      <table className="w-full border-separate border-spacing-2">
         <thead>
           <tr>
-            <th scope="col" className="w-24 text-left text-sm font-bold text-gris">
+            {/* Sticky, so the hour stays readable while the rooms scroll past.
+                Opaque background for the same reason — cards would otherwise
+                slide under it. */}
+            <th
+              scope="col"
+              className="sticky left-0 z-10 w-24 min-w-24 bg-blanc text-left text-sm font-bold text-gris"
+            >
               {labels.timeColumn}
             </th>
             {rooms.map((room) => (
               <th
                 key={room.id ?? `label:${room.name}`}
                 scope="col"
-                className="rounded-2xl bg-blanc-casse px-3 py-2 text-left text-sm font-bold text-noir"
+                className={`${MIN_COLUMN} rounded-2xl bg-blanc-casse px-3 py-2 text-left text-sm font-bold text-noir`}
               >
                 {room.name || labels.roomTba}
               </th>
@@ -52,21 +65,35 @@ export default function ScheduleGrid({
               <tr key={row.key}>
                 <td
                   colSpan={rooms.length + 1}
-                  className="rounded-2xl bg-blanc-casse px-4 py-3 text-sm font-bold text-noir"
+                  className="rounded-2xl bg-blanc-casse text-sm font-bold text-noir"
                 >
-                  <span className="text-gris">
-                    {formatEventTime(row.entry.startsAt)} – {formatEventTime(row.entry.endsAt)}
-                  </span>
-                  <span className="ml-3">{localizedField(row.entry, "label", locale)}</span>
+                  {/* The band spans every column, so its label sits at the far
+                      left and scrolls out of sight with it — leaving anonymous
+                      stripes across the grid. Pinning the text keeps "Déjeuner"
+                      readable however far right you have scrolled. */}
+                  <div className="sticky left-0 w-fit px-4 py-3">
+                    <span className="text-gris">
+                      {formatEventTime(row.entry.startsAt)} – {formatEventTime(row.entry.endsAt)}
+                    </span>
+                    <span className="ml-3">{localizedField(row.entry, "label", locale)}</span>
+                  </div>
                 </td>
               </tr>
             ) : (
               <tr key={row.key}>
-                <th scope="row" className="align-top text-left text-sm font-bold text-noir">
+                <th
+                  scope="row"
+                  className="sticky left-0 z-10 w-24 min-w-24 bg-blanc align-top text-left text-sm font-bold text-noir"
+                >
                   {formatEventTime(row.startsAt)}
                 </th>
                 {row.cells.map((talks, index) => (
-                  <td key={rooms[index]?.id ?? index} className="align-top">
+                  // `h-px` is not a height, it is the way to give the cell one:
+                  // a table cell has no resolvable height of its own, so a card
+                  // asking for `h-full` inside it stays at its content size and
+                  // the row ends up ragged. Declaring a nominal height makes the
+                  // browser resolve it against the row it actually computed.
+                  <td key={rooms[index]?.id ?? index} className={`${MIN_COLUMN} h-px align-top`}>
                     <div className="flex h-full flex-col gap-2">
                       {talks.map((talk) => (
                         <SessionCard

--- a/src/frontend/src/components/programme/SessionCard.tsx
+++ b/src/frontend/src/components/programme/SessionCard.tsx
@@ -25,13 +25,16 @@ export default function SessionCard({ talk, locale, formatLabels, roomName }: Se
       href={`/conferences/${talk.slug}`}
       className="flex h-full flex-col rounded-2xl bg-blanc p-3 shadow-card transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
     >
+      {/* whitespace-nowrap: at eight rooms a column is narrow enough to split
+          "Cloud & DevOps" across two lines mid-label (#441). The badge wraps to
+          its own line instead, and truncates only if the name is very long. */}
       <div className="flex flex-wrap items-center gap-1.5">
-        <span className="rounded-full bg-bleu/10 px-2 py-0.5 text-xs font-bold text-bleu">
+        <span className="whitespace-nowrap rounded-full bg-bleu/10 px-2 py-0.5 text-xs font-bold text-bleu">
           {formatLabels[talk.format]}
         </span>
         {categoryName && (
           <span
-            className="rounded-full px-2 py-0.5 text-xs font-bold"
+            className="max-w-full truncate whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-bold"
             style={{ backgroundColor: `${talk.category!.color}20`, color: talk.category!.color }}
           >
             {categoryName}


### PR DESCRIPTION
La grille tenait à quatre salles. Diagora en a huit.

## Ce que la mesure a corrigé

L'issue supposait un défilement horizontal trop étroit. Mesuré dans la page, c'était autre chose :

| Fenêtre | Colonne, avant | Colonne, après |
|---|---|---|
| 1024 px | 107 – 128 px | 180 px |
| 1280 px | 129 – 157 px | 180 px |
| 1920 px | 129 – 157 px | ~200 px |

**Un grand écran n'apportait rien** : la page enfermait la grille dans `max-w-7xl`, donc 1280 px de large quelle que soit la fenêtre. Elle sort maintenant de la colonne de lecture — c'est le seul contenu du site qui a plus à dire qu'un paragraphe n'est large. Le titre, l'introduction et le lien vers la liste y restent alignés.

**Et `min-w` sur la table ne mordait qu'en dessous de sa propre valeur** : au-delà, `w-full` l'emportait et les huit colonnes se partageaient ce qui restait. Le minimum est désormais **par colonne** : la table dépasse la fenêtre quand il le faut et le conteneur défile, ce à quoi son `overflow-x` servait déjà.

## Deux défauts trouvés en défilant

Le défilement, une fois qu'il fonctionne, emporte ce qui est à gauche.

1. **L'heure disparaissait.** La colonne horaire est figée (`sticky`), sur fond opaque — sans quoi les cartes glissent dessous.
2. **Les bandes hors-session devenaient des rubans anonymes.** « 12:45 – 14:15 Déjeuner » est écrit à l'extrême gauche d'une cellule qui traverse toute la grille : à 600 px de défilement il ne restait qu'une barre rose. Le texte de la bande est pinné lui aussi.

Aucun des deux ne se voit tant que la grille ne défile pas, c'est-à-dire tant qu'il y a quatre salles.

## Deux détails de mise en page

**Les cartes d'une même ligne sont alignées.** Elles ne l'étaient pas : 180 px contre 199 px côte à côte. Une cellule de tableau n'a pas de hauteur résoluble, donc un `h-full` à l'intérieur restait à la taille du contenu ; déclarer une hauteur nominale (`h-px`) sur la cellule fait résoudre le `h-full` contre la hauteur réellement calculée pour la ligne. C'est commenté dans le code, parce que `h-px` sur une cellule de tableau se lit comme une erreur.

**L'étiquette de catégorie ne se coupe plus en deux.** « Cloud & / DevOps » sur deux lignes à l'intérieur de la pastille ; elle passe en `whitespace-nowrap` et tronque si le nom est vraiment long.

## Le jeu de démonstration va jusqu'à huit salles

Huit sessions ajoutées dans Lauragais, Ellipse, Salle Quickies et Salle Communautés — 24 au total sur six créneaux. Sans cela le cas ne se reproduit pas en local, et c'est exactement ce qui a laissé passer le défaut à la livraison de #106.

## Plan de test

**Vérifié**

- Suites : frontend 147/147, backend 652/653. `tsc` et `eslint` propres des deux côtés.
- Mesures en navigateur (Chrome DevTools MCP), grille à huit salles :
  - **1920 px** — grille 1760 px, colonnes 191–203 px, pas de défilement, cartes d'une même ligne toutes à 180 px de haut.
  - **1280 px** — colonnes à 180 px, le conteneur défile (1616 px pour 1217 visibles), le corps de page **ne défile pas**.
  - **1024 px** — même chose, 961 px visibles.
  - Après 600 px de défilement : colonne horaire toujours à gauche, libellés des bandes lisibles.
- **Quatre salles** (base ramenée temporairement à quatre) à 1440 px : colonnes de 284 à 321 px, aucun défilement, pas de vide à droite.
- **Mobile 390 px** : grille masquée, agenda linéaire inchangé, pas de défilement latéral.
- Console propre hors l'avertissement `next/image` du logo, présent sur tout le site.

**Non vérifié**

- Rien n'a été rejoué sur des données de production.
- L'échec backend restant est l'artefact connu de `stat-icons.test.ts`. Une exécution complète a par ailleurs sorti un échec isolé sur `trash-endpoints` ; rejoué seul puis en suite complète, il ne se reproduit pas — collision de fixtures, le motif de #292.
- Aucun test automatisé ne couvre la largeur des colonnes : c'est de la mise en page, mesurée en navigateur et pas ailleurs.

## Note pour la suite

Le cache de données de Next en dev vit dans `.next/dev/cache/fetch-cache`, et **un redémarrage du conteneur ne le vide pas**. Deux mesures fausses avant de m'en apercevoir : l'API renvoyait quatre salles pendant que la page en affichait huit.

Refs #441
