### PR TITLE
Programme — version imprimable, sans générateur PDF

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -383,6 +383,7 @@
     "intro": "The day, room by room. Click a session to read its details.",
     "timeColumn": "Time",
     "roomTba": "Room to be confirmed",
+    "print": "Print or save as PDF",
     "allSessions": "See every session as a list",
     "comingSoonTitle": "The schedule is on its way",
     "comingSoonBody": "The DevFest Toulouse {year} sessions are still being placed. The grid will be published here as soon as it is final."

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -383,6 +383,7 @@
     "intro": "Le programme de la journée, salle par salle. Cliquez sur une session pour en lire le détail.",
     "timeColumn": "Horaire",
     "roomTba": "Salle à préciser",
+    "print": "Imprimer ou enregistrer en PDF",
     "allSessions": "Voir toutes les sessions en liste",
     "comingSoonTitle": "La grille horaire arrive bientôt",
     "comingSoonBody": "Les sessions du DevFest Toulouse {year} sont en cours de placement. La grille sera publiée ici dès qu'elle sera figée."

--- a/src/frontend/src/app/[locale]/programme/page.tsx
+++ b/src/frontend/src/app/[locale]/programme/page.tsx
@@ -108,6 +108,7 @@ export default async function ProgrammePage({
                 empty: tf("empty"),
                 exportAll: tcal("exportAll"),
                 exportMine: tcal("exportMine"),
+                print: t("print"),
               }}
               initialFavourites={parseFavourites(first(sp.fav))}
               initialView={parseView(first(sp.view))}
@@ -119,7 +120,7 @@ export default async function ProgrammePage({
                 "when and where", the list answers "what is there on my topic". */}
             <Link
               href="/conferences"
-              className="mt-8 inline-flex items-center gap-2 rounded-[12px] bg-bismarck px-4 py-2 text-sm font-bold text-blanc hover:bg-bismarck/90"
+              className="no-print mt-8 inline-flex items-center gap-2 rounded-[12px] bg-bismarck px-4 py-2 text-sm font-bold text-blanc hover:bg-bismarck/90"
             >
               {t("allSessions")}
             </Link>

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -491,3 +491,59 @@ body {
 .section-y h2 {
   text-box: trim-both cap alphabetic;
 }
+
+/* ========================================
+ * Print (#108)
+ *
+ * The printable schedule is the browser's own Save-as-PDF, driven by a
+ * stylesheet rather than a generator: no Chromium in the backend image, no
+ * layout re-implemented by hand, and a printed page that cannot drift from the
+ * one on screen because it is the one on screen.
+ *
+ * What prints is the chronological agenda, not the grid: eight rooms at 180 px
+ * come to more than 1500 px, which no sheet of A4 holds without cutting.
+ * ======================================== */
+@media print {
+  /* Site chrome carries nothing onto paper — navigation least of all. */
+  header,
+  footer,
+  nav,
+  .no-print {
+    display: none !important;
+  }
+
+  body {
+    background: #fff;
+  }
+
+  /* The grid gives way to the agenda, whatever the width of the screen this is
+     printed from. Both overrides live here rather than in Tailwind `print:`
+     variants — those emitted no CSS at all in this setup, and a class that
+     produces nothing fails without a word. */
+  .print-grid {
+    display: none !important;
+  }
+
+  .print-agenda {
+    display: block !important;
+  }
+
+  /* Ink, not screen colours: pale grey on white survives neither a laser
+     printer nor a photocopy. */
+  .print-agenda,
+  .print-agenda * {
+    color: #000 !important;
+  }
+
+  /* A session must not be cut across two sheets. */
+  .print-agenda a,
+  .print-agenda section {
+    break-inside: avoid;
+  }
+
+  /* A shadow prints as a grey smear; a hairline says the same thing. */
+  .print-agenda a {
+    box-shadow: none !important;
+    border: 1px solid #999;
+  }
+}

--- a/src/frontend/src/components/FavouriteButton.tsx
+++ b/src/frontend/src/components/FavouriteButton.tsx
@@ -30,7 +30,8 @@ export default function FavouriteButton({
       // and aria-pressed carries the state.
       aria-label={label}
       title={label}
-      className={`inline-flex size-8 items-center justify-center rounded-full text-lg transition-colors hover:bg-blanc-casse focus:outline-none focus:ring-2 focus:ring-malachite/50 ${
+      // no-print (#108): a star is a control, and a control on paper is noise.
+      className={`no-print inline-flex size-8 items-center justify-center rounded-full text-lg transition-colors hover:bg-blanc-casse focus:outline-none focus:ring-2 focus:ring-malachite/50 ${
         isFavourite ? "text-orange" : "text-gris"
       } ${className}`}
     >

--- a/src/frontend/src/components/programme/ProgrammeBrowser.tsx
+++ b/src/frontend/src/components/programme/ProgrammeBrowser.tsx
@@ -25,6 +25,7 @@ interface Labels {
   empty: string;
   exportAll: string;
   exportMine: string;
+  print: string;
 }
 
 interface ProgrammeBrowserProps {
@@ -132,7 +133,7 @@ export default function ProgrammeBrowser({
 
   return (
     <div>
-      <div className="mb-6 flex flex-wrap items-center gap-4">
+      <div className="no-print mb-6 flex flex-wrap items-center gap-4">
         {/* A radio group, not three buttons: the three views are one choice, and
             a screen reader has to hear it that way. Nothing else may live inside
             it — hence the export link as a sibling. */}
@@ -163,6 +164,16 @@ export default function ProgrammeBrowser({
         >
           {exportsSelection ? labels.exportMine : labels.exportAll}
         </a>
+
+        {/* The printable version is the browser's own (#108): what it prints is
+            this very page, minus its controls. */}
+        <button
+          type="button"
+          onClick={() => window.print()}
+          className="rounded-[12px] px-2 py-2 text-sm font-bold text-bleu hover:underline focus:outline-none focus:ring-2 focus:ring-malachite/50"
+        >
+          {labels.print}
+        </button>
       </div>
 
       {/* On `matched`, not on the length of the selection: a link bookmarked

--- a/src/frontend/src/components/programme/ScheduleAgenda.tsx
+++ b/src/frontend/src/components/programme/ScheduleAgenda.tsx
@@ -29,7 +29,12 @@ export default function ScheduleAgenda({
   favouriteLabels,
 }: ScheduleAgendaProps) {
   return (
-    <div className="space-y-6 lg:hidden">
+    // `print-agenda` (#108): on paper this is the schedule, whatever the width
+    // of the screen it was printed from — the grid does not fit on A4. The rule
+    // that swaps them lives in globals.css, not in a Tailwind `print:` variant:
+    // the variant generated nothing here, and a class that produces no CSS
+    // fails silently.
+    <div className="print-agenda space-y-6 lg:hidden">
       {rows.map((row) =>
         row.type === "band" ? (
           <div key={row.key} className="rounded-2xl bg-blanc-casse px-4 py-3">

--- a/src/frontend/src/components/programme/ScheduleGrid.tsx
+++ b/src/frontend/src/components/programme/ScheduleGrid.tsx
@@ -42,7 +42,7 @@ export default function ScheduleGrid({
 }: ScheduleGridProps) {
   return (
     // Scrolls inside its own box: the page body must never scroll sideways.
-    <div className="hidden overflow-x-auto lg:block">
+    <div className="print-grid hidden overflow-x-auto lg:block">
       <table className="w-full border-separate border-spacing-2">
         <thead>
           <tr>


### PR DESCRIPTION
La version imprimable du programme, par une feuille de style plutôt qu'un générateur.

## Pourquoi pas de générateur

L'énoncé dit de « réutiliser l'approche PDF de `brochure.ts` ». Il n'y en a pas : [brochure.ts](src/backend/src/routes/brochure.ts) redirige (302) vers un fichier téléversé depuis l'admin, et aucune bibliothèque PDF n'existe dans les dépendances des deux applications.

Restaient deux voies. Puppeteer, c'est un Chromium complet dans l'image backend ; pdfkit, c'est réécrire la mise en page à la main et la voir diverger de la grille au premier changement. La troisième — la feuille de style d'impression — ne coûte aucune dépendance, et **la page imprimée ne peut pas diverger de celle à l'écran puisque c'est la même**.

C'est un écart par rapport à la lettre de l'issue, validé avant de commencer.

## Ce qui est imprimé

**L'agenda chronologique, pas la grille.** Huit salles à 180 px font plus de 1500 px de large : aucune feuille A4 ne les tient sans couper. La liste linéaire, elle, se lit très bien sur papier — chaque session porte son horaire et sa salle, et l'ordre est celui de la journée.

Et donc : l'en-tête, le pied de page, le fil d'Ariane, le sélecteur de vue, les liens d'export et les étoiles disparaissent ; les couleurs passent à l'encre (le gris pâle ne survit ni au laser ni à la photocopie) ; une session n'est jamais coupée entre deux feuilles ; l'ombre portée devient un filet, parce qu'une ombre s'imprime en bavure grise.

Un bouton « Imprimer ou enregistrer en PDF » appelle simplement `window.print()`.

## Un piège rencontré en chemin

Les deux bascules d'affichage (masquer la grille, montrer l'agenda) étaient d'abord écrites en variantes Tailwind — `print:block`, `print:!hidden`. **Elles n'ont produit aucune règle CSS.** La page se serait imprimée avec la grille tronquée et pas d'agenda, sans le moindre signe : une classe qui ne génère rien échoue en silence.

Repéré en relisant les règles `@media print` réellement servies par la page, pas à l'œil. Les deux bascules sont désormais du CSS écrit à la main dans `globals.css`, à côté du reste du bloc d'impression, et c'est commenté.

## Plan de test

**Vérifié**

- Suites : frontend 162/162. `tsc` et `eslint` propres.
- Les règles `@media print` réellement servies contiennent bien les deux bascules et le masquage du chrome — relues depuis `document.styleSheets`, pas supposées.
- Rendu approché en navigateur en appliquant les mêmes règles sans la contrainte de média : titre conservé, chrome et contrôles absents, agenda chronologique complet avec salles.
- À l'écran, rien ne bouge : la grille reste la grille.

**Non vérifié**

- **Aucune impression réelle, ni aperçu avant impression.** Je n'ai pas de moyen d'émuler le média `print` par le pilotage du navigateur dont je dispose : ce qui est vérifié, ce sont les règles servies et leur effet appliqué hors média. **La pagination, les marges et le rendu réel d'une page A4 restent à regarder** — un Ctrl+P sur `/fr/programme` suffit.
- L'impression depuis un téléphone n'a pas été regardée.
- Rien n'a été rejoué sur des données de production.

Refs #108
