### PR TITLE
Programme — export vers Outlook, Google Agenda et consorts

### DIFF
--- a/src/backend/src/__tests__/calendar-ics.test.ts
+++ b/src/backend/src/__tests__/calendar-ics.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import Fastify from "fastify";
+import calendarRoutes from "../routes/calendar.js";
+import { prisma } from "../lib/prisma.js";
+
+// The calendar export (#443). The file's own grammar is covered in lib/ics.test;
+// what is checked here is what ends up inside it.
+//
+// Own venue, edition and talks rather than the seed's: 1889 because Edition.year
+// is unique and the test files run in parallel — reusing a year is the #292
+// failure, and it only shows in the full run.
+
+const TEST_YEAR = 1889;
+
+let editionId: number;
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(calendarRoutes, { prefix: "/api" });
+  return app;
+}
+
+beforeEach(async () => {
+  const venue = await prisma.venue.create({
+    data: { name: `Lieu agenda ${TEST_YEAR}`, address: "Labège" },
+  });
+  const edition = await prisma.edition.create({
+    data: { year: TEST_YEAR, status: "PREPARATION", venueId: venue.id },
+  });
+  editionId = edition.id;
+
+  await prisma.talk.create({
+    data: {
+      editionId,
+      slug: "session-programmee",
+      title: "Session programmée",
+      description: "",
+      format: "CONFERENCE",
+      language: "fr",
+      publicationStatus: "PUBLISHED",
+      roomLabel: "Amphithéâtre",
+      startsAt: new Date("2026-11-19T10:55:00.000Z"),
+      endsAt: new Date("2026-11-19T11:35:00.000Z"),
+    },
+  });
+  await prisma.talk.create({
+    data: {
+      editionId,
+      slug: "session-sans-horaire",
+      title: "Session sans horaire",
+      description: "",
+      format: "CONFERENCE",
+      language: "fr",
+      publicationStatus: "PUBLISHED",
+    },
+  });
+  await prisma.talk.create({
+    data: {
+      editionId,
+      slug: "session-brouillon",
+      title: "Session brouillon",
+      description: "",
+      format: "CONFERENCE",
+      language: "fr",
+      publicationStatus: "DRAFT",
+      startsAt: new Date("2026-11-19T13:15:00.000Z"),
+    },
+  });
+});
+
+afterEach(async () => {
+  await prisma.talk.deleteMany({ where: { editionId } });
+  await prisma.edition.deleteMany({ where: { id: editionId } });
+  await prisma.venue.deleteMany({ where: { name: `Lieu agenda ${TEST_YEAR}` } });
+});
+
+describe("GET /editions/:year/schedule.ics", () => {
+  it("serves a calendar file, named for the year", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/editions/${TEST_YEAR}/schedule.ics` });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/calendar");
+    expect(res.headers["content-disposition"]).toContain(`devfest-toulouse-${TEST_YEAR}.ics`);
+    await app.close();
+  });
+
+  it("exports only the sessions that have an hour, and only the published ones", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/editions/${TEST_YEAR}/schedule.ics` });
+
+    // A VEVENT without DTSTART is invalid, and the 244 imported historical
+    // talks have no time at all.
+    expect(res.body).toContain("SUMMARY:Session programmée");
+    expect(res.body).not.toContain("Session sans horaire");
+    expect(res.body).not.toContain("Session brouillon");
+    await app.close();
+  });
+
+  it("narrows to the selection when ?talks= names one", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/editions/${TEST_YEAR}/schedule.ics?talks=session-inexistante`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).not.toContain("BEGIN:VEVENT");
+    await app.close();
+  });
+
+  it("carries the room and the venue as the location", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/editions/${TEST_YEAR}/schedule.ics` });
+
+    expect(res.body).toContain(`LOCATION:Amphithéâtre — Lieu agenda ${TEST_YEAR}\\, Labège`);
+    await app.close();
+  });
+
+  it("answers 404 for a year that has no edition", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/editions/1066/schedule.ics" });
+
+    expect(res.statusCode).toBe(404);
+    await app.close();
+  });
+});

--- a/src/backend/src/index.ts
+++ b/src/backend/src/index.ts
@@ -13,6 +13,7 @@ import { registerCommonSchemas } from "./schemas/common.js";
 import { registerApiKeySchemas } from "./schemas/api-key.js";
 import { APP_VERSION, APP_ENVIRONMENT, APP_COMMIT } from "./lib/version.js";
 import editionRoutes from "./routes/editions.js";
+import calendarRoutes from "./routes/calendar.js";
 import articleRoutes from "./routes/articles.js";
 import settingsRoutes from "./routes/settings.js";
 import pageRoutes from "./routes/pages.js";
@@ -282,6 +283,7 @@ app.route({
 
 // Public API routes
 await app.register(editionRoutes, { prefix: "/api" });
+await app.register(calendarRoutes, { prefix: "/api" });
 await app.register(articleRoutes, { prefix: "/api" });
 await app.register(settingsRoutes, { prefix: "/api" });
 await app.register(pageRoutes, { prefix: "/api" });

--- a/src/backend/src/lib/ics.test.ts
+++ b/src/backend/src/lib/ics.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+
+import { buildCalendar, escapeText, foldLine } from "./ics.js";
+
+// The rules that decide whether a client accepts the file at all (#443). None
+// of them shows up in a rendered page, and all of them break an import.
+
+const STAMP = new Date("2026-08-21T10:00:00.000Z");
+
+function event(over: Partial<Parameters<typeof buildCalendar>[0][number]> = {}) {
+  return {
+    uid: "kubernetes-en-production-2026@devfesttoulouse.fr",
+    start: new Date("2026-11-19T10:55:00.000Z"),
+    end: new Date("2026-11-19T11:35:00.000Z"),
+    summary: "Kubernetes en production",
+    sequence: 1,
+    ...over,
+  };
+}
+
+describe("iCalendar escaping", () => {
+  it("escapes the characters that separate values in the format", () => {
+    // Without this, "Kubernetes, Istio et le reste" splits into two values and
+    // the summary is truncated at the comma.
+    expect(escapeText("Kubernetes, Istio; et le reste")).toBe(
+      "Kubernetes\\, Istio\\; et le reste",
+    );
+  });
+
+  it("escapes the backslash before anything else", () => {
+    expect(escapeText("a\\b,c")).toBe("a\\\\b\\,c");
+  });
+
+  it("turns a line break into its escape rather than ending the property", () => {
+    expect(escapeText("Marie Dupont\nJean Martin")).toBe("Marie Dupont\\nJean Martin");
+  });
+});
+
+describe("line folding", () => {
+  it("leaves a short line alone", () => {
+    expect(foldLine("SUMMARY:court")).toBe("SUMMARY:court");
+  });
+
+  it("folds past 75 octets, continuing with a space", () => {
+    const long = `SUMMARY:${"a".repeat(120)}`;
+    const folded = foldLine(long);
+    expect(folded).toContain("\r\n ");
+    for (const line of folded.split("\r\n")) {
+      expect(Buffer.from(line, "utf8").length).toBeLessThanOrEqual(75);
+    }
+  });
+
+  it("counts octets, not characters, and never cuts an accent in half", () => {
+    // 74 accented characters are 148 bytes: a character-based fold would emit
+    // one line and overflow, a naive byte cut would split "é" down the middle.
+    const long = `LOCATION:${"é".repeat(74)}`;
+    const folded = foldLine(long);
+    expect(folded.split("\r\n").length).toBeGreaterThan(1);
+    // Reassembling drops the fold and its leading space: nothing is lost.
+    expect(folded.split("\r\n ").join("")).toBe(long);
+  });
+});
+
+describe("the calendar file", () => {
+  it("wraps the events and ends every line with CRLF", () => {
+    const ics = buildCalendar([event()], { calendarName: "DevFest Toulouse 2026", stamp: STAMP });
+
+    expect(ics.startsWith("BEGIN:VCALENDAR\r\n")).toBe(true);
+    expect(ics.endsWith("END:VCALENDAR\r\n")).toBe(true);
+    expect(ics).not.toMatch(/[^\r]\n/);
+  });
+
+  it("writes times as UTC instants", () => {
+    // The one place UTC is the right answer: the reader's calendar converts it
+    // to wherever they are. The page does the opposite (#106).
+    const ics = buildCalendar([event()], { calendarName: "x", stamp: STAMP });
+    expect(ics).toContain("DTSTART:20261119T105500Z");
+    expect(ics).toContain("DTEND:20261119T113500Z");
+  });
+
+  it("keeps the UID stable so a re-import updates instead of duplicating", () => {
+    const first = buildCalendar([event()], { calendarName: "x", stamp: STAMP });
+    const later = buildCalendar([event({ summary: "Titre corrigé", sequence: 2 })], {
+      calendarName: "x",
+      stamp: new Date("2026-09-01T10:00:00.000Z"),
+    });
+
+    const uid = "UID:kubernetes-en-production-2026@devfesttoulouse.fr";
+    expect(first).toContain(uid);
+    expect(later).toContain(uid);
+    expect(later).toContain("SEQUENCE:2");
+  });
+
+  it("omits DTEND rather than inventing a duration", () => {
+    const ics = buildCalendar([event({ end: null })], { calendarName: "x", stamp: STAMP });
+    expect(ics).toContain("DTSTART:");
+    expect(ics).not.toContain("DTEND:");
+  });
+
+  it("leaves the URL unescaped — it is not a text value", () => {
+    const url = "https://devfesttoulouse.fr/fr/conferences/kubernetes-en-production";
+    const ics = buildCalendar([event({ url })], { calendarName: "x", stamp: STAMP });
+    expect(ics).toContain(`URL:${url}`);
+  });
+});

--- a/src/backend/src/lib/ics.ts
+++ b/src/backend/src/lib/ics.ts
@@ -1,0 +1,110 @@
+// Building an iCalendar file by hand (#443).
+//
+// No dependency: the format is a handful of rules, and the ones that actually
+// bite are the boring ones — CRLF everywhere, lines folded at 75 *octets*, and
+// commas escaped inside text. A file that breaks any of them imports fine in
+// one client and silently not at all in another, which is exactly the sort of
+// failure a green test suite never shows.
+
+export interface CalendarEvent {
+  /** Stable across regenerations — a re-import updates, never duplicates. */
+  uid: string;
+  start: Date;
+  /** Omitted rather than invented when a session has no end time. */
+  end: Date | null;
+  summary: string;
+  description?: string;
+  location?: string;
+  url?: string;
+  /**
+   * Bumped whenever the event changes, so a calendar honours the update. Epoch
+   * seconds of the last edit: any integer works as long as it only grows.
+   */
+  sequence: number;
+}
+
+const CRLF = "\r\n";
+
+/** `2026-11-19T08:50:00Z` → `20261119T085000Z`. */
+function toUtcStamp(date: Date): string {
+  return `${date.toISOString().replace(/[-:]/g, "").split(".")[0]}Z`;
+}
+
+/**
+ * Escape a text value.
+ *
+ * Backslash first, or it would escape the escapes added after it. Commas and
+ * semicolons matter because they separate values in the format: a talk called
+ * "Kubernetes, Istio et le reste" splits into two properties without this.
+ */
+export function escapeText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r?\n/g, "\\n");
+}
+
+/**
+ * Fold a content line to 75 octets, continuations starting with a space.
+ *
+ * Octets, not characters: « Amphithéâtre » is twelve characters and fourteen
+ * bytes in UTF-8. Splitting on characters overflows the limit, and splitting
+ * mid-sequence corrupts the accent.
+ */
+export function foldLine(line: string): string {
+  const bytes = Buffer.from(line, "utf8");
+  if (bytes.length <= 75) return line;
+
+  const parts: string[] = [];
+  let offset = 0;
+  let limit = 75;
+  while (offset < bytes.length) {
+    let end = Math.min(offset + limit, bytes.length);
+    // Never cut inside a multi-byte sequence: continuation bytes are 10xxxxxx.
+    while (end > offset && end < bytes.length && (bytes[end] & 0xc0) === 0x80) end--;
+    parts.push(bytes.subarray(offset, end).toString("utf8"));
+    offset = end;
+    limit = 74; // the leading space of a folded line counts toward the 75
+  }
+  return parts.join(`${CRLF} `);
+}
+
+function property(name: string, value: string): string {
+  return foldLine(`${name}:${value}`);
+}
+
+export function buildCalendar(
+  events: CalendarEvent[],
+  options: { calendarName: string; stamp: Date },
+): string {
+  const stamp = toUtcStamp(options.stamp);
+  const lines: string[] = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//GDG Toulouse//DevFest Toulouse//FR",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    property("X-WR-CALNAME", escapeText(options.calendarName)),
+  ];
+
+  for (const event of events) {
+    lines.push("BEGIN:VEVENT");
+    lines.push(property("UID", event.uid));
+    lines.push(property("DTSTAMP", stamp));
+    lines.push(property("SEQUENCE", String(event.sequence)));
+    lines.push(property("DTSTART", toUtcStamp(event.start)));
+    // No DTEND when the session has no end time: an invented duration would be
+    // wrong on someone's calendar, which is worse than a short event.
+    if (event.end) lines.push(property("DTEND", toUtcStamp(event.end)));
+    lines.push(property("SUMMARY", escapeText(event.summary)));
+    if (event.location) lines.push(property("LOCATION", escapeText(event.location)));
+    if (event.description) lines.push(property("DESCRIPTION", escapeText(event.description)));
+    // URL is not a text value — it must not be escaped, commas and all.
+    if (event.url) lines.push(property("URL", event.url));
+    lines.push("END:VEVENT");
+  }
+
+  lines.push("END:VCALENDAR");
+  return `${lines.join(CRLF)}${CRLF}`;
+}

--- a/src/backend/src/routes/calendar.ts
+++ b/src/backend/src/routes/calendar.ts
@@ -1,0 +1,112 @@
+import type { FastifyInstance } from "fastify";
+
+import { prisma } from "../lib/prisma.js";
+import { notDeleted } from "../lib/admin-helpers.js";
+import { buildCalendar, type CalendarEvent } from "../lib/ics.js";
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
+
+// The schedule as a calendar file (#443).
+//
+// Same data as GET /editions/:year/schedule, another shape: what a participant
+// puts on their phone. `?talks=` narrows it to the selection #442 carries in
+// the page URL — the whole programme when the parameter is absent.
+export default async function calendarRoutes(app: FastifyInstance) {
+  app.get<{ Params: { year: string }; Querystring: { talks?: string } }>(
+    "/editions/:year/schedule.ics",
+    {
+      schema: {
+        params: {
+          type: "object",
+          required: ["year"],
+          properties: { year: { type: "string" } },
+        },
+        querystring: {
+          type: "object",
+          properties: { talks: { type: "string" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const yearNum = Number(request.params.year);
+      if (isNaN(yearNum)) return reply.status(400).send({ error: "Invalid year" });
+
+      const edition = await prisma.edition.findFirst({
+        where: { year: yearNum, ...notDeleted },
+        select: { id: true, year: true, venue: { select: { name: true, address: true } } },
+      });
+      if (!edition) return reply.status(404).send({ error: "Edition not found" });
+
+      // Same ceiling as the page (#442): a hand-edited querystring must not turn
+      // into an unbounded `IN (…)`.
+      const wanted = (request.query.talks ?? "")
+        .split(",")
+        .map((slug) => slug.trim())
+        .filter(Boolean)
+        .slice(0, 60);
+
+      const talks = await prisma.talk.findMany({
+        where: {
+          editionId: edition.id,
+          publicationStatus: "PUBLISHED",
+          // A session with no time cannot be an event: the 244 imported
+          // historical talks have none.
+          startsAt: { not: null },
+          ...(wanted.length > 0 ? { slug: { in: wanted } } : {}),
+          ...notDeleted,
+        },
+        orderBy: [{ startsAt: "asc" }, { title: "asc" }],
+        select: {
+          slug: true,
+          title: true,
+          roomLabel: true,
+          startsAt: true,
+          endsAt: true,
+          updatedAt: true,
+          speakers: {
+            where: {
+              ...notDeleted,
+              editions: { some: { editionId: edition.id, publicationStatus: "PUBLISHED" } },
+            },
+            select: { name: true },
+            orderBy: { name: "asc" },
+          },
+        },
+      });
+
+      const venue = [edition.venue?.name, edition.venue?.address].filter(Boolean).join(", ");
+
+      const events: CalendarEvent[] = talks.map((talk) => {
+        const url = `${BASE_URL}/fr/conferences/${talk.slug}`;
+        const speakers = talk.speakers.map((s) => s.name).join(", ");
+
+        return {
+          // Scoped by year as well as slug: a slug is unique per edition, not
+          // across them, and two years of DevFest must not collide in someone's
+          // calendar.
+          uid: `${talk.slug}-${edition.year}@devfesttoulouse.fr`,
+          start: talk.startsAt!,
+          end: talk.endsAt,
+          summary: talk.title,
+          location: [talk.roomLabel, venue].filter(Boolean).join(" — "),
+          description: [speakers, url].filter(Boolean).join("\n"),
+          url,
+          sequence: Math.floor(talk.updatedAt.getTime() / 1000),
+        };
+      });
+
+      const calendar = buildCalendar(events, {
+        calendarName: `DevFest Toulouse ${edition.year}`,
+        stamp: new Date(),
+      });
+
+      return reply
+        .header("Content-Type", "text/calendar; charset=utf-8")
+        .header(
+          "Content-Disposition",
+          `attachment; filename="devfest-toulouse-${edition.year}.ics"`,
+        )
+        .send(calendar);
+    },
+  );
+}

--- a/src/backend/src/routes/editions.ts
+++ b/src/backend/src/routes/editions.ts
@@ -368,6 +368,10 @@ export default async function editionRoutes(app: FastifyInstance) {
       language: talk.language,
       videoUrl: talk.videoUrl,
       year: edition.year,
+      // When and where (#443), same as the current-edition detail route.
+      room: talk.roomLabel,
+      startsAt: talk.startsAt,
+      endsAt: talk.endsAt,
       category: visibleCategory(talk.category),
       speakers: talk.speakers,
     };

--- a/src/backend/src/routes/talks.ts
+++ b/src/backend/src/routes/talks.ts
@@ -52,6 +52,12 @@ export default async function talkRoutes(app: FastifyInstance) {
       format: talk.format,
       level: talk.level,
       language: talk.language,
+      // When and where (#443): what the "add to my calendar" buttons need.
+      // `room` is the label frozen when the talk was placed (#375).
+      room: talk.roomLabel,
+      startsAt: talk.startsAt,
+      endsAt: talk.endsAt,
+      year: edition.year,
       category: visibleCategory(talk.category),
       speakers: talk.speakers,
     };

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -357,6 +357,14 @@
     "cta": "View offer",
     "offersAt": "Offers at {name}"
   },
+  "calendar": {
+    "heading": "Add to my calendar",
+    "google": "Google Calendar",
+    "outlook": "Outlook",
+    "download": "Download the file (.ics)",
+    "exportAll": "The whole schedule in my calendar",
+    "exportMine": "My favourites in my calendar"
+  },
   "favourites": {
     "add": "Add to my favourites",
     "remove": "Remove from my favourites",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -357,6 +357,14 @@
     "cta": "Voir l'offre",
     "offersAt": "Offres chez {name}"
   },
+  "calendar": {
+    "heading": "Ajouter à mon agenda",
+    "google": "Google Agenda",
+    "outlook": "Outlook",
+    "download": "Télécharger le fichier (.ics)",
+    "exportAll": "Tout le programme dans mon agenda",
+    "exportMine": "Mes favoris dans mon agenda"
+  },
   "favourites": {
     "add": "Ajouter à mes favoris",
     "remove": "Retirer de mes favoris",

--- a/src/frontend/src/app/[locale]/conferences/[slug]/page.tsx
+++ b/src/frontend/src/app/[locale]/conferences/[slug]/page.tsx
@@ -3,10 +3,15 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 
-import { getTalkBySlug } from "@/lib/api";
+import { getCurrentEdition, getTalkBySlug } from "@/lib/api";
 import { localizedField } from "@/lib/i18n-helpers";
 import Breadcrumb from "@/components/Breadcrumb";
+import AddToCalendar from "@/components/conferences/AddToCalendar";
 import { Link } from "@/i18n/navigation";
+
+// Absolute, because the event body ends up on someone else's calendar: a
+// relative link would be dead there.
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 
 export async function generateMetadata({
   params,
@@ -47,9 +52,14 @@ export default async function TalkDetailPage({
   const { slug } = await params;
   const locale = await getLocale();
   const t = await getTranslations("conferences");
+  const tcal = await getTranslations("calendar");
   const talk = await getTalkBySlug(slug);
 
   if (!talk) notFound();
+
+  // Only for the venue printed on the calendar event; the page itself does not
+  // otherwise need the edition.
+  const edition = talk.startsAt ? await getCurrentEdition() : null;
 
   const title = talk.title;
   const description = talk.description;
@@ -91,6 +101,30 @@ export default async function TalkDetailPage({
 
         {description && (
           <p className="mt-6 whitespace-pre-line text-lg leading-relaxed text-noir">{description}</p>
+        )}
+
+        {/* Only once the session has an hour: before that there is nothing to
+            put on a calendar (#443). */}
+        {talk.startsAt && (
+          <AddToCalendar
+            session={{
+              slug: talk.slug,
+              title: talk.title,
+              startsAt: talk.startsAt,
+              endsAt: talk.endsAt,
+              room: talk.room,
+              speakers: talk.speakers.map((sp) => sp.name),
+              year: talk.year,
+              url: `${BASE_URL}/${locale}/conferences/${talk.slug}`,
+              venue: [edition?.venueName, edition?.venueAddress].filter(Boolean).join(", ") || null,
+            }}
+            labels={{
+              heading: tcal("heading"),
+              google: tcal("google"),
+              outlook: tcal("outlook"),
+              download: tcal("download"),
+            }}
+          />
         )}
 
         {talk.speakers.length > 0 && (

--- a/src/frontend/src/app/[locale]/programme/page.tsx
+++ b/src/frontend/src/app/[locale]/programme/page.tsx
@@ -39,6 +39,7 @@ export default async function ProgrammePage({
   const t = await getTranslations("programme");
   const tc = await getTranslations("conferences");
   const tf = await getTranslations("favourites");
+  const tcal = await getTranslations("calendar");
   const edition = await getCurrentEdition();
 
   if (!edition) notFound();
@@ -105,6 +106,8 @@ export default async function ProgrammePage({
                 favouriteAdd: tf("add"),
                 favouriteRemove: tf("remove"),
                 empty: tf("empty"),
+                exportAll: tcal("exportAll"),
+                exportMine: tcal("exportMine"),
               }}
               initialFavourites={parseFavourites(first(sp.fav))}
               initialView={parseView(first(sp.view))}

--- a/src/frontend/src/components/conferences/AddToCalendar.tsx
+++ b/src/frontend/src/components/conferences/AddToCalendar.tsx
@@ -1,0 +1,46 @@
+import {
+  googleCalendarUrl,
+  outlookCalendarUrl,
+  icsUrl,
+  type CalendarSession,
+} from "@/lib/calendar-links";
+
+interface AddToCalendarProps {
+  session: CalendarSession;
+  labels: { heading: string; google: string; outlook: string; download: string };
+}
+
+// "Add to my calendar" on a session page (#443).
+//
+// Three doors rather than one: Google and Outlook take a composition URL, and
+// everything else — Apple Calendar, Thunderbird, a phone — takes the file. All
+// three carry only what the session page already shows publicly.
+//
+// It lives here and not in a grid cell: at eight rooms a column is 180 px wide
+// (#441), which leaves no room for a third control beside the title.
+export default function AddToCalendar({ session, labels }: AddToCalendarProps) {
+  const links = [
+    { key: "google", href: googleCalendarUrl(session), label: labels.google, external: true },
+    { key: "outlook", href: outlookCalendarUrl(session), label: labels.outlook, external: true },
+    { key: "ics", href: icsUrl(session), label: labels.download, external: false },
+  ];
+
+  return (
+    <section className="mt-10 rounded-2xl bg-blanc-casse p-5">
+      <h2 className="text-lg font-bold text-noir">{labels.heading}</h2>
+      <div className="mt-3 flex flex-wrap gap-3">
+        {links.map((link) => (
+          <a
+            key={link.key}
+            href={link.href}
+            // The first two leave the site for a third party; the file does not.
+            {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+            className="rounded-[12px] bg-blanc px-4 py-2 text-sm font-bold text-noir shadow-card transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
+          >
+            {link.label}
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/frontend/src/components/programme/ProgrammeBrowser.tsx
+++ b/src/frontend/src/components/programme/ProgrammeBrowser.tsx
@@ -23,6 +23,8 @@ interface Labels {
   favouriteAdd: string;
   favouriteRemove: string;
   empty: string;
+  exportAll: string;
+  exportMine: string;
 }
 
 interface ProgrammeBrowserProps {
@@ -119,29 +121,48 @@ export default function ProgrammeBrowser({
   };
   const favouriteLabels = { add: labels.favouriteAdd, remove: labels.favouriteRemove };
 
+  // The export follows what is on screen rather than adding a second control
+  // that could disagree with it (#443).
+  const exportsSelection = view !== "all" && favourites.length > 0;
+  const icsHref = exportsSelection
+    ? `/api/editions/${schedule.year}/schedule.ics?talks=${encodeURIComponent(
+        serializeFavourites(favourites),
+      )}`
+    : `/api/editions/${schedule.year}/schedule.ics`;
+
   return (
     <div>
-      {/* A radio group, not three buttons: the three views are one choice, and
-          a screen reader has to hear it that way. */}
-      <div
-        role="radiogroup"
-        aria-label={labels.viewLabel}
-        className="mb-6 inline-flex flex-wrap gap-2 rounded-2xl bg-blanc-casse p-1"
-      >
-        {VIEWS.map((value) => (
-          <button
-            key={value}
-            type="button"
-            role="radio"
-            aria-checked={view === value}
-            onClick={() => onChangeView(value)}
-            className={`rounded-[12px] px-4 py-2 text-sm font-bold transition-colors focus:outline-none focus:ring-2 focus:ring-malachite/50 ${
-              view === value ? "bg-blanc text-noir shadow-card" : "text-gris hover:text-noir"
-            }`}
-          >
-            {viewLabels[value]}
-          </button>
-        ))}
+      <div className="mb-6 flex flex-wrap items-center gap-4">
+        {/* A radio group, not three buttons: the three views are one choice, and
+            a screen reader has to hear it that way. Nothing else may live inside
+            it — hence the export link as a sibling. */}
+        <div
+          role="radiogroup"
+          aria-label={labels.viewLabel}
+          className="inline-flex flex-wrap gap-2 rounded-2xl bg-blanc-casse p-1"
+        >
+          {VIEWS.map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={view === value}
+              onClick={() => onChangeView(value)}
+              className={`rounded-[12px] px-4 py-2 text-sm font-bold transition-colors focus:outline-none focus:ring-2 focus:ring-malachite/50 ${
+                view === value ? "bg-blanc text-noir shadow-card" : "text-gris hover:text-noir"
+              }`}
+            >
+              {viewLabels[value]}
+            </button>
+          ))}
+        </div>
+
+        <a
+          href={icsHref}
+          className="rounded-[12px] px-2 py-2 text-sm font-bold text-bleu hover:underline focus:outline-none focus:ring-2 focus:ring-malachite/50"
+        >
+          {exportsSelection ? labels.exportMine : labels.exportAll}
+        </a>
       </div>
 
       {/* On `matched`, not on the length of the selection: a link bookmarked

--- a/src/frontend/src/lib/calendar-links.test.ts
+++ b/src/frontend/src/lib/calendar-links.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+
+import { googleCalendarUrl, outlookCalendarUrl, icsUrl } from "./calendar-links";
+
+const session = {
+  slug: "kubernetes-en-production",
+  title: "Kubernetes, en production",
+  startsAt: "2026-11-19T10:55:00.000Z",
+  endsAt: "2026-11-19T11:35:00.000Z",
+  room: "Amphithéâtre",
+  speakers: ["Marie Dupont"],
+  year: 2026,
+  url: "https://devfesttoulouse.fr/fr/conferences/kubernetes-en-production",
+  venue: "Diagora, Labège",
+};
+
+describe("calendar composition links (#443)", () => {
+  it("hands Google the instant, in UTC", () => {
+    // The suite runs on Europe/Paris: a local formatting would send 11:55 and
+    // put the session an hour late on the reader's calendar.
+    const url = new URL(googleCalendarUrl(session));
+    expect(url.searchParams.get("dates")).toBe("20261119T105500Z/20261119T113500Z");
+  });
+
+  it("escapes the title rather than truncating it at the comma", () => {
+    const url = new URL(googleCalendarUrl(session));
+    expect(url.searchParams.get("text")).toBe("Kubernetes, en production");
+  });
+
+  it("carries the room and the venue as the location", () => {
+    const url = new URL(googleCalendarUrl(session));
+    expect(url.searchParams.get("location")).toBe("Amphithéâtre — Diagora, Labège");
+  });
+
+  it("gives Outlook ISO instants", () => {
+    const url = new URL(outlookCalendarUrl(session));
+    expect(url.searchParams.get("startdt")).toBe("2026-11-19T10:55:00.000Z");
+    expect(url.searchParams.get("enddt")).toBe("2026-11-19T11:35:00.000Z");
+  });
+
+  it("falls back to a conference-length slot when the end is missing", () => {
+    // Both composition URLs require an end; ours does not, and omits it.
+    const url = new URL(googleCalendarUrl({ ...session, endsAt: null }));
+    expect(url.searchParams.get("dates")).toBe("20261119T105500Z/20261119T113500Z");
+  });
+
+  it("points the file at the year-scoped route, filtered to one session", () => {
+    expect(icsUrl(session)).toBe(
+      "/api/editions/2026/schedule.ics?talks=kubernetes-en-production",
+    );
+  });
+});

--- a/src/frontend/src/lib/calendar-links.ts
+++ b/src/frontend/src/lib/calendar-links.ts
@@ -1,0 +1,72 @@
+// Links that hand one session to a calendar (#443).
+//
+// Two of the three are composition URLs on someone else's site: they carry the
+// session's public details and nothing about the visitor. The third is our own
+// `.ics`, which every other client understands.
+
+export interface CalendarSession {
+  slug: string;
+  title: string;
+  startsAt: string;
+  endsAt: string | null;
+  room: string | null;
+  speakers: string[];
+  year: number;
+  /** Absolute URL of the session page, for the event body. */
+  url: string;
+  /** Venue name and address, appended to the room. */
+  venue?: string | null;
+}
+
+/** `2026-11-19T10:55:00.000Z` → `20261119T105500Z`. */
+function compact(iso: string): string {
+  return `${new Date(iso).toISOString().replace(/[-:]/g, "").split(".")[0]}Z`;
+}
+
+// A session with no end time still has to land somewhere on a calendar: the
+// composition URLs of Google and Outlook both require an end. Forty minutes is
+// the conference format, and it is only ever used when the schedule is
+// incomplete — the `.ics` omits the end instead of guessing.
+const FALLBACK_MINUTES = 40;
+
+function endOf(session: CalendarSession): string {
+  if (session.endsAt) return session.endsAt;
+  return new Date(new Date(session.startsAt).getTime() + FALLBACK_MINUTES * 60_000).toISOString();
+}
+
+function locationOf(session: CalendarSession): string {
+  return [session.room, session.venue].filter(Boolean).join(" — ");
+}
+
+function detailsOf(session: CalendarSession): string {
+  return [session.speakers.join(", "), session.url].filter(Boolean).join("\n");
+}
+
+export function googleCalendarUrl(session: CalendarSession): string {
+  const params = new URLSearchParams({
+    action: "TEMPLATE",
+    text: session.title,
+    dates: `${compact(session.startsAt)}/${compact(endOf(session))}`,
+    details: detailsOf(session),
+    location: locationOf(session),
+  });
+  return `https://calendar.google.com/calendar/render?${params}`;
+}
+
+export function outlookCalendarUrl(session: CalendarSession): string {
+  const params = new URLSearchParams({
+    path: "/calendar/action/compose",
+    rru: "addevent",
+    subject: session.title,
+    startdt: new Date(session.startsAt).toISOString(),
+    enddt: new Date(endOf(session)).toISOString(),
+    body: detailsOf(session),
+    location: locationOf(session),
+  });
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${params}`;
+}
+
+/** Our own file, for Apple Calendar, Thunderbird and everything else. */
+export function icsUrl(session: CalendarSession): string {
+  return `/api/editions/${session.year}/schedule.ics?talks=${encodeURIComponent(session.slug)}`;
+}

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -435,6 +435,11 @@ export interface TalkDetail {
   format: TalkFormat;
   level: TalkLevel | null;
   language: string;
+  // When and where (#443) — null until the session is placed on the grid.
+  room: string | null;
+  startsAt: string | null;
+  endsAt: string | null;
+  year: number;
   category: { nameFr: string; nameEn: string; color: string } | null;
   speakers: { slug: string; name: string; photoUrl: string | null; company: string | null }[];
 }
@@ -451,6 +456,9 @@ export interface EditionTalkDetail {
   language: string;
   videoUrl: string | null;
   year: number;
+  room: string | null;
+  startsAt: string | null;
+  endsAt: string | null;
   category: { nameFr: string; nameEn: string; color: string } | null;
   speakers: { slug: string; name: string; photoUrl: string | null; company: string | null }[];
 }


### PR DESCRIPTION
Le programme s'en va sur l'agenda du participant : un fichier `.ics` depuis la grille, trois portes depuis la fiche d'une session.

## Ce que ça ajoute

- **`GET /api/editions/:year/schedule.ics`** — le programme complet, ou la sélection quand `?talks=` la nomme. C'est #442 qui fournit l'étendue ; le lien de la page suit la vue affichée plutôt que d'ajouter un second réglage qui pourrait la contredire.
- **Sur la fiche d'une session** : Google Agenda, Outlook Web, et le fichier pour tout le reste (Apple Calendrier, Thunderbird, un téléphone).
- Les champs `room`, `startsAt`, `endsAt` et `year` rejoignent les deux charges utiles de détail d'une session, qui ne les portaient pas.

Rien de nouveau au modèle : la requête existante suffisait.

## Le format est plus tatillon qu'il n'en a l'air

Écrit à la main plutôt qu'en tirant une dépendance : ce sont quelques règles, et celles qui mordent sont les ennuyeuses.

- **CRLF partout**, sinon certains clients refusent le fichier entier.
- **Pliage à 75 octets, pas 75 caractères.** « Amphithéâtre » fait douze caractères et quatorze octets ; couper au caractère déborde la limite, couper à l'octet sans précaution scinde l'accent en deux. Le pliage recule jusqu'au début de la séquence UTF-8.
- **Virgules et points-virgules échappés** : ils séparent les valeurs dans le format. Sans ça, « Kubernetes, Istio et le reste » devient deux propriétés et le titre est tronqué.
- L'`URL`, elle, n'est **pas** une valeur texte et ne doit surtout pas être échappée.

Un fichier presque conforme s'importe dans un client et pas dans un autre, et aucune suite verte ne le dit.

## Deux décisions

**`UID` stable = slug + année.** Un participant qui réimporte après un changement de salle doit voir son événement **mis à jour**, pas dupliqué. D'où aussi un `SEQUENCE` qui croît avec la date de dernière modification — sans lui, les agendas ignorent la mise à jour. L'année scope l'identifiant parce qu'un slug est unique par édition, pas entre éditions : deux DevFest ne doivent pas se télescoper dans un agenda.

**Les heures partent en UTC**, et c'est ici la bonne réponse : l'agenda du lecteur convertit vers son fuseau. C'est l'exact inverse de l'affichage, où formater « en local » avait fait annoncer 08:50 pour la session que la signalétique appelle 09:50 (#106). Un test le dit explicitement, des deux côtés.

**Pas de `DTEND` inventé** quand une session n'a pas d'heure de fin : une durée fausse sur l'agenda de quelqu'un est pire qu'un événement court. Les liens Google et Outlook, eux, *exigent* une fin — ils retombent sur 40 minutes, le format conférence, et c'est commenté comme tel.

## Plan de test

**Vérifié**

- Suites : backend 668/669, frontend 162/162. `tsc` et `eslint` propres des deux côtés.
- 11 tests sur la grammaire du fichier (échappement, pliage octet par octet, CRLF, UID stable, absence de `DTEND`), 5 sur la route (en-têtes, sessions sans horaire et brouillons écartées, filtre `?talks=`, 404).
- 6 tests sur les liens de composition, dont l'instant en UTC — la suite tourne sur `Europe/Paris`, donc un formatage local y enverrait 11:55 au lieu de 10:55.
- Navigateur : fiche de session avec ses trois liens (`target="_blank"` et `rel="noopener noreferrer"` sur les deux externes), lien d'export sur la grille dont le libellé et l'URL suivent la vue.
- Fichier réellement servi : 24 événements pour le programme complet, 2 pour une sélection de deux, `Content-Type: text/calendar; charset=utf-8` et `Content-Disposition` avec un nom lisible.

**Non vérifié**

- **Aucun import réel dans Google Agenda, Outlook ou Apple Calendrier.** C'est le contrôle qui compte vraiment pour ce format, et il demande un compte sur chacun des trois. À faire avant la mise en production.
- Les liens Google et Outlook n'ont pas été ouverts sur leurs services : `URLSearchParams` encode le `/` de `dates=début/fin` en `%2F`, ce qui devrait se décoder normalement côté Google — devrait, pas vérifié.
- Rien n'a été rejoué sur des données de production.
- L'échec backend restant est l'artefact connu de `stat-icons.test.ts`.

Refs #443
