### PR TITLE
Programme — filtrer d'un côté, agir de l'autre

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -362,8 +362,9 @@
     "google": "Google Calendar",
     "outlook": "Outlook",
     "download": "Download the file (.ics)",
-    "exportAll": "The whole schedule in my calendar",
-    "exportMine": "My favourites in my calendar"
+    "export": "Export",
+    "exportAll": "Export the whole schedule to my calendar",
+    "exportMine": "Export my favourites to my calendar"
   },
   "favourites": {
     "add": "Add to my favourites",
@@ -383,7 +384,11 @@
     "intro": "The day, room by room. Click a session to read its details.",
     "timeColumn": "Time",
     "roomTba": "Room to be confirmed",
-    "print": "Print or save as PDF",
+    "print": "Print",
+    "printTitle": "Print the schedule or save it as a PDF",
+    "filterZone": "Filter the schedule",
+    "actionZone": "Schedule actions",
+    "noResults": "No session matches these filters.",
     "allSessions": "See every session as a list",
     "comingSoonTitle": "The schedule is on its way",
     "comingSoonBody": "The DevFest Toulouse {year} sessions are still being placed. The grid will be published here as soon as it is final."

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -362,8 +362,9 @@
     "google": "Google Agenda",
     "outlook": "Outlook",
     "download": "Télécharger le fichier (.ics)",
-    "exportAll": "Tout le programme dans mon agenda",
-    "exportMine": "Mes favoris dans mon agenda"
+    "export": "Exporter",
+    "exportAll": "Exporter tout le programme vers mon agenda",
+    "exportMine": "Exporter mes favoris vers mon agenda"
   },
   "favourites": {
     "add": "Ajouter à mes favoris",
@@ -383,7 +384,11 @@
     "intro": "Le programme de la journée, salle par salle. Cliquez sur une session pour en lire le détail.",
     "timeColumn": "Horaire",
     "roomTba": "Salle à préciser",
-    "print": "Imprimer ou enregistrer en PDF",
+    "print": "Imprimer",
+    "printTitle": "Imprimer ou enregistrer le programme en PDF",
+    "filterZone": "Filtrer le programme",
+    "actionZone": "Actions sur le programme",
+    "noResults": "Aucune session ne correspond à ces filtres.",
     "allSessions": "Voir toutes les sessions en liste",
     "comingSoonTitle": "La grille horaire arrive bientôt",
     "comingSoonBody": "Les sessions du DevFest Toulouse {year} sont en cours de placement. La grille sera publiée ici dès qu'elle sera figée."

--- a/src/frontend/src/app/[locale]/programme/page.tsx
+++ b/src/frontend/src/app/[locale]/programme/page.tsx
@@ -7,7 +7,8 @@ import { getCurrentEdition, getEditionSchedule } from "@/lib/api";
 import Breadcrumb from "@/components/Breadcrumb";
 import ProgrammeBrowser from "@/components/programme/ProgrammeBrowser";
 import { parseFavourites, parseView } from "@/lib/favourites";
-import type { TalkFormat } from "@/lib/types";
+import { parseFilters } from "@/lib/talk-filters";
+import type { TalkFormat, TalkLevel } from "@/lib/types";
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
@@ -26,6 +27,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 const TALK_FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"];
+const TALK_LEVELS: TalkLevel[] = ["DEBUTANT", "INTERMEDIAIRE", "CONFIRME"];
 
 // The width every other page of the site reads at. The grid is the exception.
 const READING_COLUMN = "mx-auto max-w-7xl";
@@ -50,9 +52,13 @@ export default async function ProgrammePage({
   const formatLabels = Object.fromEntries(
     TALK_FORMATS.map((format) => [format, tc(`format.${format}`)]),
   );
+  const levelLabels = Object.fromEntries(
+    TALK_LEVELS.map((level) => [level, tc(`level.${level}`)]),
+  );
 
-  // Read the selection from the URL on the server, so a bookmarked link renders
-  // its selection before hydration rather than flashing the whole programme.
+  // Read the selection and the filters from the URL on the server, so a
+  // bookmarked link renders them before hydration rather than flashing the
+  // whole programme.
   const sp = await searchParams;
   const first = (v: string | string[] | undefined) => (Array.isArray(v) ? v[0] : v);
 
@@ -99,6 +105,19 @@ export default async function ProgrammePage({
               labels={{
                 timeColumn: t("timeColumn"),
                 roomTba: t("roomTba"),
+                filterZone: t("filterZone"),
+                actionZone: t("actionZone"),
+                noResults: t("noResults"),
+                filters: tc("filters.filters"),
+                reset: tc("filters.reset"),
+                format: tc("filters.format"),
+                level: tc("filters.level"),
+                language: tc("filters.language"),
+                category: tc("filters.category"),
+                moreFilters: tc("filters.moreFilters"),
+                formatLabels,
+                levelLabels,
+                languageLabels: { fr: tc("filters.langFr"), en: tc("filters.langEn") },
                 viewLabel: tf("viewLabel"),
                 viewAll: tf("viewAll"),
                 viewMine: tf("viewMine"),
@@ -106,12 +125,16 @@ export default async function ProgrammePage({
                 favouriteAdd: tf("add"),
                 favouriteRemove: tf("remove"),
                 empty: tf("empty"),
-                exportAll: tcal("exportAll"),
-                exportMine: tcal("exportMine"),
-                print: t("print"),
+                exportShort: tcal("export"),
+                exportAllTitle: tcal("exportAll"),
+                exportMineTitle: tcal("exportMine"),
+                exportTitle: tcal("exportAll"),
+                printShort: t("print"),
+                printTitle: t("printTitle"),
               }}
               initialFavourites={parseFavourites(first(sp.fav))}
               initialView={parseView(first(sp.view))}
+              initialFilters={parseFilters((key) => first(sp[key]))}
             />
           </div>
 

--- a/src/frontend/src/components/FilterChip.tsx
+++ b/src/frontend/src/components/FilterChip.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+// The chips both filter bars are built from — the session list (#107) and the
+// schedule grid (#448). Shared so the two look like one control, and so a
+// change of design lands on both at once.
+
+export function ChipRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+      <span className="shrink-0 text-sm font-semibold text-noir sm:w-24">{label}</span>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  );
+}
+
+export function Chip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+        active ? "bg-malachite text-blanc" : "bg-blanc-casse text-noir hover:bg-gris/15"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/frontend/src/components/conferences/ConferencesBrowser.tsx
+++ b/src/frontend/src/components/conferences/ConferencesBrowser.tsx
@@ -4,8 +4,9 @@ import { useMemo, useState } from "react";
 
 import { useRouter, usePathname } from "@/i18n/navigation";
 import type { EditionTalk, TalkFormat, TalkLevel } from "@/lib/types";
-import { localizedField } from "@/lib/i18n-helpers";
+import { matchesFilters, type TalkFilters } from "@/lib/talk-filters";
 import { serializeFavourites, toggleFavourite } from "@/lib/favourites";
+import { Chip, ChipRow } from "@/components/FilterChip";
 import ConferencesList from "./ConferencesList";
 
 const FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"];
@@ -33,21 +34,13 @@ interface Labels {
   favouriteLabels: { add: string; remove: string };
 }
 
-interface Filters {
-  q: string;
-  format: string;
-  level: string;
-  language: string;
-  category: string;
-}
-
 interface ConferencesBrowserProps {
   talks: EditionTalk[];
   locale: string;
   categories: CategoryOption[];
   languages: string[];
   labels: Labels;
-  initial: Filters;
+  initial: TalkFilters;
   /** The selection carried by the URL (#442), shared with /programme. */
   initialFavourites: string[];
 }
@@ -66,7 +59,7 @@ export default function ConferencesBrowser({
 }: ConferencesBrowserProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const [filters, setFilters] = useState<Filters>(initial);
+  const [filters, setFilters] = useState<TalkFilters>(initial);
   const [favourites, setFavourites] = useState<string[]>(initialFavourites);
   // Level + language live behind a "more filters" disclosure to keep the bar
   // compact (#246). Open it on mount if one of them was already active via URL.
@@ -81,7 +74,7 @@ export default function ConferencesBrowser({
   // Toggle a chip (empty value clears it) and reflect the whole filter state in
   // the URL. replace (not push) so the back button doesn't step through every
   // chip click. scroll:false keeps the viewport where the user is filtering.
-  function update(next: Partial<Filters>, nextFavourites = favourites) {
+  function update(next: Partial<TalkFilters>, nextFavourites = favourites) {
     const merged = { ...filters, ...next };
     setFilters(merged);
     const params = new URLSearchParams();
@@ -104,8 +97,8 @@ export default function ConferencesBrowser({
     update({}, next);
   }
 
-  function toggle(key: keyof Filters, value: string) {
-    update({ [key]: filters[key] === value ? "" : value } as Partial<Filters>);
+  function toggle(key: keyof TalkFilters, value: string) {
+    update({ [key]: filters[key] === value ? "" : value } as Partial<TalkFilters>);
   }
 
   const hasActiveFilter =
@@ -127,26 +120,13 @@ export default function ConferencesBrowser({
 
   const selected = useMemo(() => new Set(favourites), [favourites]);
 
-  const filtered = useMemo(() => {
-    const q = filters.q.trim().toLowerCase();
-    return talks.filter((talk) => {
-      if (filters.format && talk.format !== filters.format) return false;
-      if (filters.level && talk.level !== filters.level) return false;
-      if (filters.language && talk.language !== filters.language) return false;
-      if (filters.category) {
-        const cat = talk.category ? localizedField(talk.category, "name", locale) : "";
-        // Categories carry no slug on the public payload; match on the localized
-        // name we surfaced as the chip value.
-        if (cat !== filters.category) return false;
-      }
-      if (q) {
-        const title = talk.title.toLowerCase();
-        const speakers = talk.speakers.map((s) => s.name).join(" ").toLowerCase();
-        if (!title.includes(q) && !speakers.includes(q)) return false;
-      }
-      return true;
-    });
-  }, [talks, filters, locale]);
+  // The predicate is shared with the grid (#448): both views filter the same
+  // sessions on the same families, and a selection made in one holds in the
+  // other.
+  const filtered = useMemo(
+    () => talks.filter((talk) => matchesFilters(talk, filters, locale)),
+    [talks, filters, locale],
+  );
 
   return (
     <div>
@@ -292,39 +272,5 @@ export default function ConferencesBrowser({
         )}
       </div>
     </div>
-  );
-}
-
-function ChipRow({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-      <span className="shrink-0 text-sm font-semibold text-noir sm:w-24">{label}</span>
-      <div className="flex flex-wrap gap-2">{children}</div>
-    </div>
-  );
-}
-
-function Chip({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-        active
-          ? "bg-malachite text-blanc"
-          : "bg-blanc-casse text-noir hover:bg-gris/15"
-      }`}
-    >
-      {children}
-    </button>
   );
 }

--- a/src/frontend/src/components/programme/ProgrammeBrowser.tsx
+++ b/src/frontend/src/components/programme/ProgrammeBrowser.tsx
@@ -5,27 +5,22 @@ import { useMemo, useState } from "react";
 import { useRouter, usePathname } from "@/i18n/navigation";
 import type { EditionSchedule } from "@/lib/types";
 import { buildScheduleRows } from "@/lib/schedule";
-import {
-  serializeFavourites,
-  toggleFavourite,
-  type ScheduleView,
-} from "@/lib/favourites";
+import { serializeFavourites, toggleFavourite, type ScheduleView } from "@/lib/favourites";
+import { applyFiltersToParams, matchesFilters, type TalkFilters } from "@/lib/talk-filters";
+import { localizedField } from "@/lib/i18n-helpers";
+import ProgrammeControls, { type ControlLabels } from "./ProgrammeControls";
 import ScheduleGrid from "./ScheduleGrid";
 import ScheduleAgenda from "./ScheduleAgenda";
 
-interface Labels {
+interface Labels extends ControlLabels {
   timeColumn: string;
   roomTba: string;
-  viewLabel: string;
-  viewAll: string;
-  viewMine: string;
-  viewMineOnly: string;
   favouriteAdd: string;
   favouriteRemove: string;
   empty: string;
-  exportAll: string;
-  exportMine: string;
-  print: string;
+  noResults: string;
+  exportAllTitle: string;
+  exportMineTitle: string;
 }
 
 interface ProgrammeBrowserProps {
@@ -35,20 +30,20 @@ interface ProgrammeBrowserProps {
   labels: Labels;
   initialFavourites: string[];
   initialView: ScheduleView;
+  initialFilters: TalkFilters;
 }
 
-const VIEWS: ScheduleView[] = ["all", "mine", "mine-only"];
-
-// The interactive layer over the schedule (#442).
+// The interactive layer over the schedule (#442, #448).
 //
-// It owns the selection and mirrors it into the querystring, the same way the
-// session filters do (#107). Two consequences worth keeping in mind:
+// It owns the selection, the view and the filters, and mirrors all three into
+// the querystring — the same mechanism as the session filters (#107). Two
+// consequences worth keeping in mind:
 //
 //   - the filtering happens here, in the browser, on the payload the server
 //     already rendered. The HTML is identical for every visitor, so the page
-//     stays cacheable instead of forking into one variant per selection;
+//     stays cacheable instead of forking into one variant per combination;
 //   - `replace`, never `push`: with `push` the back button would walk back
-//     through every star the visitor clicked.
+//     through every star and every chip the visitor clicked.
 export default function ProgrammeBrowser({
   schedule,
   locale,
@@ -56,17 +51,20 @@ export default function ProgrammeBrowser({
   labels,
   initialFavourites,
   initialView,
+  initialFilters,
 }: ProgrammeBrowserProps) {
   const router = useRouter();
   const pathname = usePathname();
   const [favourites, setFavourites] = useState<string[]>(initialFavourites);
   const [view, setView] = useState<ScheduleView>(initialView);
+  const [filters, setFilters] = useState<TalkFilters>(initialFilters);
 
-  function syncUrl(nextFavourites: string[], nextView: ScheduleView) {
+  function syncUrl(nextFavourites: string[], nextView: ScheduleView, nextFilters: TalkFilters) {
     const params = new URLSearchParams();
     const fav = serializeFavourites(nextFavourites);
     if (fav) params.set("fav", fav);
     if (nextView !== "all") params.set("view", nextView);
+    applyFiltersToParams(params, nextFilters);
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   }
@@ -74,26 +72,31 @@ export default function ProgrammeBrowser({
   function onToggleFavourite(slug: string) {
     const next = toggleFavourite(favourites, slug);
     setFavourites(next);
-    syncUrl(next, view);
+    syncUrl(next, view, filters);
   }
 
   function onChangeView(next: ScheduleView) {
     setView(next);
-    syncUrl(favourites, next);
+    syncUrl(favourites, next, filters);
+  }
+
+  function onChangeFilters(next: Partial<TalkFilters>) {
+    const merged = { ...filters, ...next };
+    setFilters(merged);
+    syncUrl(favourites, view, merged);
   }
 
   const selected = useMemo(() => new Set(favourites), [favourites]);
 
   // Filtering the payload rather than the rows: the row builder then recomputes
-  // the columns too, so a selection spread over three rooms draws three columns
-  // instead of eight mostly-empty ones. Rows and columns come out of the same
-  // call — they index into each other and must never be derived apart.
+  // the columns too, so a filter that empties a room drops its column instead of
+  // leaving eight mostly-blank ones. Rows and columns come out of the same call
+  // — they index into each other and must never be derived apart.
   const { rows, rooms, matched } = useMemo(() => {
-    if (view === "all") {
-      return { rows: buildScheduleRows(schedule), rooms: schedule.rooms, matched: 0 };
-    }
-
-    const talks = schedule.talks.filter((talk) => selected.has(talk.slug));
+    const talks = schedule.talks.filter(
+      (talk) =>
+        matchesFilters(talk, filters, locale) && (view === "all" || selected.has(talk.slug)),
+    );
     const kept = new Set(
       talks.map((talk) => (talk.roomId != null ? `id:${talk.roomId}` : `label:${talk.room ?? ""}`)),
     );
@@ -107,19 +110,32 @@ export default function ProgrammeBrowser({
         talks,
         rooms: visibleRooms,
         // The shared moments — welcome, keynotes, breaks, lunch, the party —
-        // are never starred: they concern everyone. They show, or they do not.
-        entries: view === "mine" ? schedule.entries : [],
+        // are never starred and never filtered: they concern everyone. They
+        // frame the day, unless the visitor asked for their sessions alone.
+        entries: view === "mine-only" ? [] : schedule.entries,
       }),
       rooms: visibleRooms,
       matched: talks.length,
     };
-  }, [schedule, selected, view]);
+  }, [schedule, selected, view, filters, locale]);
 
-  const viewLabels: Record<ScheduleView, string> = {
-    all: labels.viewAll,
-    mine: labels.viewMine,
-    "mine-only": labels.viewMineOnly,
-  };
+  // Only the values an edition actually uses become chips: a filter that
+  // matches nothing is worse than no filter at all (#107).
+  const categories = useMemo(
+    () => [
+      ...new Set(
+        schedule.talks
+          .map((talk) => (talk.category ? localizedField(talk.category, "name", locale) : ""))
+          .filter(Boolean),
+      ),
+    ],
+    [schedule.talks, locale],
+  );
+  const languages = useMemo(
+    () => [...new Set(schedule.talks.map((talk) => talk.language).filter(Boolean))],
+    [schedule.talks],
+  );
+
   const favouriteLabels = { add: labels.favouriteAdd, remove: labels.favouriteRemove };
 
   // The export follows what is on screen rather than adding a second control
@@ -133,57 +149,28 @@ export default function ProgrammeBrowser({
 
   return (
     <div>
-      <div className="no-print mb-6 flex flex-wrap items-center gap-4">
-        {/* A radio group, not three buttons: the three views are one choice, and
-            a screen reader has to hear it that way. Nothing else may live inside
-            it — hence the export link as a sibling. */}
-        <div
-          role="radiogroup"
-          aria-label={labels.viewLabel}
-          className="inline-flex flex-wrap gap-2 rounded-2xl bg-blanc-casse p-1"
-        >
-          {VIEWS.map((value) => (
-            <button
-              key={value}
-              type="button"
-              role="radio"
-              aria-checked={view === value}
-              onClick={() => onChangeView(value)}
-              className={`rounded-[12px] px-4 py-2 text-sm font-bold transition-colors focus:outline-none focus:ring-2 focus:ring-malachite/50 ${
-                view === value ? "bg-blanc text-noir shadow-card" : "text-gris hover:text-noir"
-              }`}
-            >
-              {viewLabels[value]}
-            </button>
-          ))}
-        </div>
+      <ProgrammeControls
+        view={view}
+        onChangeView={onChangeView}
+        filters={filters}
+        onChangeFilters={onChangeFilters}
+        categories={categories}
+        languages={languages}
+        labels={{
+          ...labels,
+          exportTitle: exportsSelection ? labels.exportMineTitle : labels.exportAllTitle,
+        }}
+        icsHref={icsHref}
+      />
 
-        <a
-          href={icsHref}
-          className="rounded-[12px] px-2 py-2 text-sm font-bold text-bleu hover:underline focus:outline-none focus:ring-2 focus:ring-malachite/50"
-        >
-          {exportsSelection ? labels.exportMine : labels.exportAll}
-        </a>
-
-        {/* The printable version is the browser's own (#108): what it prints is
-            this very page, minus its controls. */}
-        <button
-          type="button"
-          onClick={() => window.print()}
-          className="rounded-[12px] px-2 py-2 text-sm font-bold text-bleu hover:underline focus:outline-none focus:ring-2 focus:ring-malachite/50"
-        >
-          {labels.print}
-        </button>
-      </div>
-
-      {/* On `matched`, not on the length of the selection: a link bookmarked
-          weeks ago may name only sessions that have since been cancelled, and
-          showing the day's skeleton with nothing in it would explain nothing.
-          aria-live because switching view changes the page under a screen
-          reader that would otherwise hear no result at all. */}
-      {view !== "all" && matched === 0 ? (
+      {/* Two different silences: nothing starred yet, or a filter that matches
+          nothing. `matched` counts what survives *both*, so the two are told
+          apart rather than sharing one vague sentence.
+          aria-live because a chip or a view change rewrites the page under a
+          screen reader that would otherwise hear no result at all. */}
+      {matched === 0 ? (
         <p className="rounded-3xl bg-blanc p-6 text-lg text-gris shadow-card" aria-live="polite">
-          {labels.empty}
+          {view !== "all" && favourites.length === 0 ? labels.empty : labels.noResults}
         </p>
       ) : (
         <>

--- a/src/frontend/src/components/programme/ProgrammeControls.tsx
+++ b/src/frontend/src/components/programme/ProgrammeControls.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useState } from "react";
+
+import { Chip, ChipRow } from "@/components/FilterChip";
+import { activeFilterCount, type TalkFilters } from "@/lib/talk-filters";
+import type { ScheduleView } from "@/lib/favourites";
+import type { TalkFormat, TalkLevel } from "@/lib/types";
+
+const FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"];
+const LEVELS: TalkLevel[] = ["DEBUTANT", "INTERMEDIAIRE", "CONFIRME"];
+const VIEWS: ScheduleView[] = ["all", "mine", "mine-only"];
+
+// Families offered here — no free-text search on the grid, so `q` never counts
+// toward the badge (#448).
+const FAMILIES: (keyof TalkFilters)[] = ["format", "category", "level", "language"];
+
+export interface ControlLabels {
+  filterZone: string;
+  actionZone: string;
+  filters: string;
+  reset: string;
+  format: string;
+  level: string;
+  language: string;
+  category: string;
+  moreFilters: string;
+  viewLabel: string;
+  viewAll: string;
+  viewMine: string;
+  viewMineOnly: string;
+  formatLabels: Record<string, string>;
+  levelLabels: Record<string, string>;
+  languageLabels: Record<string, string>;
+  exportShort: string;
+  exportTitle: string;
+  printShort: string;
+  printTitle: string;
+}
+
+interface ProgrammeControlsProps {
+  view: ScheduleView;
+  onChangeView: (view: ScheduleView) => void;
+  filters: TalkFilters;
+  onChangeFilters: (next: Partial<TalkFilters>) => void;
+  categories: string[];
+  languages: string[];
+  labels: ControlLabels;
+  icsHref: string;
+}
+
+// Everything above the grid, in two zones (#448): what filters it, and what
+// acts on it.
+//
+// They looked alike before — a radio group and two sentences in blue — and
+// nothing said that one changes the view while the other downloads a file.
+export default function ProgrammeControls({
+  view,
+  onChangeView,
+  filters,
+  onChangeFilters,
+  categories,
+  languages,
+  labels,
+  icsHref,
+}: ProgrammeControlsProps) {
+  // Same two disclosures as the session list (#246, #256): level and language
+  // behind "more filters", and the whole panel collapsed on mobile. Open on
+  // mount when a shared link already carries a filter, or the visitor cannot
+  // see what is being applied.
+  const [showMore, setShowMore] = useState(Boolean(filters.level || filters.language));
+  const [showPanel, setShowPanel] = useState(activeFilterCount(filters, FAMILIES) > 0);
+
+  const hasLanguageFilter = languages.length > 1;
+  const badge = activeFilterCount(filters, hasLanguageFilter ? FAMILIES : ["format", "category", "level"]);
+  const collapsedCount =
+    (filters.level ? 1 : 0) + (hasLanguageFilter && filters.language ? 1 : 0);
+
+  function toggle(key: keyof TalkFilters, value: string) {
+    onChangeFilters({ [key]: filters[key] === value ? "" : value });
+  }
+
+  const viewLabels: Record<ScheduleView, string> = {
+    all: labels.viewAll,
+    mine: labels.viewMine,
+    "mine-only": labels.viewMineOnly,
+  };
+
+  return (
+    // no-print: a control on paper is noise (#108).
+    <div className="no-print mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      {/* ---- Filtrer ---- */}
+      <section aria-label={labels.filterZone} className="flex-1">
+        <button
+          type="button"
+          onClick={() => setShowPanel((v) => !v)}
+          aria-expanded={showPanel}
+          aria-controls="programme-filter-panel"
+          className="mb-3 flex w-full items-center justify-between rounded-2xl bg-blanc px-5 py-3 text-sm font-semibold text-noir shadow-card sm:hidden"
+        >
+          <span className="flex items-center gap-2">
+            {labels.filters}
+            {badge > 0 && (
+              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-malachite px-1.5 text-xs font-semibold text-blanc">
+                {badge}
+              </span>
+            )}
+          </span>
+          <span aria-hidden className={`transition-transform ${showPanel ? "rotate-180" : ""}`}>
+            ⌄
+          </span>
+        </button>
+
+        <div
+          id="programme-filter-panel"
+          className={`${showPanel ? "block" : "hidden"} space-y-4 rounded-2xl bg-blanc p-5 shadow-card sm:block`}
+        >
+          {/* The view selector is a radio group and may hold nothing but its
+              three radios — the filters are its neighbours, not its children. */}
+          <div
+            role="radiogroup"
+            aria-label={labels.viewLabel}
+            className="inline-flex flex-wrap gap-2 rounded-2xl bg-blanc-casse p-1"
+          >
+            {VIEWS.map((value) => (
+              <button
+                key={value}
+                type="button"
+                role="radio"
+                aria-checked={view === value}
+                onClick={() => onChangeView(value)}
+                className={`rounded-[12px] px-4 py-2 text-sm font-bold transition-colors focus:outline-none focus:ring-2 focus:ring-malachite/50 ${
+                  view === value ? "bg-blanc text-noir shadow-card" : "text-gris hover:text-noir"
+                }`}
+              >
+                {viewLabels[value]}
+              </button>
+            ))}
+          </div>
+
+          <ChipRow label={labels.format}>
+            {FORMATS.map((format) => (
+              <Chip
+                key={format}
+                active={filters.format === format}
+                onClick={() => toggle("format", format)}
+              >
+                {labels.formatLabels[format]}
+              </Chip>
+            ))}
+          </ChipRow>
+
+          {categories.length > 0 && (
+            <ChipRow label={labels.category}>
+              {categories.map((category) => (
+                <Chip
+                  key={category}
+                  active={filters.category === category}
+                  onClick={() => toggle("category", category)}
+                >
+                  {category}
+                </Chip>
+              ))}
+            </ChipRow>
+          )}
+
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowMore((v) => !v)}
+              aria-expanded={showMore}
+              aria-controls="programme-more-filters"
+              className="flex items-center gap-1.5 text-sm font-medium text-bleu hover:underline"
+            >
+              <span aria-hidden>{showMore ? "⌄" : "›"}</span>
+              {labels.moreFilters}
+              {!showMore && collapsedCount > 0 && (
+                <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-malachite px-1.5 text-xs font-semibold text-blanc">
+                  {collapsedCount}
+                </span>
+              )}
+            </button>
+
+            <div id="programme-more-filters" className={`${showMore ? "mt-4 space-y-4" : "hidden"}`}>
+              <ChipRow label={labels.level}>
+                {LEVELS.map((level) => (
+                  <Chip
+                    key={level}
+                    active={filters.level === level}
+                    onClick={() => toggle("level", level)}
+                  >
+                    {labels.levelLabels[level]}
+                  </Chip>
+                ))}
+              </ChipRow>
+
+              {/* Only when the edition actually has two — a filter that matches
+                  everything is a filter that helps nobody. */}
+              {hasLanguageFilter && (
+                <ChipRow label={labels.language}>
+                  {languages.map((language) => (
+                    <Chip
+                      key={language}
+                      active={filters.language === language}
+                      onClick={() => toggle("language", language)}
+                    >
+                      {labels.languageLabels[language] ?? language.toUpperCase()}
+                    </Chip>
+                  ))}
+                </ChipRow>
+              )}
+            </div>
+          </div>
+
+          {badge > 0 && (
+            <button
+              type="button"
+              onClick={() =>
+                onChangeFilters({ format: "", level: "", language: "", category: "" })
+              }
+              className="text-sm font-medium text-bleu hover:underline"
+            >
+              {labels.reset}
+            </button>
+          )}
+        </div>
+      </section>
+
+      {/* ---- Agir ---- */}
+      <section
+        aria-label={labels.actionZone}
+        className="flex shrink-0 flex-wrap items-center gap-3 lg:pt-1"
+      >
+        {/* Short on the button, the whole sentence in the tooltip *and* in the
+            accessible name: `title` alone is announced by almost nothing, and a
+            visible label must be contained in the accessible one or voice
+            control cannot say "Exporter". */}
+        <a
+          href={icsHref}
+          title={labels.exportTitle}
+          aria-label={labels.exportTitle}
+          className="rounded-[12px] bg-blanc px-4 py-2 text-sm font-bold text-noir shadow-card transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
+        >
+          {labels.exportShort}
+        </a>
+        <button
+          type="button"
+          onClick={() => window.print()}
+          title={labels.printTitle}
+          aria-label={labels.printTitle}
+          className="rounded-[12px] bg-blanc px-4 py-2 text-sm font-bold text-noir shadow-card transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
+        >
+          {labels.printShort}
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/frontend/src/lib/talk-filters.test.ts
+++ b/src/frontend/src/lib/talk-filters.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  EMPTY_FILTERS,
+  activeFilterCount,
+  matchesFilters,
+  parseFilters,
+  applyFiltersToParams,
+  type FilterableTalk,
+} from "./talk-filters";
+
+const talk: FilterableTalk = {
+  title: "Kubernetes en production",
+  format: "CONFERENCE",
+  level: "CONFIRME",
+  language: "fr",
+  category: { nameFr: "Cloud & DevOps", nameEn: "Cloud & DevOps" },
+  speakers: [{ name: "Marie Dupont" }],
+};
+
+describe("session filters (#448)", () => {
+  it("keeps everything when nothing is filtered", () => {
+    expect(matchesFilters(talk, EMPTY_FILTERS, "fr")).toBe(true);
+  });
+
+  it("filters on each family", () => {
+    expect(matchesFilters(talk, { ...EMPTY_FILTERS, format: "QUICKIE" }, "fr")).toBe(false);
+    expect(matchesFilters(talk, { ...EMPTY_FILTERS, level: "DEBUTANT" }, "fr")).toBe(false);
+    expect(matchesFilters(talk, { ...EMPTY_FILTERS, language: "en" }, "fr")).toBe(false);
+    expect(matchesFilters(talk, { ...EMPTY_FILTERS, category: "Web & Mobile" }, "fr")).toBe(false);
+  });
+
+  it("matches a category on its localized name, the only handle the payload gives", () => {
+    expect(matchesFilters(talk, { ...EMPTY_FILTERS, category: "Cloud & DevOps" }, "fr")).toBe(true);
+  });
+
+  it("searches the title and the speakers", () => {
+    expect(matchesFilters(talk, { ...EMPTY_FILTERS, q: "kubernetes" }, "fr")).toBe(true);
+    expect(matchesFilters(talk, { ...EMPTY_FILTERS, q: "dupont" }, "fr")).toBe(true);
+    expect(matchesFilters(talk, { ...EMPTY_FILTERS, q: "terraform" }, "fr")).toBe(false);
+  });
+
+  it("combines families as an AND", () => {
+    const filters = { ...EMPTY_FILTERS, format: "CONFERENCE", language: "en" };
+    expect(matchesFilters(talk, filters, "fr")).toBe(false);
+  });
+
+  it("counts only the families the view actually renders", () => {
+    // The grid has no search field: counting `q` would send the visitor
+    // hunting for a control that is not there (#256).
+    const filters = { ...EMPTY_FILTERS, q: "kube", format: "CONFERENCE" };
+    expect(activeFilterCount(filters, ["format", "level", "language", "category"])).toBe(1);
+    expect(activeFilterCount(filters, ["q", "format", "level", "language", "category"])).toBe(2);
+  });
+
+  it("round-trips through the querystring", () => {
+    const filters = { ...EMPTY_FILTERS, format: "QUICKIE", category: "Web & Mobile" };
+    const params = new URLSearchParams();
+    applyFiltersToParams(params, filters);
+
+    expect(params.get("format")).toBe("QUICKIE");
+    expect(params.has("level")).toBe(false);
+    expect(parseFilters((key) => params.get(key) ?? undefined)).toEqual(filters);
+  });
+});

--- a/src/frontend/src/lib/talk-filters.ts
+++ b/src/frontend/src/lib/talk-filters.ts
@@ -1,0 +1,100 @@
+import { localizedField } from "./i18n-helpers";
+
+// The session filters, shared by the list (#107) and the grid (#448).
+//
+// Both views filter the same sessions on the same four families, and a
+// selection made in one has to hold in the other — so the predicate lives here
+// rather than being written twice and drifting.
+
+export interface TalkFilters {
+  /** Free-text search. The grid has no search field and passes an empty one. */
+  q: string;
+  format: string;
+  level: string;
+  language: string;
+  /**
+   * The localized category *name*, not a slug: the public payload carries no
+   * slug for categories, so the chip value is what the chip shows (#107).
+   */
+  category: string;
+}
+
+export const EMPTY_FILTERS: TalkFilters = {
+  q: "",
+  format: "",
+  level: "",
+  language: "",
+  category: "",
+};
+
+/** The least a session must expose to be filtered. */
+export interface FilterableTalk {
+  title: string;
+  format: string;
+  level: string | null;
+  language: string;
+  category: { nameFr: string; nameEn: string } | null;
+  speakers: { name: string }[];
+}
+
+export function matchesFilters(
+  talk: FilterableTalk,
+  filters: TalkFilters,
+  locale: string,
+): boolean {
+  if (filters.format && talk.format !== filters.format) return false;
+  if (filters.level && talk.level !== filters.level) return false;
+  if (filters.language && talk.language !== filters.language) return false;
+  if (filters.category) {
+    const name = talk.category ? localizedField(talk.category, "name", locale) : "";
+    if (name !== filters.category) return false;
+  }
+
+  const q = filters.q.trim().toLowerCase();
+  if (q) {
+    const title = talk.title.toLowerCase();
+    const speakers = talk.speakers.map((s) => s.name).join(" ").toLowerCase();
+    if (!title.includes(q) && !speakers.includes(q)) return false;
+  }
+
+  return true;
+}
+
+export function hasActiveFilter(filters: TalkFilters): boolean {
+  return Object.values(filters).some(Boolean);
+}
+
+/**
+ * How many filters to announce on the collapsed mobile panel (#256).
+ *
+ * `families` names what the view actually renders: the grid offers no search
+ * field, and the language chips only appear when an edition has more than one
+ * language — counting a filter the visitor cannot see would leave them hunting
+ * for it.
+ */
+export function activeFilterCount(
+  filters: TalkFilters,
+  families: (keyof TalkFilters)[],
+): number {
+  return families.filter((family) => filters[family]).length;
+}
+
+/** Read the filters a shared link carries. */
+export function parseFilters(
+  read: (key: string) => string | undefined,
+): TalkFilters {
+  return {
+    q: read("q") ?? "",
+    format: read("format") ?? "",
+    level: read("level") ?? "",
+    language: read("language") ?? "",
+    category: read("category") ?? "",
+  };
+}
+
+/** Write them back, dropping the empty ones so the URL stays readable. */
+export function applyFiltersToParams(params: URLSearchParams, filters: TalkFilters): void {
+  for (const [key, value] of Object.entries(filters)) {
+    if (value) params.set(key, value);
+  }
+}


### PR DESCRIPTION
Deux zones au-dessus de la grille : ce qui filtre, et ce qui agit.

## Ce qui change

**Zone « Filtrer »** — le sélecteur de vue à trois états, plus les **quatre familles de #107** : format, catégorie, niveau, langue. Mêmes paramètres d'URL que la liste, donc un filtre posé dans `/conferences` est encore actif en arrivant sur `/programme`, et réciproquement.

**Zone « Agir »** — deux boutons, « Exporter » et « Imprimer ». La phrase complète (« Exporter mes favoris vers mon agenda ») devient l'infobulle **et** le nom accessible : `title` seul n'est annoncé par presque rien, et le mot visible doit être contenu dans le nom accessible ou la commande vocale ne trouve pas « Exporter ».

**Une colonne disparaît quand le filtre la vide**, comme le faisait déjà la vue favoris.

**Et le vide se dit maintenant en deux phrases** : « vous n'avez encore choisi aucune session » n'est pas « aucune session ne correspond à ces filtres ». C'est `matched` — le compte après filtrage *et* sélection — qui tranche.

## Deux mutualisations plutôt qu'un copier-coller

Le prédicat de filtrage part dans [`lib/talk-filters.ts`](src/frontend/src/lib/talk-filters.ts) : deux vues qui filtrent les mêmes sessions sur les mêmes familles n'avaient pas à en tenir deux copies, qui auraient divergé au premier ajustement. Et les pastilles dont les deux barres sont faites deviennent un composant partagé — c'est ce qui garantit qu'elles se ressemblent.

`ConferencesBrowser` est donc touché, alors que l'issue porte sur la grille. C'est délibéré et le périmètre en reste petit : il perd sa copie du prédicat et ses définitions locales de pastilles, rien d'autre.

## Le mobile reprend ce que la liste a déjà résolu

Zone repliée derrière un bouton « Filtres » avec le nombre de filtres actifs (#256), niveau et langue derrière « Plus de filtres » (#246). Pas de troisième réponse inventée pour le même problème.

Deux détails hérités de #107 et conservés : le panneau s'ouvre au chargement si l'URL porte déjà un filtre — sinon on ne voit pas ce qui s'applique — et **le compteur ne compte que les familles réellement affichées**. La grille n'a pas de champ de recherche, `q` n'entre donc pas dans le badge, et les langues n'apparaissent que si l'édition en a plus d'une.

## Plan de test

**Vérifié**

- Suites : frontend 169/169, dont 7 nouveaux tests sur le prédicat, le comptage et l'aller-retour dans la querystring. `tsc` et `eslint` sans erreur.
- Navigateur (Chrome DevTools MCP) à 1440 px :
  - filtre « Quickie » → `?format=QUICKIE`, 5 sessions, et les colonnes tombent de huit à deux (Pastel, Salle Quickies) ;
  - `?format=QUICKIE&category=Web & Mobile` donne **les mêmes 4 sessions** sur `/conferences` et sur `/programme`, avec les mêmes pastilles actives ;
  - `?format=WORKSHOP` → « Aucune session ne correspond à ces filtres », pas de tableau, bouton « Réinitialiser » présent ;
  - boutons d'action : `title` **et** `aria-label` portent la phrase complète, l'export vise bien `/api/editions/2026/schedule.ics`.
- Mobile 390 px : panneau replié par défaut (`aria-expanded="false"`), badge « 1 » quand un filtre vient de l'URL et panneau ouvert dans ce cas, pas de défilement latéral du corps.
- Console propre hors l'avertissement `next/image` du logo, présent sur tout le site.

**Non vérifié**

- **Pas de lecteur d'écran réel.** Le `radiogroup`, les `aria-pressed` des pastilles, les noms accessibles des actions et le message en `aria-live` ont été relus dans le DOM, pas écoutés.
- Aucun test automatisé sur les composants : seul le prédicat est couvert. Le comportement de la barre a été vérifié en navigateur.
- Rien n'a été rejoué sur des données de production.
- Le rendu d'impression n'est pas touché ici — c'est #449, et c'est là que le choix « par heure / par salle » viendra se loger dans la zone d'actions.

Refs #448
