### PR TITLE
Programme — un document fait pour le papier

### DIFF
--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -391,7 +391,13 @@
     "noResults": "No session matches these filters.",
     "allSessions": "See every session as a list",
     "comingSoonTitle": "The schedule is on its way",
-    "comingSoonBody": "The DevFest Toulouse {year} sessions are still being placed. The grid will be published here as soon as it is final."
+    "comingSoonBody": "The DevFest Toulouse {year} sessions are still being placed. The grid will be published here as soon as it is final.",
+    "printGroupingLabel": "Print",
+    "printByTime": "By time",
+    "printByRoom": "By room",
+    "printSource": "Session details: {url}",
+    "printSelection": "Personal selection — this document is not the whole schedule.",
+    "printCommon": "Shared moments"
   },
   "venue": {
     "pageTitle": "Venue & practical info",

--- a/src/frontend/messages/fr.json
+++ b/src/frontend/messages/fr.json
@@ -391,7 +391,13 @@
     "noResults": "Aucune session ne correspond à ces filtres.",
     "allSessions": "Voir toutes les sessions en liste",
     "comingSoonTitle": "La grille horaire arrive bientôt",
-    "comingSoonBody": "Les sessions du DevFest Toulouse {year} sont en cours de placement. La grille sera publiée ici dès qu'elle sera figée."
+    "comingSoonBody": "Les sessions du DevFest Toulouse {year} sont en cours de placement. La grille sera publiée ici dès qu'elle sera figée.",
+    "printGroupingLabel": "Impression",
+    "printByTime": "Par heure",
+    "printByRoom": "Par salle",
+    "printSource": "Détail des sessions : {url}",
+    "printSelection": "Sélection personnelle — ce document ne contient pas tout le programme.",
+    "printCommon": "Moments communs"
   },
   "venue": {
     "pageTitle": "Lieu & infos pratiques",

--- a/src/frontend/src/app/[locale]/programme/page.tsx
+++ b/src/frontend/src/app/[locale]/programme/page.tsx
@@ -8,7 +8,13 @@ import Breadcrumb from "@/components/Breadcrumb";
 import ProgrammeBrowser from "@/components/programme/ProgrammeBrowser";
 import { parseFavourites, parseView } from "@/lib/favourites";
 import { parseFilters } from "@/lib/talk-filters";
+import { formatEventDate } from "@/lib/datetime";
+import { parsePrintGrouping } from "@/lib/print";
 import type { TalkFormat, TalkLevel } from "@/lib/types";
+
+// Absolute: the printed header carries it onto paper, where a relative path
+// means nothing (#449).
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
@@ -69,7 +75,8 @@ export default async function ProgrammePage({
 
   return (
     <div className="px-6 py-8 lg:py-12">
-      <div className={READING_COLUMN}>
+      {/* no-print: the printed document carries its own header (#449). */}
+      <div className={`${READING_COLUMN} no-print`}>
         <Breadcrumb items={breadcrumbItems} />
 
         <h1 className="mt-6 text-3xl lg:text-[64px] lg:leading-[120%] font-bold text-noir">
@@ -131,10 +138,27 @@ export default async function ProgrammePage({
                 exportTitle: tcal("exportAll"),
                 printShort: t("print"),
                 printTitle: t("printTitle"),
+                printGroupingLabel: t("printGroupingLabel"),
+                printByTime: t("printByTime"),
+                printByRoom: t("printByRoom"),
+                print: {
+                  title: `DevFest Toulouse ${edition.year}`,
+                  subtitle: [
+                    edition.startDate ? formatEventDate(edition.startDate, locale) : "",
+                    [edition.venueName, edition.venueAddress].filter(Boolean).join(", "),
+                  ]
+                    .filter(Boolean)
+                    .join(" — "),
+                  source: t("printSource", { url: `${BASE_URL}/${locale}/programme` }),
+                  selectionNote: t("printSelection"),
+                  roomTba: t("roomTba"),
+                  common: t("printCommon"),
+                },
               }}
               initialFavourites={parseFavourites(first(sp.fav))}
               initialView={parseView(first(sp.view))}
               initialFilters={parseFilters((key) => first(sp[key]))}
+              initialPrintGrouping={parsePrintGrouping(first(sp.print))}
             />
           </div>
 

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -493,16 +493,27 @@ body {
 }
 
 /* ========================================
- * Print (#108)
+ * Print (#108, rewritten in #449)
  *
  * The printable schedule is the browser's own Save-as-PDF, driven by a
  * stylesheet rather than a generator: no Chromium in the backend image, no
- * layout re-implemented by hand, and a printed page that cannot drift from the
- * one on screen because it is the one on screen.
+ * layout re-implemented by hand.
  *
- * What prints is the chronological agenda, not the grid: eight rooms at 180 px
- * come to more than 1500 px, which no sheet of A4 holds without cutting.
+ * But it is no longer the screen with its chrome removed. Paper has no hover,
+ * no link, no reliable colour and no room for cards — so a separate document
+ * (.print-only) is rendered from the same rows, and both the grid and the
+ * mobile agenda step aside.
+ *
+ * Every rule here is hand-written rather than expressed as a Tailwind `print:`
+ * variant: those emitted no CSS at all in this setup, and a class that produces
+ * nothing fails without a word.
  * ======================================== */
+
+/* Off screen, and out of the accessibility tree with it. */
+.print-only {
+  display: none;
+}
+
 @media print {
   /* Site chrome carries nothing onto paper — navigation least of all. */
   header,
@@ -514,36 +525,118 @@ body {
 
   body {
     background: #fff;
+    color: #000;
+    /* Paper is read at arm's length, not at screen distance. */
+    font-size: 10pt;
+    line-height: 1.35;
   }
 
-  /* The grid gives way to the agenda, whatever the width of the screen this is
-     printed from. Both overrides live here rather than in Tailwind `print:`
-     variants — those emitted no CSS at all in this setup, and a class that
-     produces nothing fails without a word. */
-  .print-grid {
+  /* The two screen renderings step aside for the printed document. */
+  .print-grid,
+  .print-agenda {
     display: none !important;
   }
 
-  .print-agenda {
+  .print-only {
     display: block !important;
   }
 
-  /* Ink, not screen colours: pale grey on white survives neither a laser
-     printer nor a photocopy. */
-  .print-agenda,
-  .print-agenda * {
+  .print-only * {
     color: #000 !important;
   }
 
-  /* A session must not be cut across two sheets. */
-  .print-agenda a,
-  .print-agenda section {
+  @page {
+    size: A4 portrait;
+    margin: 14mm 12mm;
+  }
+
+  /* --- Document header, repeated nowhere: it opens the first sheet --- */
+  .print-head {
+    border-bottom: 2px solid #000;
+    padding-bottom: 6pt;
+    margin-bottom: 10pt;
+  }
+  .print-head h2 {
+    font-size: 18pt;
+    font-weight: 700;
+    margin: 0;
+  }
+  .print-head p {
+    margin: 2pt 0 0;
+    font-size: 9.5pt;
+  }
+  .print-note {
+    font-weight: 700;
+  }
+  .print-source {
+    font-size: 8.5pt;
+  }
+
+  /* --- A moment shared by everyone: a full-width rule, not a card --- */
+  .print-band {
+    border-top: 1px solid #000;
+    border-bottom: 1px solid #000;
+    padding: 3pt 0;
+    margin: 8pt 0;
+    font-weight: 700;
     break-inside: avoid;
   }
 
-  /* A shadow prints as a grey smear; a hairline says the same thing. */
-  .print-agenda a {
-    box-shadow: none !important;
-    border: 1px solid #999;
+  /* --- A time slot, or a room --- */
+  .print-slot,
+  .print-room {
+    margin-bottom: 8pt;
+    break-inside: avoid;
+  }
+  .print-slot h3,
+  .print-room h3 {
+    font-size: 12pt;
+    font-weight: 700;
+    margin: 0 0 3pt;
+    border-bottom: 1px solid #666;
+  }
+  /* A room starts its own sheet: these are pinned on doors, one per door. */
+  .print-room {
+    break-before: page;
+  }
+  .print-room-sub {
+    margin: 0 0 4pt;
+    font-size: 8.5pt;
+  }
+  .print-room:first-of-type {
+    break-before: auto;
+  }
+
+  .print-slot ul,
+  .print-room ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .print-slot li,
+  .print-room li {
+    display: grid;
+    /* 28mm, not 22: "Amphithéâtre" and "Salle Communautés" overflowed into the
+       title column and printed on top of it. Seen in the PDF, invisible in the
+       rules themselves. */
+    grid-template-columns: 28mm 1fr;
+    gap: 0 4pt;
+    padding: 2.5pt 0;
+    border-bottom: 1px dotted #999;
+    break-inside: avoid;
+  }
+
+  .print-time {
+    grid-row: span 3;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    overflow-wrap: break-word;
+  }
+  .print-title {
+    font-weight: 700;
+  }
+  .print-speakers,
+  .print-meta {
+    font-size: 8.5pt;
   }
 }

--- a/src/frontend/src/components/programme/ProgrammeBrowser.tsx
+++ b/src/frontend/src/components/programme/ProgrammeBrowser.tsx
@@ -9,6 +9,8 @@ import { serializeFavourites, toggleFavourite, type ScheduleView } from "@/lib/f
 import { applyFiltersToParams, matchesFilters, type TalkFilters } from "@/lib/talk-filters";
 import { localizedField } from "@/lib/i18n-helpers";
 import ProgrammeControls, { type ControlLabels } from "./ProgrammeControls";
+import ProgrammePrint, { type PrintLabels } from "./ProgrammePrint";
+import type { PrintGrouping } from "@/lib/print";
 import ScheduleGrid from "./ScheduleGrid";
 import ScheduleAgenda from "./ScheduleAgenda";
 
@@ -21,6 +23,7 @@ interface Labels extends ControlLabels {
   noResults: string;
   exportAllTitle: string;
   exportMineTitle: string;
+  print: PrintLabels;
 }
 
 interface ProgrammeBrowserProps {
@@ -31,6 +34,7 @@ interface ProgrammeBrowserProps {
   initialFavourites: string[];
   initialView: ScheduleView;
   initialFilters: TalkFilters;
+  initialPrintGrouping: PrintGrouping;
 }
 
 // The interactive layer over the schedule (#442, #448).
@@ -52,18 +56,26 @@ export default function ProgrammeBrowser({
   initialFavourites,
   initialView,
   initialFilters,
+  initialPrintGrouping,
 }: ProgrammeBrowserProps) {
   const router = useRouter();
   const pathname = usePathname();
   const [favourites, setFavourites] = useState<string[]>(initialFavourites);
   const [view, setView] = useState<ScheduleView>(initialView);
   const [filters, setFilters] = useState<TalkFilters>(initialFilters);
+  const [printGrouping, setPrintGrouping] = useState<PrintGrouping>(initialPrintGrouping);
 
-  function syncUrl(nextFavourites: string[], nextView: ScheduleView, nextFilters: TalkFilters) {
+  function syncUrl(
+    nextFavourites: string[],
+    nextView: ScheduleView,
+    nextFilters: TalkFilters,
+    nextPrint: PrintGrouping = printGrouping,
+  ) {
     const params = new URLSearchParams();
     const fav = serializeFavourites(nextFavourites);
     if (fav) params.set("fav", fav);
     if (nextView !== "all") params.set("view", nextView);
+    if (nextPrint !== "time") params.set("print", nextPrint);
     applyFiltersToParams(params, nextFilters);
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
@@ -137,6 +149,9 @@ export default function ProgrammeBrowser({
   );
 
   const favouriteLabels = { add: labels.favouriteAdd, remove: labels.favouriteRemove };
+  // A printed sheet leaves the browser: it has to say when it is a subset, or
+  // it reads as the whole programme in someone else's hands.
+  const hasActiveFilters = Object.values(filters).some(Boolean);
 
   // The export follows what is on screen rather than adding a second control
   // that could disagree with it (#443).
@@ -161,7 +176,26 @@ export default function ProgrammeBrowser({
           exportTitle: exportsSelection ? labels.exportMineTitle : labels.exportAllTitle,
         }}
         icsHref={icsHref}
+        printGrouping={printGrouping}
+        onChangePrintGrouping={(next) => {
+          setPrintGrouping(next);
+          syncUrl(favourites, view, filters, next);
+        }}
       />
+
+      {/* The printed document: absent from the screen, and from its
+          accessibility tree, until the moment it is printed (#449). */}
+      {matched > 0 && (
+        <ProgrammePrint
+          rows={rows}
+          rooms={rooms}
+          grouping={printGrouping}
+          locale={locale}
+          formatLabels={formatLabels}
+          labels={labels.print}
+          isSelection={view !== "all" || hasActiveFilters}
+        />
+      )}
 
       {/* Two different silences: nothing starred yet, or a filter that matches
           nothing. `matched` counts what survives *both*, so the two are told

--- a/src/frontend/src/components/programme/ProgrammeControls.tsx
+++ b/src/frontend/src/components/programme/ProgrammeControls.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Chip, ChipRow } from "@/components/FilterChip";
 import { activeFilterCount, type TalkFilters } from "@/lib/talk-filters";
 import type { ScheduleView } from "@/lib/favourites";
+import type { PrintGrouping } from "@/lib/print";
 import type { TalkFormat, TalkLevel } from "@/lib/types";
 
 const FORMATS: TalkFormat[] = ["CONFERENCE", "QUICKIE", "KEYNOTE", "WORKSHOP"];
@@ -36,6 +37,9 @@ export interface ControlLabels {
   exportTitle: string;
   printShort: string;
   printTitle: string;
+  printGroupingLabel: string;
+  printByTime: string;
+  printByRoom: string;
 }
 
 interface ProgrammeControlsProps {
@@ -47,6 +51,8 @@ interface ProgrammeControlsProps {
   languages: string[];
   labels: ControlLabels;
   icsHref: string;
+  printGrouping: PrintGrouping;
+  onChangePrintGrouping: (grouping: PrintGrouping) => void;
 }
 
 // Everything above the grid, in two zones (#448): what filters it, and what
@@ -63,6 +69,8 @@ export default function ProgrammeControls({
   languages,
   labels,
   icsHref,
+  printGrouping,
+  onChangePrintGrouping,
 }: ProgrammeControlsProps) {
   // Same two disclosures as the session list (#246, #256): level and language
   // behind "more filters", and the whole panel collapsed on mobile. Open on
@@ -243,15 +251,29 @@ export default function ProgrammeControls({
         >
           {labels.exportShort}
         </a>
-        <button
-          type="button"
-          onClick={() => window.print()}
-          title={labels.printTitle}
-          aria-label={labels.printTitle}
-          className="rounded-[12px] bg-blanc px-4 py-2 text-sm font-bold text-noir shadow-card transition-shadow hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-malachite/50"
-        >
-          {labels.printShort}
-        </button>
+        {/* The grouping is chosen before printing, not after (#449): a sheet
+            pinned on a door and a programme folded into a pocket are not the
+            same document. */}
+        <span className="inline-flex items-center gap-2 rounded-[12px] bg-blanc px-2 py-1 shadow-card">
+          <button
+            type="button"
+            onClick={() => window.print()}
+            title={labels.printTitle}
+            aria-label={labels.printTitle}
+            className="rounded-[12px] px-2 py-1 text-sm font-bold text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+          >
+            {labels.printShort}
+          </button>
+          <select
+            value={printGrouping}
+            onChange={(event) => onChangePrintGrouping(event.target.value as PrintGrouping)}
+            aria-label={labels.printGroupingLabel}
+            className="rounded-[12px] bg-blanc-casse px-2 py-1 text-sm text-noir focus:outline-none focus:ring-2 focus:ring-malachite/50"
+          >
+            <option value="time">{labels.printByTime}</option>
+            <option value="room">{labels.printByRoom}</option>
+          </select>
+        </span>
       </section>
     </div>
   );

--- a/src/frontend/src/components/programme/ProgrammePrint.tsx
+++ b/src/frontend/src/components/programme/ProgrammePrint.tsx
@@ -1,0 +1,208 @@
+import type { ScheduleRow, ScheduleTalk } from "@/lib/schedule";
+import type { ScheduleRoom } from "@/lib/types";
+import { formatEventTime } from "@/lib/datetime";
+import { localizedField } from "@/lib/i18n-helpers";
+import type { PrintGrouping } from "@/lib/print";
+
+export interface PrintLabels {
+  /** "DevFest Toulouse 2026" */
+  title: string;
+  /** Date and venue, already assembled by the page. */
+  subtitle: string;
+  /** Where to read the details — printed, not linked. */
+  source: string;
+  /** Shown instead of the whole programme when a selection is printed. */
+  selectionNote: string;
+  roomTba: string;
+  common: string;
+}
+
+interface ProgrammePrintProps {
+  rows: ScheduleRow[];
+  rooms: ScheduleRoom[];
+  grouping: PrintGrouping;
+  locale: string;
+  formatLabels: Record<string, string>;
+  labels: PrintLabels;
+  isSelection: boolean;
+}
+
+// The document that comes out of the printer (#449).
+//
+// Not the screen with its chrome removed: a separate rendering, on the same
+// rows. Paper has no hover, no link, no colour worth relying on and no room for
+// cards — it wants lines, a hierarchy and a header that says what this sheet is
+// once it has left the browser.
+//
+// It exists only in print: `display: none` on screen, so nothing here is in the
+// accessibility tree of the live page and the grid stays the only thing a
+// screen reader meets.
+export default function ProgrammePrint({
+  rows,
+  rooms,
+  grouping,
+  locale,
+  formatLabels,
+  labels,
+  isSelection,
+}: ProgrammePrintProps) {
+  return (
+    <div className="print-only" aria-hidden>
+      {/* A <div>, not a <header>: the print stylesheet hides every `header` on
+          the page as site chrome, and this one vanished with it — the first
+          sheet came out with no title at all. Seen in the PDF, nowhere else. */}
+      <div className="print-head">
+        <h2>{labels.title}</h2>
+        <p>{labels.subtitle}</p>
+        {isSelection && <p className="print-note">{labels.selectionNote}</p>}
+        <p className="print-source">{labels.source}</p>
+      </div>
+
+      {grouping === "time" ? (
+        <ByTime rows={rows} rooms={rooms} locale={locale} formatLabels={formatLabels} labels={labels} />
+      ) : (
+        <ByRoom rows={rows} rooms={rooms} locale={locale} formatLabels={formatLabels} labels={labels} />
+      )}
+    </div>
+  );
+}
+
+/** The day in order — what a participant folds into a pocket. */
+function ByTime({
+  rows,
+  rooms,
+  locale,
+  formatLabels,
+  labels,
+}: Omit<ProgrammePrintProps, "grouping" | "isSelection">) {
+  return (
+    <div>
+      {rows.map((row) =>
+        row.type === "band" ? (
+          <p key={row.key} className="print-band">
+            <span className="print-time">
+              {formatEventTime(row.entry.startsAt)} – {formatEventTime(row.entry.endsAt)}
+            </span>{" "}
+            {localizedField(row.entry, "label", locale)}
+          </p>
+        ) : (
+          <section key={row.key} className="print-slot">
+            <h3>{formatEventTime(row.startsAt)}</h3>
+            <ul>
+              {row.cells.flatMap((talks, index) =>
+                talks.map((talk) => (
+                  <PrintedSession
+                    key={talk.slug}
+                    talk={talk}
+                    locale={locale}
+                    formatLabels={formatLabels}
+                    aside={rooms[index]?.name || labels.roomTba}
+                  />
+                )),
+              )}
+            </ul>
+          </section>
+        ),
+      )}
+    </div>
+  );
+}
+
+/**
+ * One section per room — a sheet to pin on each door.
+ *
+ * The same rows read down the columns instead of across them. The shared
+ * moments belong to no room: they are gathered once at the end rather than
+ * repeated under every door.
+ */
+function ByRoom({
+  rows,
+  rooms,
+  locale,
+  formatLabels,
+  labels,
+}: Omit<ProgrammePrintProps, "grouping" | "isSelection">) {
+  const perRoom = rooms.map((_, index) =>
+    rows.flatMap((row) => (row.type === "slot" ? row.cells[index] ?? [] : [])),
+  );
+  const bands = rows.filter((row) => row.type === "band");
+
+  return (
+    <div>
+      {rooms.map((room, index) =>
+        perRoom[index].length === 0 ? null : (
+          <section key={room.id ?? `label:${room.name}`} className="print-room">
+            <h3>{room.name || labels.roomTba}</h3>
+            {/* Each room starts its own sheet, and a sheet pinned on a door has
+                to name its event: only the first page carries the document
+                header. */}
+            <p className="print-room-sub">
+              {labels.title} — {labels.subtitle}
+            </p>
+            <ul>
+              {perRoom[index].map((talk) => (
+                <PrintedSession
+                  key={talk.slug}
+                  talk={talk}
+                  locale={locale}
+                  formatLabels={formatLabels}
+                  aside={`${formatEventTime(talk.startsAt)}${
+                    talk.endsAt ? ` – ${formatEventTime(talk.endsAt)}` : ""
+                  }`}
+                />
+              ))}
+            </ul>
+          </section>
+        ),
+      )}
+
+      {bands.length > 0 && (
+        <section className="print-room">
+          <h3>{labels.common}</h3>
+          <ul>
+            {bands.map((row) =>
+              row.type === "band" ? (
+                <li key={row.key}>
+                  <span className="print-time">
+                    {formatEventTime(row.entry.startsAt)} – {formatEventTime(row.entry.endsAt)}
+                  </span>
+                  <span className="print-title">{localizedField(row.entry, "label", locale)}</span>
+                </li>
+              ) : null,
+            )}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function PrintedSession({
+  talk,
+  locale,
+  formatLabels,
+  aside,
+}: {
+  talk: ScheduleTalk;
+  locale: string;
+  formatLabels: Record<string, string>;
+  aside: string;
+}) {
+  const category = talk.category ? localizedField(talk.category, "name", locale) : null;
+  // One line of context instead of the screen's coloured pills: colour does not
+  // survive a black-and-white printer, so what it carried becomes words.
+  const meta = [formatLabels[talk.format], category, talk.language.toUpperCase()]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <li>
+      <span className="print-time">{aside}</span>
+      <span className="print-title">{talk.title}</span>
+      {talk.speakers.length > 0 && (
+        <span className="print-speakers">{talk.speakers.map((s) => s.name).join(", ")}</span>
+      )}
+      <span className="print-meta">{meta}</span>
+    </li>
+  );
+}

--- a/src/frontend/src/lib/datetime.ts
+++ b/src/frontend/src/lib/datetime.ts
@@ -53,3 +53,17 @@ export function formatEventTime(iso: string): string {
   const date = new Date(iso);
   return Number.isNaN(date.getTime()) ? "" : eventTimeFormatter.format(date);
 }
+
+/**
+ * UTC instant → `19 novembre 2026`, in the reader's language but the event's
+ * zone (#449). The header of a printed programme has to name the day, and a
+ * midnight-adjacent instant would name the wrong one under any other zone.
+ */
+export function formatEventDate(iso: string, locale: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat(locale === "en" ? "en-GB" : "fr-FR", {
+    timeZone: EVENT_TIME_ZONE,
+    dateStyle: "long",
+  }).format(date);
+}

--- a/src/frontend/src/lib/print.ts
+++ b/src/frontend/src/lib/print.ts
@@ -1,0 +1,12 @@
+// How the printed programme is grouped (#449).
+//
+// In the URL rather than in local state, for two reasons: it makes the
+// per-room sheet a link someone can send ("imprime celle-ci pour l'Amphi"),
+// and it makes the second rendering reachable by anything that prints a page
+// without clicking first — which is how it gets verified at all.
+
+export type PrintGrouping = "time" | "room";
+
+export function parsePrintGrouping(param: string | undefined | null): PrintGrouping {
+  return param === "room" ? "room" : "time";
+}


### PR DESCRIPTION
Ce qui sort de l'imprimante n'est plus la page web allégée : c'est un document construit pour le papier à partir des mêmes lignes.

## Ce qui change

**Un en-tête de document** : « DevFest Toulouse 2026 », la date, le lieu, et l'adresse où lire le détail des sessions — imprimée, puisqu'un lien ne sert à rien sur une feuille.

**Des lignes, pas des cartes.** Le papier n'a ni survol, ni lien, ni couleur fiable. Les pastilles colorées deviennent donc une ligne de texte (« Conférence · Cloud & DevOps · FR »), et la densité passe à celle d'une feuille : 10 pt, A4 portrait, marges de 14 mm.

**Deux regroupements, choisis avant d'imprimer** :

| | |
|---|---|
| **Par heure** | la journée dans l'ordre, chaque créneau listant ses sessions et leurs salles |
| **Par salle** | une feuille par salle, chacune commençant une nouvelle page |

Filtres et favoris s'appliquent aux deux, et **un document partiel le dit** : « Sélection personnelle — ce document ne contient pas tout le programme. » Une feuille quitte le navigateur ; sans cette ligne elle se lit comme le programme complet dans les mains de quelqu'un d'autre.

## Le regroupement est dans l'URL

Choix délibéré, contre mon intention de départ. Deux raisons : la feuille d'une salle devient un lien qu'on peut envoyer (« imprime celle-là pour l'Amphi »), et surtout **le second rendu devient atteignable par ce qui imprime une page sans cliquer d'abord** — c'est-à-dire par la vérification elle-même. Un état local aurait été un rendu que personne ne peut contrôler autrement qu'à la main.

## Vérifié en produisant les PDF

C'est le point de l'issue, et c'est ce qui a trouvé les défauts. Chromium sans interface, sur le réseau de la pile locale, `--print-to-pdf` — puis les fichiers ouverts et relus page par page.

**Deux défauts qu'aucune relecture de CSS n'aurait donnés :**

1. **La première feuille sortait sans titre.** L'en-tête du document était un `<header>`, et la feuille d'impression masque tous les `header` de la page comme mobilier de site. Il disparaissait avec eux. C'est un `<div>` désormais.
2. **« Amphithéâtre » débordait sur le titre de la session.** La colonne de gauche faisait 22 mm ; les noms longs s'imprimaient par-dessus le texte voisin. Passée à 28 mm, avec césure.

Un troisième, plus bénin : le libellé des bandes était collé à l'horaire (« 07:30 – 08:45Accueil »).

## Plan de test

**Vérifié**

- Suites : frontend 169/169. `tsc` et `eslint` sans erreur.
- **Quatre PDF produits et relus** : par heure (3 pages), par salle (une par salle), une grille filtrée, et le second tirage après correctifs. En-tête présent, aucune session coupée entre deux pages, aucun chevauchement, tout en noir sur blanc.
- Le PDF filtré porte bien la mention de sélection partielle.
- Écran inchangé : `.print-only` est en `display: none`, la grille reste la grille, le sélecteur d'impression annonce « Impression » avec ses deux options.
- Pas de défilement latéral du corps.

**Non vérifié**

- **Aucune impression sur une imprimante physique** — les PDF ont été produits par Chromium sans interface, ce qui est le même moteur que le « Enregistrer en PDF » du navigateur, mais pas un vrai bac à papier.
- Les polices : le rendu de contrôle tombe sur une police de repli, la fonte Google Sans n'étant pas chargée dans le conteneur d'impression. L'espacement réel sera légèrement différent.
- Impression depuis un téléphone, et depuis Firefox ou Safari, dont les moteurs d'impression diffèrent.
- Aucun test automatisé sur le document imprimé : c'est de la mise en page, contrôlée sur pièce.
- Rien n'a été rejoué sur des données de production.

Refs #449
