### PR TITLE
Pages de contenu : brouillon, corbeille et placement dans la navigation

### DIFF
--- a/src/backend/prisma/migrations/20260825120000_content_page_publication/migration.sql
+++ b/src/backend/prisma/migrations/20260825120000_content_page_publication/migration.sql
@@ -1,0 +1,18 @@
+-- Publication state and trash for content pages (#419).
+--
+-- `ContentPage` was a content store for two hardcoded routes (code of conduct,
+-- legal notice) until the `[locale]/[slug]` segment opened every row to the
+-- public (#421). The publication filter that was meant to ship with that route
+-- never did, so a page created from the admin went live the moment it was
+-- saved — and, with no DELETE route, could not be taken down again.
+
+ALTER TABLE "ContentPage" ADD COLUMN "isPublished" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "ContentPage" ADD COLUMN "deletedAt" TIMESTAMP(3);
+
+-- Every existing row is already reachable in production — the two hardcoded
+-- routes serve theirs, and the ones created since #421 answer on /[slug].
+-- Leaving them at the column default would take live pages down, so they are
+-- backfilled as published; only rows created from now on start as drafts.
+UPDATE "ContentPage" SET "isPublished" = true;
+
+CREATE INDEX "ContentPage_deletedAt_idx" ON "ContentPage"("deletedAt");

--- a/src/backend/prisma/migrations/20260825130000_content_page_navigation/migration.sql
+++ b/src/backend/prisma/migrations/20260825130000_content_page_navigation/migration.sql
@@ -1,0 +1,15 @@
+-- Where a content page appears in the navigation (#420).
+--
+-- The public navigation is built in code: `getPublicNavEntries()` for the menu,
+-- literal links for the footer bar. Nothing loops over the pages table, so a
+-- page created from the admin could only be reached by typing its URL.
+
+CREATE TYPE "PageNavLocation" AS ENUM ('NONE', 'HEADER', 'FOOTER');
+
+ALTER TABLE "ContentPage"
+  ADD COLUMN "navLocation" "PageNavLocation" NOT NULL DEFAULT 'NONE',
+  ADD COLUMN "navOrder" INTEGER NOT NULL DEFAULT 0;
+
+-- The code of conduct and the legal notice already have their permanent link in
+-- the footer bar, written in the template. Placing them here as well would print
+-- them twice, so they stay at NONE.

--- a/src/backend/prisma/schema.prisma
+++ b/src/backend/prisma/schema.prisma
@@ -485,7 +485,23 @@ model ContentPage {
   titleEn   String
   contentFr String
   contentEn String
-  updatedAt DateTime @updatedAt
+  // A page is a draft until an editor publishes it (#419). The public routes
+  // filter on this; without it every row went live the moment it was saved.
+  isPublished Boolean   @default(false)
+  // Where the page shows up in the navigation, and in which order among the
+  // other free pages (#420). NONE keeps it reachable by its URL only.
+  navLocation PageNavLocation @default(NONE)
+  navOrder    Int             @default(0)
+  deletedAt   DateTime?
+  updatedAt   DateTime  @updatedAt
+
+  @@index([deletedAt])
+}
+
+enum PageNavLocation {
+  NONE
+  HEADER
+  FOOTER
 }
 
 // --- Auth (Better Auth compatible) ---

--- a/src/backend/prisma/seed-dev.ts
+++ b/src/backend/prisma/seed-dev.ts
@@ -278,10 +278,14 @@ async function seedDev() {
   console.log(`Articles created: ${articles.length}`);
 
   // --- Content Pages ---
+  // Both pages are served by their own route and linked from every footer, so
+  // they must be published — the column default is draft (#419). `update` sets
+  // it too, so a reseed repairs a row left unpublished by an earlier run (#433).
   await prisma.contentPage.upsert({
     where: { slug: "code-de-conduite" },
-    update: {},
+    update: { isPublished: true },
     create: {
+      isPublished: true,
       slug: "code-de-conduite",
       titleFr: "Code de conduite",
       titleEn: "Code of Conduct",
@@ -292,8 +296,9 @@ async function seedDev() {
 
   await prisma.contentPage.upsert({
     where: { slug: "mentions-legales" },
-    update: {},
+    update: { isPublished: true },
     create: {
+      isPublished: true,
       slug: "mentions-legales",
       titleFr: "Mentions légales",
       titleEn: "Legal Notice",

--- a/src/backend/src/__tests__/admin-pages.test.ts
+++ b/src/backend/src/__tests__/admin-pages.test.ts
@@ -57,7 +57,8 @@ describe("Admin Pages API", () => {
     const getRes2 = await app.inject({ method: "GET", url: `/api/admin/pages/${id}` });
     expect(getRes2.json().titleFr).toBe("Page Test FR Modifiee");
 
-    // Cleanup via Prisma (no DELETE endpoint for pages)
+    // Hard delete: the DELETE route is a soft one (#419), which would leave the
+    // row behind and defeat the cleanup.
     await prisma.contentPage.delete({ where: { id } });
 
     await app.close();

--- a/src/backend/src/__tests__/content-page-publication.test.ts
+++ b/src/backend/src/__tests__/content-page-publication.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { buildApp } from "./test-app.js";
+import { buildAdminApp } from "./test-admin-app.js";
+import { prisma } from "../lib/prisma.js";
+
+// #419 — `ContentPage` was a store for two hardcoded routes until the
+// `[locale]/[slug]` segment opened every row to the public (#421). The
+// publication filter meant to ship with that route never did, so a page created
+// from the admin went live the moment it was saved, and no DELETE route existed
+// to take it down.
+
+const created: number[] = [];
+
+async function createPage(payload: Record<string, unknown>) {
+  const app = await buildAdminApp();
+  const res = await app.inject({ method: "POST", url: "/api/admin/pages", payload });
+  await app.close();
+  const { id } = res.json();
+  created.push(id);
+  return { id, status: res.statusCode };
+}
+
+afterEach(async () => {
+  while (created.length) {
+    const id = created.pop();
+    await prisma.contentPage.deleteMany({ where: { id } });
+  }
+});
+
+describe("Content page publication", () => {
+  it("should create a page as a draft when nothing says otherwise", async () => {
+    const slug = `draft-page-${Date.now()}`;
+    const { id, status } = await createPage({
+      slug,
+      titleFr: "Brouillon",
+      titleEn: "Draft",
+      contentFr: "<p>FR</p>",
+      contentEn: "<p>EN</p>",
+    });
+    expect(status).toBe(201);
+
+    const stored = await prisma.contentPage.findUnique({ where: { id } });
+    expect(stored?.isPublished).toBe(false);
+  });
+
+  it("should answer 404 on the public route while the page is a draft", async () => {
+    const slug = `hidden-page-${Date.now()}`;
+    await createPage({
+      slug,
+      titleFr: "Cachée",
+      titleEn: "Hidden",
+      contentFr: "<p>FR</p>",
+      contentEn: "<p>EN</p>",
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/pages/${slug}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("should serve the page once it is published", async () => {
+    const slug = `live-page-${Date.now()}`;
+    const { id } = await createPage({
+      slug,
+      titleFr: "Visible",
+      titleEn: "Visible",
+      contentFr: "<p>FR</p>",
+      contentEn: "<p>EN</p>",
+    });
+
+    const admin = await buildAdminApp();
+    const put = await admin.inject({
+      method: "PUT",
+      url: `/api/admin/pages/${id}`,
+      payload: { isPublished: true },
+    });
+    await admin.close();
+    expect(put.statusCode).toBe(200);
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/pages/${slug}` });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().slug).toBe(slug);
+  });
+
+  it("should leave a draft out of the public list", async () => {
+    const slug = `unlisted-page-${Date.now()}`;
+    await createPage({
+      slug,
+      titleFr: "Hors liste",
+      titleEn: "Unlisted",
+      contentFr: "<p>FR</p>",
+      contentEn: "<p>EN</p>",
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/pages" });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    const slugs = res.json().map((p: { slug: string }) => p.slug);
+    expect(slugs).not.toContain(slug);
+  });
+
+  it("should take a published page down again when it goes back to draft", async () => {
+    const slug = `retracted-page-${Date.now()}`;
+    const { id } = await createPage({
+      slug,
+      titleFr: "Retirée",
+      titleEn: "Retracted",
+      contentFr: "<p>FR</p>",
+      contentEn: "<p>EN</p>",
+      isPublished: true,
+    });
+
+    const live = await buildApp();
+    expect((await live.inject({ method: "GET", url: `/api/pages/${slug}` })).statusCode).toBe(200);
+    await live.close();
+
+    const admin = await buildAdminApp();
+    await admin.inject({
+      method: "PUT",
+      url: `/api/admin/pages/${id}`,
+      payload: { isPublished: false },
+    });
+    await admin.close();
+
+    const after = await buildApp();
+    const res = await after.inject({ method: "GET", url: `/api/pages/${slug}` });
+    await after.close();
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("Content page deletion", () => {
+  it("should move the page to the trash and free its slug", async () => {
+    const slug = `deletable-page-${Date.now()}`;
+    const { id } = await createPage({
+      slug,
+      titleFr: "Jetable",
+      titleEn: "Disposable",
+      contentFr: "",
+      contentEn: "",
+      isPublished: true,
+    });
+
+    const admin = await buildAdminApp();
+    const del = await admin.inject({ method: "DELETE", url: `/api/admin/pages/${id}` });
+    await admin.close();
+    expect(del.statusCode).toBe(200);
+
+    const stored = await prisma.contentPage.findUnique({ where: { id } });
+    expect(stored?.deletedAt).not.toBeNull();
+    // The slug is globally unique; a trashed row parks it so the same slug can
+    // be used again (#146).
+    expect(stored?.slug).not.toBe(slug);
+
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: `/api/pages/${slug}` });
+    await app.close();
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("should hide a trashed page from the admin list", async () => {
+    const slug = `trashed-page-${Date.now()}`;
+    const { id } = await createPage({
+      slug,
+      titleFr: "Corbeille",
+      titleEn: "Trash",
+      contentFr: "",
+      contentEn: "",
+    });
+
+    const admin = await buildAdminApp();
+    await admin.inject({ method: "DELETE", url: `/api/admin/pages/${id}` });
+    const list = await admin.inject({ method: "GET", url: "/api/admin/pages" });
+    await admin.close();
+
+    const ids = list.json().map((p: { id: number }) => p.id);
+    expect(ids).not.toContain(id);
+  });
+
+  it("should refuse to delete a page served by its own route", async () => {
+    const existing = await prisma.contentPage.findUnique({ where: { slug: "mentions-legales" } });
+    if (!existing) return; // seeded environments only
+
+    const admin = await buildAdminApp();
+    const res = await admin.inject({ method: "DELETE", url: `/api/admin/pages/${existing.id}` });
+    await admin.close();
+
+    expect(res.statusCode).toBe(409);
+    const still = await prisma.contentPage.findUnique({ where: { id: existing.id } });
+    expect(still?.deletedAt).toBeNull();
+  });
+
+  it("should refuse to unpublish a page served by its own route", async () => {
+    const existing = await prisma.contentPage.findUnique({ where: { slug: "code-de-conduite" } });
+    if (!existing) return; // seeded environments only
+
+    const admin = await buildAdminApp();
+    const res = await admin.inject({
+      method: "PUT",
+      url: `/api/admin/pages/${existing.id}`,
+      payload: { isPublished: false },
+    });
+    await admin.close();
+
+    expect(res.statusCode).toBe(409);
+    const still = await prisma.contentPage.findUnique({ where: { id: existing.id } });
+    expect(still?.isPublished).toBe(true);
+  });
+});

--- a/src/backend/src/lib/revalidate.ts
+++ b/src/backend/src/lib/revalidate.ts
@@ -52,6 +52,24 @@ export function revalidateArticle(slug: string): Promise<void> {
   ]);
 }
 
+/**
+ * A content page was saved, published, unpublished or trashed (#419).
+ *
+ * Public pages sit behind `s-maxage=3600`, so without this purge a page
+ * published in the admin would stay a 404 for up to an hour — and, worse, one
+ * taken back to draft would keep being served just as long. The header and
+ * footer carry the navigation, so every page is purged, not just this one.
+ */
+export function revalidateContentPage(slug: string): Promise<void> {
+  return revalidatePaths([
+    ...bilingualPaths(""),
+    ...bilingualPaths(`/${slug}`),
+    // The sitemap is the whole point of publishing: leaving it stale would list
+    // a page that 404s, or hide one that is live. It has no locale prefix.
+    "/sitemap.xml",
+  ]);
+}
+
 export function revalidateEdition(year: number): Promise<void> {
   return revalidatePaths([
     ...bilingualPaths(""),

--- a/src/backend/src/lib/trash-registry.ts
+++ b/src/backend/src/lib/trash-registry.ts
@@ -3,7 +3,7 @@ import { prisma } from "./prisma.js";
 /**
  * What the trash knows about each soft-deletable entity (#148).
  *
- * Twelve entities × three operations (list / restore / purge) is thirty-six
+ * Thirteen entities × three operations (list / restore / purge) is thirty-nine
  * routes if written by hand. They only differ by four things — the Prisma
  * delegate, which field labels a row in the UI, which unique fields were parked
  * on the way in, and which fields hold uploaded files — so those differences
@@ -129,6 +129,14 @@ export const TRASH_ENTITIES: readonly TrashEntity[] = [
     parkedFields: ["email"],
     fileFields: [],
     adminOnly: true,
+  },
+  {
+    key: "pages",
+    model: "contentPage",
+    labelField: "titleFr",
+    parkedFields: ["slug"],
+    fileFields: [],
+    adminOnly: false,
   },
 ];
 

--- a/src/backend/src/routes/admin/pages.ts
+++ b/src/backend/src/routes/admin/pages.ts
@@ -1,7 +1,23 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../../lib/prisma.js";
 import { sanitizeRichHtml } from "../../lib/sanitize.js";
-import { parseIdParam, notFound } from "../../lib/admin-helpers.js";
+import {
+  parseIdParam,
+  notFound,
+  notDeleted,
+  softDeleteData,
+  parkUniqueValue,
+} from "../../lib/admin-helpers.js";
+import { revalidateContentPage } from "../../lib/revalidate.js";
+
+// Two pages are served by their own hardcoded routes and linked from the footer
+// on every page. Trashing one would leave a 404 behind a permanent link, so the
+// delete is refused rather than undone afterwards — same call as blocking the
+// removal of a venue still attached to an edition (#105).
+const SYSTEM_SLUGS = ["code-de-conduite", "mentions-legales"] as const;
+
+type NavLocation = "NONE" | "HEADER" | "FOOTER";
+const NAV_LOCATIONS: readonly NavLocation[] = ["NONE", "HEADER", "FOOTER"];
 
 interface PageBody {
   slug: string;
@@ -9,12 +25,22 @@ interface PageBody {
   titleEn: string;
   contentFr: string;
   contentEn: string;
+  isPublished?: boolean;
+  navLocation?: NavLocation;
+  navOrder?: number;
+}
+
+// The navigation location comes from a select, but it reaches Prisma as an enum
+// value: an unknown string would throw a 500 rather than a 400 (#420).
+function readNavLocation(value: unknown, fallback: NavLocation): NavLocation {
+  return NAV_LOCATIONS.includes(value as NavLocation) ? (value as NavLocation) : fallback;
 }
 
 export default async function adminPageRoutes(app: FastifyInstance) {
   // GET /api/admin/pages — list all content pages
   app.get("/pages", async () => {
     const pages = await prisma.contentPage.findMany({
+      where: notDeleted,
       orderBy: { slug: "asc" },
     });
 
@@ -23,6 +49,9 @@ export default async function adminPageRoutes(app: FastifyInstance) {
       slug: p.slug,
       titleFr: p.titleFr,
       titleEn: p.titleEn,
+      isPublished: p.isPublished,
+      navLocation: p.navLocation,
+      navOrder: p.navOrder,
       updatedAt: p.updatedAt,
     }));
   });
@@ -32,7 +61,7 @@ export default async function adminPageRoutes(app: FastifyInstance) {
     const id = await parseIdParam(request, reply);
     if (id === null) return;
 
-    const page = await prisma.contentPage.findUnique({ where: { id } });
+    const page = await prisma.contentPage.findFirst({ where: { id, ...notDeleted } });
     if (!page) return notFound(reply, "Page");
 
     return page;
@@ -46,10 +75,17 @@ export default async function adminPageRoutes(app: FastifyInstance) {
     const id = await parseIdParam(request, reply);
     if (id === null) return;
 
-    const existing = await prisma.contentPage.findUnique({ where: { id } });
+    const existing = await prisma.contentPage.findFirst({ where: { id, ...notDeleted } });
     if (!existing) return notFound(reply, "Page");
 
     const body = request.body;
+
+    const isSystemPage = (SYSTEM_SLUGS as readonly string[]).includes(existing.slug);
+    if (isSystemPage && body.isPublished === false) {
+      return reply.status(409).send({
+        error: "Cette page est servie par une route dédiée et ne peut pas être dépubliée.",
+      });
+    }
 
     const page = await prisma.contentPage.update({
       where: { id },
@@ -58,10 +94,14 @@ export default async function adminPageRoutes(app: FastifyInstance) {
         titleEn: body.titleEn?.trim() ?? existing.titleEn,
         contentFr: body.contentFr !== undefined ? sanitizeRichHtml(body.contentFr) : existing.contentFr,
         contentEn: body.contentEn !== undefined ? sanitizeRichHtml(body.contentEn) : existing.contentEn,
+        isPublished: body.isPublished ?? existing.isPublished,
+        navLocation: readNavLocation(body.navLocation, existing.navLocation),
+        navOrder: Number.isFinite(body.navOrder) ? Number(body.navOrder) : existing.navOrder,
       },
     });
 
-    return { id: page.id, slug: page.slug };
+    await revalidateContentPage(page.slug);
+    return { id: page.id, slug: page.slug, isPublished: page.isPublished };
   });
 
   // POST /api/admin/pages — create content page
@@ -82,9 +122,39 @@ export default async function adminPageRoutes(app: FastifyInstance) {
         titleEn: body.titleEn.trim(),
         contentFr: sanitizeRichHtml(body.contentFr),
         contentEn: sanitizeRichHtml(body.contentEn),
+        // A new page is a draft: publishing is a deliberate second gesture.
+        isPublished: body.isPublished === true,
       },
     });
 
+    if (page.isPublished) await revalidateContentPage(page.slug);
     return reply.status(201).send({ id: page.id, slug: page.slug });
+  });
+
+  // DELETE /api/admin/pages/:id — moves the page to the trash (#419). There was
+  // no delete route at all: a page created by mistake could not be taken down.
+  app.delete<{ Params: { id: string } }>("/pages/:id", async (request, reply) => {
+    const id = await parseIdParam(request, reply);
+    if (id === null) return;
+
+    const existing = await prisma.contentPage.findFirst({ where: { id, ...notDeleted } });
+    if (!existing) return notFound(reply, "Page");
+
+    if ((SYSTEM_SLUGS as readonly string[]).includes(existing.slug)) {
+      return reply.status(409).send({
+        error: "Cette page est servie par une route dédiée et ne peut pas être supprimée.",
+      });
+    }
+
+    // The slug is globally unique and a trashed row keeps its slot, so park it
+    // out of the live namespace — otherwise re-creating a page under the same
+    // slug would hit the constraint (#146).
+    await prisma.contentPage.update({
+      where: { id },
+      data: { ...softDeleteData(), slug: parkUniqueValue(existing.slug, id) },
+    });
+
+    await revalidateContentPage(existing.slug);
+    return { success: true };
   });
 }

--- a/src/backend/src/routes/pages.ts
+++ b/src/backend/src/routes/pages.ts
@@ -1,13 +1,40 @@
 import type { FastifyInstance } from "fastify";
 import { prisma } from "../lib/prisma.js";
 
+// Only a published, non-trashed page is public (#419). Both conditions matter:
+// a draft must never be served, and a trashed row keeps its slug until it is
+// purged, so it would otherwise still answer on its URL.
+const publiclyVisible = { isPublished: true, deletedAt: null } as const;
+
 export default async function pageRoutes(app: FastifyInstance) {
-  // GET /api/pages/:slug — returns a content page (CoC, Legal, etc.)
+  // GET /api/pages — published pages, for the sitemap and the navigation.
+  // Content is left out: callers here want the list, not the bodies.
+  app.get("/pages", async () => {
+    const pages = await prisma.contentPage.findMany({
+      where: publiclyVisible,
+      // Navigation order first, so the header and footer can render the list as
+      // it comes; the slug only breaks ties between pages left at the same rank.
+      orderBy: [{ navOrder: "asc" }, { slug: "asc" }],
+    });
+
+    return pages.map((p: (typeof pages)[number]) => ({
+      id: p.id,
+      slug: p.slug,
+      titleFr: p.titleFr,
+      titleEn: p.titleEn,
+      hasEnglish: p.titleEn.trim().length > 0 && p.contentEn.trim().length > 0,
+      navLocation: p.navLocation,
+      navOrder: p.navOrder,
+      updatedAt: p.updatedAt,
+    }));
+  });
+
+  // GET /api/pages/:slug — returns a content page (CoC, Legal, admin-authored)
   app.get<{
     Params: { slug: string };
   }>("/pages/:slug", async (request, reply) => {
-    const page = await prisma.contentPage.findUnique({
-      where: { slug: request.params.slug },
+    const page = await prisma.contentPage.findFirst({
+      where: { slug: request.params.slug, ...publiclyVisible },
     });
 
     if (!page) {

--- a/src/frontend/src/app/[locale]/layout.tsx
+++ b/src/frontend/src/app/[locale]/layout.tsx
@@ -13,7 +13,13 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import LanguageSuggestionBanner from "@/components/LanguageSuggestionBanner";
 import { EditionProvider } from "@/contexts/EditionContext";
-import { getCfpSettings, getCurrentEdition, getIdentitySettings, getSocialLinks } from "@/lib/api";
+import {
+  getCfpSettings,
+  getCurrentEdition,
+  getIdentitySettings,
+  getPublishedPages,
+  getSocialLinks,
+} from "@/lib/api";
 import { buildFaviconMetadata, getLogoUrl } from "@/lib/identity";
 import { pageMetadata } from "@/lib/page-metadata";
 import { jsonLdScript } from "@/lib/seo";
@@ -79,11 +85,12 @@ export default async function LocaleLayout({
     notFound();
   }
 
-  const [edition, cfp, identity, socialLinks] = await Promise.all([
+  const [edition, cfp, identity, socialLinks, pages] = await Promise.all([
     getCurrentEdition(),
     getCfpSettings(),
     getIdentitySettings(),
     getSocialLinks(),
+    getPublishedPages(),
   ]);
 
   const logoPath = getLogoUrl(identity, "square");
@@ -130,7 +137,13 @@ export default async function LocaleLayout({
       </a>
       <NextIntlClientProvider>
         <LanguageSuggestionBanner />
-        <EditionProvider edition={edition} cfp={cfp} identity={identity} socialLinks={socialLinks}>
+        <EditionProvider
+          edition={edition}
+          cfp={cfp}
+          identity={identity}
+          socialLinks={socialLinks}
+          pages={pages}
+        >
           <Header />
           <main id="main-content" role="main" className="flex-1">
             {children}

--- a/src/frontend/src/app/admin/pages/page.tsx
+++ b/src/frontend/src/app/admin/pages/page.tsx
@@ -6,12 +6,29 @@ import BilingualInput from "@/components/admin/BilingualInput";
 import BilingualTabs from "@/components/admin/BilingualTabs";
 import RichTextEditor from "@/components/admin/RichTextEditor";
 import SaveFeedback, { type SaveState } from "@/components/admin/SaveFeedback";
+import ConfirmDialog from "@/components/admin/ConfirmDialog";
+
+// Served by their own route and linked from every footer: the backend refuses
+// to unpublish or trash them, and the UI hides the actions rather than letting
+// an editor discover the refusal (#419).
+const SYSTEM_SLUGS = ["code-de-conduite", "mentions-legales"];
+
+type NavLocation = "NONE" | "HEADER" | "FOOTER";
+
+const NAV_LABELS: Record<NavLocation, string> = {
+  NONE: "Nulle part — accessible par son adresse uniquement",
+  HEADER: "Menu principal",
+  FOOTER: "Pied de page",
+};
 
 interface PageSummary {
   id: number;
   slug: string;
   titleFr: string;
   titleEn: string;
+  isPublished: boolean;
+  navLocation: NavLocation;
+  navOrder: number;
   updatedAt: string;
 }
 
@@ -31,6 +48,8 @@ export default function PagesAdminPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>(null);
+  const [deleteTarget, setDeleteTarget] = useState<PageSummary | null>(null);
+  const [listState, setListState] = useState<SaveState>(null);
 
   async function loadPages() {
     setIsLoading(true);
@@ -93,6 +112,9 @@ export default function PagesAdminPage() {
         titleEn: editing.titleEn,
         contentFr: editing.contentFr,
         contentEn: editing.contentEn,
+        isPublished: editing.isPublished,
+        navLocation: editing.navLocation,
+        navOrder: editing.navOrder,
       }),
     });
     setIsSaving(false);
@@ -103,6 +125,25 @@ export default function PagesAdminPage() {
       return;
     }
     setEditing(null);
+    loadPages();
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    const target = deleteTarget;
+    setDeleteTarget(null);
+    const { status } = await adminFetch(`/pages/${target.id}`, { method: "DELETE" });
+    if (status !== 200) {
+      setListState({
+        kind: "error",
+        text:
+          status === 409
+            ? "Cette page est servie par une route dédiée et ne peut pas être supprimée."
+            : "La suppression a échoué. Réessayez.",
+      });
+      return;
+    }
+    setListState({ kind: "ok", text: `« ${target.titleFr} » est dans la corbeille.` });
     loadPages();
   }
 
@@ -157,6 +198,10 @@ export default function PagesAdminPage() {
               />
             </div>
           </div>
+          <p className="text-xs text-gris">
+            La page est créée en brouillon. Elle ne sera visible qu&apos;une fois publiée depuis son
+            écran de modification.
+          </p>
           {createError && (
             <p role="alert" aria-live="assertive" className="text-sm text-terre-cuite">{createError}</p>
           )}
@@ -199,6 +244,71 @@ export default function PagesAdminPage() {
             }
           />
 
+          {SYSTEM_SLUGS.includes(editing.slug) ? (
+            <p className="text-sm text-gris">
+              Cette page a sa propre adresse et un lien permanent en pied de page : elle reste
+              publiée.
+            </p>
+          ) : (
+            <div className="rounded-lg border border-gris/20 p-4">
+              <label className="flex items-center gap-3 text-sm text-noir">
+                <input
+                  type="checkbox"
+                  checked={editing.isPublished}
+                  onChange={(e) => setEditing({ ...editing, isPublished: e.target.checked })}
+                  className="size-4 accent-malachite"
+                />
+                <span className="font-medium">Page publiée</span>
+              </label>
+              <p className="mt-2 text-xs text-gris">
+                {editing.isPublished
+                  ? `Visible de tous à l'adresse /${editing.slug}.`
+                  : "Brouillon : la page répond 404 pour les visiteurs et n'apparaît pas au plan du site."}
+              </p>
+
+              <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-[1fr_auto]">
+                <div>
+                  <label htmlFor="navLocation" className="block text-sm font-medium text-noir mb-1">
+                    Emplacement dans la navigation
+                  </label>
+                  <select
+                    id="navLocation"
+                    value={editing.navLocation}
+                    onChange={(e) =>
+                      setEditing({ ...editing, navLocation: e.target.value as NavLocation })
+                    }
+                    className="w-full rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                  >
+                    {(Object.keys(NAV_LABELS) as NavLocation[]).map((value) => (
+                      <option key={value} value={value}>
+                        {NAV_LABELS[value]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="navOrder" className="block text-sm font-medium text-noir mb-1">
+                    Ordre
+                  </label>
+                  <input
+                    id="navOrder"
+                    type="number"
+                    value={editing.navOrder}
+                    onChange={(e) =>
+                      setEditing({ ...editing, navOrder: Number(e.target.value) || 0 })
+                    }
+                    className="w-24 rounded-lg border border-gris/30 px-3 py-2 text-sm text-noir bg-blanc focus:outline-none focus:ring-2 focus:ring-malachite/50"
+                  />
+                </div>
+              </div>
+              <p className="mt-2 text-xs text-gris">
+                Les pages s&apos;ajoutent après les entrées du site (Programme, Conférenciers,
+                Sponsors…), du plus petit ordre au plus grand. Un brouillon n&apos;apparaît nulle
+                part, quel que soit son emplacement.
+              </p>
+            </div>
+          )}
+
           <div className="flex items-center justify-end gap-3">
             <SaveFeedback state={saveState} onDismiss={() => setSaveState(null)} />
             <button onClick={handleSave} disabled={isSaving} className="px-4 py-2 bg-malachite text-blanc rounded-lg text-sm font-medium hover:bg-malachite/90 disabled:opacity-50">
@@ -207,31 +317,66 @@ export default function PagesAdminPage() {
           </div>
         </div>
       ) : (
-        <div className="overflow-x-auto overflow-y-hidden rounded-xl shadow-card bg-blanc">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="bg-blanc-casse/60 border-b border-gris/20">
-                <th className="text-left px-4 py-3 font-medium text-gris">Slug</th>
-                <th className="text-left px-4 py-3 font-medium text-gris">Titre (FR)</th>
-                <th className="text-left px-4 py-3 font-medium text-gris">Mis à jour</th>
-                <th className="text-right px-4 py-3 font-medium text-gris">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {pages.map((page) => (
-                <tr key={page.id} className="border-b border-gris/10 hover:bg-blanc-casse/50">
-                  <td className="px-4 py-3 text-noir font-medium">/{page.slug}</td>
-                  <td className="px-4 py-3 text-noir">{page.titleFr}</td>
-                  <td className="px-4 py-3 text-gris text-xs">{new Date(page.updatedAt).toLocaleDateString("fr-FR")}</td>
-                  <td className="px-4 py-3 text-right">
-                    <button onClick={() => startEdit(page)} className="text-bleu hover:underline text-sm">Modifier</button>
-                  </td>
+        <>
+          <div className="mb-4 flex justify-end">
+            <SaveFeedback state={listState} onDismiss={() => setListState(null)} />
+          </div>
+          <div className="overflow-x-auto overflow-y-hidden rounded-xl shadow-card bg-blanc">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-blanc-casse/60 border-b border-gris/20">
+                  <th className="text-left px-4 py-3 font-medium text-gris">Slug</th>
+                  <th className="text-left px-4 py-3 font-medium text-gris">Titre (FR)</th>
+                  <th className="text-left px-4 py-3 font-medium text-gris">Statut</th>
+                  <th className="text-left px-4 py-3 font-medium text-gris">Mis à jour</th>
+                  <th className="text-right px-4 py-3 font-medium text-gris">Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {pages.map((page) => (
+                  <tr key={page.id} className="border-b border-gris/10 hover:bg-blanc-casse/50">
+                    <td className="px-4 py-3 text-noir font-medium">/{page.slug}</td>
+                    <td className="px-4 py-3 text-noir">{page.titleFr}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={
+                          page.isPublished
+                            ? "inline-block rounded-full bg-malachite/15 px-2 py-0.5 text-xs font-medium text-malachite"
+                            : "inline-block rounded-full bg-gris/15 px-2 py-0.5 text-xs font-medium text-gris"
+                        }
+                      >
+                        {page.isPublished ? "Publiée" : "Brouillon"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gris text-xs">{new Date(page.updatedAt).toLocaleDateString("fr-FR")}</td>
+                    <td className="px-4 py-3 text-right">
+                      <button onClick={() => startEdit(page)} className="text-bleu hover:underline text-sm">Modifier</button>
+                      {!SYSTEM_SLUGS.includes(page.slug) && (
+                        <button
+                          onClick={() => setDeleteTarget(page)}
+                          className="ml-4 text-terre-cuite hover:underline text-sm"
+                        >
+                          Supprimer
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
+
+      <ConfirmDialog
+        isOpen={deleteTarget !== null}
+        title="Supprimer cette page ?"
+        message={`« ${deleteTarget?.titleFr} » ira à la corbeille et ne sera plus accessible à l'adresse /${deleteTarget?.slug}. Vous pourrez la restaurer depuis la corbeille.`}
+        confirmLabel="Supprimer"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/src/frontend/src/app/admin/trash/page.tsx
+++ b/src/frontend/src/app/admin/trash/page.tsx
@@ -23,6 +23,7 @@ const TRASH_ENTITIES: { key: string; label: string; adminOnly: boolean }[] = [
   { key: "sponsor-tiers", label: "Niveaux sponsors", adminOnly: true },
   { key: "editions", label: "Éditions", adminOnly: true },
   { key: "users", label: "Utilisateurs", adminOnly: true },
+  { key: "pages", label: "Pages", adminOnly: false },
 ];
 
 interface TrashItem {

--- a/src/frontend/src/app/sitemap.test.ts
+++ b/src/frontend/src/app/sitemap.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/api", () => ({
   getEditionTalks: vi.fn(),
   getHallOfFame: vi.fn(),
   getIndexableSponsors: vi.fn(),
+  getPublishedPages: vi.fn(),
 }));
 
 import {
@@ -23,6 +24,7 @@ import {
   getEditionTalks,
   getHallOfFame,
   getIndexableSponsors,
+  getPublishedPages,
 } from "@/lib/api";
 import sitemap, { dynamic } from "./sitemap";
 
@@ -55,6 +57,7 @@ beforeEach(() => {
   vi.mocked(getHallOfFame).mockResolvedValue([]);
   vi.mocked(getContentPage).mockResolvedValue(null);
   vi.mocked(getArticles).mockResolvedValue({ articles: [], total: 0, page: 1, totalPages: 0 });
+  vi.mocked(getPublishedPages).mockResolvedValue([]);
 });
 
 describe("sitemap — talk pages (#379)", () => {
@@ -168,6 +171,34 @@ describe("sitemap — every article, not the first hundred (#379)", () => {
     // The old code called getArticles(1, 100) once and stopped there.
     expect(paths(entries)).toContain("/fr/actualites/article-1");
     expect(paths(entries)).toContain("/fr/actualites/article-3");
+  });
+});
+
+describe("sitemap — pages written from the admin (#419)", () => {
+  it("lists a published page, in both languages when it has an English version", async () => {
+    vi.mocked(getPublishedPages).mockResolvedValue([
+      { id: 3, slug: "recrutement", titleFr: "Recrutement", titleEn: "Jobs", hasEnglish: true, navLocation: "HEADER", navOrder: 0, updatedAt: "2026-06-01T00:00:00Z" },
+      { id: 4, slug: "faq", titleFr: "FAQ", titleEn: "", hasEnglish: false, navLocation: "NONE", navOrder: 0, updatedAt: "2026-06-02T00:00:00Z" },
+    ]);
+
+    const entries = await sitemap();
+
+    expect(paths(entries)).toContain("/fr/recrutement");
+    expect(paths(entries)).toContain("/en/recrutement");
+    expect(paths(entries)).toContain("/fr/faq");
+    expect(paths(entries)).not.toContain("/en/faq");
+  });
+
+  // The two legal pages have their own hardcoded route, already listed above.
+  // Without the exclusion they would appear twice in the same sitemap.
+  it("lists a page that also has its own route only once", async () => {
+    vi.mocked(getPublishedPages).mockResolvedValue([
+      { id: 1, slug: "code-de-conduite", titleFr: "Code de conduite", titleEn: "Code of Conduct", hasEnglish: true, navLocation: "NONE", navOrder: 0, updatedAt: "2026-06-01T00:00:00Z" },
+    ]);
+
+    const entries = await sitemap();
+
+    expect(paths(entries).filter((p) => p === "/fr/code-de-conduite")).toHaveLength(1);
   });
 });
 

--- a/src/frontend/src/app/sitemap.ts
+++ b/src/frontend/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 import {
   getArticles,
   getContentPage,
+  getPublishedPages,
   getCurrentEdition,
   getEditions,
   getEditionTalks,
@@ -146,6 +147,28 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           locales,
           path,
           lastModified,
+          "monthly",
+          0.4,
+        ),
+      );
+    }
+  }
+
+  // Pages created from the admin, served by the [locale]/[slug] segment (#421).
+  // Only published ones are listed — a draft is a 404 (#419). The two routes
+  // above have their own path and are excluded here to avoid a duplicate entry.
+  const cmsSlugs = new Set<string>(CMS_BACKED_ROUTES.map((r) => r.slug));
+  for (const page of await getPublishedPages()) {
+    if (cmsSlugs.has(page.slug)) continue;
+    const path = `/${page.slug}`;
+    const locales: Locale[] = page.hasEnglish ? ["fr", "en"] : ["fr"];
+    for (const locale of locales) {
+      entries.push(
+        buildEntry(
+          `${BASE_URL}/${locale}${path}`,
+          locales,
+          path,
+          toDate(page.updatedAt),
           "monthly",
           0.4,
         ),

--- a/src/frontend/src/components/Footer.tsx
+++ b/src/frontend/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 
 import {
@@ -7,24 +7,29 @@ import {
   getEcosystemPartners,
   getEditions,
   getIdentitySettings,
+  getPublishedPages,
   getSocialLinks,
 } from "@/lib/api";
 import { getLogoUrl } from "@/lib/identity";
-import { getPublicNavEntries } from "@/lib/nav";
+import { getFooterPageEntries, getPublicNavEntries } from "@/lib/nav";
 import SocialIcons from "./SocialIcons";
 
 export default async function Footer() {
-  const [tNav, tFooter, tCta, edition, editions, socialLinks, identity, ecosystemPartners] =
+  const [tNav, tFooter, tCta, locale, edition, editions, socialLinks, identity, ecosystemPartners, pages] =
     await Promise.all([
       getTranslations("nav"),
       getTranslations("footer"),
       getTranslations("cta"),
+      getLocale(),
       getCurrentEdition(),
       getEditions(),
       getSocialLinks(),
       getIdentitySettings(),
       getEcosystemPartners(),
+      getPublishedPages(),
     ]);
+
+  const footerPages = getFooterPageEntries(pages, locale);
 
   // Footer sits on a dark green background — pick the white variant.
   const logoUrl = getLogoUrl(identity, "white");
@@ -72,7 +77,7 @@ export default async function Footer() {
             {(() => {
               // Flatten parent + children into one list (the footer has no
               // dropdowns); children render indented under their parent (#203).
-              const footerEntries = getPublicNavEntries(edition)
+              const footerEntries = getPublicNavEntries(edition, pages, locale)
                 .flatMap((entry) => [
                   { ...entry, indented: false },
                   ...(entry.children ?? []).map((child) => ({ ...child, indented: true })),
@@ -96,7 +101,7 @@ export default async function Footer() {
                           href={entry.href}
                           className={`text-blanc text-base hover:opacity-70 transition-opacity ${entry.indented ? "pl-4" : ""}`}
                         >
-                          {tNav(entry.labelKey)}
+                          {entry.label ?? tNav(entry.labelKey)}
                         </Link>
                       </li>
                     ))}
@@ -179,7 +184,18 @@ export default async function Footer() {
         <p className="text-blanc/85 text-sm italic">
           {tFooter("tagline")}
         </p>
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          {/* Pages an editor placed in the footer bar (#420), before the
+              permanent links so those keep their familiar last position. */}
+          {footerPages.map((entry) => (
+            <Link
+              key={entry.key}
+              href={entry.href}
+              className="text-blanc/85 text-sm hover:text-blanc transition-colors"
+            >
+              {entry.label}
+            </Link>
+          ))}
           <Link href="/mentions-legales" className="text-blanc/85 text-sm hover:text-blanc transition-colors">
             {tFooter("legalNotice")}
           </Link>

--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -2,17 +2,18 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import SocialIcons from "./SocialIcons";
 import LanguageSwitcher from "./LanguageSwitcher";
-import { useCfpSettings, useEdition, useIdentitySettings, useSocialLinks } from "@/contexts/EditionContext";
+import { useCfpSettings, useEdition, useIdentitySettings, useNavPages, useSocialLinks } from "@/contexts/EditionContext";
 import { getCfpCtaUrl } from "@/lib/cfp";
 import { getLogoUrl } from "@/lib/identity";
 import { getPublicNavEntries } from "@/lib/nav";
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const locale = useLocale();
   const t = useTranslations("nav");
   const tCta = useTranslations("cta");
   const tHeader = useTranslations("header");
@@ -20,6 +21,7 @@ export default function Header() {
   const cfp = useCfpSettings();
   const identity = useIdentitySettings();
   const socialLinks = useSocialLinks();
+  const pages = useNavPages();
   // Header sits on a white bar — use the square / main logo (color on white).
   const logoUrl = getLogoUrl(identity, "square");
 
@@ -28,7 +30,7 @@ export default function Header() {
   const showSponsorCta = edition && edition.sponsorPageStatus !== "SOLD_OUT";
   const cfpUrl = getCfpCtaUrl(cfp);
 
-  const navEntries = getPublicNavEntries(edition);
+  const navEntries = getPublicNavEntries(edition, pages, locale);
 
   return (
     <header
@@ -58,7 +60,7 @@ export default function Header() {
                     className="flex items-center gap-1 text-gris text-base hover:text-noir transition-colors"
                     aria-haspopup="true"
                   >
-                    {t(entry.labelKey)}
+                    {entry.label ?? t(entry.labelKey)}
                     <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                     </svg>
@@ -70,7 +72,7 @@ export default function Header() {
                         href={child.href}
                         className="px-4 py-2 text-gris text-base hover:text-noir hover:bg-blanc-casse transition-colors"
                       >
-                        {t(child.labelKey)}
+                        {child.label ?? t(child.labelKey)}
                       </Link>
                     ))}
                   </div>
@@ -81,7 +83,7 @@ export default function Header() {
                   href={entry.href}
                   className="text-gris text-base hover:text-noir transition-colors"
                 >
-                  {t(entry.labelKey)}
+                  {entry.label ?? t(entry.labelKey)}
                 </Link>
               ),
             )}
@@ -148,7 +150,7 @@ export default function Header() {
                   className="text-gris text-base hover:text-noir transition-colors"
                   onClick={() => setIsMenuOpen(false)}
                 >
-                  {t(entry.labelKey)}
+                  {entry.label ?? t(entry.labelKey)}
                 </Link>
                 {entry.children?.map((child) => (
                   <Link
@@ -157,7 +159,7 @@ export default function Header() {
                     className="pl-4 text-gris text-base hover:text-noir transition-colors"
                     onClick={() => setIsMenuOpen(false)}
                   >
-                    {t(child.labelKey)}
+                    {child.label ?? t(child.labelKey)}
                   </Link>
                 ))}
               </div>

--- a/src/frontend/src/contexts/EditionContext.tsx
+++ b/src/frontend/src/contexts/EditionContext.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import type { CfpSettings, Edition, SocialLinks } from "@/lib/types";
+import type { CfpSettings, ContentPageSummary, Edition, SocialLinks } from "@/lib/types";
 
 interface EditionContextValue {
   edition: Edition | null;
   cfp: CfpSettings | null;
   identity: Record<string, string>;
   socialLinks: SocialLinks;
+  // Published admin-authored pages, so the header — a client component — can
+  // place the ones an editor put in the menu (#420).
+  pages: ContentPageSummary[];
 }
 
 const EditionContext = createContext<EditionContextValue>({
@@ -15,6 +18,7 @@ const EditionContext = createContext<EditionContextValue>({
   cfp: null,
   identity: {},
   socialLinks: {},
+  pages: [],
 });
 
 export function EditionProvider({
@@ -22,16 +26,18 @@ export function EditionProvider({
   cfp,
   identity,
   socialLinks,
+  pages = [],
   children,
 }: {
   edition: Edition | null;
   cfp: CfpSettings | null;
   identity: Record<string, string>;
   socialLinks: SocialLinks;
+  pages?: ContentPageSummary[];
   children: React.ReactNode;
 }) {
   return (
-    <EditionContext.Provider value={{ edition, cfp, identity, socialLinks }}>
+    <EditionContext.Provider value={{ edition, cfp, identity, socialLinks, pages }}>
       {children}
     </EditionContext.Provider>
   );
@@ -51,4 +57,8 @@ export function useIdentitySettings() {
 
 export function useSocialLinks() {
   return useContext(EditionContext).socialLinks;
+}
+
+export function useNavPages() {
+  return useContext(EditionContext).pages;
 }

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   KeyFigure,
   Tag,
   ContentPage,
+  ContentPageSummary,
   CfpSettings,
   ContactCategory,
   PaginatedArticles,
@@ -162,6 +163,10 @@ export async function getTags(): Promise<Tag[]> {
 
 export async function getContentPage(slug: string): Promise<ContentPage | null> {
   return fetchAPI<ContentPage>(`/api/pages/${encodeURIComponent(slug)}`);
+}
+
+export async function getPublishedPages(): Promise<ContentPageSummary[]> {
+  return (await fetchAPI<ContentPageSummary[]>("/api/pages")) || [];
 }
 
 export async function getCfpSettings(): Promise<CfpSettings> {

--- a/src/frontend/src/lib/nav.test.ts
+++ b/src/frontend/src/lib/nav.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 
-import { getPublicNavEntries } from "./nav";
-import type { Edition } from "./types";
+import { getFooterPageEntries, getPublicNavEntries } from "./nav";
+import type { ContentPageSummary, Edition } from "./types";
 import fr from "../../messages/fr.json";
 import en from "../../messages/en.json";
 
@@ -125,5 +125,79 @@ describe("getPublicNavEntries", () => {
       }),
     );
     expect(keys(entries)).toEqual(["conferences", "speakers", "sponsors", "venue", "blog"]);
+  });
+});
+
+// #420 — admin-authored pages join the navigation. Only the placement is the
+// editor's to choose: the system entries keep their status-driven order.
+
+function page(overrides: Partial<ContentPageSummary> = {}): ContentPageSummary {
+  return {
+    id: 1,
+    slug: "une-page",
+    titleFr: "Une page",
+    titleEn: "A page",
+    hasEnglish: true,
+    navLocation: "HEADER",
+    navOrder: 0,
+    updatedAt: "2026-08-25T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("content pages in the navigation", () => {
+  it("appends a header page after the system entries, never between them", () => {
+    const entries = getPublicNavEntries(
+      edition({ isProgramPublished: true, hasSpeakers: true }),
+      [page({ slug: "recrutement" })],
+    );
+    expect(keys(entries)).toEqual(["conferences", "speakers", "blog", "page-recrutement"]);
+  });
+
+  it("keeps a footer page out of the main menu", () => {
+    const entries = getPublicNavEntries(edition(), [page({ navLocation: "FOOTER" })]);
+    expect(keys(entries)).toEqual(["blog"]);
+    expect(getFooterPageEntries([page({ navLocation: "FOOTER" })]).map((e) => e.key)).toEqual([
+      "page-une-page",
+    ]);
+  });
+
+  it("shows a page placed nowhere in neither navigation", () => {
+    const nowhere = [page({ navLocation: "NONE" })];
+    expect(keys(getPublicNavEntries(edition(), nowhere))).toEqual(["blog"]);
+    expect(getFooterPageEntries(nowhere)).toEqual([]);
+  });
+
+  it("orders pages by navOrder, then by slug when they tie", () => {
+    const entries = getPublicNavEntries(edition(), [
+      page({ slug: "troisieme", navOrder: 2 }),
+      page({ slug: "beta", navOrder: 1 }),
+      page({ slug: "alpha", navOrder: 1 }),
+    ]);
+    expect(keys(entries)).toEqual(["blog", "page-alpha", "page-beta", "page-troisieme"]);
+  });
+
+  it("carries a literal label rather than an i18n key", () => {
+    const [entry] = getFooterPageEntries([
+      page({ navLocation: "FOOTER", titleFr: "Nous rejoindre", titleEn: "Join us" }),
+    ]);
+    expect(entry.label).toBe("Nous rejoindre");
+    expect(entry.href).toBe("/une-page");
+  });
+
+  it("switches the label to English on the /en side", () => {
+    const [entry] = getFooterPageEntries(
+      [page({ navLocation: "FOOTER", titleFr: "Nous rejoindre", titleEn: "Join us" })],
+      "en",
+    );
+    expect(entry.label).toBe("Join us");
+  });
+
+  it("falls back to the French title when the English one is empty", () => {
+    const [entry] = getFooterPageEntries(
+      [page({ navLocation: "FOOTER", titleFr: "Nous rejoindre", titleEn: "  " })],
+      "en",
+    );
+    expect(entry.label).toBe("Nous rejoindre");
   });
 });

--- a/src/frontend/src/lib/nav.ts
+++ b/src/frontend/src/lib/nav.ts
@@ -1,4 +1,4 @@
-import type { Edition } from "@/lib/types";
+import type { ContentPageSummary, Edition } from "@/lib/types";
 
 // A public navigation entry. `labelKey` is a key under the `nav` i18n
 // namespace. An entry may carry `children` — currently only "Programme",
@@ -8,6 +8,10 @@ export interface NavEntry {
   labelKey: string;
   href: string;
   children?: NavEntry[];
+  // Admin-authored pages carry their own title in both languages and have no
+  // i18n key, so they bring a ready-made label instead (#420). Callers must
+  // prefer it over translating `labelKey`.
+  label?: string;
 }
 
 const CONFERENCES_ENTRY: NavEntry = {
@@ -45,7 +49,37 @@ const VENUE_ENTRY: NavEntry = { key: "venue", labelKey: "venue", href: "/lieu" }
 // While there are published talks but no schedule yet, "Conférences" is a
 // top-level link; once the schedule is ready it becomes a "Programme" menu
 // with "Conférences" nested underneath (#203).
-export function getPublicNavEntries(edition: Edition | null): NavEntry[] {
+// An admin-authored page as a navigation entry (#420). Only published pages
+// reach here — the API filters drafts out — so no status check is needed.
+function pageEntry(page: ContentPageSummary, locale: string): NavEntry {
+  const title = locale === "en" && page.titleEn.trim() ? page.titleEn : page.titleFr;
+  return { key: `page-${page.slug}`, labelKey: "", href: `/${page.slug}`, label: title };
+}
+
+function pagesAt(
+  pages: ContentPageSummary[],
+  location: "HEADER" | "FOOTER",
+  locale: string,
+): NavEntry[] {
+  return pages
+    .filter((p) => p.navLocation === location)
+    .sort((a, b) => a.navOrder - b.navOrder || a.slug.localeCompare(b.slug))
+    .map((p) => pageEntry(p, locale));
+}
+
+// Pages placed in the footer bar, beside the permanent legal links (#420).
+export function getFooterPageEntries(
+  pages: ContentPageSummary[] = [],
+  locale = "fr",
+): NavEntry[] {
+  return pagesAt(pages, "FOOTER", locale);
+}
+
+export function getPublicNavEntries(
+  edition: Edition | null,
+  pages: ContentPageSummary[] = [],
+  locale = "fr",
+): NavEntry[] {
   const entries: NavEntry[] = [];
 
   if (edition?.isScheduleReady) {
@@ -68,6 +102,10 @@ export function getPublicNavEntries(edition: Edition | null): NavEntry[] {
   }
   if (edition?.hasVenueInfo) entries.push(VENUE_ENTRY);
   entries.push(BLOG_ENTRY);
+
+  // Free pages come after the system entries, never between them: the order of
+  // those is driven by the edition's status and is not the editor's to change.
+  entries.push(...pagesAt(pages, "HEADER", locale));
 
   return entries;
 }

--- a/src/frontend/src/lib/types.ts
+++ b/src/frontend/src/lib/types.ts
@@ -123,6 +123,21 @@ export interface ContentPage {
   updatedAt: string;
 }
 
+// A published page as listed by GET /api/pages — no body, since the callers
+// (sitemap, navigation) want the entry, not the content (#419).
+export interface ContentPageSummary {
+  id: number;
+  slug: string;
+  titleFr: string;
+  titleEn: string;
+  /** Both the English title and body are filled — gates the /en sitemap entry. */
+  hasEnglish: boolean;
+  /** Where the page shows in the navigation, and its rank there (#420). */
+  navLocation: "NONE" | "HEADER" | "FOOTER";
+  navOrder: number;
+  updatedAt: string;
+}
+
 // A sponsoring offer shown on /devenir-sponsor (#318). One row of the shared
 // SponsorTier catalogue, joined to the current edition (price is the edition
 // override). Replaces the former SponsorPlan.


### PR DESCRIPTION
## Résumé

- Une page de contenu a désormais un cycle de vie : **brouillon par défaut**, publication, mise à la corbeille avec parking du slug. L'écran d'admin n'avait aucune suppression jusqu'ici (#419).
- Une page publiée peut être **placée dans le menu principal ou la barre de pied de page**, avec un ordre entre elles ; elles s'ajoutent *après* les entrées du site, jamais entre elles — cet ordre-là dépend du statut de l'édition (#420).
- Le plan du site liste les pages publiées et est purgé à chaque enregistrement.

## Deux garde-fous que les issues ne demandaient pas

`code-de-conduite` et `mentions-legales` sont servies par leurs **routes codées en dur** et liées depuis chaque pied de page. Rien n'empêchait de les dépublier ou de les mettre à la corbeille — un 404 derrière un lien permanent. Le backend renvoie **409** dans les deux cas et l'admin masque les commandes plutôt que de laisser découvrir le refus. Même arbitrage que « bloquer plutôt que mettre à la corbeille » retenu pour les lieux et salles (#105).

La migration **repose `isPublished = true` sur les lignes existantes**. Sans ce backfill, les deux pages légales tombaient en 404 au moment même du déploiement.

## Un commit et non deux

Les deux issues partagent la même table, les mêmes routes et le même écran. Découpé en deux, le premier commit aurait porté une colonne que sa migration ne crée pas — donc un commit qui ne démarre pas. Le message dit lequel des deux périmètres porte quoi.

## Plan de test

**Vérifié**

- Migrations jouées sur la base locale ; backfill contrôlé en SQL (les deux pages existantes ressortent publiées).
- Suites : backend **705/706**, frontend **329/329**. Le seul échec backend est un artefact de conteneur — `stat-icons.test.ts` lit `../../../frontend/src/lib/stat-icons.ts`, invisible depuis `/app` ; en copiant le fichier à l'emplacement attendu, il passe (4/4). Rien à voir avec ce changement.
- `tsc --noEmit` propre sur les deux applications, `pnpm lint` sans erreur (9 avertissements préexistants, aucun dans les fichiers touchés).
- Parcours navigateur complet via Chrome DevTools MCP : création → **404 en brouillon** (API, `/fr`, `/en`) → publication → servie en 200 → placement au menu (apparaît en dernier) → placement au pied de page (quitte le menu, rejoint la barre avant les liens légaux) → dépublication (404, disparaît du menu **et** du plan du site) → suppression (corbeille, slug parqué `__trash_99__…`) → restauration (slug rendu, reste en brouillon).
- 409 confirmés en direct sur `DELETE` et sur la dépublication de `code-de-conduite`.
- `seed-dev.ts` republie les deux pages système : reposé après les avoir mises en brouillon à la main, elles ressortent publiées.
- Menu mobile (412×915) : l'entrée apparaît en dernier, mise en page tenue, **console vide**.

**Non vérifié**

- Rien en beta ni en prod — les migrations n'y sont pas jouées.
- L'étiquette `/en` d'une page dont seul le titre anglais est saisi affiche bien l'anglais, alors que `hasEnglish` (titre **et** contenu) la garde hors du plan du site anglais. C'est cohérent avec le repli existant de la route `[slug]`, mais je ne l'ai pas éprouvé au-delà de ce cas.
- Le plan du site reste en retard d'une heure au maximum pour les **articles, conférences et sponsors** : aucun de leurs helpers de purge ne mentionne `/sitemap.xml`. Je n'ai corrigé que le cas des pages, qui est le périmètre de #419.

Refs #419
Refs #420
