### PR TITLE
Programme — favoris de sessions portés par l'URL

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -357,6 +357,15 @@
     "cta": "View offer",
     "offersAt": "Offers at {name}"
   },
+  "favourites": {
+    "add": "Add to my favourites",
+    "remove": "Remove from my favourites",
+    "viewLabel": "Schedule view",
+    "viewAll": "The whole schedule",
+    "viewMine": "My favourites and the shared moments",
+    "viewMineOnly": "My favourites only",
+    "empty": "You haven't picked a session yet. Add the ones you're interested in to build your day — your selection lives in the page address, so bookmark it to find it again."
+  },
   "programme": {
     "title": "Schedule",
     "pageTitle": "Schedule — the full grid",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -357,6 +357,15 @@
     "cta": "Voir l'offre",
     "offersAt": "Offres chez {name}"
   },
+  "favourites": {
+    "add": "Ajouter à mes favoris",
+    "remove": "Retirer de mes favoris",
+    "viewLabel": "Affichage du programme",
+    "viewAll": "Tout le programme",
+    "viewMine": "Mes favoris et les moments communs",
+    "viewMineOnly": "Mes favoris seuls",
+    "empty": "Vous n'avez encore choisi aucune session. Ajoutez celles qui vous intéressent pour composer votre journée — votre sélection tient dans l'adresse de la page, gardez-la en favori pour la retrouver."
+  },
   "programme": {
     "title": "Programme",
     "pageTitle": "Programme — la grille horaire",

--- a/src/frontend/src/app/[locale]/conferences/page.tsx
+++ b/src/frontend/src/app/[locale]/conferences/page.tsx
@@ -5,6 +5,7 @@ import { getCurrentEdition, getEditionTalks } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
 import ConferencesBrowser from "@/components/conferences/ConferencesBrowser";
 import { localizedField } from "@/lib/i18n-helpers";
+import { parseFavourites } from "@/lib/favourites";
 import type { TalkFormat, TalkLevel } from "@/lib/types";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -30,6 +31,7 @@ export default async function ConferencesPage({
 }) {
   const locale = await getLocale();
   const t = await getTranslations("conferences");
+  const tf = await getTranslations("favourites");
   const edition = await getCurrentEdition();
   const year = edition?.year ?? new Date().getFullYear();
   const talks = edition ? await getEditionTalks(edition.year) : [];
@@ -84,6 +86,7 @@ export default async function ConferencesPage({
     formatLabels,
     levelLabels,
     languageLabels: { fr: t("filters.langFr"), en: t("filters.langEn") },
+    favouriteLabels: { add: tf("add"), remove: tf("remove") },
   };
 
   return (
@@ -104,6 +107,7 @@ export default async function ConferencesPage({
               languages={languages}
               labels={labels}
               initial={initial}
+              initialFavourites={parseFavourites(first(sp.fav))}
             />
           </div>
         ) : (

--- a/src/frontend/src/app/[locale]/programme/page.tsx
+++ b/src/frontend/src/app/[locale]/programme/page.tsx
@@ -5,9 +5,8 @@ import { notFound } from "next/navigation";
 import { Link } from "@/i18n/navigation";
 import { getCurrentEdition, getEditionSchedule } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
-import ScheduleGrid from "@/components/programme/ScheduleGrid";
-import ScheduleAgenda from "@/components/programme/ScheduleAgenda";
-import { buildScheduleRows } from "@/lib/schedule";
+import ProgrammeBrowser from "@/components/programme/ProgrammeBrowser";
+import { parseFavourites, parseView } from "@/lib/favourites";
 import type { TalkFormat } from "@/lib/types";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -31,20 +30,30 @@ const TALK_FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHO
 // The width every other page of the site reads at. The grid is the exception.
 const READING_COLUMN = "mx-auto max-w-7xl";
 
-export default async function ProgrammePage() {
+export default async function ProgrammePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const locale = await getLocale();
   const t = await getTranslations("programme");
   const tc = await getTranslations("conferences");
+  const tf = await getTranslations("favourites");
   const edition = await getCurrentEdition();
 
   if (!edition) notFound();
 
   const schedule = await getEditionSchedule(edition.year);
-  const rows = schedule ? buildScheduleRows(schedule) : [];
+  const hasSchedule = (schedule?.talks.length ?? 0) > 0 || (schedule?.entries.length ?? 0) > 0;
 
   const formatLabels = Object.fromEntries(
     TALK_FORMATS.map((format) => [format, tc(`format.${format}`)]),
   );
+
+  // Read the selection from the URL on the server, so a bookmarked link renders
+  // its selection before hydration rather than flashing the whole programme.
+  const sp = await searchParams;
+  const first = (v: string | string[] | undefined) => (Array.isArray(v) ? v[0] : v);
 
   const breadcrumbItems = [
     { label: t("home"), href: `/${locale}` },
@@ -63,38 +72,42 @@ export default async function ProgrammePage() {
         {/* An edition with rooms but no session placed yet still lands here from
             a shared link: it says "soon" rather than 404, because a 404 cached
             for an hour outlives the state that caused it (#345). */}
-        {rows.length === 0 ? (
+        {hasSchedule ? (
+          <p className="mt-4 text-lg text-gris">{t("intro")}</p>
+        ) : (
           <div className="mt-8 rounded-3xl bg-blanc p-8 shadow-card">
             <h2 className="text-2xl font-bold text-noir lg:text-3xl">{t("comingSoonTitle")}</h2>
             <p className="mt-4 text-lg leading-relaxed text-gris">
               {t("comingSoonBody", { year: edition.year })}
             </p>
           </div>
-        ) : (
-          <p className="mt-4 text-lg text-gris">{t("intro")}</p>
         )}
       </div>
 
-      {rows.length > 0 && (
+      {hasSchedule ? (
         <>
           {/* The grid leaves the reading column (#441): eight rooms inside
               max-w-7xl gave 130 px per column, and a wider screen changed
               nothing at all. Everything else on the page stays aligned with
               the rest of the site. */}
           <div className="mx-auto mt-8 max-w-[110rem]">
-            <ScheduleGrid
-              rows={rows}
-              rooms={schedule!.rooms}
+            <ProgrammeBrowser
+              schedule={schedule!}
               locale={locale}
               formatLabels={formatLabels}
-              labels={{ timeColumn: t("timeColumn"), roomTba: t("roomTba") }}
-            />
-            <ScheduleAgenda
-              rows={rows}
-              rooms={schedule!.rooms}
-              locale={locale}
-              formatLabels={formatLabels}
-              labels={{ roomTba: t("roomTba") }}
+              labels={{
+                timeColumn: t("timeColumn"),
+                roomTba: t("roomTba"),
+                viewLabel: tf("viewLabel"),
+                viewAll: tf("viewAll"),
+                viewMine: tf("viewMine"),
+                viewMineOnly: tf("viewMineOnly"),
+                favouriteAdd: tf("add"),
+                favouriteRemove: tf("remove"),
+                empty: tf("empty"),
+              }}
+              initialFavourites={parseFavourites(first(sp.fav))}
+              initialView={parseView(first(sp.view))}
             />
           </div>
 
@@ -109,7 +122,7 @@ export default async function ProgrammePage() {
             </Link>
           </div>
         </>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/frontend/src/components/FavouriteButton.tsx
+++ b/src/frontend/src/components/FavouriteButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+interface FavouriteButtonProps {
+  isFavourite: boolean;
+  onToggle: () => void;
+  labels: { add: string; remove: string };
+  /** Positioning is the caller's business — the card decides where it sits. */
+  className?: string;
+}
+
+// The star on a session (#442). Shared by the grid, the mobile agenda and the
+// session list, so the three stay one gesture.
+//
+// It sits *beside* the card's link, never inside it: a button nested in an
+// anchor is invalid, and swallows the click on one of the two.
+export default function FavouriteButton({
+  isFavourite,
+  onToggle,
+  labels,
+  className = "",
+}: FavouriteButtonProps) {
+  const label = isFavourite ? labels.remove : labels.add;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={isFavourite}
+      // The visible star is decorative; the accessible name carries the action,
+      // and aria-pressed carries the state.
+      aria-label={label}
+      title={label}
+      className={`inline-flex size-8 items-center justify-center rounded-full text-lg transition-colors hover:bg-blanc-casse focus:outline-none focus:ring-2 focus:ring-malachite/50 ${
+        isFavourite ? "text-orange" : "text-gris"
+      } ${className}`}
+    >
+      <span aria-hidden>{isFavourite ? "★" : "☆"}</span>
+    </button>
+  );
+}

--- a/src/frontend/src/components/conferences/ConferencesBrowser.tsx
+++ b/src/frontend/src/components/conferences/ConferencesBrowser.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { useRouter, usePathname } from "@/i18n/navigation";
 import type { EditionTalk, TalkFormat, TalkLevel } from "@/lib/types";
 import { localizedField } from "@/lib/i18n-helpers";
+import { serializeFavourites, toggleFavourite } from "@/lib/favourites";
 import ConferencesList from "./ConferencesList";
 
 const FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"];
@@ -29,6 +30,7 @@ interface Labels {
   formatLabels: Record<string, string>;
   levelLabels: Record<string, string>;
   languageLabels: Record<string, string>; // { fr, en }
+  favouriteLabels: { add: string; remove: string };
 }
 
 interface Filters {
@@ -46,6 +48,8 @@ interface ConferencesBrowserProps {
   languages: string[];
   labels: Labels;
   initial: Filters;
+  /** The selection carried by the URL (#442), shared with /programme. */
+  initialFavourites: string[];
 }
 
 // Client layer over the SSR-rendered list (#107): search + toggleable chips
@@ -58,10 +62,12 @@ export default function ConferencesBrowser({
   languages,
   labels,
   initial,
+  initialFavourites,
 }: ConferencesBrowserProps) {
   const router = useRouter();
   const pathname = usePathname();
   const [filters, setFilters] = useState<Filters>(initial);
+  const [favourites, setFavourites] = useState<string[]>(initialFavourites);
   // Level + language live behind a "more filters" disclosure to keep the bar
   // compact (#246). Open it on mount if one of them was already active via URL.
   const [showMore, setShowMore] = useState(Boolean(initial.level || initial.language));
@@ -75,7 +81,7 @@ export default function ConferencesBrowser({
   // Toggle a chip (empty value clears it) and reflect the whole filter state in
   // the URL. replace (not push) so the back button doesn't step through every
   // chip click. scroll:false keeps the viewport where the user is filtering.
-  function update(next: Partial<Filters>) {
+  function update(next: Partial<Filters>, nextFavourites = favourites) {
     const merged = { ...filters, ...next };
     setFilters(merged);
     const params = new URLSearchParams();
@@ -84,8 +90,18 @@ export default function ConferencesBrowser({
     if (merged.level) params.set("level", merged.level);
     if (merged.language) params.set("language", merged.language);
     if (merged.category) params.set("category", merged.category);
+    // Carried through every filter change: a selection started here has to
+    // survive to /programme, and losing it on a chip click would be silent.
+    const fav = serializeFavourites(nextFavourites);
+    if (fav) params.set("fav", fav);
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }
+
+  function onToggleFavourite(slug: string) {
+    const next = toggleFavourite(favourites, slug);
+    setFavourites(next);
+    update({}, next);
   }
 
   function toggle(key: keyof Filters, value: string) {
@@ -108,6 +124,8 @@ export default function ConferencesBrowser({
     (filters.level ? 1 : 0) +
     (hasLanguageFilter && filters.language ? 1 : 0) +
     (filters.category ? 1 : 0);
+
+  const selected = useMemo(() => new Set(favourites), [favourites]);
 
   const filtered = useMemo(() => {
     const q = filters.q.trim().toLowerCase();
@@ -259,7 +277,14 @@ export default function ConferencesBrowser({
 
       <div className="mt-8">
         {filtered.length > 0 ? (
-          <ConferencesList talks={filtered} locale={locale} formatLabels={labels.formatLabels} />
+          <ConferencesList
+            talks={filtered}
+            locale={locale}
+            formatLabels={labels.formatLabels}
+            favourites={selected}
+            onToggleFavourite={onToggleFavourite}
+            favouriteLabels={labels.favouriteLabels}
+          />
         ) : (
           <p className="rounded-2xl bg-blanc p-8 text-center text-gris shadow-card">
             {labels.noResults}

--- a/src/frontend/src/components/conferences/ConferencesList.tsx
+++ b/src/frontend/src/components/conferences/ConferencesList.tsx
@@ -3,6 +3,7 @@ import { Link } from "@/i18n/navigation";
 import type { EditionTalk } from "@/lib/types";
 import { localizedField } from "@/lib/i18n-helpers";
 import SpeakerAvatars from "@/components/speakers/SpeakerAvatars";
+import FavouriteButton from "@/components/FavouriteButton";
 
 interface ConferencesListProps {
   talks: EditionTalk[];
@@ -10,11 +11,22 @@ interface ConferencesListProps {
   // Pre-resolved labels: the parent owns the `conferences` translation
   // namespace, so this component stays a plain server component.
   formatLabels: Record<string, string>;
+  /** Favourites (#442) — the same selection the schedule grid works on. */
+  favourites: Set<string>;
+  onToggleFavourite: (slug: string) => void;
+  favouriteLabels: { add: string; remove: string };
 }
 
 // Public list of the current edition's published talks (#207). Each entry links
 // to its detail page; badges mirror the ones used there.
-export default function ConferencesList({ talks, locale, formatLabels }: ConferencesListProps) {
+export default function ConferencesList({
+  talks,
+  locale,
+  formatLabels,
+  favourites,
+  onToggleFavourite,
+  favouriteLabels,
+}: ConferencesListProps) {
   return (
     <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {talks.map((talk) => {
@@ -23,14 +35,14 @@ export default function ConferencesList({ talks, locale, formatLabels }: Confere
         const categoryName = talk.category ? localizedField(talk.category, "name", locale) : null;
 
         return (
-          <li key={talk.slug} className="h-full">
+          <li key={talk.slug} className="relative h-full">
             {/* Cards stretch to the tallest in their row, so the speaker line
                 stays pinned to the bottom whatever the title length. */}
             <Link
               href={`/conferences/${talk.slug}`}
               className="flex h-full flex-col rounded-2xl bg-blanc shadow-card p-5 transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
             >
-              <div className="flex flex-wrap items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2 pr-8">
                 <span className="rounded-full bg-bleu/10 px-3 py-1 text-sm font-bold text-bleu">
                   {formatLabels[talk.format]}
                 </span>
@@ -53,6 +65,14 @@ export default function ConferencesList({ talks, locale, formatLabels }: Confere
                 </div>
               )}
             </Link>
+
+            {/* Outside the link, never inside it — see FavouriteButton. */}
+            <FavouriteButton
+              isFavourite={favourites.has(talk.slug)}
+              onToggle={() => onToggleFavourite(talk.slug)}
+              labels={favouriteLabels}
+              className="absolute right-3 top-4"
+            />
           </li>
         );
       })}

--- a/src/frontend/src/components/programme/ProgrammeBrowser.tsx
+++ b/src/frontend/src/components/programme/ProgrammeBrowser.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { useRouter, usePathname } from "@/i18n/navigation";
+import type { EditionSchedule } from "@/lib/types";
+import { buildScheduleRows } from "@/lib/schedule";
+import {
+  serializeFavourites,
+  toggleFavourite,
+  type ScheduleView,
+} from "@/lib/favourites";
+import ScheduleGrid from "./ScheduleGrid";
+import ScheduleAgenda from "./ScheduleAgenda";
+
+interface Labels {
+  timeColumn: string;
+  roomTba: string;
+  viewLabel: string;
+  viewAll: string;
+  viewMine: string;
+  viewMineOnly: string;
+  favouriteAdd: string;
+  favouriteRemove: string;
+  empty: string;
+}
+
+interface ProgrammeBrowserProps {
+  schedule: EditionSchedule;
+  locale: string;
+  formatLabels: Record<string, string>;
+  labels: Labels;
+  initialFavourites: string[];
+  initialView: ScheduleView;
+}
+
+const VIEWS: ScheduleView[] = ["all", "mine", "mine-only"];
+
+// The interactive layer over the schedule (#442).
+//
+// It owns the selection and mirrors it into the querystring, the same way the
+// session filters do (#107). Two consequences worth keeping in mind:
+//
+//   - the filtering happens here, in the browser, on the payload the server
+//     already rendered. The HTML is identical for every visitor, so the page
+//     stays cacheable instead of forking into one variant per selection;
+//   - `replace`, never `push`: with `push` the back button would walk back
+//     through every star the visitor clicked.
+export default function ProgrammeBrowser({
+  schedule,
+  locale,
+  formatLabels,
+  labels,
+  initialFavourites,
+  initialView,
+}: ProgrammeBrowserProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [favourites, setFavourites] = useState<string[]>(initialFavourites);
+  const [view, setView] = useState<ScheduleView>(initialView);
+
+  function syncUrl(nextFavourites: string[], nextView: ScheduleView) {
+    const params = new URLSearchParams();
+    const fav = serializeFavourites(nextFavourites);
+    if (fav) params.set("fav", fav);
+    if (nextView !== "all") params.set("view", nextView);
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }
+
+  function onToggleFavourite(slug: string) {
+    const next = toggleFavourite(favourites, slug);
+    setFavourites(next);
+    syncUrl(next, view);
+  }
+
+  function onChangeView(next: ScheduleView) {
+    setView(next);
+    syncUrl(favourites, next);
+  }
+
+  const selected = useMemo(() => new Set(favourites), [favourites]);
+
+  // Filtering the payload rather than the rows: the row builder then recomputes
+  // the columns too, so a selection spread over three rooms draws three columns
+  // instead of eight mostly-empty ones. Rows and columns come out of the same
+  // call — they index into each other and must never be derived apart.
+  const { rows, rooms, matched } = useMemo(() => {
+    if (view === "all") {
+      return { rows: buildScheduleRows(schedule), rooms: schedule.rooms, matched: 0 };
+    }
+
+    const talks = schedule.talks.filter((talk) => selected.has(talk.slug));
+    const kept = new Set(
+      talks.map((talk) => (talk.roomId != null ? `id:${talk.roomId}` : `label:${talk.room ?? ""}`)),
+    );
+    const visibleRooms = schedule.rooms.filter((room) =>
+      kept.has(room.id != null ? `id:${room.id}` : `label:${room.name}`),
+    );
+
+    return {
+      rows: buildScheduleRows({
+        ...schedule,
+        talks,
+        rooms: visibleRooms,
+        // The shared moments — welcome, keynotes, breaks, lunch, the party —
+        // are never starred: they concern everyone. They show, or they do not.
+        entries: view === "mine" ? schedule.entries : [],
+      }),
+      rooms: visibleRooms,
+      matched: talks.length,
+    };
+  }, [schedule, selected, view]);
+
+  const viewLabels: Record<ScheduleView, string> = {
+    all: labels.viewAll,
+    mine: labels.viewMine,
+    "mine-only": labels.viewMineOnly,
+  };
+  const favouriteLabels = { add: labels.favouriteAdd, remove: labels.favouriteRemove };
+
+  return (
+    <div>
+      {/* A radio group, not three buttons: the three views are one choice, and
+          a screen reader has to hear it that way. */}
+      <div
+        role="radiogroup"
+        aria-label={labels.viewLabel}
+        className="mb-6 inline-flex flex-wrap gap-2 rounded-2xl bg-blanc-casse p-1"
+      >
+        {VIEWS.map((value) => (
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={view === value}
+            onClick={() => onChangeView(value)}
+            className={`rounded-[12px] px-4 py-2 text-sm font-bold transition-colors focus:outline-none focus:ring-2 focus:ring-malachite/50 ${
+              view === value ? "bg-blanc text-noir shadow-card" : "text-gris hover:text-noir"
+            }`}
+          >
+            {viewLabels[value]}
+          </button>
+        ))}
+      </div>
+
+      {/* On `matched`, not on the length of the selection: a link bookmarked
+          weeks ago may name only sessions that have since been cancelled, and
+          showing the day's skeleton with nothing in it would explain nothing.
+          aria-live because switching view changes the page under a screen
+          reader that would otherwise hear no result at all. */}
+      {view !== "all" && matched === 0 ? (
+        <p className="rounded-3xl bg-blanc p-6 text-lg text-gris shadow-card" aria-live="polite">
+          {labels.empty}
+        </p>
+      ) : (
+        <>
+          <ScheduleGrid
+            rows={rows}
+            rooms={rooms}
+            locale={locale}
+            formatLabels={formatLabels}
+            labels={{ timeColumn: labels.timeColumn, roomTba: labels.roomTba }}
+            favourites={selected}
+            onToggleFavourite={onToggleFavourite}
+            favouriteLabels={favouriteLabels}
+          />
+          <ScheduleAgenda
+            rows={rows}
+            rooms={rooms}
+            locale={locale}
+            formatLabels={formatLabels}
+            labels={{ roomTba: labels.roomTba }}
+            favourites={selected}
+            onToggleFavourite={onToggleFavourite}
+            favouriteLabels={favouriteLabels}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/programme/ScheduleAgenda.tsx
+++ b/src/frontend/src/components/programme/ScheduleAgenda.tsx
@@ -10,6 +10,10 @@ interface ScheduleAgendaProps {
   locale: string;
   formatLabels: Record<string, string>;
   labels: { roomTba: string };
+  /** Favourites (#442) — passed straight down to the cards. */
+  favourites: Set<string>;
+  onToggleFavourite: (slug: string) => void;
+  favouriteLabels: { add: string; remove: string };
 }
 
 // The same schedule read on a phone (#106): one column, chronological, each
@@ -20,6 +24,9 @@ export default function ScheduleAgenda({
   locale,
   formatLabels,
   labels,
+  favourites,
+  onToggleFavourite,
+  favouriteLabels,
 }: ScheduleAgendaProps) {
   return (
     <div className="space-y-6 lg:hidden">
@@ -45,6 +52,9 @@ export default function ScheduleAgenda({
                     locale={locale}
                     formatLabels={formatLabels}
                     roomName={rooms[index]?.name || labels.roomTba}
+                    isFavourite={favourites.has(talk.slug)}
+                    onToggleFavourite={() => onToggleFavourite(talk.slug)}
+                    favouriteLabels={favouriteLabels}
                   />
                 )),
               )}

--- a/src/frontend/src/components/programme/ScheduleGrid.tsx
+++ b/src/frontend/src/components/programme/ScheduleGrid.tsx
@@ -10,6 +10,10 @@ interface ScheduleGridProps {
   locale: string;
   formatLabels: Record<string, string>;
   labels: { timeColumn: string; roomTba: string };
+  /** Favourites (#442) — passed straight down to the cards. */
+  favourites: Set<string>;
+  onToggleFavourite: (slug: string) => void;
+  favouriteLabels: { add: string; remove: string };
 }
 
 // The desktop grid (#106): rooms across, start times down.
@@ -32,6 +36,9 @@ export default function ScheduleGrid({
   locale,
   formatLabels,
   labels,
+  favourites,
+  onToggleFavourite,
+  favouriteLabels,
 }: ScheduleGridProps) {
   return (
     // Scrolls inside its own box: the page body must never scroll sideways.
@@ -101,6 +108,9 @@ export default function ScheduleGrid({
                           talk={talk}
                           locale={locale}
                           formatLabels={formatLabels}
+                          isFavourite={favourites.has(talk.slug)}
+                          onToggleFavourite={() => onToggleFavourite(talk.slug)}
+                          favouriteLabels={favouriteLabels}
                         />
                       ))}
                     </div>

--- a/src/frontend/src/components/programme/SessionCard.tsx
+++ b/src/frontend/src/components/programme/SessionCard.tsx
@@ -3,6 +3,7 @@ import { Link } from "@/i18n/navigation";
 import type { ScheduleTalk } from "@/lib/schedule";
 import { localizedField } from "@/lib/i18n-helpers";
 import { formatEventTime } from "@/lib/datetime";
+import FavouriteButton from "@/components/FavouriteButton";
 
 interface SessionCardProps {
   talk: ScheduleTalk;
@@ -12,48 +13,74 @@ interface SessionCardProps {
   formatLabels: Record<string, string>;
   /** Shown on the mobile agenda, where there is no column to say which room. */
   roomName?: string;
+  /** Favourites (#442). Absent when the caller renders no star at all. */
+  isFavourite?: boolean;
+  onToggleFavourite?: () => void;
+  favouriteLabels?: { add: string; remove: string };
 }
 
 // One session inside the grid (#106). The whole card is the link to its detail
 // page, so the target is comfortable on a touch screen.
-export default function SessionCard({ talk, locale, formatLabels, roomName }: SessionCardProps) {
+export default function SessionCard({
+  talk,
+  locale,
+  formatLabels,
+  roomName,
+  isFavourite = false,
+  onToggleFavourite,
+  favouriteLabels,
+}: SessionCardProps) {
   const categoryName = talk.category ? localizedField(talk.category, "name", locale) : null;
   const endsAt = talk.endsAt ? formatEventTime(talk.endsAt) : null;
 
   return (
-    <Link
-      href={`/conferences/${talk.slug}`}
-      className="flex h-full flex-col rounded-2xl bg-blanc p-3 shadow-card transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
-    >
-      {/* whitespace-nowrap: at eight rooms a column is narrow enough to split
-          "Cloud & DevOps" across two lines mid-label (#441). The badge wraps to
-          its own line instead, and truncates only if the name is very long. */}
-      <div className="flex flex-wrap items-center gap-1.5">
-        <span className="whitespace-nowrap rounded-full bg-bleu/10 px-2 py-0.5 text-xs font-bold text-bleu">
-          {formatLabels[talk.format]}
-        </span>
-        {categoryName && (
-          <span
-            className="max-w-full truncate whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-bold"
-            style={{ backgroundColor: `${talk.category!.color}20`, color: talk.category!.color }}
-          >
-            {categoryName}
+    // The star lives beside the link, not inside it (#442) — a button nested in
+    // an anchor is invalid markup, and one of the two clicks gets eaten.
+    <div className="relative h-full">
+      <Link
+        href={`/conferences/${talk.slug}`}
+        className="flex h-full flex-col rounded-2xl bg-blanc p-3 shadow-card transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
+      >
+        {/* whitespace-nowrap: at eight rooms a column is narrow enough to split
+            "Cloud & DevOps" across two lines mid-label (#441). The badge wraps to
+            its own line instead, and truncates only if the name is very long.
+            The right padding keeps them clear of the star. */}
+        <div className={`flex flex-wrap items-center gap-1.5 ${onToggleFavourite ? "pr-8" : ""}`}>
+          <span className="whitespace-nowrap rounded-full bg-bleu/10 px-2 py-0.5 text-xs font-bold text-bleu">
+            {formatLabels[talk.format]}
           </span>
+          {categoryName && (
+            <span
+              className="max-w-full truncate whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-bold"
+              style={{ backgroundColor: `${talk.category!.color}20`, color: talk.category!.color }}
+            >
+              {categoryName}
+            </span>
+          )}
+        </div>
+
+        {/* The title is not localized (#293) — a talk is given in one language. */}
+        <p className="mt-2 text-sm font-bold leading-snug text-noir">{talk.title}</p>
+
+        {talk.speakers.length > 0 && (
+          <p className="mt-1 text-xs text-gris">{talk.speakers.map((s) => s.name).join(", ")}</p>
         )}
-      </div>
 
-      {/* The title is not localized (#293) — a talk is given in one language. */}
-      <p className="mt-2 text-sm font-bold leading-snug text-noir">{talk.title}</p>
+        <p className="mt-auto pt-2 text-xs text-gris">
+          {formatEventTime(talk.startsAt)}
+          {endsAt ? ` – ${endsAt}` : ""}
+          {roomName ? ` · ${roomName}` : ""}
+        </p>
+      </Link>
 
-      {talk.speakers.length > 0 && (
-        <p className="mt-1 text-xs text-gris">{talk.speakers.map((s) => s.name).join(", ")}</p>
+      {onToggleFavourite && favouriteLabels && (
+        <FavouriteButton
+          isFavourite={isFavourite}
+          onToggle={onToggleFavourite}
+          labels={favouriteLabels}
+          className="absolute right-1 top-1"
+        />
       )}
-
-      <p className="mt-auto pt-2 text-xs text-gris">
-        {formatEventTime(talk.startsAt)}
-        {endsAt ? ` – ${endsAt}` : ""}
-        {roomName ? ` · ${roomName}` : ""}
-      </p>
-    </Link>
+    </div>
   );
 }

--- a/src/frontend/src/lib/favourites.test.ts
+++ b/src/frontend/src/lib/favourites.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  MAX_FAVOURITES,
+  parseFavourites,
+  parseView,
+  serializeFavourites,
+  toggleFavourite,
+} from "./favourites";
+
+describe("favourites in the URL (#442)", () => {
+  it("reads a comma-separated list", () => {
+    expect(parseFavourites("terraform-sans-douleur,postgres-plan-execution")).toEqual([
+      "terraform-sans-douleur",
+      "postgres-plan-execution",
+    ]);
+  });
+
+  it("treats an absent or empty parameter as no selection", () => {
+    expect(parseFavourites(undefined)).toEqual([]);
+    expect(parseFavourites("")).toEqual([]);
+    expect(parseFavourites(",, ,")).toEqual([]);
+  });
+
+  it("keeps a bookmarked link working when a session no longer exists", () => {
+    // The whole point of putting the selection in a URL is that it outlives the
+    // page it was copied from. A cancelled session must not empty the link.
+    const slugs = parseFavourites("session-annulee,terraform-sans-douleur");
+    expect(slugs).toContain("terraform-sans-douleur");
+    expect(slugs).toHaveLength(2);
+  });
+
+  it("drops duplicates rather than starring the same session twice", () => {
+    expect(parseFavourites("a,b,a")).toEqual(["a", "b"]);
+  });
+
+  it("caps a hand-edited URL instead of trusting it", () => {
+    const many = Array.from({ length: MAX_FAVOURITES + 20 }, (_, i) => `talk-${i}`).join(",");
+    expect(parseFavourites(many)).toHaveLength(MAX_FAVOURITES);
+  });
+
+  it("round-trips a selection", () => {
+    const slugs = ["a", "b", "c"];
+    expect(parseFavourites(serializeFavourites(slugs))).toEqual(slugs);
+  });
+
+  it("adds and removes on toggle, keeping the order of selection", () => {
+    expect(toggleFavourite(["a"], "b")).toEqual(["a", "b"]);
+    expect(toggleFavourite(["a", "b"], "a")).toEqual(["b"]);
+  });
+});
+
+describe("the view parameter", () => {
+  it("accepts the three views", () => {
+    expect(parseView("all")).toBe("all");
+    expect(parseView("mine")).toBe("mine");
+    expect(parseView("mine-only")).toBe("mine-only");
+  });
+
+  it("falls back to the whole programme on anything else", () => {
+    expect(parseView(undefined)).toBe("all");
+    expect(parseView("favoris")).toBe("all");
+  });
+});

--- a/src/frontend/src/lib/favourites.ts
+++ b/src/frontend/src/lib/favourites.ts
@@ -1,0 +1,52 @@
+// The visitor's own selection of sessions (#442).
+//
+// It lives in the URL and nowhere else: no account, no server-side storage, no
+// browser storage. The visitor bookmarks the page, reopens it on another
+// device, or sends it to a colleague — and gets the same selection back.
+//
+// The sessions are named by `slug` because that is the only identifier the
+// public payload carries; there is no numeric id to shorten it with.
+
+/**
+ * How many sessions a link may carry.
+ *
+ * A DevFest day holds fewer than fifty sessions in total, so this is a guard
+ * against a hand-edited or mangled URL, not a limit anyone reaches: past it the
+ * querystring gets long enough for mail clients to wrap and break the link.
+ */
+export const MAX_FAVOURITES = 60;
+
+/** The three ways to read the grid. */
+export type ScheduleView = "all" | "mine" | "mine-only";
+
+const VIEWS: ScheduleView[] = ["all", "mine", "mine-only"];
+
+/** `?fav=a,b,c` → `["a", "b", "c"]`, cleaned of blanks and duplicates. */
+export function parseFavourites(param: string | undefined | null): string[] {
+  if (!param) return [];
+  const seen = new Set<string>();
+  for (const raw of param.split(",")) {
+    const slug = raw.trim();
+    // An unknown slug is not filtered here — a session cancelled after someone
+    // bookmarked the page simply matches nothing, and the page still renders.
+    if (slug) seen.add(slug);
+    if (seen.size >= MAX_FAVOURITES) break;
+  }
+  return [...seen];
+}
+
+/** `["a", "b"]` → `"a,b"`, empty when there is nothing to say. */
+export function serializeFavourites(slugs: string[]): string {
+  return slugs.slice(0, MAX_FAVOURITES).join(",");
+}
+
+export function toggleFavourite(slugs: string[], slug: string): string[] {
+  return slugs.includes(slug)
+    ? slugs.filter((s) => s !== slug)
+    : [...slugs, slug].slice(0, MAX_FAVOURITES);
+}
+
+/** Anything unexpected in `?view=` falls back to the whole programme. */
+export function parseView(param: string | undefined | null): ScheduleView {
+  return VIEWS.includes(param as ScheduleView) ? (param as ScheduleView) : "all";
+}


### PR DESCRIPTION
La sélection personnelle, sans compte : une étoile par session, un sélecteur à trois états, et tout ça dans l'adresse de la page.

## Ce que ça donne

`?fav=accessibilite-par-ou-commencer,refactoring-en-binome&view=mine` — le visiteur met la page en favori et retrouve sa journée, sur un autre appareil ou dans la boîte d'un collègue. Rien chez nous : pas de compte, pas de stockage serveur, rien à purger après l'événement.

Les trois états du sélecteur :

| État | Ce qu'on voit |
|---|---|
| Tout le programme | l'intégralité |
| Mes favoris et les moments communs | mes sessions, plus l'accueil, les keynotes, les pauses, le déjeuner et la soirée |
| Mes favoris seuls | uniquement mes sessions |

En vue filtrée, **les colonnes se réduisent aux salles concernées** : deux favoris dans deux salles donnent deux colonnes, pas huit dont six vides.

## Trois choses qui méritent un mot

**Le filtrage a lieu dans le navigateur**, sur la charge utile déjà rendue par le serveur. Le HTML servi reste identique pour tous et la page reste en cache, au lieu de se démultiplier en une variante par sélection. C'est aussi ce que fait #107 pour les filtres, et pour la même raison.

**L'étoile est à côté du lien de la carte, jamais dedans.** Un `<button>` imbriqué dans un `<a>` est du HTML invalide, et l'un des deux clics se fait manger. D'où la carte enveloppée dans un conteneur positionné.

**Les moments communs ne sont pas « favorisables »** : ils concernent tout le monde. Dans l'état intermédiaire ils forment le squelette de la journée — sans lui, trois sessions cochées ne sont qu'une liste d'heures.

## Détails d'implémentation

- `?view=` plutôt que `?vue=` comme l'illustrait l'issue : les paramètres existants (`q`, `format`, `level`, `category`) sont en anglais, autant ne pas mélanger.
- La sélection est **relue côté serveur** depuis `searchParams` : un lien partagé rend sa sélection avant l'hydratation, il n'y a pas de clignotement du programme complet.
- `router.replace`, jamais `push` — sinon le bouton Précédent repasse une par une chaque étoile cliquée. Le défaut déjà évité dans #107.
- Le message d'invite s'affiche sur le **nombre de sessions retrouvées**, pas sur la longueur de la sélection : un lien vieux de trois semaines peut ne nommer que des sessions annulées, et afficher le squelette de la journée sans rien dedans n'expliquerait rien.
- Borne à 60 sessions dans l'URL — garde-fou contre une adresse trafiquée, pas une limite que quelqu'un atteint : une journée en compte moins de cinquante.

## Ce que ça ne fait pas

Aucun export. Cette issue **possède l'étendue** et la transmet ; le fichier `.ics` et les boutons agenda sont #443, la vue imprimable #108.

## Plan de test

**Vérifié**

- Suites : frontend 156/156 (9 nouveaux tests sur le paramètre). `tsc` propre, `eslint` sans erreur.
- Navigateur (Chrome DevTools MCP), à 1440 px :
  - cocher deux sessions → l'URL se remplit, les étoiles passent en `aria-pressed="true"` ;
  - passer en « Mes favoris et les moments communs » → deux sessions, deux colonnes (Pastel, Salle Quickies), les sept moments communs conservés ;
  - passer en « Mes favoris seuls » → zéro bande, deux cartes ;
  - **rechargement** de l'URL complète → même sélection, même état, rendus par le serveur ;
  - `?fav=session-inexistante` → message d'invite, aucune erreur ;
  - sur `/conferences`, une session cochée reste cochée après un clic sur un filtre de format, et l'URL porte les deux.
- Mobile 390 px : sélecteur empilé et lisible, étoile atteignable, agenda inchangé.
- Console propre hors l'avertissement `next/image` du logo, présent sur tout le site.

**Non vérifié**

- **Aucun test automatisé sur les composants** : seul le module de sérialisation est couvert. Le comportement du sélecteur et des étoiles a été vérifié en navigateur, pas par une suite.
- Pas de passage au lecteur d'écran réel. Le sélecteur est un `role="radiogroup"` avec `aria-checked`, les étoiles portent `aria-pressed` et un nom accessible, et le message d'invite est en `aria-live` — vérifié dans le DOM, pas à l'oreille.
- Rien n'a été rejoué sur des données de production.
- Le comportement à la limite des 60 favoris n'a été éprouvé qu'en test unitaire.

Refs #442
