### PR TITLE
Les cinq bugs ouverts : références de fichiers et performances mobiles

### DIFF
--- a/src/backend/src/__tests__/file-delete-references.test.ts
+++ b/src/backend/src/__tests__/file-delete-references.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import Fastify from "fastify";
+import fs from "node:fs";
+import path from "node:path";
+
+import adminFileRoutes from "../routes/admin/files.js";
+import { UPLOADS_DIR } from "../lib/image-store.js";
+import { prisma } from "../lib/prisma.js";
+
+// #486 — the media library is a *shared* library: the same upload can be a
+// speaker's photo, a sponsor's frozen logo and the site's header logo at once.
+// Deleting from /admin/files always succeeded, leaving the referencing column
+// pointing at a file that no longer exists. No fallback catches that — the
+// speaker's initial only shows when photoUrl is null, and here it stays set.
+
+async function deleteFile(filename: string) {
+  const app = Fastify({ logger: false });
+  await app.register(adminFileRoutes, { prefix: "/api/admin" });
+  const res = await app.inject({ method: "DELETE", url: `/api/admin/files/${filename}` });
+  await app.close();
+  return res;
+}
+
+/** A real file on disk, so a passing delete is a delete that actually happened. */
+async function writeUpload(): Promise<string> {
+  const filename = `${Date.now()}-${Math.random().toString(16).slice(2, 10)}.png`;
+  await fs.promises.writeFile(path.join(UPLOADS_DIR, filename), "not-really-a-png");
+  written.push(filename);
+  return filename;
+}
+
+const written: string[] = [];
+const speakerIds: number[] = [];
+const settingKeys: string[] = [];
+
+afterEach(async () => {
+  for (const id of speakerIds.splice(0)) {
+    await prisma.speaker.delete({ where: { id } }).catch(() => {});
+  }
+  for (const key of settingKeys.splice(0)) {
+    await prisma.siteSetting.deleteMany({ where: { key } });
+  }
+  for (const name of written.splice(0)) {
+    await fs.promises.unlink(path.join(UPLOADS_DIR, name)).catch(() => {});
+    await prisma.fileMetadata.deleteMany({ where: { filename: name } });
+  }
+});
+
+describe("deleting a file from the media library", () => {
+  it("removes one nothing points at", async () => {
+    const filename = await writeUpload();
+
+    const res = await deleteFile(filename);
+
+    expect(res.statusCode).toBe(200);
+    await expect(fs.promises.access(path.join(UPLOADS_DIR, filename))).rejects.toThrow();
+  });
+
+  it("refuses in 409 when a speaker still shows it", async () => {
+    const filename = await writeUpload();
+    const speaker = await prisma.speaker.create({
+      data: {
+        name: "Référence Test",
+        slug: `reference-test-${Date.now()}`,
+        photoUrl: `/uploads/${filename}`,
+      },
+    });
+    speakerIds.push(speaker.id);
+
+    const res = await deleteFile(filename);
+
+    expect(res.statusCode).toBe(409);
+    // The file must still be there: a refusal that deleted anyway is worse
+    // than no guard at all.
+    await expect(fs.promises.access(path.join(UPLOADS_DIR, filename))).resolves.toBeUndefined();
+  });
+
+  it("names what is using it, so the admin knows where to go", async () => {
+    const filename = await writeUpload();
+    const speaker = await prisma.speaker.create({
+      data: {
+        name: "Référence Nommée",
+        slug: `reference-nommee-${Date.now()}`,
+        photoUrl: `/uploads/${filename}`,
+      },
+    });
+    speakerIds.push(speaker.id);
+
+    const res = await deleteFile(filename);
+
+    expect(res.json().error).toContain("speaker");
+    expect(res.json().usages).toEqual([{ model: "speaker", field: "photoUrl", count: 1 }]);
+  });
+
+  // The site logo, the favicons, the home carousel and the OG image are
+  // key/value rows, not typed columns — so no `fileFields` entry can describe
+  // them. They are also the most visible references there are: deleting the
+  // logo breaks the header of every page on the site.
+  it("refuses one held by the site settings", async () => {
+    const filename = await writeUpload();
+    await prisma.siteSetting.create({
+      data: { key: "identity_logo_main", value: `/uploads/${filename}` },
+    });
+    settingKeys.push("identity_logo_main");
+
+    const res = await deleteFile(filename);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain("réglages du site");
+  });
+
+  it("refuses one buried in the carousel's JSON", async () => {
+    const filename = await writeUpload();
+    await prisma.siteSetting.create({
+      data: {
+        key: "about_carousel",
+        value: JSON.stringify([{ url: `/uploads/${filename}`, alt: "Ambiance" }]),
+      },
+    });
+    settingKeys.push("about_carousel");
+
+    const res = await deleteFile(filename);
+
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("still refuses a filename that traverses", async () => {
+    const res = await deleteFile("..%2F..%2Fetc%2Fpasswd");
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/src/backend/src/__tests__/file-delete-references.test.ts
+++ b/src/backend/src/__tests__/file-delete-references.test.ts
@@ -99,10 +99,12 @@ describe("deleting a file from the media library", () => {
   // logo breaks the header of every page on the site.
   it("refuses one held by the site settings", async () => {
     const filename = await writeUpload();
-    await prisma.siteSetting.create({
-      data: { key: "identity_logo_main", value: `/uploads/${filename}` },
-    });
-    settingKeys.push("identity_logo_main");
+    // A key of its own rather than the real `identity_logo_main`: the scan is
+    // on `value`, so the key is irrelevant to what is verified, and borrowing a
+    // real one collides with whatever the local database already holds.
+    const key = `test_identity_logo_${Date.now()}`;
+    await prisma.siteSetting.create({ data: { key, value: `/uploads/${filename}` } });
+    settingKeys.push(key);
 
     const res = await deleteFile(filename);
 
@@ -110,15 +112,13 @@ describe("deleting a file from the media library", () => {
     expect(res.json().error).toContain("réglages du site");
   });
 
-  it("refuses one buried in the carousel's JSON", async () => {
+  it("refuses one buried in a setting's JSON, as the carousel stores it", async () => {
     const filename = await writeUpload();
+    const key = `test_about_carousel_${Date.now()}`;
     await prisma.siteSetting.create({
-      data: {
-        key: "about_carousel",
-        value: JSON.stringify([{ url: `/uploads/${filename}`, alt: "Ambiance" }]),
-      },
+      data: { key, value: JSON.stringify([{ url: `/uploads/${filename}`, alt: "Ambiance" }]) },
     });
-    settingKeys.push("about_carousel");
+    settingKeys.push(key);
 
     const res = await deleteFile(filename);
 

--- a/src/backend/src/lib/trash-files.test.ts
+++ b/src/backend/src/lib/trash-files.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import { FILE_REFERENCES } from "./trash-files.js";
-import { TRASH_ENTITIES } from "./trash-registry.js";
+import { FILE_ONLY_MODELS, TRASH_ENTITIES } from "./trash-registry.js";
 
 // FILE_REFERENCES (used to reference-count a shared upload before purging it)
 // is now derived from the registry's `fileFields` rather than maintained as a
@@ -11,7 +11,10 @@ import { TRASH_ENTITIES } from "./trash-registry.js";
 
 describe("FILE_REFERENCES derivation (#307)", () => {
   it("covers exactly the registry's file fields, nothing more, nothing less", () => {
-    const expected = TRASH_ENTITIES.flatMap((e) => e.fileFields.map((f) => `${e.model}.${f}`)).sort();
+    const expected = [
+      ...TRASH_ENTITIES.flatMap((e) => e.fileFields.map((f) => `${e.model}.${f}`)),
+      ...FILE_ONLY_MODELS.flatMap((e) => e.fileFields.map((f) => `${e.model}.${f}`)),
+    ].sort();
     const actual = FILE_REFERENCES.map((r) => `${r.model}.${r.field}`).sort();
     expect(actual).toEqual(expected);
   });
@@ -22,5 +25,17 @@ describe("FILE_REFERENCES derivation (#307)", () => {
     expect(keys).toContain("speaker.photoUrl");
     expect(keys).toContain("sponsor.logoUrl");
     expect(keys).toContain("edition.heroImageUrl");
+  });
+
+  // A participation is not soft-deletable, so it has no entry in the trash
+  // registry and its four upload columns escaped the count entirely (#486). A
+  // file used only by one was reported as unreferenced, and purging any other
+  // row pointing at it erased a past edition's frozen logo (#375).
+  it("counts the sponsor participation's frozen logo and com-kit files (#486)", () => {
+    const keys = FILE_REFERENCES.map((r) => `${r.model}.${r.field}`);
+    expect(keys).toContain("editionSponsor.logoUrl");
+    expect(keys).toContain("editionSponsor.comKitLogoWebUrl");
+    expect(keys).toContain("editionSponsor.comKitLogoPrintUrl");
+    expect(keys).toContain("editionSponsor.comKitCharterUrl");
   });
 });

--- a/src/backend/src/lib/trash-files.ts
+++ b/src/backend/src/lib/trash-files.ts
@@ -2,14 +2,15 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { prisma } from "./prisma.js";
-import { TRASH_ENTITIES } from "./trash-registry.js";
+import { FILE_ONLY_MODELS, TRASH_ENTITIES } from "./trash-registry.js";
 
 const UPLOADS_DIR = process.env.UPLOADS_DIR || "/app/uploads";
 
 // Every column that can point at an /uploads/ path, derived from the single
-// source of truth (each entity's `fileFields` in the registry). Purging a row
-// must not delete a file another row still shows: uploads live in a shared
-// library (/admin/files), they are not owned by the referencing entity.
+// source of truth (each entity's `fileFields` in the registry, plus the models
+// that hold uploads without being soft-deletable). Purging a row must not
+// delete a file another row still shows: uploads live in a shared library
+// (/admin/files), they are not owned by the referencing entity.
 //
 // Verified on real data: one image was already referenced by two articles. A
 // naive "delete the row's files" purge would have broken the survivor's image.
@@ -17,31 +18,72 @@ const UPLOADS_DIR = process.env.UPLOADS_DIR || "/app/uploads";
 // Deriving this instead of maintaining a second flat list (the old shape) means
 // adding an entity with an upload column can no longer forget to update the
 // reference count — the bug this comment used to warn about.
-export const FILE_REFERENCES: readonly { model: string; field: string }[] = TRASH_ENTITIES.flatMap(
-  (entity) => entity.fileFields.map((field) => ({ model: entity.model, field })),
-);
+export const FILE_REFERENCES: readonly { model: string; field: string }[] = [
+  ...TRASH_ENTITIES.flatMap((entity) =>
+    entity.fileFields.map((field) => ({ model: entity.model, field })),
+  ),
+  ...FILE_ONLY_MODELS.flatMap((entity) =>
+    entity.fileFields.map((field) => ({ model: entity.model, field })),
+  ),
+];
 
 type CountDelegate = { count: (args: unknown) => Promise<number> };
 
+/** One place an upload is used, as the admin needs to hear it. */
+export interface FileReferenceUsage {
+  model: string;
+  field: string;
+  count: number;
+}
+
 /**
- * How many rows still point at this upload, ignoring one row about to go.
+ * The site-wide settings are key/value rows, not typed columns: the logos, the
+ * favicons, the home carousel and the OG image all live in `SiteSetting.value`
+ * (#486). They are the most visible references of all — deleting the site logo
+ * breaks the header of every page — so they are counted too.
+ *
+ * A substring match, since `about_carousel` stores a JSON array rather than a
+ * bare URL. It can only over-count (one filename being the prefix of another),
+ * and over-counting merely refuses a deletion — the safe direction.
+ */
+async function countSettingReferences(url: string): Promise<number> {
+  return prisma.siteSetting.count({ where: { value: { contains: url } } });
+}
+
+/**
+ * Where an upload is still used, ignoring one row about to go.
  *
  * Counts across ALL entities, trashed ones included: a trashed row can still be
  * restored, and it would come back to a missing image otherwise.
  */
-export async function countFileReferences(
+export async function listFileReferences(
   url: string,
-  excluding: { model: string; id: number | string },
-): Promise<number> {
-  let total = 0;
+  excluding?: { model: string; id: number | string },
+): Promise<FileReferenceUsage[]> {
+  const usages: FileReferenceUsage[] = [];
+
   for (const ref of FILE_REFERENCES) {
     const delegate = (prisma as unknown as Record<string, CountDelegate>)[ref.model];
     if (!delegate) continue;
     const where: Record<string, unknown> = { [ref.field]: url };
-    if (ref.model === excluding.model) where.id = { not: excluding.id };
-    total += await delegate.count({ where });
+    if (excluding && ref.model === excluding.model) where.id = { not: excluding.id };
+    const count = await delegate.count({ where });
+    if (count > 0) usages.push({ model: ref.model, field: ref.field, count });
   }
-  return total;
+
+  const settings = await countSettingReferences(url);
+  if (settings > 0) usages.push({ model: "siteSetting", field: "value", count: settings });
+
+  return usages;
+}
+
+/** How many rows still point at this upload. See `listFileReferences`. */
+export async function countFileReferences(
+  url: string,
+  excluding?: { model: string; id: number | string },
+): Promise<number> {
+  const usages = await listFileReferences(url, excluding);
+  return usages.reduce((total, usage) => total + usage.count, 0);
 }
 
 /** Guard against a crafted path escaping the uploads directory. */

--- a/src/backend/src/lib/trash-registry.ts
+++ b/src/backend/src/lib/trash-registry.ts
@@ -140,6 +140,27 @@ export const TRASH_ENTITIES: readonly TrashEntity[] = [
   },
 ];
 
+/**
+ * Models that hold /uploads/ columns without being soft-deletable (#486).
+ *
+ * The reference count has to span every column that can point at an upload, but
+ * the trash only knows the entities it can restore. `EditionSponsor` is what
+ * revealed the gap: it carries the logo frozen for one edition (#375) plus the
+ * com-kit files picked from the media library, and a file used only there was
+ * counted as unreferenced — so purging any other row pointing at it erased a
+ * past edition's logo.
+ *
+ * Kept beside TRASH_ENTITIES rather than in a second file: the two are read
+ * together by `FILE_REFERENCES`, and splitting them is how the flat list this
+ * registry replaced went out of date.
+ */
+export const FILE_ONLY_MODELS: readonly { model: string; fileFields: readonly string[] }[] = [
+  {
+    model: "editionSponsor",
+    fileFields: ["logoUrl", "comKitLogoWebUrl", "comKitLogoPrintUrl", "comKitCharterUrl"],
+  },
+];
+
 export function findTrashEntity(key: string): TrashEntity | undefined {
   return TRASH_ENTITIES.find((e) => e.key === key);
 }

--- a/src/backend/src/routes/admin/files.ts
+++ b/src/backend/src/routes/admin/files.ts
@@ -15,6 +15,7 @@ import {
 } from "../../lib/image-store.js";
 import { sanitizeSvg } from "../../lib/svg-sanitize.js";
 import { TranslationError, sendTranslationError } from "../../lib/translation/errors.js";
+import { listFileReferences, type FileReferenceUsage } from "../../lib/trash-files.js";
 
 const ALLOWED_MIMES = [
   // Images. SVG was excluded outright by #306 — served same-origin from
@@ -35,6 +36,27 @@ const ALLOWED_MIMES = [
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ];
 const MAX_FILE_SIZE = 20_000_000; // 20 MB
+
+// What each model is called in the refusal shown to the admin (#486). The
+// message has to name the place to go and fix it, not a Prisma delegate.
+const USAGE_LABELS: Record<string, { one: string; many: string }> = {
+  article: { one: "un article", many: "articles" },
+  speaker: { one: "un speaker", many: "speakers" },
+  sponsor: { one: "un sponsor", many: "sponsors" },
+  editionSponsor: { one: "une participation sponsor", many: "participations sponsor" },
+  edition: { one: "une édition", many: "éditions" },
+  siteSetting: { one: "les réglages du site", many: "les réglages du site" },
+};
+
+function describeUsages(usages: readonly FileReferenceUsage[]): string {
+  const parts = usages.map(({ model, count }) => {
+    const label = USAGE_LABELS[model];
+    if (!label) return `${count} ligne(s) « ${model} »`;
+    return count > 1 ? `${count} ${label.many}` : label.one;
+  });
+  if (parts.length === 1) return parts[0];
+  return `${parts.slice(0, -1).join(", ")} et ${parts[parts.length - 1]}`;
+}
 
 export default async function adminFileRoutes(app: FastifyInstance) {
   // POST /api/admin/files — upload a single file (image or document)
@@ -322,6 +344,20 @@ export default async function adminFileRoutes(app: FastifyInstance) {
       // Prevent path traversal
       if (filename.includes("/") || filename.includes("\\") || filename.includes("..")) {
         return reply.code(400).send({ error: "Invalid filename" });
+      }
+
+      // The media library is shared: a file here may be a speaker's photo, a
+      // sponsor's frozen logo or the site's own header logo. Deleting it used to
+      // always succeed, leaving the referencing column pointing at nothing and
+      // the public page showing a broken image — no fallback fires, because
+      // photoUrl is still set (#486). The counter already existed for the trash
+      // purge; this is the path that never asked it.
+      const usages = await listFileReferences(`/uploads/${filename}`);
+      if (usages.length > 0) {
+        return reply.code(409).send({
+          error: `Ce fichier est encore utilisé par ${describeUsages(usages)}. Remplacez-le là où il sert avant de le supprimer.`,
+          usages,
+        });
       }
 
       const filePath = path.join(UPLOADS_DIR, filename);

--- a/src/frontend/next.config.ts
+++ b/src/frontend/next.config.ts
@@ -213,6 +213,19 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "picsum.photos",
       },
+      // Video thumbnails, proxied through /_next/image so the browser never
+      // contacts Google before the visitor clicks play (#474). YouTube serves
+      // the same images from both hosts depending on the video.
+      {
+        protocol: "https",
+        hostname: "img.youtube.com",
+        pathname: "/vi/**",
+      },
+      {
+        protocol: "https",
+        hostname: "i.ytimg.com",
+        pathname: "/vi/**",
+      },
     ],
   },
 };

--- a/src/frontend/src/app/admin/files/page.tsx
+++ b/src/frontend/src/app/admin/files/page.tsx
@@ -115,12 +115,14 @@ export default function FilesAdminPage() {
   async function handleDelete() {
     if (!deleteTarget) return;
     setError("");
-    const { status } = await adminFetch(`/files/${deleteTarget}`, { method: "DELETE" });
+    const { status, error: serverError } = await adminFetch(`/files/${deleteTarget}`, {
+      method: "DELETE",
+    });
     setDeleteTarget(null);
-    // A file still referenced elsewhere comes back on the next load; without
-    // this the dialog just closed and the file silently reappeared (#412).
+    // The server now refuses in 409 and names the entities still using the file
+    // (#486) — show its sentence rather than the guess this used to print.
     if (status !== 204 && status !== 200) {
-      setError("La suppression a échoué. Le fichier est peut-être encore utilisé.");
+      setError(serverError ?? "La suppression a échoué. Réessayez.");
       return;
     }
     loadFiles();

--- a/src/frontend/src/app/layout.tsx
+++ b/src/frontend/src/app/layout.tsx
@@ -3,9 +3,23 @@ import { Google_Sans } from "next/font/google";
 import { routing } from "@/i18n/routing";
 import "./globals.css";
 
+// `optional`, not `swap` (#481). next/font normally hides a font swap by
+// emitting a fallback face with matching metrics, but it has none for Google
+// Sans — the build says so out loud ("Failed to find font override values for
+// font `Google Sans`. Skipping generating a fallback font."), and the built CSS
+// carries no size-adjust/ascent-override rule to prove it. So `swap` replaced
+// system-ui with a font of different metrics after first paint, and every line
+// of the hero changed height: PageSpeed put the page's whole 0.063 CLS on
+// `section.hero`, a 412 × 947 block — the entire first screen.
+//
+// With `optional` the browser takes the font if it is ready within its ~100 ms
+// window and otherwise keeps the fallback for that page load, never swapping.
+// The trade is that a first visit on a slow link may render in system-ui; the
+// alternative, a hand-measured metric-matched fallback, keeps the brand font on
+// those loads too and is the move if this trade reads wrong.
 const googleSans = Google_Sans({
   subsets: ["latin"],
-  display: "swap",
+  display: "optional",
   variable: "--font-google-sans",
 });
 

--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
-import { Link } from "@/i18n/navigation";
+import { Link, usePathname } from "@/i18n/navigation";
 import SocialIcons from "./SocialIcons";
 import LanguageSwitcher from "./LanguageSwitcher";
 import { useCfpSettings, useEdition, useIdentitySettings, useNavPages, useSocialLinks } from "@/contexts/EditionContext";
@@ -32,6 +32,14 @@ export default function Header() {
 
   const navEntries = getPublicNavEntries(edition, pages, locale);
 
+  // next/link prefetches a target without noticing the visitor is already on
+  // it: standing on the home page, the logo link had the server re-render /fr
+  // for nothing (#476). An `_rsc` prefetch is a server render, not a static
+  // file, so it costs on both ends — and on a throttled link it competes with
+  // the page still loading.
+  const pathname = usePathname();
+  const prefetchUnlessHere = (href: string) => (href === pathname ? false : undefined);
+
   return (
     <header
       role="banner"
@@ -40,7 +48,7 @@ export default function Header() {
       <div className="mx-auto flex h-full max-w-[1440px] items-center px-4 lg:px-[100px]">
         {/* Logo + Nav grouped on left */}
         <div className="flex items-center gap-8">
-          <Link href="/" className="shrink-0">
+          <Link href="/" prefetch={prefetchUnlessHere("/")} className="shrink-0">
             <Image
               src={logoUrl}
               alt="DevFest Toulouse"
@@ -57,6 +65,7 @@ export default function Header() {
                 <div key={entry.key} className="group relative">
                   <Link
                     href={entry.href}
+                    prefetch={prefetchUnlessHere(entry.href)}
                     className="flex items-center gap-1 text-gris text-base hover:text-noir transition-colors"
                     aria-haspopup="true"
                   >
@@ -70,6 +79,7 @@ export default function Header() {
                       <Link
                         key={child.key}
                         href={child.href}
+                        prefetch={prefetchUnlessHere(child.href)}
                         className="px-4 py-2 text-gris text-base hover:text-noir hover:bg-blanc-casse transition-colors"
                       >
                         {child.label ?? t(child.labelKey)}
@@ -81,6 +91,7 @@ export default function Header() {
                 <Link
                   key={entry.key}
                   href={entry.href}
+                  prefetch={prefetchUnlessHere(entry.href)}
                   className="text-gris text-base hover:text-noir transition-colors"
                 >
                   {entry.label ?? t(entry.labelKey)}
@@ -147,6 +158,7 @@ export default function Header() {
               <div key={entry.key} className="flex flex-col gap-4">
                 <Link
                   href={entry.href}
+                  prefetch={prefetchUnlessHere(entry.href)}
                   className="text-gris text-base hover:text-noir transition-colors"
                   onClick={() => setIsMenuOpen(false)}
                 >
@@ -156,6 +168,7 @@ export default function Header() {
                   <Link
                     key={child.key}
                     href={child.href}
+                    prefetch={prefetchUnlessHere(child.href)}
                     className="pl-4 text-gris text-base hover:text-noir transition-colors"
                     onClick={() => setIsMenuOpen(false)}
                   >

--- a/src/frontend/src/components/YouTubeFacade.test.tsx
+++ b/src/frontend/src/components/YouTubeFacade.test.tsx
@@ -1,6 +1,21 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// next/image reads its allowed hosts from next.config.ts, which vitest never
+// loads: the real component throws "hostname is not configured" on a remote
+// source (#474). Rendered as a plain <img> here, so these tests keep asserting
+// what they are about — which URL, and nothing sent to YouTube before the
+// click. The configuration itself is asserted at the bottom of this file, so
+// the mock cannot hide a missing remotePattern.
+vi.mock("next/image", () => ({
+  default: ({ src, alt, onError }: { src: string; alt: string; onError?: () => void }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} onError={onError} />
+  ),
+}));
 
 import YouTubeFacade from "./YouTubeFacade";
 
@@ -75,5 +90,47 @@ describe("YouTubeFacade — URL forms", () => {
 
     expect(screen.getByRole("link", { name: /Un talk/ })).toHaveAttribute("href", url);
     expect(iframe()).toBeNull();
+  });
+});
+
+describe("YouTubeFacade — the thumbnail goes through the proxy (#474)", () => {
+  // Served straight from img.youtube.com, the thumbnail called Google on every
+  // page load — before the visitor asked for anything, which is precisely what
+  // a facade exists to prevent. It also arrived as an 80 kB JPEG for a 364 px
+  // box; through /_next/image it is a 23 kB AVIF.
+  it("asks next/image for it rather than YouTube directly", () => {
+    render(<YouTubeFacade videoUrl={WATCH_URL} title="Un talk" />);
+
+    // The mock renders whatever src the component passed to next/image, so a
+    // raw <img> would show here as the same string — the guard below is what
+    // proves the proxy can actually serve it.
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "https://img.youtube.com/vi/Jcs2Fp8jHEQ/maxresdefault.jpg",
+    );
+  });
+
+  it.each(["img.youtube.com", "i.ytimg.com"])(
+    "declares %s in next.config so the proxy accepts it",
+    (hostname) => {
+      // Without this the component throws "hostname is not configured" at
+      // render — in production only, since vitest never loads the config.
+      const config = readFileSync(resolve(process.cwd(), "next.config.ts"), "utf8");
+
+      expect(config).toContain(hostname);
+    },
+  );
+
+  it("falls back to hqdefault when maxresdefault does not exist", () => {
+    render(<YouTubeFacade videoUrl={WATCH_URL} title="Un talk" />);
+
+    // YouTube only generates maxresdefault above a source resolution; older
+    // talks 404 on it, and the block would show an empty frame.
+    fireEvent.error(screen.getByRole("img"));
+
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "https://img.youtube.com/vi/Jcs2Fp8jHEQ/hqdefault.jpg",
+    );
   });
 });

--- a/src/frontend/src/components/YouTubeFacade.tsx
+++ b/src/frontend/src/components/YouTubeFacade.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import Image from "next/image";
 
 interface YouTubeFacadeProps {
   videoUrl: string;
   title?: string;
 }
+
+// YouTube only generates maxresdefault (1280×720) for videos uploaded above a
+// certain resolution; for the rest it answers 404. hqdefault always exists, so
+// it takes over when the first one fails — otherwise the block would show an
+// empty frame on exactly the older talks the replay archive is made of (#474).
+const THUMBNAIL_QUALITIES = ["maxresdefault", "hqdefault"] as const;
 
 function extractVideoId(url: string): string | null {
   const patterns = [
@@ -21,6 +28,7 @@ function extractVideoId(url: string): string | null {
 
 export default function YouTubeFacade({ videoUrl, title = "Video" }: YouTubeFacadeProps) {
   const [isPlaying, setIsPlaying] = useState(false);
+  const [qualityIndex, setQualityIndex] = useState(0);
   const videoId = extractVideoId(videoUrl);
 
   const handlePlay = useCallback(() => {
@@ -44,7 +52,7 @@ export default function YouTubeFacade({ videoUrl, title = "Video" }: YouTubeFaca
     );
   }
 
-  const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
+  const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/${THUMBNAIL_QUALITIES[qualityIndex]}.jpg`;
 
   if (isPlaying) {
     return (
@@ -67,12 +75,19 @@ export default function YouTubeFacade({ videoUrl, title = "Video" }: YouTubeFaca
       className="relative w-full aspect-video rounded-3xl overflow-hidden group cursor-pointer"
       aria-label={`Play ${title}`}
     >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
+      {/* Through next/image, not a raw <img>: the proxy converts to AVIF and
+          resizes to what is actually displayed — 80 kB became ~10 kB — and,
+          more to the point, it is what makes the facade a facade. Served
+          straight from img.youtube.com, the thumbnail called Google on every
+          page load, before the visitor had asked for anything (#474). */}
+      <Image
+        key={thumbnailUrl}
         src={thumbnailUrl}
         alt={title}
-        className="w-full h-full object-cover"
-        loading="lazy"
+        fill
+        sizes="(min-width: 1024px) 896px, 100vw"
+        className="object-cover"
+        onError={() => setQualityIndex((i) => Math.min(i + 1, THUMBNAIL_QUALITIES.length - 1))}
       />
 
       {/* Dark overlay */}

--- a/src/frontend/src/components/home/AboutCarousel.tsx
+++ b/src/frontend/src/components/home/AboutCarousel.tsx
@@ -14,6 +14,11 @@ interface AboutCarouselProps {
 // Lightweight, dependency-free carousel (CSS scroll-snap + arrow buttons) for
 // the "Derrière le DevFest Toulouse" block (#59). Keyboard-accessible: the
 // track is focusable and scrolls with arrow keys; buttons scroll by one slide.
+//
+// No `priority` on the first slide: the block sits far below the fold on the
+// home page, its only caller, and preloading it put a second <link rel=preload
+// as=image> in the head — 45.8 kB competing with the hero's LCP on the same
+// throttled link (#473).
 export default function AboutCarousel({ slides, prevLabel, nextLabel }: AboutCarouselProps) {
   const trackRef = useRef<HTMLUListElement>(null);
 
@@ -34,7 +39,7 @@ export default function AboutCarousel({ slides, prevLabel, nextLabel }: AboutCar
         tabIndex={0}
         className="flex flex-1 min-h-[260px] gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory rounded-m [scrollbar-width:none] [&::-webkit-scrollbar]:hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-blanc"
       >
-        {slides.map((slide, i) => (
+        {slides.map((slide) => (
           <li
             key={slide.url}
             className="relative shrink-0 snap-start w-full sm:w-[85%] h-full overflow-hidden rounded-m bg-noir/20"
@@ -45,7 +50,6 @@ export default function AboutCarousel({ slides, prevLabel, nextLabel }: AboutCar
               fill
               sizes="(min-width: 640px) 60vw, 90vw"
               className="object-cover"
-              priority={i === 0}
             />
           </li>
         ))}

--- a/src/frontend/src/components/home/HeroSection.tsx
+++ b/src/frontend/src/components/home/HeroSection.tsx
@@ -113,9 +113,14 @@ export default function HeroSection({ edition, cfp, locale, figures = [] }: Hero
             upload was served as-is and the browser only discovered it after
             parsing the CSS, pushing LCP past 20 s on slow 4G (#197). Rendering
             it through <Image priority> gets it WebP/AVIF conversion, a size
-            matched to the viewport, a preload in the document head and
-            fetchpriority=high. The overlay reproduces the darkening gradient
-            the background used to carry. */}
+            matched to the viewport and a preload in the document head. The
+            overlay reproduces the darkening gradient the background used to
+            carry.
+
+            `fetchPriority` is passed explicitly: `priority` alone stopped
+            emitting it in Next 16, and the LCP request went out at Low priority
+            behind everything else — 498 ms of load delay for a download that
+            takes 1 ms (#473). */}
         <div className="hero-photo" aria-hidden="true">
           {heroImageUrl && (
             <Image
@@ -123,6 +128,7 @@ export default function HeroSection({ edition, cfp, locale, figures = [] }: Hero
               alt=""
               fill
               priority
+              fetchPriority="high"
               sizes="(max-width: 1024px) 100vw, 50vw"
               className="hero-photo-img"
             />


### PR DESCRIPTION
Les cinq bugs ouverts, un commit par issue.

## #486 — la médiathèque supprimait un fichier encore affiché

Le compteur de références existait déjà pour la purge de corbeille, avec le commentaire qui explique pourquoi on ne peut pas s'en passer. `DELETE /api/admin/files/:filename` était le seul chemin de suppression qui ne l'interrogeait pas. Il renvoie maintenant **409** en nommant ce qui utilise le fichier.

Deux trous dans le comptage lui-même, qui auraient rendu ce refus mensonger :

- **`EditionSponsor`** n'est pas une entité de corbeille, donc ses quatre colonnes de fichiers échappaient au recensement — le logo figé qu'affiche une archive (#375) et les fichiers du kit com. Un fichier utilisé uniquement là comptait pour zéro.
- **`SiteSetting`** : les logos, favicons, le carrousel d'accueil et l'image OG sont des lignes clé/valeur qu'aucune entrée `fileFields` ne peut décrire. **Au-delà de l'énoncé de l'issue**, mais ce sont les références les plus visibles qui soient : supprimer le logo casse l'en-tête de toutes les pages, et un garde-fou qui les ignore donne une fausse assurance.

Pas de « supprimer quand même » : retirer la référence là où elle sert, puis supprimer, est le bon ordre. À rediscuter si ça coince à l'usage.

## #473 — l'image LCP repassée en priorité haute

`priority` sur `next/image` n'émet plus `fetchpriority` depuis Next 16 : le preload était bien là, l'attribut non, et la requête partait en priorité **Low**. Le commentaire au-dessus du composant décrivait l'ancien comportement, ce qui explique que rien ne clochait à la lecture.

Le carrousel « Derrière le DevFest » préchargeait en plus sa première diapo — 45,8 ko pour un bloc très en dessous de la ligne de flottaison, en concurrence directe avec le hero.

## #474 — la vignette YouTube passe par le proxy

La façade existe pour ne rien coûter avant le clic. Sa vignette partait chez Google **à chaque chargement de page**, et pesait 79,7 ko de JPEG en 1280×720 pour une boîte de 364 px. Via `next/image` : **23,5 ko d'AVIF**, et plus aucune requête vers Google avant le clic.

`maxresdefault` n'existe pas pour toutes les vidéos ; repli sur `hqdefault`, vérifié sur une vraie vidéo de 2005 où le proxy renvoie 404 sur la première et sert la seconde.

## #476 — deux constats sur trois n'existaient pas

**Le vrai défaut** : `/fr` était préchargée depuis `/fr`. Corrigé sur tous les liens de l'en-tête, pas seulement le logo — le même gaspillage se produisait sur « Actus » depuis `/fr/actualites`.

**Les doublons n'en sont pas.** Les six lignes de l'issue sont trois requêtes sur deux chargements : c'est ce qu'affiche un onglet réseau avec le journal conservé. En relisant la beta avec les requêtes préservées j'obtiens exactement la liste de l'issue ; par navigation, j'en obtiens trois.

**Les deux requêtes restantes vers `/devenir-sponsor` non plus.** Elles portent des en-têtes et des charges différentes : l'une est `next-router-segment-prefetch: /_tree` (l'arbre de routes), l'autre `next-router-state-tree: [...,"metadata-only"]` (le `<head>` de la page). Deux moitiés complémentaires d'un même prefetch, par conception dans le routeur Next 16.

## #481 — la cause n'est pas dans le hero

`next/font` masque normalement un échange de police en émettant une police de repli aux métriques identiques. Il n'en a pas pour Google Sans et **le dit à la construction** : `Failed to find font override values for font 'Google Sans'. Skipping generating a fallback font.` Le CSS produit le confirme — aucune règle `size-adjust` ni `ascent-override`.

Avec `display: swap` et un repli non ajusté, chaque ligne de texte change de hauteur à l'arrivée du woff2, et le hero est le plus grand bloc de texte du site. D'où les 0,063 entièrement imputés à `section.hero`, un rectangle de 412 × 947.

Passé en `optional` : la police est prise si elle est prête dans la fenêtre d'environ 100 ms, sinon le repli est conservé pour ce chargement, sans échange. **Le compromis** : une première visite sur lien lent peut s'afficher en `system-ui`. Un repli aux métriques mesurées à la main garderait la police de marque ; c'est le coup d'après si ce compromis vous paraît mauvais.

## Plan de test

**Vérifié**

- Backend **712/713**, frontend **333/333**, `tsc` propre des deux côtés, `lint` sans erreur (9 avertissements préexistants).
- Le seul échec backend est l'artefact de conteneur connu — `stat-icons.test.ts` lit un fichier du frontend, invisible depuis `/app`.
- #486 : les quatre tests du 409 passent **au rouge** quand on neutralise la garde, et le refus a été vu à l'écran dans l'admin, sur une référence `SiteSetting` puis sur une `EditionSponsor`.
- #473 : trace Slow 4G + CPU 4× sur la pile locale — un seul `<link rel=preload as=image>` au lieu de deux, `fetchpriority="high"` sur le lien **et** sur l'image. Remettre `priority` sur le carrousel fait aussitôt réapparaître le second preload.
- #474 : 79 672 → 23 525 octets, `image/avif`, aucune requête vers `img.youtube.com` depuis le navigateur. Repli `hqdefault` observé sur une vidéo réelle sans `maxresdefault`.
- #476 : vérifié sur une **construction de production locale** — le prefetch est désactivé en `next dev`, ce bug est invisible sur la pile habituelle. Avant : `/fr` préchargée depuis `/fr`. Après : plus aucune requête `_rsc` vers la page courante, ni depuis l'accueil ni depuis `/fr/actualites`.

**Non vérifié**

- **Le CLS de #481 n'a pas été reproduit**, et c'est à dire franchement : il mesure 0,00 ici sous Slow 4G et CPU 4×, avant comme après, sur la pile de dev, sur une construction de production locale et contre la beta dans un contexte navigateur froid. Ce qui est établi, c'est le mécanisme — l'avertissement de build, la règle d'override absente — et que le CSS produit porte désormais `font-display: optional` sur ses 25 faces. Les 0,063 n'ont jamais été vus que depuis l'infrastructure de Google.
- Rien en beta ni en prod.
- `i.ytimg.com` est déclaré mais jamais exercé : YouTube n'a servi que `img.youtube.com` pendant les essais.
- L'effet réel de `optional` sur une première visite lente n'a pas été observé : la police arrive dans la fenêtre sur tous les liens que j'ai pu émuler.

Refs #473
Refs #474
Refs #476
Refs #481
Refs #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
