### PR TITLE
Admin — un seed qui répare, un message qui se montre

### DIFF
--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -15,10 +15,18 @@ async function seedDev() {
   // --- Venues (#105) ---
   // Upsert by name: the venue is the shared entity, so re-seeding must find the
   // existing row rather than fail on the unique name.
+  //
+  // `update` carries the same fields as `create` (#452). With an empty update,
+  // the row the #105 migration had backfilled from `Edition.venueName` — with
+  // no coordinates, because the local edition had none — was never repaired:
+  // `hasVenueInfo` stayed false, /fr/lieu answered 404 and the "Lieu" menu
+  // entry never appeared. A dev seed has to converge on the state it describes,
+  // or "replay the seed" stops meaning anything.
+  const diagoraFields = { address: "Labège", lat: 43.5497, lng: 1.5119 };
   const diagora = await prisma.venue.upsert({
     where: { name: "Diagora" },
-    update: {},
-    create: { name: "Diagora", address: "Labège", lat: 43.5497, lng: 1.5119 },
+    update: diagoraFields,
+    create: { name: "Diagora", ...diagoraFields },
   });
 
   // The eight rooms of the 2026 edition, with their real capacities — the
@@ -44,7 +52,7 @@ async function seedDev() {
 
   const pierreBaudis = await prisma.venue.upsert({
     where: { name: "Centre de Congrès Pierre Baudis" },
-    update: {},
+    update: { address: "Toulouse" },
     create: { name: "Centre de Congrès Pierre Baudis", address: "Toulouse" },
   });
 

--- a/src/frontend/src/components/admin/SaveFeedback.test.tsx
+++ b/src/frontend/src/components/admin/SaveFeedback.test.tsx
@@ -17,6 +17,22 @@ describe("SaveFeedback", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("brings itself into view — it sits far above the button that triggers it", () => {
+    // On the venue page the message and the save button were 1092 px apart,
+    // the message outside the viewport at the moment of the click: a refused
+    // deletion read as nothing happening at all (#453). jsdom has no layout, so
+    // what is asserted is that the scroll is asked for, and asked for gently —
+    // "nearest" leaves a message already on screen where it is.
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    render(<SaveFeedback state={{ kind: "error", text: "Suppression refusée." }} />);
+
+    expect(scrollIntoView).toHaveBeenCalledWith(
+      expect.objectContaining({ block: "nearest" }),
+    );
+  });
+
   it("announces a success politely", () => {
     render(<SaveFeedback state={{ kind: "ok", text: "Modifications enregistrées." }} />);
     const message = screen.getByRole("status");

--- a/src/frontend/src/components/admin/SaveFeedback.tsx
+++ b/src/frontend/src/components/admin/SaveFeedback.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // Feedback after a save (#394). The editor screens used to redirect to their
 // list with no message at all — the same outcome as pressing Cancel, so nothing
@@ -23,6 +23,23 @@ interface SaveFeedbackProps {
 
 export default function SaveFeedback({ state, onDismiss, successTimeout = 4000 }: SaveFeedbackProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef<HTMLParagraphElement>(null);
+
+  // Bring the message into view (#453). It sits at the top of its screen, while
+  // the buttons that trigger it can be a whole form below: on the venue page the
+  // two were 1092 px apart, the message outside the viewport at the moment of
+  // the click. A refused deletion then looked like nothing at all — the dialog
+  // closed, the room stayed, and the reason was a thousand pixels away.
+  //
+  // `block: "nearest"` scrolls only when it has to, so a message already in view
+  // does not make a short screen jump.
+  //
+  // Depends on `isVisible` as well as on `state`: the first render after a save
+  // still returns null — the paragraph, and its ref, only exist once the effect
+  // below has flipped isVisible. Watching `state` alone scrolled nothing at all.
+  useEffect(() => {
+    if (state && isVisible) ref.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [state, isVisible]);
 
   useEffect(() => {
     setIsVisible(!!state);
@@ -40,6 +57,7 @@ export default function SaveFeedback({ state, onDismiss, successTimeout = 4000 }
   const isOk = state.kind === "ok";
   return (
     <p
+      ref={ref}
       role={isOk ? "status" : "alert"}
       aria-live={isOk ? "polite" : "assertive"}
       className={`rounded-lg px-3 py-2 text-sm ${

--- a/src/frontend/vitest.setup.ts
+++ b/src/frontend/vitest.setup.ts
@@ -6,3 +6,11 @@ import { cleanup } from "@testing-library/react";
 afterEach(() => {
   cleanup();
 });
+
+// jsdom implements no layout, so `scrollIntoView` simply does not exist on an
+// element — and a component that calls it (#453) throws in every test that
+// renders it, however unrelated. Stubbed here rather than guarded at each call
+// site: the gap is the test environment's, not the code's.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}


### PR DESCRIPTION
Deux défauts trouvés en pilotant l'admin dans un navigateur, pas en le relisant.

## #452 — le seed ne réparait jamais le lieu

`/fr/lieu` répondait **404 en local** et l'entrée « Lieu » n'apparaissait pas dans le menu, sur une installation à jour.

Le seed fait un `upsert` par nom avec `update: {}`. Or la ligne qu'il trouve n'a pas été créée par lui : c'est **la reprise de la migration #105** qui l'a écrite à partir de `Edition.venueName`, sans coordonnées, parce que l'édition locale n'en avait pas. Les seeds suivants tombaient donc dans la branche vide et laissaient la ligne en l'état, indéfiniment — `hasVenueInfo` faux, page refusée, entrée de menu masquée.

L'`update` porte désormais les mêmes champs que le `create`. **Un seed de développement doit converger vers l'état qu'il décrit**, sinon « rejouer le seed » ne veut plus rien dire.

Ce n'est pas un défaut de production : la prod et la bêta ont leurs lieux saisis depuis l'admin. Mais #109 était intestable en local.

## #453 — le retour d'une action s'affichait hors du champ visible

Le message de confirmation ou d'erreur est rendu en haut de son écran ; les boutons qui le déclenchent peuvent être un formulaire entier plus bas. Mesuré sur la fiche d'un lieu : **1092 px d'écart, message hors du viewport au moment du clic**.

La confirmation manquante n'était qu'inutile. Le refus, lui, était trompeur :

> Clic sur « Supprimer » d'une salle occupée, confirmation dans la boîte de dialogue, elle se ferme… la salle est toujours là. Le motif — « 5 conférences sont programmées dans cette salle » — s'affichait mille pixels plus haut. À l'écran, l'action semblait n'avoir rien fait.

Le message se ramène maintenant dans le champ visible tout seul. **Un seul composant, les sept écrans qui l'utilisent en bénéficient, aucune mise en page redessinée** — ce qui le distingue de la passe d'ergonomie globale de l'admin, volontairement reportée.

Deux détails : `block: "nearest"` pour qu'un message déjà visible ne fasse sauter aucun écran court, et l'effet observe `isVisible` autant que l'état — le premier rendu après un enregistrement renvoie encore `null`, donc ni le paragraphe ni sa `ref` n'existent. **Observer l'état seul ne faisait défiler rien du tout ; c'est le test ajouté qui l'a dit.**

Et un ajout au fichier de mise en place des tests : jsdom n'implémente pas `scrollIntoView`, si bien qu'appeler la méthode faisait échouer deux tests d'un écran sans rapport. Le manque est celui de l'environnement de test, pas du code — il est bouché là, plutôt que gardé à chaque appel.

## Plan de test

**Vérifié**

- Suites : frontend 170/170, backend 667/669. `tsc` et `eslint` propres des deux côtés.
- **#452, test discriminant** : coordonnées mises à `NULL` à la main, seed rejoué, coordonnées revenues. Avant le correctif, elles restaient nulles.
- `/fr/lieu` répond 200, l'entrée « Lieu » est de retour dans le menu.
- **#453 en navigateur** : depuis le bas de la fiche d'un lieu, « Enregistrer » puis lecture du message — `messageInViewport: true`, alors que le bouton, lui, est sorti du champ. Avant le correctif : `false`.
- Les données ne sont pas touchées par l'enregistrement (coordonnées intactes après coup).

**Non vérifié**

- Le refus de suppression n'a pas été rejoué **après** le correctif : c'est le même composant et le même chemin que l'enregistrement, mais je ne l'ai pas revu à l'écran.
- Pas de lecteur d'écran réel ; les rôles et l'annonce sont inchangés, seule la position à l'écran bouge.
- Les échecs backend restants : l'artefact connu `stat-icons`, plus un échec isolé de `public-hall-of-fame` qui **ne se reproduit pas seul** — collision de fixtures, motif de #292. Il est apparu deux fois aujourd'hui dans des exécutions complètes ; s'il revient, il mérite son issue.

Refs #452, #453
